### PR TITLE
Update sandbox cron schedule to 5 AM HKT

### DIFF
--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -4,26 +4,26 @@ import { internal } from "./_generated/api";
 const crons = cronJobs();
 
 // Sandbox instance lifecycle maintenance (all providers: morph, pve-lxc, docker, daytona)
-// Runs daily at 18:00 UTC (2 AM HKT)
+// Runs daily at 21:00 UTC (5 AM HKT)
 crons.daily(
   "pause old sandbox instances",
-  { hourUTC: 18, minuteUTC: 0 },
+  { hourUTC: 21, minuteUTC: 0 },
   internal.sandboxInstanceMaintenance.pauseOldSandboxInstances
 );
 
 // Stop inactive sandbox instances (paused for >14 days)
-// Runs daily at 18:20 UTC (2:20 AM HKT)
+// Runs daily at 21:20 UTC (5:20 AM HKT)
 crons.daily(
   "stop old sandbox instances",
-  { hourUTC: 18, minuteUTC: 20 },
+  { hourUTC: 21, minuteUTC: 20 },
   internal.sandboxInstanceMaintenance.stopOldSandboxInstances
 );
 
 // Clean up orphaned containers (exist in provider but not in Convex)
-// Runs daily at 18:40 UTC (2:40 AM HKT)
+// Runs daily at 21:40 UTC (5:40 AM HKT)
 crons.daily(
   "cleanup orphaned containers",
-  { hourUTC: 18, minuteUTC: 40 },
+  { hourUTC: 21, minuteUTC: 40 },
   internal.sandboxInstanceMaintenance.cleanupOrphanedContainers
 );
 


### PR DESCRIPTION
## Task

# Plan: Change Sandbox Cron Schedule from 2 AM HKT to 5 AM HKT

## Summary

Change the sandbox instance lifecycle maintenance cron jobs from running at 2 AM HKT to 5 AM HKT.

## File to Modify

- `/Users/karlchow/Desktop/code/cmux/packages/convex/convex/crons.ts`

## Changes

### Time Conversion

- Current: 18:00 UTC = 2:00 AM HKT (UTC + 8)
- New: 21:00 UTC = 5:00 AM HKT (UTC + 8)

### Specific Edits

1. **Line 7**: Update comment from `18:00 UTC (2 AM HKT)` to `21:00 UTC (5 AM HKT)`
2. **Line 10**: Change `hourUTC: 18` to `hourUTC: 21`
3. **Line 15**: Update comment from `18:20 UTC (2:20 AM HKT)` to `21:20 UTC (5:20 AM HKT)`
4. **Line 18**: Change `hourUTC: 18` to `hourUTC: 21`
5. **Line 23**: Update comment from `18:40 UTC (2:40 AM HKT)` to `21:40 UTC (5:40 AM HKT)`
6. **Line 26**: Change `hourUTC: 18` to `hourUTC: 21`

## PR Review Summary
- What Changed:
  - The sandbox instance lifecycle maintenance cron jobs in `packages/convex/convex/crons.ts` have been rescheduled from 2 AM HKT (18:00 UTC) to 5 AM HKT (21:00 UTC).
  - Specifically, the `hourUTC` parameter for three daily cron jobs (pause old sandbox instances, stop old sandbox instances, cleanup orphaned containers) was updated from `18` to `21`.
  - Corresponding inline comments for these cron jobs were updated to reflect the new 21:00 UTC (5 AM HKT) schedule.
- Review Focus:
  - Confirm that all three `crons.daily` calls now specify `hourUTC: 21` and that the `minuteUTC` values remain unchanged (0, 20, 40 respectively).
  - Verify that the updated comments accurately reflect the new UTC and HKT times.
  - Consider any potential downstream effects or dependencies that might be sensitive to this 3-hour shift in the maintenance schedule.
- Test Plan:
  - After deployment, monitor the cron job execution logs to confirm that "pause old sandbox instances," "stop old sandbox instances," and "cleanup orphaned containers" now reliably trigger at 21:00 UTC, 21:20 UTC, and 21:40 UTC respectively.
  - Validate that sandbox instance lifecycle operations (pausing, stopping, cleaning up) continue to function correctly and as expected under the new schedule.