### PR TITLE
Ensure worker uses express path-to-regexp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -490,14 +490,15 @@ mv ./apps/worker/build/browser-agent/runBrowserAgentFromPrompt.js ./apps/worker/
 rm -rf ./apps/worker/build/browser-agent
 echo "Built worker"
 mkdir -p ./apps/worker/build/node_modules
-if [ -d ./node_modules/path-to-regexp ]; then
-  cp -RL ./node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
-elif [ -d ./node_modules/express/node_modules/path-to-regexp ]; then
-  cp -RL ./node_modules/express/node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
-else
-  echo "Missing path-to-regexp dependency (expected in node_modules/path-to-regexp or express/node_modules/path-to-regexp)" >&2
-  exit 1
-fi
+  # Prefer the express-pinned path-to-regexp (0.1.x) to avoid bundling newer incompatible versions
+  if [ -d ./node_modules/express/node_modules/path-to-regexp ]; then
+    cp -RL ./node_modules/express/node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
+  elif [ -d ./node_modules/path-to-regexp ]; then
+    cp -RL ./node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
+  else
+    echo "Missing path-to-regexp dependency (expected in node_modules/path-to-regexp or express/node_modules/path-to-regexp)" >&2
+    exit 1
+  fi
 shopt -s nullglob
 declare -A COPIED_PACKAGES=()
 

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -3068,10 +3068,11 @@ async def task_build_worker(ctx: PveTaskContext) -> None:
           exit 1
         fi
         install -d ./apps/worker/build/node_modules
-        if [ -d ./node_modules/path-to-regexp ]; then
-          cp -RL ./node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
-        elif [ -d ./node_modules/express/node_modules/path-to-regexp ]; then
+        # Prefer express-pinned path-to-regexp (0.1.x) to avoid bundling newer incompatible version
+        if [ -d ./node_modules/express/node_modules/path-to-regexp ]; then
           cp -RL ./node_modules/express/node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
+        elif [ -d ./node_modules/path-to-regexp ]; then
+          cp -RL ./node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
         else
           echo "Missing express path-to-regexp dependency" >&2
           exit 1

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -2012,10 +2012,11 @@ async def task_build_worker(ctx: TaskContext) -> None:
           exit 1
         fi
         install -d ./apps/worker/build/node_modules
-        if [ -d ./node_modules/path-to-regexp ]; then
-          cp -RL ./node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
-        elif [ -d ./node_modules/express/node_modules/path-to-regexp ]; then
+        # Prefer express-pinned path-to-regexp (0.1.x) to avoid bundling newer incompatible version
+        if [ -d ./node_modules/express/node_modules/path-to-regexp ]; then
           cp -RL ./node_modules/express/node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
+        elif [ -d ./node_modules/path-to-regexp ]; then
+          cp -RL ./node_modules/path-to-regexp ./apps/worker/build/node_modules/path-to-regexp
         else
           echo "Missing express path-to-regexp dependency" >&2
           exit 1


### PR DESCRIPTION
## Summary
- prefer express-pinned path-to-regexp (0.1.x) when copying deps into worker build
- keep same preference in snapshot scripts to avoid bundling newer incompatible versions

## Testing
- not run (infrastructure change)