### PR TITLE
Fix Electron dev log EXTENDS_RESOLVE errors by skipping dev-docs

### DIFF
--- a/apps/client/electron.vite.config.ts
+++ b/apps/client/electron.vite.config.ts
@@ -150,7 +150,9 @@ export default defineConfig({
       exclude: ["monaco-editor"],
     },
     plugins: [
-      tsconfigPaths(),
+      tsconfigPaths({
+        skip: (dir) => dir.includes("dev-docs"),
+      }),
       tanstackRouter({
         target: "react",
         autoCodeSplitting: true,


### PR DESCRIPTION
## Task

# Fix EXTENDS\_RESOLVE Errors in Electron Dev Log

## Problem

When starting the Electron app, Vite logs many `EXTENDS_RESOLVE` errors because `vite-tsconfig-paths` scans the `dev-docs/` directory which contains cloned repositories with `tsconfig.json` files that extend packages not installed in cmux (e.g., `@tsconfig/bun`, `nitro/tsconfig`).

## Solution

Use the `skip` option in `vite-tsconfig-paths` to exclude the `dev-docs` directory from tsconfig scanning. This is the recommended approach per Context7 documentation.

**From Context7 docs:**

```typescript
tsconfigPaths({
  skip: (dir) => dir === 'legacy' // Skip specific directories
})
```

## Implementation

### File to modify

- `apps/client/electron.vite.config.ts:153`

### Change

Update the `tsconfigPaths()` call in the renderer config to skip the `dev-docs` directory:

```typescript
// Before
tsconfigPaths(),

// After
tsconfigPaths({
  skip: (dir) => dir.includes('dev-docs'),
}),
```

## Verification

1. Run `make dev-electron` or `./scripts/dev.sh`
2. Check `logs/electron.log` - should no longer contain `EXTENDS_RESOLVE` errors for `dev-docs/` paths
3. Verify the app still starts and functions correctly