### PR TITLE
[Crown] # Bug: Single-Run Crown Evaluation Missing UI Status Updates
...

### DIFF
--- a/packages/convex/convex/crown_http.ts
+++ b/packages/convex/convex/crown_http.ts
@@ -713,11 +713,14 @@ async function handleCrownCheckRequest(
       ? completedRuns[0]._id
       : null;
 
-  if (
-    shouldEvaluate &&
+  // Set crown evaluation status to pending for both multi-run (shouldEvaluate) and single-run cases
+  const needsCrownStatusUpdate =
+    (shouldEvaluate || singleRunWinnerId) &&
     currentStatus !== "pending" &&
-    currentStatus !== "in_progress"
-  ) {
+    currentStatus !== "in_progress" &&
+    !existingEvaluation;
+
+  if (needsCrownStatusUpdate) {
     try {
       await ctx.runMutation(internal.tasks.setCrownEvaluationStatusInternal, {
         taskId,


### PR DESCRIPTION
## Task

# Bug: Single-Run Crown Evaluation Missing UI Status Updates

## Context

When a cmux task has multiple candidates (2+), the frontend correctly shows:

- "Crown evaluation in progress"
- "Evaluating submissions..."
- Retry status when evaluation fails

But when a task has only a single candidate (single-run), the frontend does NOT show these status updates.

## Current Behavior

- **Multi-run (2+ candidates)**: Shows "Crown evaluation in progress" and "Evaluating submissions..." during crown evaluation
- **Single-run (1 candidate)**: No crown evaluation status shown in UI; task appears to go directly from "completed" to crowned without intermediate status

## Expected Behavior

Both single-run and multi-run cases should show consistent UI status:

- "Crown evaluation in progress" while summarization is running
- Retry status if evaluation/summarization fails

## Root Cause Investigation

The single-run path in the worker (`apps/worker/src/crown/workflow.ts`) may not be updating the task's `crownEvaluationStatus` to "pending" or "in\_progress" before calling summarization. Or the frontend may not be handling the single-run case status updates correctly.

Check:

1. Worker code: Does single-run path call `/api/crown/check` which sets `crownEvaluationStatus: "pending"`?
2. Convex `crown_http.ts`: Does the status get set for single-run case?
3. Frontend `task-timeline.tsx`: Does it handle single-run crown status display?

## Requirements

- Follow existing codebase code style
- Prefer changes in non-worker code (apps/server, apps/www, packages/convex, etc.) as they take effect immediately
- If worker changes (apps/worker) are required, still make them but note that they require snapshot rebuild to take effect

## Files to Investigate

- `apps/worker/src/crown/workflow.ts` - single-run crown evaluation flow
- `packages/convex/convex/crown_http.ts` - crown status updates
- `apps/client/src/components/task-timeline.tsx` - crown evaluation UI display
- `packages/convex/convex/tasks.ts` - crownEvaluationStatus mutations

The PR modifies `crown_http.ts` to ensure that crown evaluation status is set to "pending" for both multi-run and single-run scenarios before starting evaluation. It introduces `needsCrownStatusUpdate` condition that also considers `singleRunWinnerId`, and adds checks for existing evaluation. The change makes status updates consistent across runner types.

- **What Changed**
  - Updated `handleCrownCheckRequest` in `packages/convex/convex/crown_http.ts`
  - Added `needsCrownStatusUpdate` logic that triggers status update when either `shouldEvaluate` or a single-run winner exists
  - Status is now set to "pending" before calling `setCrownEvaluationStatusInternal`
  - Added guard against duplicate updates (`!existingEvaluation`)

- **Review Focus**
  - Verify that the condition correctly identifies single-run cases and doesn't inadvertently trigger status updates when already "in_progress"
  - Ensure `currentStatus !== "in_progress"` check still works with the new `needsCrownStatusUpdate` logic
  - Confirm that `existingEvaluation` is properly defined and prevents unnecessary mutations
  - Validate that the mutation payload (`taskId`, `status: "pending"`) matches schema expectations
  - Assess any side effects on retry flows or task cancellation paths

- **Test Plan**
  1. Simulate a crown check for a task with a single candidate and confirm the UI shows "Crown evaluation in progress" and updates status to "pending" before summarization starts
  2. Run a multi-run scenario to ensure existing behavior remains unchanged
  3. Trigger evaluation failure and verify retry status is displayed
  4. Check that existing evaluations are not re‑set to pending when already in progress
  5. Run unit tests for `crown_http.ts` and integration tests covering both run types

- **Follow-ups**
  - Add coverage for single-run status updates in the test suite
  - Document the new `singleRunWinnerId` handling in code comments
  - Monitor for snapshot rebuilds if related worker changes are made later