### PR TITLE
fix: Handle PKCS#1 to PKCS#8 conversion at runtime in Convex

### DIFF
--- a/scripts/setup-convex-env.sh
+++ b/scripts/setup-convex-env.sh
@@ -96,20 +96,9 @@ else
 fi
 
 # Read the GitHub private key properly (multi-line)
+# Note: PKCS#1 to PKCS#8 conversion is now handled at runtime in Convex
+# (see packages/convex/_shared/githubApp.ts wrapPkcs1InPkcs8 function)
 GITHUB_PRIVATE_KEY=$(sed -n '/^CMUX_GITHUB_APP_PRIVATE_KEY=/,/-----END.*KEY-----/p' "$ENV_FILE" | sed 's/^CMUX_GITHUB_APP_PRIVATE_KEY="//' | sed 's/"$//')
-
-# Convert PKCS#1 (RSA PRIVATE KEY) to PKCS#8 (PRIVATE KEY) if needed
-# Web Crypto API's subtle.importKey("pkcs8", ...) requires PKCS#8 format
-if [[ "$GITHUB_PRIVATE_KEY" == *"BEGIN RSA PRIVATE KEY"* ]]; then
-  echo "Converting GitHub private key from PKCS#1 to PKCS#8 format..."
-  GITHUB_PRIVATE_KEY=$(echo "$GITHUB_PRIVATE_KEY" | openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt 2>&1)
-  if [[ "$GITHUB_PRIVATE_KEY" != *"BEGIN PRIVATE KEY"* ]]; then
-    echo "Error: Failed to convert private key to PKCS#8 format"
-    echo "$GITHUB_PRIVATE_KEY"
-    exit 1
-  fi
-  echo "Private key converted to PKCS#8 format"
-fi
 
 # Set INSTALL_STATE_SECRET based on mode
 if [ "$MODE" = "production" ]; then


### PR DESCRIPTION
## Summary

- Add pure JavaScript PKCS#1 → PKCS#8 ASN.1 wrapping in Convex runtime to support raw GitHub App private keys
- Remove `openssl pkcs8` pre-conversion step from `setup-convex-env.sh` since conversion now happens at runtime

## Background

GitHub generates private keys in PKCS#1 format (`-----BEGIN RSA PRIVATE KEY-----`), but the Web Crypto API's `importKey("pkcs8", ...)` only accepts PKCS#8 format (`-----BEGIN PRIVATE KEY-----`).

Previously, `setup-convex-env.sh` required `openssl` to pre-convert the key before uploading to Convex. Now the conversion happens automatically at runtime using pure JavaScript ASN.1 manipulation.

## Changes

### `packages/convex/_shared/githubApp.ts`
- `isPkcs1Format()` - Detects PKCS#1 format PEM
- `encodeAsn1Length()` - Encodes ASN.1 length bytes (handles short/long form)
- `wrapPkcs1InPkcs8()` - Wraps PKCS#1 DER in PKCS#8 ASN.1 structure
- Updated `importPrivateKey()` - Auto-converts PKCS#1 → PKCS#8 before importing

### `scripts/setup-convex-env.sh`
- Removed `openssl pkcs8` conversion block (no longer needed)
- Added comment explaining conversion is now handled at runtime

## Test plan

- [ ] Verify Convex functions using GitHub App auth still work with PKCS#1 keys
- [ ] Verify `setup-convex-env.sh` uploads raw PEM without conversion
- [ ] Verify CI passes (the original motivation for this fix)