### PR TITLE
fix: expose port 39383 for terminal (xterm) service

### DIFF
--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -16,7 +16,7 @@ import {
 } from "@cmux/shared/pull-request-state";
 
 function rewriteMorphUrl(url: string): string {
-  // do not rewrite ports 39375 39377 39378 39379 39380 39381
+  // do not rewrite ports 39375 39377 39378 39379 39380 39381 39383
   if (
     url.includes("http.cloud.morph.so") &&
     (url.startsWith("https://port-39375-") ||
@@ -24,7 +24,8 @@ function rewriteMorphUrl(url: string): string {
       url.startsWith("https://port-39378-") ||
       url.startsWith("https://port-39379-") ||
       url.startsWith("https://port-39380-") ||
-      url.startsWith("https://port-39381-"))
+      url.startsWith("https://port-39381-") ||
+      url.startsWith("https://port-39383-"))
   ) {
     return url;
   }

--- a/packages/shared/src/utils/reserved-cmux-ports.ts
+++ b/packages/shared/src/utils/reserved-cmux-ports.ts
@@ -1,3 +1,3 @@
-export const RESERVED_CMUX_PORTS = [39375, 39377, 39378, 39379, 39380, 39381] as const;
+export const RESERVED_CMUX_PORTS = [39375, 39377, 39378, 39379, 39380, 39381, 39383] as const;
 
 export const RESERVED_CMUX_PORT_SET = new Set<number>(RESERVED_CMUX_PORTS);

--- a/scripts/morph_dockerfile.py
+++ b/scripts/morph_dockerfile.py
@@ -59,7 +59,7 @@ snapshot = (
     )
     .exec("echo '::1     localhost' >> /etc/hosts")
     .upload(".", "/")
-    .as_container(dockerfile=dockerfile, ports=[39375, 39377, 39378, 39379, 39380, 39381])
+    .as_container(dockerfile=dockerfile, ports=[39375, 39377, 39378, 39379, 39380, 39381, 39383])
 )
 
 print(f"Snapshot ID: {snapshot.id}")

--- a/scripts/morph_snapshot.py
+++ b/scripts/morph_snapshot.py
@@ -708,7 +708,7 @@ def main() -> None:
 
         print(f"Instance ID: {instance.id}")
         # expose the ports
-        expose_ports = [39375, 39377, 39378, 39379, 39380, 39381]
+        expose_ports = [39375, 39377, 39378, 39379, 39380, 39381, 39383]
         for port in expose_ports:
             instance.expose_http_service(port=port, name=f"port-{port}")
         instance.wait_until_ready()


### PR DESCRIPTION
## Summary

- Fix missing port 39383 (cmux-xterm terminal server) from Morph VM port exposure
- This was a missed merge bug - port was added in feature branch but lost during unrelated file modification

## Root Cause

| Commit | Author | What Happened |
|--------|--------|---------------|
| `d9d3ccec9` | austinpower1258 | Added port 39383 in feature branch |
| `64f9f17b1` | Lawrence Chen | Modified same file from main (which never had 39383), overwriting change |

**NOT intentional removal** - just a missed merge.

## Changes

| File | Change |
|------|--------|
| `packages/shared/src/utils/reserved-cmux-ports.ts` | Added `39383` to `RESERVED_CMUX_PORTS` |
| `packages/convex/convex/taskRuns.ts` | Added `port-39383-` to URL rewrite bypass |
| `scripts/morph_snapshot.py` | Added `39383` to `expose_ports` list |
| `scripts/morph_dockerfile.py` | Added `39383` to container ports |

## Port Reference

| Port | Service |
|------|---------|
| 39375 | execd (command execution) |
| 39377 | worker service |
| 39378 | VS Code / IDE |
| 39379 | cmux-proxy |
| 39380 | VNC (noVNC) |
| 39381 | Chrome DevTools Protocol |
| **39383** | **xterm terminal server (was missing)** |

## Test plan

- [ ] Rebuild Morph snapshot with `scripts/snapshot.py`
- [ ] Verify port 39383 appears in Morph instance exposed services
- [ ] Test terminal WebSocket connection works