### PR TITLE
Propagate VSCode theme into cloud sandboxes

### DIFF
--- a/apps/server/src/vscode/CmuxVSCodeInstance.ts
+++ b/apps/server/src/vscode/CmuxVSCodeInstance.ts
@@ -58,6 +58,7 @@ export class CmuxVSCodeInstance extends VSCodeInstance {
         taskRunId: this.taskRunId,
         taskRunJwt: this.taskRunJwt || "",
         isCloudWorkspace: this.config.agentName === "cloud-workspace",
+        ...(this.config.theme ? { theme: this.config.theme } : {}),
         ...(this.environmentId ? { environmentId: this.environmentId } : {}),
         ...(this.repoUrl
           ? {

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -604,6 +604,7 @@ export type StartSandboxBody = {
     taskRunId?: string;
     taskRunJwt?: string;
     isCloudWorkspace?: boolean;
+    theme?: 'dark' | 'light' | 'system';
     repoUrl?: string;
     branch?: string;
     newBranch?: string;


### PR DESCRIPTION
## Summary
- forward the UI-selected theme into `/api/sandboxes/start`
- apply `VSCODE_THEME` inside the sandbox via envctl and IDE configure script (no service restart)
- update the OpenAPI client types to include the new `theme` field

## Testing
- not run
