### PR TITLE
Assess Convex OCC write conflicts in githubCheckRuns; no action needed

### DIFF
--- a/packages/convex/convex/github_check_runs.ts
+++ b/packages/convex/convex/github_check_runs.ts
@@ -115,7 +115,9 @@ export const upsertCheckRunFromWebhook = internalMutation({
     // Duplicate path: cleanup when needed (5 handles rare concurrent webhook storms)
     const existingRecords = await ctx.db
       .query("githubCheckRuns")
-      .withIndex("by_checkRunId", (q) => q.eq("checkRunId", checkRunId))
+      .withIndex("by_installation_checkRunId", (q) =>
+        q.eq("installationId", installationId).eq("checkRunId", checkRunId)
+      )
       .take(5);
 
     // Find the newest record by updatedAt (handles duplicates correctly)

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1092,6 +1092,7 @@ const convexSchema = defineSchema({
     .index("by_team", ["teamId", "updatedAt"])
     .index("by_team_repo", ["teamId", "repoFullName", "updatedAt"])
     .index("by_team_repo_pr", ["teamId", "repoFullName", "triggeringPrNumber", "updatedAt"])
+    .index("by_installation_checkRunId", ["installationId", "checkRunId"])
     .index("by_checkRunId", ["checkRunId"])
     .index("by_headSha", ["headSha", "updatedAt"]),
 


### PR DESCRIPTION
## Task

# Investigation: Write Conflicts in `githubCheckRuns` Table

## Summary

The `upsertCheckRunFromWebhook` function is experiencing write conflicts due to **Optimistic Concurrency Control (OCC)** violations when multiple webhook events arrive simultaneously for the same check run.

## Convex OCC Documentation Reference

From [Convex Error Docs](https://docs.convex.dev/error):

> **Write conflict: Optimistic concurrency control**
> This system error is thrown when a mutation repeatedly fails due to conflicting changes from parallel mutation executions. Convex internally does several retries to mitigate this concern, but if the mutation is called more rapidly than Convex can execute it, some invocations will eventually throw this error.

From [Convex OCC Docs](https://docs.convex.dev/database/advanced/occ):

> Optimistic concurrency control treats the transaction as a *declarative proposal* to write records on the basis of any read record versions (the "read set"). At the end of the transaction, the writes all commit if every version in the read set is still the latest version. Since transactions are deterministic, **Convex can simply re-run transactions** without worrying about temporary data races.

**Key insight**: OCC conflicts with automatic retry are **expected behavior** in Convex. The system handles this gracefully.

## Root Cause Analysis

### The Problem

The current implementation at `packages/convex/convex/github_check_runs.ts:30-175` uses a **read-modify-write** pattern:

1. **Read**: Query by `checkRunId` index (line 116-119)
2. **Modify**: Check staleness, determine if update needed (lines 152-163)
3. **Write**: Patch the document (line 166)

When two webhook events arrive nearly simultaneously:

- Both mutations read the **same version** of the document
- Both mutations try to write to it
- The second write **fails with OCC conflict** because the document was modified since it was read

### Evidence from Screenshot

The screenshot shows:

- Multiple events with **Retry # = 0, 1, 2** for the same document ID `kh799xvt7j5xdvc7yrk86g6te9804zdt`
- All conflicts are **"Self"** - meaning the same function is conflicting with itself
- Events clustered at the same timestamp `29/1/2026 3:19:32 PM`

This confirms that GitHub is sending rapid webhook events for the same check run (e.g., status changes from `queued` -> `in_progress` -> `completed`).

### Why This Happens

GitHub sends `check_run` webhooks for:

- `created` - when check starts
- `completed` - when check finishes
- `rerequested` - when re-run requested
- `requested_action` - when action requested

For fast-completing checks (like Vercel preview deployments), these events can arrive within milliseconds of each other.

## Current Mitigations (Already in Place)

The code already has several mitigations:

1. **Stale update detection** (line 152-155): Skips updates if incoming `updatedAt` < existing `updatedAt`
2. **No-op skip** (line 158-168): Only patches if fields actually changed
3. **Duplicate cleanup** (line 142-149): Handles race-condition duplicates

**However**, these mitigations only help **after** the OCC conflict is detected. Convex automatically retries, so the function eventually succeeds.

## Assessment: Is This a Problem?

Looking at the data:

- **Retry counts are low** (0-2 retries)
- **Events are infrequent** (spikes on 29/1/2026 only)
- **Convex handles retries automatically**

**This appears to be normal behavior**, not a bug. The system is working as designed:

1. Webhook arrives with check\_run update
2. If conflict occurs, Convex retries
3. Stale update detection prevents data inconsistency
4. Eventually converges to correct state

## Recommendations

### Option A: No Action Needed (Recommended)

The current implementation is **working correctly**. Write conflicts with automatic retry are expected behavior for high-concurrency upsert patterns. The retry count (0-2) is acceptable.

Per Convex docs: "Convex internally does several retries to mitigate this concern." The insight dashboard is showing the **successful retries**, not failures.

**When to reconsider**: If retry counts consistently exceed 5, or if functions start timing out.

### Option B: Add Composite Index (Minor Improvement)

If you want to reduce potential for duplicates across different installations:

```typescript
// In schema.ts - add unique composite index
.index("by_installation_checkRunId", ["installationId", "checkRunId"])
```

Then update the query in `upsertCheckRunFromWebhook`:

```typescript
const existingRecords = await ctx.db
  .query("githubCheckRuns")
  .withIndex("by_installation_checkRunId", (q) =>
    q.eq("installationId", installationId).eq("checkRunId", checkRunId)
  )
  .take(5);
```

This ensures the lookup is scoped to the correct installation, preventing theoretical cross-installation collisions.

### Option C: Reduce Webhook Processing (If Needed)

If conflicts become a problem, consider processing only `completed` events and ignoring intermediate status updates. This reduces write frequency by \~50%.

## Files Involved

- `packages/convex/convex/github_check_runs.ts:30-175` - The upsert function
- `packages/convex/convex/schema.ts:1040-1096` - Table schema and indexes

## Verification

To verify the dev database is healthy:

```bash
cd packages/convex
bunx convex data githubCheckRuns --format jsonl | head -20
```

Check for:

- Recent records have sensible `updatedAt` timestamps
- No excessive duplicates with same `checkRunId`
- Status/conclusion values are being updated correctly

## Conclusion

**The write conflicts shown in the Convex Health dashboard are normal OCC behavior.** The retries (0-2) indicate the system is working as designed - Convex automatically retries conflicting mutations and they eventually succeed. No code changes are required unless retry counts increase significantly.

## PR Review Summary
- What Changed:
  - A new composite index, `by_installation_checkRunId`, has been added to the `githubCheckRuns` table in `packages/convex/convex/schema.ts`. This index includes both `installationId` and `checkRunId`.
  - The `upsertCheckRunFromWebhook` function in `packages/convex/convex/github_check_runs.ts` was updated to utilize this new composite index (`by_installation_checkRunId`) instead of the previous `by_checkRunId` index when querying for existing check run records.
- Review Focus:
  - **Correctness of Lookup**: Verify that using `installationId` in addition to `checkRunId` correctly identifies unique check runs and does not introduce any unintended side effects or missed records across different GitHub installations.
  - **Performance**: Monitor the performance of the `upsertCheckRunFromWebhook` function to ensure the new composite index does not degrade query times or increase database write load.
  - **Impact on OCC Conflicts**: While OCC conflicts are expected, observe if this change leads to any noticeable reduction in retry counts for `upsertCheckRunFromWebhook` by making the initial record lookup more specific.
- Test Plan:
  - Deploy the changes to a staging or development environment.
  - Monitor the Convex Health dashboard for the `upsertCheckRunFromWebhook` function, specifically looking at retry counts and execution times.
  - Trigger various GitHub `check_run` webhook events (e.g., `created`, `in_progress`, `completed`, `rerequested`) for repositories associated with the application.
  - Inspect the `githubCheckRuns` data in Convex (e.g., `bunx convex data githubCheckRuns`) to confirm that records are being created and updated correctly, `updatedAt` timestamps are sensible, and no unexpected duplicates or data inconsistencies are introduced.
  - Pay close attention to data for different GitHub installations to ensure cross-installation uniqueness is maintained.