### PR TITLE
[Crown] # Plan: Sync Upstream snapshot.py Changes to PVE LXC Sandbox
...

### DIFF
--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -2536,7 +2536,11 @@ async def task_install_cmux_code(ctx: PveTaskContext) -> None:
   "security.workspace.trust.enabled": false,
   "telemetry.telemetryLevel": "off",
   "update.mode": "none",
-  "extensions.verifySignature": false
+  "extensions.verifySignature": false,
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
+  "files.autoSave": "afterDelay",
+  "files.autoSaveDelay": 1000
 }
 EOF
 

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1164,7 +1164,7 @@ async def task_install_go_toolchain(ctx: TaskContext) -> None:
     cmd = textwrap.dedent(
         """
         set -eux
-        GO_VERSION="1.25.2"
+        GO_VERSION="1.25.5"
         ARCH="$(uname -m)"
         case "${ARCH}" in
           x86_64)
@@ -1371,7 +1371,11 @@ async def task_install_cmux_code(ctx: TaskContext) -> None:
   "security.workspace.trust.enabled": false,
   "telemetry.telemetryLevel": "off",
   "update.mode": "none",
-  "extensions.verifySignature": false
+  "extensions.verifySignature": false,
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
+  "files.autoSave": "afterDelay",
+  "files.autoSaveDelay": 1000
 }
 EOF
         """


### PR DESCRIPTION
## Task

# Plan: Sync Upstream snapshot.py Changes to PVE LXC Sandbox

## Summary

Analyzing the upstream `scripts/snapshot.py` changes to identify what needs to be synced to the PVE LXC implementation (`scripts/snapshot-pvelxc.py`).

## Key Findings

### Changes in Upstream `snapshot.py` That Need Sync

| Change | Morph | PVE LXC | Action Required |
|--------|-------|---------|-----------------|
| Go version | **1.25.2** | **1.25.5** | **SYNC: Align Go version** |
| IDE settings | Has formatOnSave | **Missing 4 settings** | **SYNC: Add missing settings** |
| Swapfile size | 2 GiB | Not present | No sync - different architecture |
| Node version | 24.9.0 | 24.9.0 | Already in sync |
| pnpm version | 10.14.0 | 10.14.0 | Already in sync |

### Detailed Discrepancies Found

#### 1. Go Version Mismatch

- **Morph:** `GO_VERSION="1.25.2"` (line 1167)
- **PVE LXC:** `GO_VERSION="1.25.5"` (line 2324)
- **Action:** PVE LXC is ahead - consider syncing Morph UP to 1.25.5, or align both

#### 2. IDE Settings Missing in PVE LXC

**Morph has these additional settings** that PVE LXC is missing:

```json
"editor.formatOnSave": true,
"editor.formatOnSaveMode": "file",
"files.autoSave": "afterDelay",
"files.autoSaveDelay": 1000
```

- **Location:** `task_install_cmux_code` in both files
- **Action:** Add missing settings to PVE LXC

### Architecture Differences

| Aspect | Morph | PVE LXC |
|--------|-------|---------|
| Task context | `TaskContext` (generic) | `PveTaskContext` (custom) |
| Task registries | Single `registry` | Dual: `registry` + `update_registry` |
| Memory protection | `configure-memory-protection` task | **Not implemented** |
| Swapfile config | Explicit 2 GiB swap setup | Handled by PVE host |

## Tasks NOT Requiring Sync

1. **`configure-memory-protection`** - PVE LXC containers have different memory management (host-controlled). Swapfile creation inside LXC containers may not work the same way due to container isolation.
2. **`configure-provisioning-cgroup`** - Resource limits in PVE LXC are managed by the host via `pct` configuration, not internal cgroups.
3. **`build-setup-exec-binary`** - PVE LXC has its own `build-execd` task with different deployment strategy.

## Tasks Requiring Review

### 1. Version Parity Check (Low Priority)

Verify toolchain versions match between both scripts:

**Files to compare:**

- `scripts/snapshot.py` lines 1090 (Node), 1167 (Go), 1111 (pnpm)
- `scripts/snapshot-pvelxc.py` corresponding tasks

### 2. IDE Settings Sync (Medium Priority)

Both scripts install cmux-code with user settings. Verify settings match:

**Morph** (`scripts/snapshot.py` lines 1371-1385):

```json
{
  "workbench.startupEditor": "none",
  "workbench.secondarySideBar.defaultVisibility": "hidden",
  "security.workspace.trust.enabled": false,
  "telemetry.telemetryLevel": "off",
  "update.mode": "none",
  "extensions.verifySignature": false,
  "editor.formatOnSave": true,
  "editor.formatOnSaveMode": "file",
  "files.autoSave": "afterDelay",
  "files.autoSaveDelay": 1000
}
```

**PVE LXC** - Verify same settings in `task_install_cmux_code`.

---

## Migration Plan

### Phase 1: Sync IDE Settings to PVE LXC (Required)

**File:** `scripts/snapshot-pvelxc.py`
**Location:** `task_install_cmux_code` function (around line 2450)

**Change:** Update the settings.json heredoc to include the missing editor settings:

```python
# Current (PVE LXC):
cat > /root/.vscode-server-oss/data/User/settings.json << 'EOF'
{
  "workbench.startupEditor": "none",
  "workbench.secondarySideBar.defaultVisibility": "hidden",
  "security.workspace.trust.enabled": false,
  "telemetry.telemetryLevel": "off",
  "update.mode": "none",
  "extensions.verifySignature": false
}
EOF

# Updated (match Morph):
cat > /root/.vscode-server-oss/data/User/settings.json << 'EOF'
{
  "workbench.startupEditor": "none",
  "workbench.secondarySideBar.defaultVisibility": "hidden",
  "security.workspace.trust.enabled": false,
  "telemetry.telemetryLevel": "off",
  "update.mode": "none",
  "extensions.verifySignature": false,
  "editor.formatOnSave": true,
  "editor.formatOnSaveMode": "file",
  "files.autoSave": "afterDelay",
  "files.autoSaveDelay": 1000
}
EOF
```

### Phase 2: Go Version Alignment (Decision Required)

**Current state:**

- Morph: Go 1.25.2
- PVE LXC: Go 1.25.5

**Options:**

1. **Sync Morph UP to 1.25.5** - PVE LXC is ahead, bring Morph to latest
2. **Sync PVE LXC DOWN to 1.25.2** - Match upstream exactly
3. **Leave as-is** - Minor version difference, unlikely to cause issues

**Recommendation:** Option 1 (sync Morph UP) since 1.25.5 is newer

### Phase 3: No Memory Protection Sync (Skip)

The `configure-memory-protection` task in Morph is not applicable to PVE LXC:

- PVE host manages container memory limits via `pct set <vmid> --memory <MB>`
- Swapfile creation inside LXC containers has compatibility limitations
- No action needed

---

## Test Plan

### 1. Syntax Validation (After Edit)

```bash
# Verify Python syntax is valid
python3 -m py_compile scripts/snapshot-pvelxc.py

# Check for obvious errors
python3 -c "import scripts.snapshot_pvelxc" 2>&1 || echo "Import check requires proper module setup"
```

### 2. Dependency Graph Validation

```bash
# Print task graph without executing
uv run --env-file .env ./scripts/snapshot-pvelxc.py --print-deps
```

### 3. Update Mode Test (Fast, Incremental)

```bash
# Update existing template to test IDE settings change
uv run --env-file .env ./scripts/snapshot-pvelxc.py --update --update-vmid <existing_vmid>
```

### 4. Full Snapshot Build Test

```bash
# Full rebuild from base template
uv run --env-file .env ./scripts/snapshot-pvelxc.py --template-vmid 9000
```

### 5. Service Validation Checklist

After snapshot build, verify in running container:

```bash
# Connect to container
pct exec <vmid> -- bash -l

# Toolchain checks
node --version     # Should be 24.9.0
go version         # Should be 1.25.2 or 1.25.5
cargo --version    # Rust toolchain
bun --version      # Bun runtime

# IDE settings check
cat /root/.vscode-server-oss/data/User/settings.json
# Verify formatOnSave settings are present

# Service checks
curl -s http://127.0.0.1:39378/ | head -5  # VS Code
curl -s http://127.0.0.1:39377/health      # Worker
curl -s http://127.0.0.1:39380/vnc.html | head -5  # VNC
```

### 6. CI/CD Integration Test

```bash
# Trigger GitHub Actions workflow
gh workflow run "Weekly PVE LXC Snapshot" --repo karlorz/cmux --ref <branch>
```

---

## Files to Modify

| File | Line | Change |
|------|------|--------|
| `scripts/snapshot-pvelxc.py` | \~2450 | Add 4 missing IDE settings to cmux-code settings.json |
| `scripts/snapshot.py` | \~1167 | Bump Go version from 1.25.2 to 1.25.5 |

---

## Summary

### Required Changes (1 file)

1. **`scripts/snapshot-pvelxc.py`** - Add missing IDE editor settings:

- `editor.formatOnSave: true`
- `editor.formatOnSaveMode: "file"`
- `files.autoSave: "afterDelay"`
- `files.autoSaveDelay: 1000`

### Required Changes (2nd file)

2. **`scripts/snapshot.py`** - Sync Go version UP to 1.25.5:

- Line 1167: Change `GO_VERSION="1.25.2"` to `GO_VERSION="1.25.5"`

### No Changes Needed

- Swapfile/memory protection (architecture difference)
- Node.js version (already in sync: 24.9.0)
- pnpm version (already in sync: 10.14.0)
- Most task definitions (already aligned)

## PR Review Summary
- What Changed:
  - In `scripts/snapshot-pvelxc.py`, added four missing VS Code editor settings (`editor.formatOnSave`, `editor.formatOnSaveMode`, `files.autoSave`, `files.autoSaveDelay`) to the `settings.json` configured within the `task_install_cmux_code` function.
  - In `scripts/snapshot.py`, updated the Go version from `1.25.2` to `1.25.5` within the `task_install_go_toolchain` function.
  - Also, `scripts/snapshot.py` had the same four VS Code editor settings added to its `task_install_cmux_code` function, ensuring consistency.
- Review Focus:
  - Carefully verify that the newly added IDE settings in `scripts/snapshot-pvelxc.py` are correctly applied and function as expected within the PVE LXC sandbox.
  - Confirm that bumping the Go version in `scripts/snapshot.py` does not introduce any build or runtime regressions in the standard snapshot environment.
  - Ensure Node.js (24.9.0) and pnpm (10.14.0) versions remain in sync and unaffected by these changes.
- Test Plan:
  - Run `python3 -m py_compile scripts/snapshot-pvelxc.py` to validate Python syntax.
  - Execute an update on an existing template: `uv run --env-file .env ./scripts/snapshot-pvelxc.py --update --update-vmid <existing_vmid>`.
  - Perform a full snapshot build: `uv run --env-file .env ./scripts/snapshot-pvelxc.py --template-vmid 9000`.
  - Inside a running container, verify:
    - `go version` shows `1.25.5`.
    - `cat /root/.vscode-server-oss/data/User/settings.json` contains the new editor settings.
    - `node --version` and `pnpm --version` match the expected versions.
  - Trigger the `Weekly PVE LXC Snapshot` GitHub Actions workflow to confirm CI/CD integration.