### PR TITLE
fix: Add CONVEX_SITE_URL support for self-hosted Convex

### DIFF
--- a/apps/worker/src/crown/convex.ts
+++ b/apps/worker/src/crown/convex.ts
@@ -1,11 +1,30 @@
 import { log } from "../logger";
 
+/**
+ * Resolves the base URL for Convex HTTP actions.
+ *
+ * For Convex Cloud: transforms `.convex.cloud` → `.convex.site`
+ * For self-hosted Convex: uses CONVEX_SITE_URL directly (different port for HTTP actions)
+ *
+ * Priority:
+ * 1. CONVEX_SITE_URL (explicit HTTP action URL - used as-is for self-hosted)
+ * 2. Override URL with .convex.cloud → .convex.site transformation
+ */
 function getConvexBaseUrl(override?: string): string | null {
+  // If CONVEX_SITE_URL is explicitly set, use it directly
+  // This is the primary way to configure self-hosted Convex HTTP action URLs
+  const explicitSiteUrl = process.env.CONVEX_SITE_URL;
+  if (explicitSiteUrl) {
+    return explicitSiteUrl.replace(/\/$/, "");
+  }
+
   const url = override;
   if (!url) {
     log("ERROR", "Convex URL is not configured; cannot call crown endpoints");
     return null;
   }
+
+  // For Convex Cloud URLs, transform .convex.cloud → .convex.site
   const httpActionUrl = url.replace(".convex.cloud", ".convex.site");
   return httpActionUrl.replace(/\/$/, "");
 }


### PR DESCRIPTION
## Summary

- Fix activity completion not working in self-hosted Convex environments
- Add support for `CONVEX_SITE_URL` environment variable to explicitly specify the HTTP action URL
- Maintains backward compatibility with Convex Cloud (`.convex.cloud` → `.convex.site` transformation)

## Problem

For self-hosted Convex:
- Backend runs on port `3210`
- HTTP actions run on port `3211`

The existing code only handled Convex Cloud URLs by transforming `.convex.cloud` → `.convex.site`. For self-hosted URLs, this transformation did nothing, causing crown completion requests to go to the wrong port.

## Solution

The `getConvexBaseUrl` function now:
1. Prioritizes `CONVEX_SITE_URL` if explicitly set (for self-hosted)
2. Falls back to the `.convex.cloud` → `.convex.site` transformation (for Convex Cloud)

## Test plan

- [ ] Verify activity completion works with self-hosted Convex when `CONVEX_SITE_URL` is set
- [ ] Verify existing Convex Cloud behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)