### PR TITLE
[Crown] # Plan: Fix Image Upload Filename Handling for Task Descripti...

### DIFF
--- a/apps/client/src/components/lexical/EditorStatePlugin.tsx
+++ b/apps/client/src/components/lexical/EditorStatePlugin.tsx
@@ -16,7 +16,9 @@ import {
 import { useEffect } from "react";
 import { $isImageNode, ImageNode } from "./ImageNode";
 
-// Custom transformer for ImageNode to export as markdown image syntax
+// Custom transformer for ImageNode to export as plain filename
+// Using plain filename instead of markdown syntax to avoid shell pattern issues
+// when CLI tools process the task description
 const IMAGE_TRANSFORMER: Transformer = {
   dependencies: [ImageNode],
   export: (node) => {
@@ -27,9 +29,9 @@ const IMAGE_TRANSFORMER: Transformer = {
     const altText = node.getAltText();
     // Use fileName if available, otherwise use altText as reference
     const imageRef = fileName || `image: ${altText}`;
-    // Export as markdown image syntax: ![alt](reference)
-    // The actual image data is handled separately via the images array
-    return `![${altText}](${imageRef})`;
+    // Export as plain filename with surrounding spaces to ensure proper separation
+    // from adjacent text. The backend will replace this with the sanitized path.
+    return ` ${imageRef} `;
   },
   regExp: /!\[([^\]]*)\]\(([^)]+)\)/,
   replace: () => {


### PR DESCRIPTION
## Task

# Plan: Fix Image Upload Filename Handling for Task Descriptions

## Problem Summary

When uploading an image with non-ASCII filename like `螢幕截圖 2025-11-30 15.00.14.jpg`:

1. **Frontend** generates markdown: `![螢幕截圖 2025-11-30 15.00.14.jpg](螢幕截圖 2025-11-30 15.00.14.jpg)`
2. **Backend** sanitizes filename to: `_____2025-11-30_15.00.14.jpg` and stores at `/root/prompt/_____2025-11-30_15.00.14.jpg`
3. **Backend** tries to find/replace original filename in task description, but the markdown syntax \`![...](...)\` confuses CLI tools (see screenshot - "bad pattern" error)

**User Request**: Use just the filename `螢幕截圖 2025-11-30 15.00.14.jpg` in task description, and sanitized path `/root/prompt/_____2025-11-30_15.00.14.jpg` as the reference.

## Root Cause Analysis

The current flow in `apps/server/src/agentSpawner.ts` (lines 186-250):

1. Sanitizes filename: `螢幕截圖 2025-11-30 15.00.14.jpg` -> `_____2025-11-30_15.00.14.jpg`
2. Creates path: `/root/prompt/_____2025-11-30_15.00.14.jpg`
3. Replaces original filename in task description with the full path

But the task description from frontend contains markdown like:

```
![螢幕截圖 2025-11-30 15.00.14.jpg](螢幕截圖 2025-11-30 15.00.14.jpg)read the image
```

After replacement, it becomes:

```
![/root/prompt/_____2025-11-30_15.00.14.jpg](/root/prompt/_____2025-11-30_15.00.14.jpg)read the image
```

This is problematic because CLI tools may try to parse the markdown image syntax as shell patterns.

## Approved Solution: Plain Filename with Space Separation

Change the frontend to output just the filename (without markdown syntax) and ensure proper spacing before/after the filename.

**Problem**: Currently `japan-560x420.jpgread the image` has no space between filename and prompt text.

**Frontend change** - `EditorStatePlugin.tsx` line 32:

```typescript
// Instead of: return `![${altText}](${imageRef})`;
// Add space padding to ensure filename is separated from surrounding text
return ` ${imageRef} `;  // Pad with spaces on both sides
```

**Result**:

- Task description will contain: `&#32;螢幕截圖 2025-11-30 15.00.14.jpg read the image` (properly spaced)
- After backend processing: `&#32;/root/prompt/_____2025-11-30_15.00.14.jpg read the image`

Note: Extra spaces will be naturally trimmed or harmless in the final prompt.

## Implementation Plan

### Step 1: Modify Frontend Image Export

**File**: `apps/client/src/components/lexical/EditorStatePlugin.tsx`

Change line 32 from:

```typescript
return `![${altText}](${imageRef})`;
```

To:

```typescript
return ` ${imageRef} `;
```

This ensures the filename is always separated from surrounding text with spaces.

### Step 2: Verify Backend Path Replacement Works

**File**: `apps/server/src/agentSpawner.ts` (lines 200-250)

The existing code should work correctly since it searches for the original filename and replaces it with the sanitized path. No changes needed if Step 1 is implemented.

### Step 3: Test the Change

1. Upload an image with Chinese filename (e.g., `螢幕截圖 2025-11-30 15.00.14.jpg`)
2. Create a task with text like "read the image"
3. Verify task description shows: `螢幕截圖 2025-11-30 15.00.14.jpg read the image`
4. Verify in sandbox the prompt becomes: `/root/prompt/_____2025-11-30_15.00.14.jpg read the image`
5. Verify CLI tool can process the prompt without "bad pattern" errors

## PR Review Summary
- What Changed:
  - Modified `apps/client/src/components/lexical/EditorStatePlugin.tsx` to change how image nodes are exported for task descriptions.
  - The `IMAGE_TRANSFORMER` now exports a plain filename with surrounding spaces (` ${imageRef} `) instead of the previous markdown image syntax (`![${altText}](${imageRef})`).
  - This change ensures that the image filename in the task description is separated from adjacent text and prevents CLI tools from misinterpreting markdown image syntax as shell patterns, which caused "bad pattern" errors, especially with non-ASCII filenames.
- Review Focus:
  - Verify that the backend's `agentSpawner.ts` still correctly identifies and replaces the original `imageRef` (plain filename) with the sanitized full path, even with the added leading and trailing spaces.
  - Confirm that the removal of markdown syntax and the introduction of extra spaces do not cause any unforeseen parsing or rendering issues in other parts of the application that consume the task description.
  - Ensure that the fallback `imageRef` (`image: ${altText}`) is handled gracefully if `fileName` is unavailable.
- Test Plan:
  - Upload an image with a non-ASCII filename (e.g., `螢幕截圖 2025-11-30 15.00.14.jpg`).
  - Create a new task and add text both before and after the uploaded image (e.g., "Please review this image `[image upload]` for details.").
  - Verify that the task description in the frontend displays the plain filename (e.g., "Please review this image 螢幕截圖 2025-11-30 15.00.14.jpg for details.") with proper spacing.
  - In the sandbox, confirm that the final prompt has the sanitized full path replacing the filename (e.g., "Please review this image /root/prompt/_____2025-11-30_15.00.14.jpg for details.").
  - Execute the task and ensure that no "bad pattern" errors or similar issues occur in the CLI tool's processing of the prompt.