### PR TITLE
Fix Sentry DSN hardcoding with environment variable check

### DIFF
--- a/apps/www/instrumentation-client.ts
+++ b/apps/www/instrumentation-client.ts
@@ -8,10 +8,11 @@ import { SENTRY_RELEASE } from "@/lib/sentry-release";
 import posthog from "posthog-js";
 
 const isDev = process.env.NODE_ENV === "development";
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-if (!isDev) {
+if (!isDev && SENTRY_DSN) {
   Sentry.init({
-    dsn: "https://96214f39aa409867381a22a79ff3e6a4@o4507547940749312.ingest.us.sentry.io/4510308518854656",
+    dsn: SENTRY_DSN,
     release: SENTRY_RELEASE,
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/apps/www/sentry.edge.config.ts
+++ b/apps/www/sentry.edge.config.ts
@@ -6,9 +6,11 @@
 import * as Sentry from "@sentry/nextjs";
 import { SENTRY_RELEASE } from "@/lib/sentry-release";
 
-if (process.env.NODE_ENV !== "development") {
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (process.env.NODE_ENV !== "development" && SENTRY_DSN) {
   Sentry.init({
-    dsn: "https://96214f39aa409867381a22a79ff3e6a4@o4507547940749312.ingest.us.sentry.io/4510308518854656",
+    dsn: SENTRY_DSN,
     release: SENTRY_RELEASE,
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.

--- a/apps/www/sentry.server.config.ts
+++ b/apps/www/sentry.server.config.ts
@@ -1,9 +1,11 @@
 import * as Sentry from "@sentry/nextjs";
 import { SENTRY_RELEASE } from "@/lib/sentry-release";
 
-if (process.env.NODE_ENV !== "development") {
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (process.env.NODE_ENV !== "development" && SENTRY_DSN) {
   Sentry.init({
-    dsn: "https://96214f39aa409867381a22a79ff3e6a4@o4507547940749312.ingest.us.sentry.io/4510308518854656",
+    dsn: SENTRY_DSN,
     release: SENTRY_RELEASE,
     tracesSampleRate: 1,
     enableLogs: true,


### PR DESCRIPTION
## Task

# Fix Sentry Hardcoded DSN - Add Environment Variable Check

## Problem

Sentry connections occur even without setting an API key because `apps/www` has hardcoded DSN values.

## Solution

Add environment variable check (`NEXT_PUBLIC_SENTRY_DSN`) to all three Sentry config files.

## Implementation

### 1. `apps/www/sentry.server.config.ts`

```ts
import * as Sentry from "@sentry/nextjs";
import { SENTRY_RELEASE } from "@/lib/sentry-release";

const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;

if (process.env.NODE_ENV !== "development" && SENTRY_DSN) {
  Sentry.init({
    dsn: SENTRY_DSN,
    release: SENTRY_RELEASE,
    tracesSampleRate: 1,
    enableLogs: true,
    sendDefaultPii: true,
  });
}
```

### 2. `apps/www/sentry.edge.config.ts`

Same pattern - add `SENTRY_DSN` const and check before init.

### 3. `apps/www/instrumentation-client.ts`

Same pattern - add `SENTRY_DSN` const and check before init.

## Verification

1. Run `./scripts/dev.sh`
2. Open browser DevTools Network tab
3. Filter by `sentry`
4. Confirm no Sentry requests without `NEXT_PUBLIC_SENTRY_DSN` set
5. Run `bun check` to ensure no type errors

## PR Review Summary
- **What Changed**: Replaced hardcoded Sentry DSN strings with `process.env.NEXT_PUBLIC_SENTRY_DSN` in `instrumentation-client.ts`, `sentry.edge.config.ts`, and `sentry.server.config.ts`. Sentry now only initializes if the environment variable is present and the application is not running in development mode.
- **Review Focus**: Verify that the `NEXT_PUBLIC_SENTRY_DSN` environment variable is configured in production and staging environments. Ensure that exposing the DSN via the `NEXT_PUBLIC_` prefix aligns with security expectations (common for Sentry client-side SDKs).
- **Test Plan**: 1. Run the app locally without the environment variable and verify via DevTools Network tab that no requests are sent to Sentry. 2. Temporarily set the environment variable and confirm Sentry initializes correctly. 3. Run `bun check` to ensure no TypeScript regressions.