### PR TITLE
Adjust cron frequency for stuck crown evaluations to 1 hour

### DIFF
--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -28,10 +28,10 @@ crons.daily(
 );
 
 // Recover crown evaluations stuck in pending/in_progress state
-// Runs every 5 minutes to detect evaluations that failed without proper error handling
+// Runs every hour to detect evaluations that failed without proper error handling
 crons.interval(
   "recover stuck crown evaluations",
-  { minutes: 5 },
+  { hours: 1 },
   internal.crown.recoverStuckEvaluations
 );
 


### PR DESCRIPTION
## Task

change the cron convex;recover stuck crown evaluations

Every 300 seconds

[crown:recoverStuckEvaluations](https://dashboard.convex.dev/t/karl-logon/cmux-e0b4c/outstanding-stoat-794/functions?function=crown:recoverStuckEvaluations); into 1 hour

## PR Review Summary
- **What Changed**:
  - Modified the cron interval for the `recover stuck crown evaluations` job in `packages/convex/convex/crons.ts`.
  - Changed the execution frequency from every 5 minutes (`{ minutes: 5 }`) to every 1 hour (`{ hours: 1 }`).

- **Review Focus**:
  - **Latency Impact**: Ensure that delaying the recovery of stuck evaluations by up to an hour (instead of 5 minutes) is acceptable for the system's consistency and user experience.
  - **Logic Validity**: Confirm that `internal.crown.recoverStuckEvaluations` does not rely on a high-frequency trigger to prevent race conditions or data staleness.

- **Test Plan**:
  - **Deployment Verification**: Check the [Convex Dashboard](https://dashboard.convex.dev/t/karl-logon/cmux-e0b4c/outstanding-stoat-794/functions?function=crown:recoverStuckEvaluations) after merging to confirm the cron schedule reflects the new 1-hour interval.
  - **Manual Trigger**: Manually execute the `crown:recoverStuckEvaluations` function in the Convex dashboard to ensure it still runs successfully without errors.