### PR TITLE
feat: Add Windows Electron support and fix protocol handler

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -18,6 +18,7 @@
     "build": "vite build -c vite.config.ts",
     "build:electron": "bun run ./scripts/generate-icons.mjs && electron-vite build -c electron.vite.config.ts && electron-builder",
     "build:mac": "node ./scripts/generate-icons.mjs && electron-vite build -c electron.vite.config.ts && electron-builder --mac",
+    "build:win": "node ./scripts/generate-icons.mjs && electron-vite build -c electron.vite.config.ts && electron-builder --win",
     "prebuild:mac:workaround": "node ./scripts/run-electron-rebuild.mjs",
     "build:mac:workaround": "./build-mac-workaround.sh",
     "prepublish:mac:workaround": "node ./scripts/run-electron-rebuild.mjs",

--- a/apps/client/scripts/run-electron-rebuild.mjs
+++ b/apps/client/scripts/run-electron-rebuild.mjs
@@ -151,5 +151,6 @@ try {
   if (error?.error) {
     console.error("Failed to launch electron-rebuild:", error.error);
   }
-  process.exit(error?.code ?? 1);
+  const exitCode = typeof error?.code === "number" ? error.code : 1;
+  process.exit(exitCode);
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "generate-openapi-client": "cd apps/www && bun run generate-openapi-client",
     "generate-morphcloud-openapi-client": "cd packages/morphcloud-openapi-client && bun run generate",
     "build:mac-arm64-prod": "bash scripts/build-prod-mac-arm64.sh",
+    "build:win-prod": "bash scripts/build-prod-win.sh",
+    "dev:electron": "bash scripts/dev.sh --electron",
+    "dev:electron:simple": "bash scripts/dev-electron-simple.sh",
     "convex:deploy:prod": "(cd packages/convex && bun run deploy:prod)",
     "convex:deploy": "(cd packages/convex && bun run deploy)",
     "convex:setup": "bun run --env-file .env --cwd packages/convex setup"

--- a/scripts/build-prod-win.sh
+++ b/scripts/build-prod-win.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Build cmux Electron app for Windows (production)
+#
+# Usage: ./scripts/build-prod-win.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLIENT_DIR="$ROOT_DIR/apps/client"
+
+# Prefer production env for packaging; fall back to .env if missing
+ENV_FILE="$ROOT_DIR/.env.production"
+if [[ ! -f "$ENV_FILE" ]]; then
+  ENV_FILE="$ROOT_DIR/.env"
+fi
+
+echo "==> Using env file: $ENV_FILE"
+echo "==> Building cmux for Windows..."
+
+# Generate OpenAPI client first
+echo "==> Generating OpenAPI client..."
+(cd "$ROOT_DIR/apps/www" && bun run generate-openapi-client)
+
+# Build the Electron app for Windows
+echo "==> Building Electron app..."
+(cd "$CLIENT_DIR" && bun run --env-file "$ENV_FILE" build:win)
+
+echo "==> Build complete!"
+echo "==> Output: $CLIENT_DIR/dist-electron/"
+ls -la "$CLIENT_DIR/dist-electron/"*.exe 2>/dev/null || echo "(no .exe files found)"

--- a/scripts/dev-electron-simple.sh
+++ b/scripts/dev-electron-simple.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# dev-electron-simple.sh - Start Electron dev without native Rust build
+#
+# Usage: ./scripts/dev-electron-simple.sh
+#
+# This is a simplified script that skips the native Rust addon build
+# and just starts the Electron app directly.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env if it exists
+if [ -f "$ROOT_DIR/.env" ]; then
+    echo "Loading .env file"
+    set -a
+    . "$ROOT_DIR/.env"
+    set +a
+fi
+
+echo "Starting Electron dev (simple mode - no Rust/native build)..."
+
+# Generate OpenAPI client first
+echo "==> Generating OpenAPI client..."
+(cd "$ROOT_DIR/apps/www" && bun run generate-openapi-client)
+
+# Start Electron dev directly (bypassing predev:electron hook)
+echo "==> Starting Electron..."
+cd "$ROOT_DIR/apps/client"
+bunx electron-vite dev -c electron.vite.config.ts


### PR DESCRIPTION
## Summary
- Add Windows protocol handler for `cmux://` deep links using `requestSingleInstanceLock` and `second-instance` event
- Add `build:win` script for Windows production builds
- Add `dev:electron:simple` script to bypass Rust native build
- Fix exit code type error in `run-electron-rebuild.mjs`
- Enhanced dev mode protocol registration for Windows

## Test plan
- [x] Tested Windows production build (`bun run build:win-prod`)
- [x] Tested Electron dev mode on Windows (`bun run dev:electron:simple`)
- [ ] Test sign-in flow with `cmux://auth-callback` deep link