### PR TITLE
Add multi-port internal listeners to CDP proxy for MCP tools

### DIFF
--- a/scripts/cdp-proxy/main.go
+++ b/scripts/cdp-proxy/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -10,14 +11,43 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 )
 
 type proxyConfig struct {
-	listenPort int
-	targetPort int
-	targetHost string
-	hostHeader string
+	externalPort  int
+	internalPorts []int
+	targetPort    int
+	targetHost    string
+	hostHeader    string
+}
+
+type intSliceFlag struct {
+	values []int
+}
+
+func (f *intSliceFlag) String() string {
+	if len(f.values) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%v", f.values)
+}
+
+func (f *intSliceFlag) Set(value string) error {
+	port, err := parsePortValue(value)
+	if err != nil {
+		return err
+	}
+	f.values = append(f.values, port)
+	return nil
+}
+
+var internalPortFlags intSliceFlag
+
+func init() {
+	flag.Var(&internalPortFlags, "internal-port", "Internal listener port (repeatable). Binds to 127.0.0.1")
 }
 
 func getenv(key string, fallback string) string {
@@ -28,30 +58,88 @@ func getenv(key string, fallback string) string {
 	return value
 }
 
+func parsePortValue(raw string) (int, error) {
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 || value > 65535 {
+		return 0, fmt.Errorf("invalid port value %q", raw)
+	}
+	return value, nil
+}
+
 func parsePort(raw string, fallback int) int {
 	if raw == "" {
 		return fallback
 	}
-	value, err := strconv.Atoi(raw)
-	if err != nil || value <= 0 || value > 65535 {
-		log.Fatalf("invalid port value %q", raw)
+	value, err := parsePortValue(raw)
+	if err != nil {
+		log.Fatal(err)
 	}
 	return value
 }
 
-func loadConfig() proxyConfig {
+func parseInternalPorts(raw string) []int {
+	if raw == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	var ports []int
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		value, err := parsePortValue(trimmed)
+		if err != nil {
+			log.Fatal(err)
+		}
+		ports = append(ports, value)
+	}
+
+	return ports
+}
+
+func dedupePorts(ports []int) []int {
+	seen := make(map[int]struct{}, len(ports))
+	var result []int
+	for _, port := range ports {
+		if _, ok := seen[port]; ok {
+			continue
+		}
+		seen[port] = struct{}{}
+		result = append(result, port)
+	}
+	return result
+}
+
+func loadConfig(flagPorts []int) proxyConfig {
 	targetPort := parsePort(getenv("CMUX_CDP_TARGET_PORT", "39382"), 39382)
+
+	envInternalPorts := parseInternalPorts(getenv("CMUX_CDP_INTERNAL_PORTS", ""))
+	var internalPorts []int
+	switch {
+	case len(flagPorts) > 0:
+		internalPorts = flagPorts
+	case len(envInternalPorts) > 0:
+		internalPorts = envInternalPorts
+	default:
+		internalPorts = []int{9222}
+	}
+
 	return proxyConfig{
-		listenPort: parsePort(getenv("CMUX_CDP_PROXY_PORT", "39381"), 39381),
-		targetPort: targetPort,
-		targetHost: getenv("CMUX_CDP_TARGET_HOST", "127.0.0.1"),
-		hostHeader: getenv("CMUX_CDP_TARGET_HOST_HEADER", fmt.Sprintf("localhost:%d", targetPort)),
+		externalPort:  parsePort(getenv("CMUX_CDP_PROXY_PORT", "39381"), 39381),
+		internalPorts: dedupePorts(internalPorts),
+		targetPort:    targetPort,
+		targetHost:    getenv("CMUX_CDP_TARGET_HOST", "127.0.0.1"),
+		hostHeader:    getenv("CMUX_CDP_TARGET_HOST_HEADER", fmt.Sprintf("localhost:%d", targetPort)),
 	}
 }
 
 func main() {
+	flag.Parse()
+
 	log.SetFlags(log.LstdFlags | log.LUTC)
-	cfg := loadConfig()
+	cfg := loadConfig(internalPortFlags.values)
 
 	targetURL := &url.URL{
 		Scheme: "http",
@@ -105,20 +193,63 @@ func main() {
 
 	log.Print("TCP_NODELAY enabled for low-latency proxying")
 
-	server := &http.Server{
-		Addr:              net.JoinHostPort("0.0.0.0", strconv.Itoa(cfg.listenPort)),
-		Handler:           proxy,
-		ReadHeaderTimeout: 5 * time.Second,
+	type listenerConfig struct {
+		host  string
+		port  int
+		label string
 	}
 
-	log.Printf(
-		"cmux CDP proxy listening on %d, forwarding to %s (Host header: %s)",
-		cfg.listenPort,
-		targetURL.Host,
-		cfg.hostHeader,
-	)
-
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("server exited: %v", err)
+	listeners := []listenerConfig{
+		{host: "0.0.0.0", port: cfg.externalPort, label: "external"},
 	}
+	for _, port := range cfg.internalPorts {
+		listeners = append(listeners, listenerConfig{host: "127.0.0.1", port: port, label: "internal"})
+	}
+
+	errCh := make(chan error, len(listeners))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, listener := range listeners {
+		listener := listener
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			addr := net.JoinHostPort(listener.host, strconv.Itoa(listener.port))
+			server := &http.Server{
+				Addr:              addr,
+				Handler:           proxy,
+				ReadHeaderTimeout: 5 * time.Second,
+			}
+
+			go func() {
+				<-ctx.Done()
+				shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancelShutdown()
+				_ = server.Shutdown(shutdownCtx)
+			}()
+
+			log.Printf(
+				"cmux CDP proxy listening on %s (%s), forwarding to %s (Host header: %s)",
+				addr,
+				listener.label,
+				targetURL.Host,
+				cfg.hostHeader,
+			)
+
+			if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				select {
+				case errCh <- fmt.Errorf("%s listener on %s exited: %w", listener.label, addr, err):
+				default:
+				}
+			}
+		}()
+	}
+
+	err := <-errCh
+	cancel()
+	wg.Wait()
+	log.Fatalf("server exited: %v", err)
 }


### PR DESCRIPTION
# CDP Proxy Multi-Port Support (Internal MCP)## RoleSenior Go Engineer & Systems Architect## TaskExtend the CDP proxy to support internal multi-port listening for local MCP tools.## Context- Sandbox runs Chrome on 39382 behind a CDP proxy.- Proxy currently exposes 39381 externally.- MCP tools expect Chrome debugging ports 9222/9223 on localhost; today users juggle dual configs.## Goal- Keep external listener on 0.0.0.0:39381.- Add internal listeners on 127.0.0.1:9222 and 127.0.0.1:9223 for MCP/local tools.- All listeners forward to Chrome on 39382.## Requirements (scripts/cdp-proxy/main.go)- Multi-port: Start listeners concurrently (goroutines + WaitGroup/error channel) so one failure doesn’t block others.- Bindings:  - External: 0.0.0.0:39381 (unchanged).  - Internal: 127.0.0.1:9222 (primary MCP), 127.0.0.1:9223 (secondary/optional).- Configuration:  - Env: `CMUX_CDP_INTERNAL_PORTS` (CSV of ports) or per-port flags.  - Defaults: If unset, enable 9222; keep 39381 always on.- Security:  - Internal ports must bind only to 127.0.0.1 (never exposed externally).  - 39381 remains the distinct external entry point.