### PR TITLE
feat: add CONVEX_SITE_URL support for self-hosted Convex

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -78,8 +78,7 @@ export async function spawnAgent(
       options.newBranch ||
       (await generateNewBranchName(options.taskDescription, teamSlugOrId));
     serverLogger.info(
-      `[AgentSpawner] New Branch: ${newBranch}, Base Branch: ${
-        options.branch ?? "(auto)"
+      `[AgentSpawner] New Branch: ${newBranch}, Base Branch: ${options.branch ?? "(auto)"
       }`
     );
 
@@ -510,12 +509,12 @@ export async function spawnAgent(
     // Get ports if it's a Docker instance
     let ports:
       | {
-          vscode: string;
-          worker: string;
-          extension?: string;
-          proxy?: string;
-          vnc?: string;
-        }
+        vscode: string;
+        worker: string;
+        extension?: string;
+        proxy?: string;
+        vnc?: string;
+      }
       | undefined;
     if (vscodeInstance instanceof DockerVSCodeInstance) {
       const dockerPorts = vscodeInstance.getPorts();
@@ -635,30 +634,30 @@ export async function spawnAgent(
     // The notify command contains complex JSON that gets mangled through shell layers
     const tmuxArgs = agent.name.toLowerCase().includes("codex")
       ? [
-          "new-session",
-          "-d",
-          "-s",
-          tmuxSessionName,
-          "-c",
-          "/root/workspace",
-          actualCommand,
-          ...actualArgs.map((arg) => {
-            // Replace $CMUX_PROMPT with actual prompt value
-            if (arg === "$CMUX_PROMPT") {
-              return processedTaskDescription;
-            }
-            return arg;
-          }),
-        ]
+        "new-session",
+        "-d",
+        "-s",
+        tmuxSessionName,
+        "-c",
+        "/root/workspace",
+        actualCommand,
+        ...actualArgs.map((arg) => {
+          // Replace $CMUX_PROMPT with actual prompt value
+          if (arg === "$CMUX_PROMPT") {
+            return processedTaskDescription;
+          }
+          return arg;
+        }),
+      ]
       : [
-          "new-session",
-          "-d",
-          "-s",
-          tmuxSessionName,
-          "bash",
-          "-lc",
-          `${unsetCommand}exec ${commandString}`,
-        ];
+        "new-session",
+        "-d",
+        "-s",
+        tmuxSessionName,
+        "bash",
+        "-lc",
+        `${unsetCommand}exec ${commandString}`,
+      ];
 
     const terminalCreationCommand: WorkerCreateTerminal = {
       terminalId: tmuxSessionName,
@@ -670,7 +669,8 @@ export async function spawnAgent(
       taskRunContext: {
         taskRunToken: taskRunJwt,
         prompt: processedTaskDescription,
-        convexUrl: env.NEXT_PUBLIC_CONVEX_URL,
+        // Use CONVEX_SITE_URL for HTTP actions (crown endpoints), fall back to NEXT_PUBLIC_CONVEX_URL
+        convexUrl: env.CONVEX_SITE_URL || env.NEXT_PUBLIC_CONVEX_URL,
       },
       taskRunId,
       agentModel: agent.name,
@@ -959,22 +959,22 @@ export async function spawnAllAgents(
   // If selectedAgents is provided, map each entry to an AgentConfig to preserve duplicates
   const agentsToSpawn = options.selectedAgents
     ? options.selectedAgents
-        .map((name) => AGENT_CONFIGS.find((agent) => agent.name === name))
-        .filter((a): a is AgentConfig => Boolean(a))
+      .map((name) => AGENT_CONFIGS.find((agent) => agent.name === name))
+      .filter((a): a is AgentConfig => Boolean(a))
     : AGENT_CONFIGS;
 
   // Generate unique branch names for all agents at once to ensure no collisions
   const branchNames = options.prTitle
     ? await generateUniqueBranchNamesFromTitle(
-        options.prTitle!,
-        agentsToSpawn.length,
-        teamSlugOrId
-      )
+      options.prTitle!,
+      agentsToSpawn.length,
+      teamSlugOrId
+    )
     : await generateUniqueBranchNames(
-        options.taskDescription,
-        agentsToSpawn.length,
-        teamSlugOrId
-      );
+      options.taskDescription,
+      agentsToSpawn.length,
+      teamSlugOrId
+    );
 
   serverLogger.info(
     `[AgentSpawner] Generated ${branchNames.length} unique branch names for agents`

--- a/apps/server/src/utils/server-env.ts
+++ b/apps/server/src/utils/server-env.ts
@@ -7,6 +7,9 @@ export const env = createEnv({
     // Public origin used across the app; prefer this for WWW base URL
     NEXT_PUBLIC_WWW_ORIGIN: z.string().min(1).optional(),
     NEXT_PUBLIC_CONVEX_URL: z.string().min(1),
+    // Convex HTTP actions URL (for crown endpoints, screenshots, etc.)
+    // Falls back to NEXT_PUBLIC_CONVEX_URL if not set
+    CONVEX_SITE_URL: z.string().min(1).optional(),
     // When enabled, restricts features to web-compatible only (e.g., cloud mode only, no local Docker)
     NEXT_PUBLIC_WEB_MODE: z
       .enum(["true", "false"])

--- a/apps/www/lib/services/code-review/start-code-review.ts
+++ b/apps/www/lib/services/code-review/start-code-review.ts
@@ -83,6 +83,11 @@ function resolveStrategy(): PrReviewStrategyId {
 }
 
 export function getConvexHttpActionBaseUrl(): string | null {
+  // Prefer explicit CONVEX_SITE_URL for self-hosted setups where HTTP actions are on a different port
+  if (env.CONVEX_SITE_URL) {
+    return env.CONVEX_SITE_URL.replace(/\/$/, "");
+  }
+  // Fall back to transforming NEXT_PUBLIC_CONVEX_URL for Convex Cloud
   const url = env.NEXT_PUBLIC_CONVEX_URL;
   if (!url) {
     return null;

--- a/apps/www/lib/utils/www-env.ts
+++ b/apps/www/lib/utils/www-env.ts
@@ -17,6 +17,9 @@ export const env = createEnv({
     GEMINI_API_KEY: z.string().min(1).optional(),
     ANTHROPIC_API_KEY: z.string().min(1),
     CMUX_TASK_RUN_JWT_SECRET: z.string().min(1),
+    // Convex HTTP actions URL (for self-hosted setups where HTTP actions are on a different port)
+    // Falls back to NEXT_PUBLIC_CONVEX_URL with .convex.cloud -> .convex.site transformation
+    CONVEX_SITE_URL: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),


### PR DESCRIPTION
## Summary
- Add optional `CONVEX_SITE_URL` environment variable to server and www apps
- Self-hosted Convex instances serve HTTP actions on a separate port (e.g., 8001) from the main Convex URL (e.g., 3210)
- Update `agentSpawner` to pass `CONVEX_SITE_URL` for crown/HTTP action endpoints
- Update `getConvexHttpActionBaseUrl()` to prefer `CONVEX_SITE_URL` over the `.convex.cloud` → `.convex.site` URL transformation

## Test plan
- [ ] Test with Convex Cloud (no `CONVEX_SITE_URL` set) - should continue working as before
- [ ] Test with self-hosted Convex by setting `CONVEX_SITE_URL` to the HTTP actions endpoint (e.g., `http://localhost:8001`)
- [ ] Verify crown endpoints work correctly with self-hosted setup
- [ ] Verify code review screenshot functionality works with self-hosted setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)