### PR TITLE
[Crown] # Plan: Fix Crown PR Title for Single-Run Scenarios

## Probl...

### DIFF
--- a/apps/worker/src/crown/pullRequest.ts
+++ b/apps/worker/src/crown/pullRequest.ts
@@ -8,9 +8,12 @@ import type {
   WorkerRunContext,
 } from "./types";
 
-export function buildPullRequestTitle(prompt: string): string {
+export function buildPullRequestTitle(
+  prompt: string,
+  isCrownCompetition = true
+): string {
   const base = prompt.trim() || "cmux changes";
-  const title = `[Crown] ${base}`;
+  const title = isCrownCompetition ? `[Crown] ${base}` : base;
   return title.length > 72 ? `${title.slice(0, 69)}...` : title;
 }
 

--- a/apps/worker/src/crown/workflow.ts
+++ b/apps/worker/src/crown/workflow.ts
@@ -546,6 +546,20 @@ async function startCrownEvaluation({
       summaryPreview: summary?.slice(0, 120),
     });
 
+    // Generate PR title and description for single run (no [Crown] prefix since no competition)
+    const pullRequestTitle = buildPullRequestTitle(
+      crownData.task?.text || "cmux changes",
+      false // Not a crown competition
+    );
+    const pullRequestDescription = buildPullRequestBody({
+      summary,
+      prompt: crownData.task?.text || "Task description not available",
+      agentName: candidate.agentName,
+      branch: candidate.newBranch || "",
+      taskId: crownData.taskId,
+      runId: candidate.runId,
+    });
+
     await convexRequest(
       "/api/crown/finalize",
       runContext.token,
@@ -560,6 +574,8 @@ async function startCrownEvaluation({
         }),
         candidateRunIds: [candidate.runId],
         summary,
+        pullRequestTitle,
+        pullRequestDescription,
       },
       baseUrlOverride
     );
@@ -707,7 +723,8 @@ async function startCrownEvaluation({
     : undefined;
 
   // Always generate PR title and description (for manual draft PRs even if auto-PR is disabled)
-  const pullRequestTitle = buildPullRequestTitle(promptText);
+  // Use [Crown] prefix since this is a multi-candidate competition
+  const pullRequestTitle = buildPullRequestTitle(promptText, true);
   const pullRequestDescription = buildPullRequestBody({
     summary,
     prompt: promptText,

--- a/packages/convex/convex/crown/actions.ts
+++ b/packages/convex/convex/crown/actions.ts
@@ -36,10 +36,15 @@ const RETRY_BASE_DELAY_MS = 1000; // 1 second base delay, doubles each retry
 
 /**
  * Build PR title from task prompt (inline version for Convex action)
+ * @param prompt - The task prompt
+ * @param isCrownCompetition - If true, adds [Crown] prefix (for multi-candidate competition)
  */
-function buildPullRequestTitle(prompt: string): string {
+function buildPullRequestTitle(
+  prompt: string,
+  isCrownCompetition = true
+): string {
   const base = prompt.trim() || "cmux changes";
-  const title = `[Crown] ${base}`;
+  const title = isCrownCompetition ? `[Crown] ${base}` : base;
   return title.length > 72 ? `${title.slice(0, 69)}...` : title;
 }
 
@@ -570,7 +575,9 @@ export const retryEvaluation = internalAction({
       }
 
       // Generate PR title and description (for consistency with normal path)
-      const pullRequestTitle = buildPullRequestTitle(parsedData.prompt);
+      // Only use [Crown] prefix if there were multiple candidates (competition)
+      const isCrownCompetition = retryData.candidateRunIds.length > 1;
+      const pullRequestTitle = buildPullRequestTitle(parsedData.prompt, isCrownCompetition);
       const pullRequestDescription = buildPullRequestBody({
         summary,
         prompt: parsedData.prompt,


### PR DESCRIPTION
## Task

# Plan: Fix Crown PR Title for Single-Run Scenarios

## Problem Summary

When there's only one candidate (single run, no competition), the PR title and content vary incorrectly:

1. **First-time success** (correct): Title = task prompt (no `[Crown]` prefix), shows "Single run automatically selected (no competition)"
2. **After retry/crown elevate** (incorrect): Title gets `[Crown]` prefix even for single candidate

**Expected behavior**: Single-run scenarios should NEVER have `[Crown]` prefix in title, regardless of whether it's first attempt or retry.

## Root Cause Analysis

### Issue 1: Single-run path doesn't generate PR title/description

In `apps/worker/src/crown/workflow.ts`:

- **Multi-candidate path** (lines 710-750): Generates `pullRequestTitle` and `pullRequestDescription` using `buildPullRequestTitle()` and passes them to `/api/crown/finalize`
- **Single-run path** (lines 549-565): Does NOT pass `pullRequestTitle` or `pullRequestDescription` to `/api/crown/finalize`

### Issue 2: `buildPullRequestTitle()` always adds `[Crown]` prefix

Both implementations of `buildPullRequestTitle()` unconditionally add `[Crown]` prefix:

```typescript
// apps/worker/src/crown/pullRequest.ts:11-14
export function buildPullRequestTitle(prompt: string): string {
  const base = prompt.trim() || "cmux changes";
  const title = `[Crown] ${base}`;  // ALWAYS adds [Crown]
  return title.length > 72 ? `${title.slice(0, 69)}...` : title;
}
```

Same in `packages/convex/convex/crown/actions.ts:40-44`.

### Issue 3: Retry path always uses `[Crown]` prefix

In `packages/convex/convex/crown/actions.ts:573`:

```typescript
const pullRequestTitle = buildPullRequestTitle(parsedData.prompt);
```

The retry flow doesn't check if it's a single-candidate scenario.

## Solution

Modify `buildPullRequestTitle()` to accept an optional `isCrownCompetition` parameter (or `candidateCount`):

- When `candidateCount === 1` or `isCrownCompetition === false`: Don't add `[Crown]` prefix
- When multiple candidates competed: Add `[Crown]` prefix

### Files to Modify

1. **`apps/worker/src/crown/pullRequest.ts`**

- Update `buildPullRequestTitle()` signature to accept optional `isCrownCompetition: boolean` parameter
- Only add `[Crown]` prefix when `isCrownCompetition === true`

2. **`apps/worker/src/crown/workflow.ts`**

- **Single-run path** (lines 549-565): Generate and pass `pullRequestTitle` and `pullRequestDescription` (without `[Crown]` prefix)
- **Multi-candidate path** (line 710): Pass `isCrownCompetition: true` to `buildPullRequestTitle()`

3. **`packages/convex/convex/crown/actions.ts`**

- Update inline `buildPullRequestTitle()` to accept `isCrownCompetition` parameter
- **Retry path**: Determine if single-candidate from `retryData.candidateRunIds.length` and pass accordingly

## Detailed Changes

### 1. `apps/worker/src/crown/pullRequest.ts`

```typescript
export function buildPullRequestTitle(
  prompt: string,
  isCrownCompetition = true
): string {
  const base = prompt.trim() || "cmux changes";
  const title = isCrownCompetition ? `[Crown] ${base}` : base;
  return title.length > 72 ? `${title.slice(0, 69)}...` : title;
}
```

### 2. `apps/worker/src/crown/workflow.ts` - Single-run path (around line 540)

Add PR title/description generation before calling `/api/crown/finalize`:

```typescript
// Generate PR title and description for single run (no [Crown] prefix)
const pullRequestTitle = buildPullRequestTitle(
  crownData.task?.text || "cmux changes",
  false // Not a crown competition
);
const pullRequestDescription = buildPullRequestBody({
  summary,
  prompt: crownData.task?.text || "Task description not available",
  agentName: candidate.agentName,
  branch: candidate.newBranch || "",
  taskId: crownData.taskId,
  runId: candidate.runId,
});

await convexRequest(
  "/api/crown/finalize",
  runContext.token,
  {
    taskId: crownData.taskId,
    winnerRunId: candidate.runId,
    reason: "Single run automatically selected (no competition)",
    evaluationPrompt: "Single run - no evaluation needed",
    evaluationResponse: JSON.stringify({
      winner: 0,
      reason: "Single run - no competition",
    }),
    candidateRunIds: [candidate.runId],
    summary,
    pullRequestTitle,         // ADD THIS
    pullRequestDescription,   // ADD THIS
  },
  baseUrlOverride
);
```

### 3. `apps/worker/src/crown/workflow.ts` - Multi-candidate path (line 710)

Update to explicitly pass `true` for competition:

```typescript
const pullRequestTitle = buildPullRequestTitle(promptText, true);
```

### 4. `packages/convex/convex/crown/actions.ts`

Update inline function:

```typescript
function buildPullRequestTitle(prompt: string, isCrownCompetition = true): string {
  const base = prompt.trim() || "cmux changes";
  const title = isCrownCompetition ? `[Crown] ${base}` : base;
  return title.length > 72 ? `${title.slice(0, 69)}...` : title;
}
```

Update retry path (around line 573):

```typescript
const isCrownCompetition = retryData.candidateRunIds.length > 1;
const pullRequestTitle = buildPullRequestTitle(parsedData.prompt, isCrownCompetition);
```

## Verification

1. **Test single-run first success**:

- Create a task with only one agent/candidate
- Verify PR title has NO `[Crown]` prefix
- Verify "Single run automatically selected (no competition)" message appears

2. **Test single-run with retry**:

- Create a task with only one agent/candidate
- Force a retry (simulate failure then manual retry)
- Verify PR title still has NO `[Crown]` prefix after retry

3. **Test multi-candidate (competition)**:

- Create a task with 2+ agents
- Verify PR title HAS `[Crown]` prefix
- Verify proper evaluation reason appears

4. **Run type checking**:

```bash
   bun check
```

## PR Review Summary

- **What Changed**:
  - Updated `buildPullRequestTitle` in both the worker and Convex actions to accept an `isCrownCompetition` boolean parameter.
  - Modified `apps/worker/src/crown/workflow.ts` to generate and pass PR metadata in the single-run path (setting competition to `false`).
  - Updated the retry logic in `packages/convex/convex/crown/actions.ts` to dynamically determine if the `[Crown]` prefix is needed based on the number of candidates (`candidateRunIds.length > 1`).
  - Ensured multi-candidate paths explicitly pass `true` to maintain existing behavior for actual competitions.

- **Review Focus**:
  - **Consistency**: Verify that both the worker and Convex implementations of `buildPullRequestTitle` remain in sync, as they are duplicated across the codebase.
  - **Default Parameters**: The default for `isCrownCompetition` is `true`; ensure all intentional single-candidate callsites are correctly overriding this to `false`.
  - **Title Length**: The title truncation logic (`72` characters) is still applied after the conditional prefixing.

- **Test Plan**:
  - **Single Run**: Create a task with one agent. Verify the PR title excludes the `[Crown]` prefix.
  - **Retry Path**: Trigger a retry on a single-candidate task and confirm the prefix remains absent.
  - **Competition**: Create a task with 2+ agents. Verify the PR title still includes the `[Crown]` prefix.
  - **Validation**: Run `bun check` to ensure no type regressions in the worker or Convex packages.