### PR TITLE
Update auto-refresh empty diff evaluations cron to run hourly

### DIFF
--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -36,10 +36,10 @@ crons.interval(
 );
 
 // Auto-refresh crown evaluations that succeeded with empty diffs
-// Runs every 5 minutes to re-evaluate when fresh diffs may be available from GitHub
+// Runs every hour to re-evaluate when fresh diffs may be available from GitHub
 crons.interval(
   "auto-refresh empty diff evaluations",
-  { minutes: 5 },
+  { hours: 1 },
   internal.crown.autoRefreshEmptyDiffEvaluations
 );
 


### PR DESCRIPTION
## Task

change cron convex to 1 hour for following; auto-refresh empty diff evaluations

Every 300 seconds

[crown:autoRefreshEmptyDiffEvaluat](https://dashboard.convex.dev/t/karl-logon/cmux-e0b4c/outstanding-stoat-794/functions?function=crown:autoRefreshEmptyDiffEvaluations)

## PR Review Summary
- What Changed:
  - The cron job interval for `internal.crown.autoRefreshEmptyDiffEvaluations` in `packages/convex/convex/crons.ts` was changed from every 5 minutes to every 1 hour.
  - The comment for this cron job was updated to reflect the new hourly schedule.
- Review Focus:
  - Evaluate if extending the refresh interval for "auto-refresh empty diff evaluations" from 5 minutes to 1 hour aligns with the expected responsiveness and data freshness requirements for this specific process. Ensure that less frequent re-evaluations for empty diffs do not negatively impact user experience or system state.
- Test Plan:
  - Deploy the changes to a staging or development environment.
  - Monitor the Convex dashboard for the `auto-refresh empty diff evaluations` cron job to verify it now executes on an hourly schedule.
  - If feasible, manually trigger scenarios that would result in an "empty diff evaluation" and observe that the system correctly re-evaluates them within the new 1-hour window.
  - Confirm that no related processes exhibit unexpected behavior due to the reduced refresh frequency.