### PR TITLE
[Crown] # Fix: PVE LXC Worker Socket Connection Failure

## Problem S...

### DIFF
--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -90,6 +90,39 @@ async function waitForVSCodeReady(
 }
 
 /**
+ * Wait for the Worker socket server to be ready by polling the socket.io endpoint.
+ * This prevents "Worker socket not available" errors when the agent spawner tries to connect
+ * before the worker service is actually listening.
+ */
+async function waitForWorkerReady(
+  workerUrl: string,
+  options: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<boolean> {
+  const { timeoutMs = 15_000, intervalMs = 500 } = options;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      // Worker service uses socket.io - check if the HTTP endpoint responds
+      // Socket.io exposes a polling transport at /socket.io/?EIO=4&transport=polling
+      const response = await fetch(`${workerUrl}/socket.io/?EIO=4&transport=polling`, {
+        method: "GET",
+        signal: AbortSignal.timeout(3_000),
+      });
+      // Socket.io returns 200 with polling data when ready
+      if (response.ok) {
+        return true;
+      }
+    } catch {
+      // Connection refused or timeout - server not ready yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  return false;
+}
+
+/**
  * Extract a safe, descriptive error message from sandbox start errors.
  * Avoids leaking sensitive information like API keys, tokens, or internal paths.
  */
@@ -535,6 +568,20 @@ sandboxesRouter.openapi(
       } else {
         console.log(
           `[sandboxes.start] VSCode server ready for ${instance.id}`,
+        );
+      }
+
+      // Wait for Worker socket server to be ready before returning
+      // This prevents "Worker socket not available" errors when the agent spawner
+      // tries to connect before the worker service is actually listening
+      const workerReady = await waitForWorkerReady(workerService.url);
+      if (!workerReady) {
+        console.warn(
+          `[sandboxes.start] Worker server did not become ready within timeout for ${instance.id}, proceeding anyway`,
+        );
+      } else {
+        console.log(
+          `[sandboxes.start] Worker server ready for ${instance.id}`,
         );
       }
 


### PR DESCRIPTION
## Task

# Fix: PVE LXC Worker Socket Connection Failure

## Problem Summary

Agent spawn fails with error: **"Agent spawn failed: Worker socket not available"**

The issue occurs because PVE LXC containers return service URLs before the worker socket server (port 39377) is actually ready to accept connections.

## Root Cause Analysis

1. **VSCode Ready Check Exists** (`apps/www/lib/routes/sandboxes.route.ts:530`):

- `waitForVSCodeReady()` polls the VSCode URL until it responds (15s timeout)
- Even this check sometimes fails: `"VSCode server did not become ready within timeout for pvelxc-559f9347, proceeding anyway"`

2. **No Worker Ready Check**:

- Worker URL is returned immediately after container starts
- No validation that the worker service is actually listening
- `connectToWorker()` has a 30s timeout but the URL may be unreachable

3. **Timing Gap**:

- PVE container networking may not be stable when URLs are built
- Cloudflare Tunnel routing may have propagation delays
- Worker service inside container may still be starting

## Solution

Add a `waitForWorkerReady()` function similar to `waitForVSCodeReady()` that validates the worker service is responding before returning from the sandbox start API.

## Files to Modify

### 1. `apps/www/lib/routes/sandboxes.route.ts`

**Add new function** (near line 65, after `waitForVSCodeReady`):

```typescript
async function waitForWorkerReady(
  workerUrl: string,
  options: { timeoutMs?: number; intervalMs?: number } = {}
): Promise<boolean> {
  const { timeoutMs = 15_000, intervalMs = 500 } = options;
  const start = Date.now();

  while (Date.now() - start < timeoutMs) {
    try {
      // Worker service uses socket.io - check if the HTTP endpoint responds
      // Socket.io exposes a polling transport at /socket.io/?EIO=4&transport=polling
      const response = await fetch(`${workerUrl}/socket.io/?EIO=4&transport=polling`, {
        method: "GET",
        signal: AbortSignal.timeout(3_000),
      });
      // Socket.io returns 200 with polling data when ready
      if (response.ok) {
        return true;
      }
    } catch {
      // Connection refused or timeout - server not ready yet
    }
    await new Promise((resolve) => setTimeout(resolve, intervalMs));
  }
  return false;
}
```

**Modify sandbox start handler** (around line 530):

```typescript
// Add worker ready check after VSCode ready check
const workerReady = await waitForWorkerReady(workerService.url);
if (!workerReady) {
  console.warn(
    `[sandboxes.start] Worker server did not become ready within timeout for ${instance.id}, proceeding anyway`,
  );
} else {
  console.log(
    `[sandboxes.start] Worker server ready for ${instance.id}`,
  );
}
```

### 2. Optional: Increase Timeout for PVE Containers

In `apps/www/lib/utils/pve-lxc-client.ts`, the container waits only 3 seconds for "fully running" status. Consider increasing for PVE if delays persist.

## Verification

1. **Start dev server**: `make dev-electron`
2. **Create a new task** on a PVE LXC container
3. **Check logs** in `logs/www.log` for:

- `[sandboxes.start] Worker server ready for pvelxc-...` (success)
- OR `Worker server did not become ready within timeout` (timeout but continues)

4. **Verify agent spawns successfully** without "Worker socket not available" error

## Alternative Approaches Considered

1. **Retry in agentSpawner.ts**: Could retry `connectToWorker()` multiple times, but this is a workaround not a fix
2. **Longer timeout in www API**: Extends container startup time for all containers, not ideal
3. **Health check endpoint in worker**: Would require modifying the sandbox worker code

The chosen approach (waitForWorkerReady) is minimal, matches existing patterns, and validates the service at the source.;

# review the plan and implement

## PR Review Summary
- What Changed:
  - Added a new asynchronous function, `waitForWorkerReady`, in `apps/www/lib/routes/sandboxes.route.ts`.
  - This function polls the worker service's Socket.IO HTTP polling endpoint (`/socket.io/?EIO=4&transport=polling`) to confirm it's ready and accepting connections.
  - The `waitForWorkerReady` check has a default timeout of 15 seconds and polls every 500ms.
  - Integrated this new check into the sandbox start handler within `sandboxesRouter.openapi` (around line 538).
  - The purpose is to prevent "Agent spawn failed: Worker socket not available" errors, particularly in PVE LXC environments, by ensuring the worker service is fully listening before proceeding.
- Review Focus:
  - The effectiveness and reliability of the `fetch` call against the Socket.IO polling endpoint as a true indicator of worker service readiness across various network conditions.
  - The impact of the additional 15-second timeout (if worker isn't ready) on overall sandbox startup times, especially for users not on PVE LXC.
  - The decision to `proceed anyway` with a `console.warn` if the worker server does not become ready within the timeout, which might still lead to a subsequent agent connection failure.
- Test Plan:
  - Start the development server using `make dev-electron`.
  - Initiate a new task specifically on a PVE LXC container.
  - Monitor the `logs/www.log` file for `[sandboxes.start] Worker server ready for pvelxc-...` (indicating success) or `Worker server did not become ready within timeout` (indicating a timeout but continued processing).
  - Confirm that agent spawns are consistently successful and the "Worker socket not available" error is no longer observed.