### PR TITLE
Resolve Morph Snapshot disk space issue: reduce swapfile to 2GiB

### DIFF
--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1943,8 +1943,8 @@ async def task_configure_memory_protection(ctx: TaskContext) -> None:
     cmd = textwrap.dedent(
         """
         set -euo pipefail
-        CMUX_FORCE_SWAP=1 CMUX_SWAPFILE_SIZE_GIB=6 /usr/local/sbin/cmux-configure-memory
-        expected_kib=$((6 * 1024 * 1024))
+        CMUX_FORCE_SWAP=1 CMUX_SWAPFILE_SIZE_GIB=2 /usr/local/sbin/cmux-configure-memory
+        expected_kib=$((2 * 1024 * 1024))
         tolerance_kib=8
         min_expected_kib=$((expected_kib - tolerance_kib))
         actual_kib="$(awk '$1 == "/var/swap/cmux-swapfile" {print $3}' /proc/swaps 2>/dev/null || true)"
@@ -1961,7 +1961,7 @@ async def task_configure_memory_protection(ctx: TaskContext) -> None:
                 ;;
         esac
         if [ "${actual_kib}" -lt "${min_expected_kib}" ]; then
-            echo "Swapfile size ${actual_kib} KiB is below required ${min_expected_kib} KiB minimum (6 GiB minus tolerance)." >&2
+            echo "Swapfile size ${actual_kib} KiB is below required ${min_expected_kib} KiB minimum (2 GiB minus tolerance)." >&2
             swapon --show=NAME,TYPE,SIZE,USED,PRIO || true
             exit 1
         fi


### PR DESCRIPTION
## Task

# Plan: Fix Morph Snapshot Disk Space Issue

## Problem Analysis


The Daily Morph Snapshot workflow is failing with:

```

RuntimeError: configure-memory-protection failed with exit code 1
Swapfile /var/swap/cmux-swapfile missing from /proc/swaps after configuration.
```

### Root Cause

The `configure-memory-protection` task attempts to create a **6 GiB swapfile**, but insufficient disk space remains on the 32GB VM after installing all required software.

**Disk space breakdown (32 GB total):**
| Component | Size |
|-----------|------|
| Base OS + apt packages | ~4 GB |
| Node.js, Bun, Go, Rust toolchains | ~3 GB |
| VS Code server + extensions | ~2 GB |
| Rust compiled binaries + cargo cache | ~4 GB |
| Python (uv) + misc tools | ~1 GB |
| Swapfile (current config) | 6 GB |
| Safety margin | 0.5 GB |
| **Subtotal** | **~20.5 GB** |
| **Remaining for user workspace** | **~11.5 GB** |

The issue: When disk usage fluctuates during build (temp files, parallel downloads), available space can drop below the 6.5 GB required (6 GB swap + 512 MB margin), causing swapfile creation to be skipped silently, then failing validation.

---

## Recommended Solution: Reduce Swapfile to 2 GiB

Reduce the swapfile from 6 GiB to **2 GiB**.

### Why 2 GiB is Sufficient

| Memory Layer | Size | Notes |
|--------------|------|-------|
| Physical RAM | 8 GB | Base memory |
| zram (compressed) | ~4 GB | 50% of RAM, ~2-3x compression ratio = 8-12 GB effective |
| Swapfile | 2 GB | Disk-backed fallback |
| **Total effective** | **~18-22 GB** | More than adequate for coding workloads |

The zram layer (already configured) provides the primary swap with high-speed compressed memory. The disk swapfile serves as a secondary fallback for extreme cases.

### Disk Space Savings

| Config | Swapfile | Free Space for User |
|--------|----------|---------------------|
| Current (6 GB) | 6 GB | ~11.5 GB |
| **New (2 GB)** | **2 GB** | **~15.5 GB** |

---

## Implementation

### File: `scripts/snapshot.py`

**Location:** Lines 1942-1973 (`task_configure_memory_protection`)

**Change 1:** Update swapfile size (line 1946)
```bash
# Before:
CMUX_FORCE_SWAP=1 CMUX_SWAPFILE_SIZE_GIB=6 /usr/local/sbin/cmux-configure-memory

# After:
CMUX_FORCE_SWAP=1 CMUX_SWAPFILE_SIZE_GIB=2 /usr/local/sbin/cmux-configure-memory
```

**Change 2:** Update validation expected size (line 1947)
```bash
# Before:
expected_kib=$((6 * 1024 * 1024))

# After:
expected_kib=$((2 * 1024 * 1024))
```

---

## Verification Steps

1. **Run `bun check`** - Ensure no type errors

2. **Trigger workflow:**
   ```bash
   gh workflow run "Daily Morph Snapshot" --repo karlorz/cmux --ref main
   ```

3. **Expected results:**
   - Workflow completes successfully
   - Swapfile appears in `/proc/swaps` with ~2 GiB
   - Snapshot JSON updated with new snapshot IDs

---

## Files to Modify

| File | Lines | Change |
|------|-------|--------|
| `scripts/snapshot.py` | 1946 | `CMUX_SWAPFILE_SIZE_GIB=6` -> `CMUX_SWAPFILE_SIZE_GIB=2` |
| `scripts/snapshot.py` | 1947 | `expected_kib=$((6 * 1024 * 1024))` -> `expected_kib=$((2 * 1024 * 1024))` |
```

## PR Review Summary
- What Changed:
  - In `scripts/snapshot.py`, the `task_configure_memory_protection` function was updated.
  - The `CMUX_SWAPFILE_SIZE_GIB` environment variable was changed from `6` to `2` for the `/usr/local/sbin/cmux-configure-memory` command. This reduces the target swapfile size from 6 GiB to 2 GiB.
  - The `expected_kib` variable, used for validating the swapfile size, was updated from `6 * 1024 * 1024` to `2 * 1024 * 1024`.
  - An associated error message was updated to reflect the new 2 GiB target size.
  - **Why:** This change addresses a `RuntimeError` during the Daily Morph Snapshot workflow caused by insufficient disk space for a 6 GiB swapfile. By reducing the swapfile to 2 GiB, approximately 4 GiB of disk space is freed, preventing the swapfile creation failure.
- Review Focus:
  - Carefully check that the reduced 2 GiB swapfile size, in conjunction with the existing zram (compressed RAM) swap, is sufficient for all typical build and development workloads.
  - Verify that the `cmux-configure-memory` script correctly interprets the `CMUX_SWAPFILE_SIZE_GIB=2` parameter and creates a 2 GiB swapfile as expected.
  - Confirm that the updated validation logic (`expected_kib`, `min_expected_kib`) accurately checks for a swapfile of approximately 2 GiB.
- Test Plan:
  - Run `bun check` to ensure no type errors.
  - Trigger the "Daily Morph Snapshot" workflow using the command: `gh workflow run "Daily Morph Snapshot" --repo karlorz/cmux --ref main`.
  - Verify that the workflow completes successfully without any memory protection or swapfile-related errors.
  - After the workflow, log into the VM and confirm that `/var/swap/cmux-swapfile` appears in `/proc/swaps` with a size of approximately 2 GiB.
  - Ensure that the snapshot JSON is updated with new snapshot IDs, indicating a successful workflow run.