### PR TITLE
[Crown] # Fix Docker Worker Image Build Failure

## Problem Summary

...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -499,15 +499,16 @@ bun build ./apps/worker/src/runBrowserAgentFromPrompt.ts \
 mv ./apps/worker/build/browser-agent/runBrowserAgentFromPrompt.js ./apps/worker/build/runBrowserAgentFromPrompt.js
 rm -rf ./apps/worker/build/browser-agent
 echo "Built worker"
-mkdir -p ./apps/worker/build/node_modules
+mkdir -p /cmux/apps/worker/build/node_modules
 # Install express-compatible path-to-regexp 0.1.x explicitly
 # bun hoisting can place dependencies differently, so we install directly
-cd ./apps/worker/build/node_modules
-npm pack path-to-regexp@0.1.12 --silent
-tar -xzf path-to-regexp-0.1.12.tgz
-mv package path-to-regexp
-rm -f path-to-regexp-0.1.12.tgz
-cd /app
+(
+  cd /cmux/apps/worker/build/node_modules
+  npm pack path-to-regexp@0.1.12 --silent
+  tar -xzf path-to-regexp-0.1.12.tgz
+  mv package path-to-regexp
+  rm -f path-to-regexp-0.1.12.tgz
+)
 shopt -s nullglob
 declare -A COPIED_PACKAGES=()
 
@@ -526,15 +527,15 @@ copy_scope_directory() {
   local source_dir="$1"
   local scope_name
   scope_name="$(basename "$source_dir")"
-  mkdir -p "./apps/worker/build/node_modules/$scope_name"
+  mkdir -p "/cmux/apps/worker/build/node_modules/$scope_name"
   for scoped_entry in "$source_dir"/*; do
     if [ ! -e "$scoped_entry" ]; then
       continue
     fi
     local scoped_name
     scoped_name="$(basename "$scoped_entry")"
-    rm -rf "./apps/worker/build/node_modules/$scope_name/$scoped_name"
-    cp -RL "$scoped_entry" "./apps/worker/build/node_modules/$scope_name/$scoped_name"
+    rm -rf "/cmux/apps/worker/build/node_modules/$scope_name/$scoped_name"
+    cp -RL "$scoped_entry" "/cmux/apps/worker/build/node_modules/$scope_name/$scoped_name"
   done
 }
 
@@ -549,8 +550,8 @@ copy_bundle_directory() {
     if [[ "$entry_name" == @* ]]; then
       copy_scope_directory "$entry"
     else
-      rm -rf "./apps/worker/build/node_modules/$entry_name"
-      cp -RL "$entry" "./apps/worker/build/node_modules/$entry_name"
+      rm -rf "/cmux/apps/worker/build/node_modules/$entry_name"
+      cp -RL "$entry" "/cmux/apps/worker/build/node_modules/$entry_name"
     fi
   done
 }
@@ -566,7 +567,7 @@ copy_dependency_tree() {
   sanitized="$(sanitize_package_name "$package")"
   local found=false
 
-  for bundle_dir in node_modules/.bun/"${sanitized}"@*/node_modules; do
+  for bundle_dir in /cmux/node_modules/.bun/"${sanitized}"@*/node_modules; do
     if [ ! -d "$bundle_dir" ]; then
       continue
     fi
@@ -615,8 +616,8 @@ copy_dependency_tree() {
 }
 
 copy_dependency_tree "magnitude-core"
-cp -r ./apps/worker/build /builtins/build
-cp ./apps/worker/wait-for-docker.sh /usr/local/bin/
+cp -r /cmux/apps/worker/build /builtins/build
+cp /cmux/apps/worker/wait-for-docker.sh /usr/local/bin/
 chmod +x /usr/local/bin/wait-for-docker.sh
 EOF
 


### PR DESCRIPTION
## Task

# Fix Docker Worker Image Build Failure

## Problem Summary

The Docker (Worker Image) builds for both `linux/amd64` and `linux/arm64` are failing with:

```
Warning: package magnitude-core not found in Bun cache
cp: cannot stat './apps/worker/build': No such file or directory
```

## Root Cause

Commit `cdb1ce2b1` ("chore: weekly PVE LXC snapshot update #127") introduced a fix for `path-to-regexp` compatibility, but it inadvertently broke the build by changing the working directory without updating subsequent relative paths.

### The Breaking Change (Dockerfile lines 505-510)

**Before (working):**

```bash
mkdir -p ./apps/worker/build/node_modules
shopt -s nullglob
# ... rest of script uses relative paths from /cmux
```

**After (broken):**

```bash
mkdir -p ./apps/worker/build/node_modules
cd ./apps/worker/build/node_modules  # Now in /cmux/apps/worker/build/node_modules
npm pack path-to-regexp@0.1.12 --silent
tar -xzf path-to-regexp-0.1.12.tgz
mv package path-to-regexp
rm -f path-to-regexp-0.1.12.tgz
cd /app                              # <-- PROBLEM: Changes to /app instead of back to /cmux
shopt -s nullglob
# ... rest of script uses relative paths expecting /cmux but we're in /app
```

### Why It Fails

1. The script starts in `/cmux` (WORKDIR)
2. Build output goes to `/cmux/apps/worker/build/`
3. After installing path-to-regexp, `cd /app` changes to `/app`
4. All subsequent relative paths like `./apps/worker/build` now resolve to `/app/apps/worker/build` which doesn't exist
5. Line 618 `cp -r ./apps/worker/build /builtins/build` fails because `/app/apps/worker/build` doesn't exist

---

## Recommended Fix: Use Absolute Paths Throughout

Convert all relative paths in the script to absolute paths for clarity and to prevent future directory-context bugs.

### File to Modify

- `Dockerfile` (lines 502-620)

### Changes

**1. Line 502:** Use absolute path for mkdir

```diff
-mkdir -p ./apps/worker/build/node_modules
+mkdir -p /cmux/apps/worker/build/node_modules
```

**2. Lines 505-510:** Use subshell to isolate directory change for path-to-regexp installation

```diff
-cd ./apps/worker/build/node_modules
-npm pack path-to-regexp@0.1.12 --silent
-tar -xzf path-to-regexp-0.1.12.tgz
-mv package path-to-regexp
-rm -f path-to-regexp-0.1.12.tgz
-cd /app
+(
+  cd /cmux/apps/worker/build/node_modules
+  npm pack path-to-regexp@0.1.12 --silent
+  tar -xzf path-to-regexp-0.1.12.tgz
+  mv package path-to-regexp
+  rm -f path-to-regexp-0.1.12.tgz
+)
```

**3. Line 529:** Use absolute path in copy\_scope\_directory

```diff
-  mkdir -p "./apps/worker/build/node_modules/$scope_name"
+  mkdir -p "/cmux/apps/worker/build/node_modules/$scope_name"
```

**4. Lines 536-537:** Use absolute paths in copy\_scope\_directory

```diff
-    rm -rf "./apps/worker/build/node_modules/$scope_name/$scoped_name"
-    cp -RL "$scoped_entry" "./apps/worker/build/node_modules/$scope_name/$scoped_name"
+    rm -rf "/cmux/apps/worker/build/node_modules/$scope_name/$scoped_name"
+    cp -RL "$scoped_entry" "/cmux/apps/worker/build/node_modules/$scope_name/$scoped_name"
```

**5. Lines 552-553:** Use absolute paths in copy\_bundle\_directory

```diff
-      rm -rf "./apps/worker/build/node_modules/$entry_name"
-      cp -RL "$entry" "./apps/worker/build/node_modules/$entry_name"
+      rm -rf "/cmux/apps/worker/build/node_modules/$entry_name"
+      cp -RL "$entry" "/cmux/apps/worker/build/node_modules/$entry_name"
```

**6. Line 569:** Use absolute path for node\_modules search

```diff
-  for bundle_dir in node_modules/.bun/"${sanitized}"@*/node_modules; do
+  for bundle_dir in /cmux/node_modules/.bun/"${sanitized}"@*/node_modules; do
```

**7. Lines 618-619:** Use absolute paths for final copy operations

```diff
-cp -r ./apps/worker/build /builtins/build
-cp ./apps/worker/wait-for-docker.sh /usr/local/bin/
+cp -r /cmux/apps/worker/build /builtins/build
+cp /cmux/apps/worker/wait-for-docker.sh /usr/local/bin/
```

---

## Alternative: Minimal Fix

If you prefer a minimal change, simply fix line 510:

```diff
-cd /app
+cd /cmux
```

This restores the original working directory context. However, the absolute paths approach is more robust and prevents similar bugs in the future.

---

## Verification

After the fix:

1. Run locally: `docker build -f Dockerfile --target builder .` (to test the builder stage)
2. Push to trigger CI: The Docker workflow will run automatically
3. Or manually trigger: `gh workflow run "Docker (Worker Image)" --repo karlorz/cmux --ref <branch>`
4. Verify both `linux/amd64` and `linux/arm64` builds succeed
5. The multi-arch manifest job should complete successfully

## PR Review Summary
- **What Changed:**
  - Fixed Docker Worker Image build failures (both `linux/amd64` and `linux/arm64`) by addressing an issue where relative paths broke after an unexpected `cd /app` command.
  - The fix converts most relative paths in the `Dockerfile` (lines 502-619) to absolute paths, specifically prefixing them with `/cmux`.
  - The `path-to-regexp` installation block (lines 505-510) is now encapsulated within a subshell `(...)` to isolate its `cd` commands and prevent subsequent path issues.
  - Specific changes include updating `mkdir -p`, `rm -rf`, `cp -RL` commands within `copy_scope_directory`, `copy_bundle_directory` functions, and the final `cp` commands to use absolute paths.
  - The search path for `bundle_dir` in `copy_dependency_tree` (line 569) now also uses an absolute path (`/cmux/node_modules/.bun/...`).
- **Review Focus:**
  - Carefully verify that all necessary relative paths in the worker build stage of the `Dockerfile` have been correctly converted to their absolute `/cmux/` equivalents.
  - Ensure the subshell used for `path-to-regexp` installation (`(...)`) fully isolates its directory changes and does not introduce any unintended side effects on commands outside its scope.
  - Confirm that the new absolute paths resolve correctly within the Docker build environment for all target architectures.
- **Test Plan:**
  - Build the Dockerfile locally targeting the builder stage: `docker build -f Dockerfile --target builder .`.
  - Push the branch to trigger the CI/CD pipeline, or manually trigger the `Docker (Worker Image)` workflow (`gh workflow run "Docker (Worker Image)" --repo karlorz/cmux --ref <branch>`).
  - Verify that the Docker builds for both `linux/amd64` and `linux/arm64` succeed.
  - Confirm that the multi-arch manifest job completes successfully.