### PR TITLE
Remove highlightedSetId prop from RunScreenshotGallery

### DIFF
--- a/apps/client/src/components/RunScreenshotGallery.tsx
+++ b/apps/client/src/components/RunScreenshotGallery.tsx
@@ -44,7 +44,7 @@ interface RunScreenshotSet {
 
 interface RunScreenshotGalleryProps {
   screenshotSets: RunScreenshotSet[];
-  highlightedSetId?: Id<"taskRunScreenshotSets"> | null;
+  // Note: highlightedSetId was removed as the component now only shows the latest set
 }
 
 const MIN_ZOOM = 0.2;

--- a/apps/client/src/components/TaskRunGitDiffPanel.tsx
+++ b/apps/client/src/components/TaskRunGitDiffPanel.tsx
@@ -119,10 +119,7 @@ export function TaskRunGitDiffPanel({ task, selectedRun, teamSlugOrId, taskId, s
           Loading screenshots...
         </div>
       ) : (
-        <RunScreenshotGallery
-          screenshotSets={screenshotSets}
-          highlightedSetId={selectedRun?.latestScreenshotSetId ?? null}
-        />
+        <RunScreenshotGallery screenshotSets={screenshotSets} />
       )}
       <MonacoGitDiffViewer diffs={allDiffs} />
     </div>

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx
@@ -1092,10 +1092,7 @@ function RunDiffPage() {
                 Loading screenshots...
               </div>
             ) : screenshotSets.length > 0 ? (
-              <RunScreenshotGallery
-                screenshotSets={screenshotSets}
-                highlightedSetId={selectedRun?.latestScreenshotSetId ?? null}
-              />
+              <RunScreenshotGallery screenshotSets={screenshotSets} />
             ) : null}
             <div
               className={cn("flex-1 min-h-0", screenshotSets.length > 0 && "mt-6")}


### PR DESCRIPTION
The highlightedSetId prop was removed from RunScreenshotGallery and its usages, as the component now only displays the latest screenshot set. This simplifies the component interface and related calls.
