### PR TITLE
fix: always fetch when head equals base in stale ref detection

### DIFF
--- a/apps/server/native/core/src/repo/cache.rs
+++ b/apps/server/native/core/src/repo/cache.rs
@@ -308,7 +308,8 @@ fn set_map_last_fetch(repo_path: &Path, t: u128) {
 }
 
 /// Returns true if the repo was fetched within the given window (ms).
-/// Used to avoid redundant fetches when refs appear stale but were recently fetched.
+/// Currently unused but kept for potential future optimizations.
+#[allow(dead_code)]
 pub fn was_recently_fetched(path: &std::path::Path, window_ms: u128) -> bool {
     let cwd = path.to_string_lossy().to_string();
     let root = default_cache_root();


### PR DESCRIPTION
## Summary
Fixes git diff showing "+0 -0" for branches with actual commits when the local git cache has stale refs.

## Problem
When viewing git diff in cmux, the app uses a local git cache (`~/Library/Caches/cmux-git-cache/`) to avoid cloning repos repeatedly. The issue occurs when:

1. A task pushes commits to a branch (e.g., `cmux/optimize-convex-bandwidth-p3mn7`)
2. The local cache has a **stale ref** for that branch (pointing to an old commit)
3. Git diff calculates changes between the stale ref and main → finds **0 changes**
4. User sees "+0 -0" even though there are real commits

### Example Scenario
```
Remote (correct):
  branch p3mn7 -> 73f9b73 (5 files changed, +275 -26)

Local cache (stale):
  branch p3mn7 -> 5c6b78 (old main commit)
  
Result: diff(5c6b78, main) = 0 changes
```

## Root Cause Analysis

### Why the Initial Fix Failed
The first approach checked `if head_oid == base_oid` (if head equals base directly). But this fails when main has moved forward:

```
head_oid (stale branch) = 5c6b78
base_oid (current main) = e69226
→ NOT equal, fix never triggers
```

### The Correct Approach
Check `if merge_base == head_oid` instead:

```
main:         A --- B --- C --- D (e69226)
                    \
stale branch:        X (5c6b78, actually equals B)

merge_base(main, stale_head) = 5c6b78
head_oid = 5c6b78
→ EQUAL! Branch appears to have 0 commits ahead → suspicious → fetch
```

After fetching, the branch updates to the real commit and diff works correctly.

## Implementation

**File:** `apps/server/native/core/src/diff/refs.rs`

### Detection Logic
```rust
// After computing merge-base
if compare_base_oid == head_oid {
    // Branch appears to have 0 commits ahead - likely stale ref
    // Fetch and retry...
}
```

### Recovery Flow
1. Detect: `merge_base == head` (no commits ahead = suspicious)
2. Fetch: `git fetch origin <branch>` to get latest refs
3. Re-open: `gix::open()` to get fresh repo state
4. Re-resolve: Get new head_oid from updated ref
5. Recompute: Calculate new merge-base with fresh head

### Why Re-open Repo is Required
After `git fetch`, the gix Repository object still has cached refs. Must re-open to see the updated refs - this is consistent with gix documentation which shows ref updates require refreshing the repo state.

## Validation

### Verified Against gix Documentation (via Context7)
- `merge_base()` - "finds the best merge-base between two commits" ✓
- `find_reference().try_id()` - standard approach for ref resolution ✓
- After fetch, need to refresh repo state to see new refs ✓

### Test Results
| Scenario | Before Fix | After Fix |
|----------|------------|-----------|
| Stale ref (head=old main commit) | +0 -0 | +275 -26 ✓ |
| Fresh ref (already up to date) | Works | Works ✓ |
| Branch with no changes | +0 -0 | +0 -0 ✓ |

## Files Changed
- `apps/server/native/core/src/diff/refs.rs` - Add stale ref detection after merge-base calculation
- `apps/server/native/core/src/repo/cache.rs` - Mark unused `was_recently_fetched()` with `#[allow(dead_code)]`

## Test Plan
- [x] `cargo check` passes
- [x] `cargo fmt` passes  
- [x] `bun check` passes
- [x] Manual test: Branch with stale cache shows correct diff after fix
- [x] Manual test: Clicking refresh updates stale refs automatically