### PR TITLE
Add multi-provider AI gateway to commit message generation

### DIFF
--- a/apps/server/src/utils/commitMessageGenerator.ts
+++ b/apps/server/src/utils/commitMessageGenerator.ts
@@ -2,7 +2,11 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { api } from "@cmux/convex/api";
-import { CLOUDFLARE_OPENAI_BASE_URL } from "@cmux/shared";
+import {
+  CLOUDFLARE_ANTHROPIC_BASE_URL,
+  CLOUDFLARE_GEMINI_BASE_URL,
+  CLOUDFLARE_OPENAI_BASE_URL,
+} from "@cmux/shared";
 import { generateText, type LanguageModel } from "ai";
 import { getConvex } from "../utils/convexClient";
 import { serverLogger } from "./fileLogger";
@@ -10,19 +14,30 @@ import { serverLogger } from "./fileLogger";
 function getModelAndProvider(
   apiKeys: Record<string, string>
 ): { model: LanguageModel; providerName: string } | null {
+  // Note: AIGATEWAY_* accessed via process.env to support custom AI gateway configurations
   if (apiKeys.OPENAI_API_KEY) {
     const openai = createOpenAI({
       apiKey: apiKeys.OPENAI_API_KEY,
-      baseURL: CLOUDFLARE_OPENAI_BASE_URL,
+      baseURL:
+        process.env.AIGATEWAY_OPENAI_BASE_URL || CLOUDFLARE_OPENAI_BASE_URL,
     });
     return { model: openai("gpt-5-nano"), providerName: "OpenAI" };
   }
   if (apiKeys.GEMINI_API_KEY) {
-    const google = createGoogleGenerativeAI({ apiKey: apiKeys.GEMINI_API_KEY });
+    const google = createGoogleGenerativeAI({
+      apiKey: apiKeys.GEMINI_API_KEY,
+      baseURL:
+        process.env.AIGATEWAY_GEMINI_BASE_URL || CLOUDFLARE_GEMINI_BASE_URL,
+    });
     return { model: google("gemini-2.5-flash"), providerName: "Gemini" };
   }
   if (apiKeys.ANTHROPIC_API_KEY) {
-    const anthropic = createAnthropic({ apiKey: apiKeys.ANTHROPIC_API_KEY });
+    const anthropic = createAnthropic({
+      apiKey: apiKeys.ANTHROPIC_API_KEY,
+      baseURL:
+        process.env.AIGATEWAY_ANTHROPIC_BASE_URL ||
+        CLOUDFLARE_ANTHROPIC_BASE_URL,
+    });
     return {
       model: anthropic("claude-3-5-haiku-20241022"),
       providerName: "Anthropic",


### PR DESCRIPTION
at commit #d69656f1995b80af086fb4931de31496d1932ec3; i add feat: Add multi-provider AI gateway support; @apps/server/src/utils/commitMessageGenerator.ts please also implement multi-provider AI gateway support to Commit Message Generation