### PR TITLE
[Crown] # Fix: PVE-LXC Sandbox Maintenance Production Check

## Probl...

### DIFF
--- a/packages/convex/convex/sandboxInstanceMaintenance.ts
+++ b/packages/convex/convex/sandboxInstanceMaintenance.ts
@@ -479,7 +479,7 @@ export const pauseOldSandboxInstances = internalAction({
   args: {},
   handler: async (ctx) => {
     // Only run in production
-    if (!env.CONVEX_IS_PRODUCTION) {
+    if (env.CONVEX_IS_PRODUCTION !== "true") {
       console.log("[sandboxMaintenance:pause] Skipping: not in production");
       return;
     }
@@ -627,7 +627,7 @@ export const stopOldSandboxInstances = internalAction({
   args: {},
   handler: async (ctx) => {
     // Only run in production
-    if (!env.CONVEX_IS_PRODUCTION) {
+    if (env.CONVEX_IS_PRODUCTION !== "true") {
       console.log("[sandboxMaintenance:stop] Skipping: not in production");
       return;
     }
@@ -794,6 +794,12 @@ export const stopOldSandboxInstances = internalAction({
 export const cleanupOrphanedContainers = internalAction({
   args: {},
   handler: async (ctx) => {
+    // Only run in production
+    if (env.CONVEX_IS_PRODUCTION !== "true") {
+      console.log("[sandboxMaintenance:orphanCleanup] Skipping: not in production");
+      return;
+    }
+
     console.log("[sandboxMaintenance:orphanCleanup] Starting orphan cleanup...");
     const now = Date.now();
     const orphanMinAgeMs = ORPHAN_MIN_AGE_DAYS * 24 * MILLISECONDS_PER_HOUR;


### PR DESCRIPTION
## Task

# Fix: PVE-LXC Sandbox Maintenance Production Check

## Problem

The sandbox maintenance cron jobs (`pauseOldSandboxInstances`, `stopOldSandboxInstances`, `cleanupOrphanedContainers`) are running in non-production environments even when `CONVEX_IS_PRODUCTION=false`.

### Root Cause

1. **String "false" is truthy in JavaScript**:

- The check `if (!env.CONVEX_IS_PRODUCTION)` fails because `!"false"` is `false`
- When `CONVEX_IS_PRODUCTION="false"`, the check passes and maintenance runs

2. **`cleanupOrphanedContainers`&#32;has no production check at all** (line 794)

### Evidence

From dev Convex deployment `quirky-lapwing-216`:

```
CONVEX_IS_PRODUCTION=false
```

Yet the cron jobs ran (Feb 01, 05:00-05:40):

- `pauseOldSandboxInstances`: "Finished: 10 paused, 8 failed"
- `stopOldSandboxInstances`: "Finished: 37 stopped, 23 skipped, 0 failed"
- `cleanupOrphanedContainers`: "Finished: 0 cleaned, 2 skipped"

From `packages/convex/_shared/convex-env.ts`:

```typescript
CONVEX_IS_PRODUCTION: z.string().optional(),
```

- `"true"` → truthy (maintenance runs)
- `"false"` → truthy (maintenance runs - BUG!)
- `undefined` → falsy (maintenance skipped)

## Solution

### Fix Production Check (3 locations)

**File**: `packages/convex/convex/sandboxInstanceMaintenance.ts`

**Change from:**

```typescript
if (!env.CONVEX_IS_PRODUCTION) {
  return;
}
```

**To:**

```typescript
if (env.CONVEX_IS_PRODUCTION !== "true") {
  return;
}
```

### Locations to Modify

1. **`pauseOldSandboxInstances`** (line 482):

- Change `if (!env.CONVEX_IS_PRODUCTION)` to `if (env.CONVEX_IS_PRODUCTION !== "true")`

2. **`stopOldSandboxInstances`** (line 630):

- Change `if (!env.CONVEX_IS_PRODUCTION)` to `if (env.CONVEX_IS_PRODUCTION !== "true")`

3. **`cleanupOrphanedContainers`** (line 796-797):

- ADD the production check after the opening handler:

```typescript
   handler: async (ctx) => {
     // Only run in production
     if (env.CONVEX_IS_PRODUCTION !== "true") {
       console.log("[sandboxMaintenance:orphanCleanup] Skipping: not in production");
       return;
     }

     console.log("[sandboxMaintenance:orphanCleanup] Starting orphan cleanup...");
```

## Files to Modify

- `packages/convex/convex/sandboxInstanceMaintenance.ts`

## Verification

1. Run `bun check` to verify no type errors
2. Deploy to environment with `CONVEX_IS_PRODUCTION=false`
3. Check Convex logs at 21:00/21:20/21:40 UTC for "Skipping: not in production"
4. Verify production (`CONVEX_IS_PRODUCTION=true`) still runs maintenance normally

## PR Review Summary
- What Changed:
  - Fixed a bug in `packages/convex/convex/sandboxInstanceMaintenance.ts` where sandbox maintenance cron jobs (`pauseOldSandboxInstances`, `stopOldSandboxInstances`, `cleanupOrphanedContainers`) were incorrectly running in non-production environments (when `CONVEX_IS_PRODUCTION="false"`).
  - The production check in `pauseOldSandboxInstances` (line 482) and `stopOldSandboxInstances` (line 630) was changed from `!env.CONVEX_IS_PRODUCTION` to `env.CONVEX_IS_PRODUCTION !== "true"` to correctly evaluate the string value.
  - A new production check, `if (env.CONVEX_IS_PRODUCTION !== "true")`, was added to `cleanupOrphanedContainers` (line 796-797), which previously lacked any production check.
  - Console log messages indicating skipping due to non-production environment were added to `cleanupOrphanedContainers`.
- Review Focus:
  - Confirm that the updated production check `env.CONVEX_IS_PRODUCTION !== "true"` robustly handles all non-production scenarios (e.g., `undefined`, `null`, `"false"`, empty string, etc.) and only allows execution when `CONVEX_IS_PRODUCTION` is explicitly `"true"`.
  - Ensure the change doesn't introduce any unintended side effects or performance overhead.
- Test Plan:
  - Run `bun check` to verify no type errors.
  - Deploy to a non-production environment (e.g., `CONVEX_IS_PRODUCTION=false`) and confirm that logs show "Skipping: not in production" messages for all three sandbox maintenance functions at their scheduled run times, and no maintenance actions are performed.
  - Deploy to a production environment (e.g., `CONVEX_IS_PRODUCTION=true`) and verify that all sandbox maintenance functions execute normally and perform their intended operations.