### PR TITLE
Run extension install script at startup for all agents

### DIFF
--- a/apps/server/src/utils/editorSettings.test.ts
+++ b/apps/server/src/utils/editorSettings.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getEditorSettingsUpload } from "./editorSettings";
+
+describe("getEditorSettingsUpload (user-uploaded)", () => {
+  it("includes extension installer auth files and startup command", async () => {
+    const upload = await getEditorSettingsUpload({
+      extensions: "ms-python.python\n\nfoo.bar\nms-python.python\n",
+    });
+
+    expect(upload).not.toBeNull();
+    expect(upload?.startupCommands).toEqual([
+      'bash "/root/.cmux/install-extensions-background.sh" || true',
+    ]);
+
+    const authFiles = upload?.authFiles ?? [];
+
+    const extensionList = authFiles.find(
+      (f) => f.destinationPath === "/root/.cmux/user-extensions.txt"
+    );
+    expect(extensionList).toBeDefined();
+    expect(
+      Buffer.from(extensionList?.contentBase64 ?? "", "base64").toString("utf8")
+    ).toBe("foo.bar\nms-python.python\n");
+
+    expect(
+      authFiles.some(
+        (f) => f.destinationPath === "/root/.cmux/install-extensions-background.sh"
+      )
+    ).toBe(true);
+    expect(
+      authFiles.some((f) => f.destinationPath === "/etc/profile.d/cmux-extensions.sh")
+    ).toBe(true);
+  });
+});
+

--- a/apps/server/src/utils/editorSettings.ts
+++ b/apps/server/src/utils/editorSettings.ts
@@ -596,6 +596,8 @@ touch "$LOCK_FILE"
         contentBase64: encode(profileHook),
         mode: "644",
       });
+
+      startupCommands.push(`bash "${installScriptPath}" || true`);
     }
   }
 
@@ -748,6 +750,8 @@ touch "$LOCK_FILE"
       contentBase64: encode(profileHook),
       mode: "644",
     });
+
+    startupCommands.push(`bash "${installScriptPath}" || true`);
   }
 
   if (authFiles.length === 0 && startupCommands.length === 0) {


### PR DESCRIPTION
## Task

# Plan: Fix VS Code Extension Sync Across Agent Types

## Problem Summary

VS Code extensions sync correctly for Claude Code workspaces but only the cmux extension is installed for Codex and OpenCode workspaces.

**Evidence from PVE containers:**

- Container 212 (Claude): 14 extensions installed (anthropic.claude-code, docker, gitlens, prettier, gitlab-workflow, gemini-cli, python, etc.)
- Container 210 (OpenCode): Only 1 extension (cmux.cmux-vscode-extension)
- Container 211 (Codex): Only 1 extension (cmux.cmux-vscode-extension)

**Key observation:** No `/etc/profile.d/*cmux*` files, no `/root/.cmux/extensions.list`, no install logs found on ANY container - yet Claude container has extensions installed.

## Root Cause Analysis

### Finding 1: cmux Extension Sync NOT Used

The cmux Editor Settings Sync feature creates:

- `/root/.cmux/extensions.list`
- `/root/.cmux/install-extensions-background.sh`
- `/etc/profile.d/cmux-extensions.sh`

**None of these files exist on any container**, including the Claude container that has extensions. This means the cmux extension sync mechanism is NOT being used.

### Finding 2: VS Code Native Settings Sync

The Claude container's extra extensions (docker, gitlens, prettier, gitlab-workflow, etc.) are NOT from:

- `ide-deps.json` snapshot (only has 5 base extensions)
- cmux Editor Settings Sync (no files present)

**Most likely cause:** VS Code's native Settings Sync feature (via Microsoft/GitHub account login) is working for Claude workspace but not for Codex/OpenCode workspaces.

### Finding 3: Extension Versions Don't Match Snapshot

- Container 212 has `anthropic.claude-code-2.0.13`
- `ide-deps.json` specifies version `2.1.19`

This confirms extensions came from a runtime sync, not the snapshot.

## Root Cause (CONFIRMED)

**The profile.d hook is not being executed** because VS Code/cmux terminals don't source `/etc/profile.d/` scripts on startup.

**Evidence from live containers:**

- Container 212 (Claude): Extensions installed, `extensions-installed` marker exists
- Container 211 (Codex): Extension files present but NO `extensions-installed` marker
- Both containers have `/etc/profile.d/cmux-extensions.sh` hook script
- Manually running the install script on Codex container works perfectly

**Why Claude container worked but Codex didn't:**

- Claude container likely had a terminal session that triggered the profile.d hook
- Codex/OpenCode containers never had a login shell that sources profile.d

## Proposed Fix

**Run extension installation script proactively** instead of relying on profile.d hooks.

### Option 1: Run install script as a startup command (Recommended)

Add the extension install script execution to `startupCommands` in `editorSettings.ts` so it runs immediately when the sandbox starts.

**Implementation:**

```typescript
// In buildUpload() and buildUploadFromUserSettings()
// After creating the install script authFile, add:
startupCommands.push(`bash /root/.cmux/install-extensions-background.sh`);
```

### Option 2: Use Worker's postStartCommands

Execute the install script via Worker after auth files are written.

### Option 3: Integrate into cmux terminal initialization

The cmux VS Code extension could trigger the install script when it initializes.

## Implementation Plan

### Fix: Add startupCommand to run extension installer

**Goal:** Ensure extension installation runs immediately when sandbox starts, not waiting for profile.d hooks.

#### Step 1: Modify `buildUpload()` in editorSettings.ts

In the section that creates extension auth files (around line 692-751), add a startupCommand to execute the install script:

```typescript
// After creating the profile.d hook authFile, add:
startupCommands.push(
  `nohup bash /root/.cmux/install-extensions-background.sh >/dev/null 2>&1 &`
);
```

#### Step 2: Modify `buildUploadFromUserSettings()` in editorSettings.ts

Same change for user-uploaded settings (around line 536-600).

#### Step 3: Test with new sandbox spawns

Spawn new workspaces for Claude, Codex, and OpenCode agents to verify extensions install automatically.

### Optional Enhancement: Add Extensions to Snapshot (Option A)

After fixing the sync mechanism, can optionally add popular extensions to snapshot for faster startup:

- Update `configs/ide-deps.json` with common extensions
- Rebuild PVE snapshot

## Files to Modify

- `apps/server/src/utils/editorSettings.ts` (lines \~700 and \~580) - Add startupCommand for extension install

## Verification Plan

1. Spawn a new workspace for each agent type (Claude, Codex, OpenCode)
2. SSH into container immediately after spawn and check:

```bash
   ssh root@karlws "pct exec <vmid> -- ls -la /root/.cmux/"
   # Should see extensions-installed marker after ~30-60 seconds
```

3. Verify extensions appear in VS Code extension panel for all agent types
4. Alternatively, use browser MCP to take snapshot of VS Code sidebar and verify extension tabs are present

## PR Review Summary
- What Changed:
  - The core change modifies `apps/server/src/utils/editorSettings.ts` in both `buildUpload()` and `buildUploadFromUserSettings()` functions.
  - A new `startupCommand` has been added: `bash "/root/.cmux/install-extensions-background.sh" || true`. This command ensures that the VS Code extension installation script runs proactively and immediately when a sandbox starts.
  - This addresses a previous issue where extension installation, relying on `/etc/profile.d` hooks, was unreliable across different agent types (Codex, OpenCode) because terminals didn't consistently source these scripts.
  - A new test file, `apps/server/src/utils/editorSettings.test.ts`, was added to verify that user-uploaded extensions correctly generate the necessary auth files (`user-extensions.txt`, `install-extensions-background.sh`, `cmux-extensions.sh`) and that the `startupCommand` is included.
- Review Focus:
  - **Startup Reliability**: Confirm the new `startupCommand` consistently executes the extension installer across all agent types and scenarios, including cold starts and restarts.
  - **Performance Impact**: Evaluate if adding the installation script to startup commands significantly increases sandbox spin-up time.
  - **Error Handling (`|| true`)**: Understand the implications of the `|| true` addition. Does it mask critical failures if the extension installation script encounters an error, potentially leading to a sandbox that appears ready but lacks required extensions?
  - **Idempotency**: Verify that running `install-extensions-background.sh` multiple times (e.g., if a user manually runs it later) does not cause issues or unnecessary work.
- Test Plan:
  1. Spawn new workspaces for Claude, Codex, and OpenCode agent types.
  2. Immediately after spawning, SSH into each container and check for the `extensions-installed` marker file:
     `ssh root@karlws "pct exec <vmid> -- ls -la /root/.cmux/"`
     (Expect `extensions-installed` to appear within ~30-60 seconds.)
  3. Open the VS Code environment for each agent type and verify that expected extensions are listed and functional in the Extensions panel.
  4. If applicable, test with user-uploaded custom extensions to ensure they are installed correctly using the new mechanism.
- Follow-ups:
  - Consider the "Optional Enhancement: Add Extensions to Snapshot" from the original plan to potentially speed up startup times further by pre-installing common extensions.