### PR TITLE
fix(www): request workflows permission for GitHub App tokens

### DIFF
--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -657,6 +657,9 @@ sandboxesRouter.openapi(
               permissions: {
                 contents: "write",
                 metadata: "read",
+                // Required for pushing workflow files (.github/workflows/*)
+                // Without this, pushes containing workflow files are rejected
+                workflows: "write",
               },
             });
             gitAuthToken = appToken;

--- a/apps/www/lib/utils/github-app-token.ts
+++ b/apps/www/lib/utils/github-app-token.ts
@@ -15,6 +15,7 @@ interface GenerateInstallationTokenOptions {
     metadata?: "read";
     pull_requests?: "read" | "write";
     statuses?: "read" | "write";
+    workflows?: "write";
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `workflows` permission option to GitHub App token generation interface
- Request `workflows: write` permission when generating installation tokens for sandbox git operations
- Fixes push failures when tasks create/modify workflow files (`.github/workflows/*`)

## Test plan
- [x] Verified push succeeds for tasks that create workflow files
- [x] Confirmed fallback to OAuth still works when GitHub App lacks workflows permission