### PR TITLE
Prefer public exec host and accept PVE_CF_DOMAIN

### DIFF
--- a/apps/www/lib/utils/pve-lxc-client.ts
+++ b/apps/www/lib/utils/pve-lxc-client.ts
@@ -269,8 +269,7 @@ export class PveLxcClient {
     this.apiUrl = options.apiUrl.replace(/\/$/, "");
     this.apiToken = options.apiToken;
     this.node = options.node || null; // Will be auto-detected if not provided
-    // Support both PVE_PUBLIC_DOMAIN (preferred) and legacy PVE_CF_DOMAIN
-    this.publicDomain = options.publicDomain || env.PVE_CF_DOMAIN || null;
+    this.publicDomain = options.publicDomain || null;
   }
 
   private generateInstanceId(): string {

--- a/apps/www/lib/utils/www-env.ts
+++ b/apps/www/lib/utils/www-env.ts
@@ -47,8 +47,6 @@ export const env = createEnv({
     // Public domain for PVE sandbox URLs via Cloudflare Tunnel (e.g., "example.com")
     // When set, generates URLs like https://port-{port}-{instanceId}.example.com
     PVE_PUBLIC_DOMAIN: z.string().min(1).optional(),
-    // Alias for public domain (legacy env var name used by scripts)
-    PVE_CF_DOMAIN: z.string().min(1).optional(),
     // Whether to verify PVE TLS certs (default: false for self-signed)
     PVE_VERIFY_TLS: z
       .string()

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -18,12 +18,10 @@ Required environment variables:
     PVE_API_TOKEN - API token in format: user@realm!tokenid=secret
 
 Optional environment variables:
-    PVE_CF_DOMAIN - Cloudflare Tunnel domain for HTTP exec (e.g., alphasolves.com)
+    PVE_PUBLIC_DOMAIN - Cloudflare Tunnel domain for HTTP exec (e.g., alphasolves.com)
                     When set, uses instanceId-based URL pattern:
                     https://port-{port}-{instanceId}.{domain} for command execution via
-                    cmux-execd instead of SSH+pct exec. Falls back to
-                    PVE_PUBLIC_DOMAIN if not set, then to SSH if neither is set.
-    PVE_PUBLIC_DOMAIN - Alias for PVE_CF_DOMAIN (used as fallback)
+                    cmux-execd instead of SSH+pct exec. Falls back to SSH if not set.
     PVE_NODE - Target PVE node name (auto-detected if not set)
     PVE_SSH_HOST - SSH host for fallback (derived from PVE_API_URL if not set)
 
@@ -4114,7 +4112,7 @@ async def provision_and_snapshot(args: argparse.Namespace) -> None:
         console.always("  export PVE_API_TOKEN=root@pam!cmux=your-secret")
         sys.exit(1)
 
-    cf_domain = os.environ.get("PVE_CF_DOMAIN") or os.environ.get("PVE_PUBLIC_DOMAIN")
+    cf_domain = os.environ.get("PVE_PUBLIC_DOMAIN")
 
     client = PveLxcClient(
         api_url=api_url,
@@ -4136,7 +4134,7 @@ async def provision_and_snapshot(args: argparse.Namespace) -> None:
         if client._ssh_host_explicit:
             console.info(f"Using SSH host: {client.ssh_host}")
         else:
-            console.always("ERROR: No exec method configured. Set PVE_CF_DOMAIN or PVE_SSH_HOST")
+            console.always("ERROR: No exec method configured. Set PVE_PUBLIC_DOMAIN or PVE_SSH_HOST")
             sys.exit(1)
 
     # Test connection
@@ -4455,7 +4453,7 @@ async def run_update_mode(args: argparse.Namespace) -> None:
         console.always("ERROR: PVE_API_URL and PVE_API_TOKEN must be set")
         sys.exit(1)
 
-    cf_domain = os.environ.get("PVE_CF_DOMAIN") or os.environ.get("PVE_PUBLIC_DOMAIN")
+    cf_domain = os.environ.get("PVE_PUBLIC_DOMAIN")
 
     client = PveLxcClient(
         api_url=api_url,
@@ -4477,7 +4475,7 @@ async def run_update_mode(args: argparse.Namespace) -> None:
         if client._ssh_host_explicit:
             console.info(f"Using SSH host: {client.ssh_host}")
         else:
-            console.always("ERROR: No exec method configured. Set PVE_CF_DOMAIN or PVE_SSH_HOST")
+            console.always("ERROR: No exec method configured. Set PVE_PUBLIC_DOMAIN or PVE_SSH_HOST")
             sys.exit(1)
 
     # Test connection

--- a/scripts/test-pve-bun-install.py
+++ b/scripts/test-pve-bun-install.py
@@ -28,10 +28,10 @@ async def main():
     # Get PVE config from environment
     api_url = os.environ["PVE_API_URL"]
     api_token = os.environ["PVE_API_TOKEN"]
-    public_domain = os.environ.get("PVE_PUBLIC_DOMAIN") or os.environ.get("PVE_CF_DOMAIN")
+    public_domain = os.environ.get("PVE_PUBLIC_DOMAIN")
 
     if not public_domain:
-        print("ERROR: PVE_PUBLIC_DOMAIN or PVE_CF_DOMAIN not set", file=sys.stderr)
+        print("ERROR: PVE_PUBLIC_DOMAIN not set", file=sys.stderr)
         sys.exit(1)
 
     print(f"Connecting to {api_url}")

--- a/scripts/test-pve-gitdiff.py
+++ b/scripts/test-pve-gitdiff.py
@@ -367,9 +367,9 @@ def main():
     parser.add_argument("--repo-root", default=".", help="Repository root (default: current directory)")
     args = parser.parse_args()
 
-    cf_domain = os.environ.get("PVE_CF_DOMAIN") or os.environ.get("PVE_PUBLIC_DOMAIN")
+    cf_domain = os.environ.get("PVE_PUBLIC_DOMAIN")
     if not cf_domain:
-        print("ERROR: PVE_CF_DOMAIN or PVE_PUBLIC_DOMAIN must be set")
+        print("ERROR: PVE_PUBLIC_DOMAIN must be set")
         sys.exit(1)
 
     if not args.instance_id:


### PR DESCRIPTION
- prefer public Cloudflare/Caddy exec URL before fqdn/ip when running cmux-execd\n- allow legacy PVE_CF_DOMAIN as alias for public domain env\n- update env schema accordingly