### PR TITLE
Change cmux-cdp-proxy Systemd dependency from Requires to Wants

### DIFF
--- a/configs/systemd/cmux-cdp-proxy.service
+++ b/configs/systemd/cmux-cdp-proxy.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Cmux Chrome DevTools proxy
 After=cmux-devtools.service
-Requires=cmux-devtools.service
+Wants=cmux-devtools.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Task

# Plan: Change cmux-cdp-proxy Systemd Dependency to Wants

## Summary

Change `cmux-cdp-proxy.service` from `Requires=cmux-devtools.service` to `Wants=cmux-devtools.service` so the proxy stays running even when Chrome/devtools stops.

## Pre-tested on PVE LXC

Tested live on current LXC container:

| Test | Result |
|------|--------|
| Stop devtools with `Requires=` | Proxy stopped (both inactive) |
| Stop devtools with `Wants=` | **Proxy stays running** |
| Curl proxy when Chrome down | Returns HTTP 502 "Bad Gateway" |
| Start devtools again | **Proxy recovers automatically** |

## Implementation

### File to Modify

`configs/systemd/cmux-cdp-proxy.service`

### Change

```diff
[Unit]
Description=Cmux Chrome DevTools proxy
After=cmux-devtools.service
-Requires=cmux-devtools.service
+Wants=cmux-devtools.service
```

## Verification

1. Run `bun check` after the change
2. Commit and push to remote branch
3. Rebuild snapshots via GitHub workflows (not local):

- **PVE LXC**: `gh workflow run "Weekly PVE LXC Snapshot" --repo karlorz/cmux --ref <branch>`
- **Morph**: `gh workflow run "Daily Morph Snapshot" --repo karlorz/cmux --ref <branch>`

## PR Review Summary
- What Changed:
  - Modified `configs/systemd/cmux-cdp-proxy.service` to change its systemd dependency on `cmux-devtools.service` from `Requires=` to `Wants=`.
  - This modification ensures that the `cmux-cdp-proxy` service remains running even if the `cmux-devtools` service (Chrome/devtools) stops.
  - The change aims to improve system resilience by allowing the proxy to automatically recover functionality when `cmux-devtools` restarts, without the proxy itself needing to be restarted.
- Review Focus:
  - Confirm that the desired behavior – the proxy staying active and returning HTTP 502 "Bad Gateway" when Chrome/devtools is down – is acceptable for all intended use cases.
  - Verify there are no unintended consequences or edge cases where the proxy remaining active without its dependent service could cause issues.
- Test Plan:
  - Deploy the updated service configuration to a test environment (e.g., PVE LXC or Morph snapshot).
  - Verify that `cmux-cdp-proxy.service` is active.
  - Manually stop `cmux-devtools.service`.
  - Confirm that `cmux-cdp-proxy.service` remains active and running.
  - Attempt to connect to the `cmux-cdp-proxy` (e.g., via `curl`), expecting an HTTP 502 "Bad Gateway" response.
  - Manually start `cmux-devtools.service`.
  - Confirm that `cmux-cdp-proxy.service` automatically recovers and can successfully proxy requests to devtools.