### PR TITLE
[Crown] # Fix Cloud-Workspace Terminal Not Working

## Problem Summar...

### DIFF
--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -2027,6 +2027,8 @@ export function setupSocketHandlers(
           const sandboxId = data.instanceId;
           const sandboxProvider = data.provider ?? "morph";
           const vscodeBaseUrl = data.vscodeUrl;
+          const vncUrl = data.vncUrl;
+          const xtermUrl = data.xtermUrl;
           const workspaceUrl = `${vscodeBaseUrl}?folder=/root/workspace`;
 
           serverLogger.info(
@@ -2049,6 +2051,8 @@ export function setupSocketHandlers(
               status: "running",
               url: vscodeBaseUrl,
               workspaceUrl,
+              vncUrl,
+              xtermUrl,
               startedAt: now,
             },
           });
@@ -2070,6 +2074,8 @@ export function setupSocketHandlers(
             instanceId: sandboxId,
             url: vscodeBaseUrl,
             workspaceUrl,
+            vncUrl,
+            xtermUrl,
             provider: sandboxProvider,
           });
 

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -308,6 +308,7 @@ const StartSandboxResponse = z
     vscodeUrl: z.string(),
     workerUrl: z.string(),
     vncUrl: z.string().optional(),
+    xtermUrl: z.string().optional(),
     provider: z.enum(["morph", "pve-lxc"]).default("morph"),
     vscodePersisted: z.boolean().optional(),
   })
@@ -824,6 +825,7 @@ sandboxesRouter.openapi(
         vscodeUrl: vscodeService.url,
         workerUrl: workerService.url,
         vncUrl: vncService?.url,
+        xtermUrl: xtermService?.url,
         provider: provider === "pve-lxc" ? "pve-lxc" : "morph",
         vscodePersisted,
       });

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -290,6 +290,8 @@ export const VSCodeSpawnedSchema = z.object({
   instanceId: z.string(),
   url: z.string(),
   workspaceUrl: z.string(),
+  vncUrl: z.string().optional(),
+  xtermUrl: z.string().optional(),
   provider: z.enum(["docker", "morph", "daytona", "pve-lxc", "other"]),
 });
 

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -592,6 +592,7 @@ export type StartSandboxResponse = {
     vscodeUrl: string;
     workerUrl: string;
     vncUrl?: string;
+    xtermUrl?: string;
     provider?: 'morph' | 'pve-lxc';
     vscodePersisted?: boolean;
 };


### PR DESCRIPTION
## Task

# Fix Cloud-Workspace Terminal Not Working

## Problem Summary

The Terminal panel in cloud-workspace shows "Starting terminal - Connecting to the workspace terminal session" and never connects. The cmux-pty service (port 39383) is healthy and has an active session, but the frontend doesn't receive the `xtermUrl`.

## Root Cause

In `apps/server/src/socket-handlers.ts`, the `create-cloud-workspace` handler updates the VSCode instance (lines 2041-2051) **without** `xtermUrl` or `vncUrl`:

```typescript
await convex.mutation(api.taskRuns.updateVSCodeInstance, {
  teamSlugOrId,
  id: taskRunId,
  vscode: {
    provider: sandboxProvider,
    containerName: sandboxId,
    status: "running",
    url: vscodeBaseUrl,
    workspaceUrl,
    startedAt: now,
    // Missing: vncUrl, xtermUrl
  },
});
```

While `sandboxes.route.ts` saves `xtermUrl` and `vncUrl` to Convex correctly (line 609), the cloud-workspace code in `socket-handlers.ts` **overwrites** that data without these fields.

Additionally, `StartSandboxResponse` schema in `sandboxes.route.ts` doesn't include `xtermUrl` in the API response, so even if the cloud-workspace handler wanted to use it, it's not available in the response.

## Fix Plan

### Step 1: Add `xtermUrl` to `StartSandboxResponse` schema

**File**: `apps/www/lib/routes/sandboxes.route.ts` (line \~310)

```typescript
const StartSandboxResponse = z
  .object({
    instanceId: z.string(),
    vscodeUrl: z.string(),
    workerUrl: z.string(),
    vncUrl: z.string().optional(),
    xtermUrl: z.string().optional(),  // ADD THIS
    provider: z.enum(["morph", "pve-lxc"]).default("morph"),
    vscodePersisted: z.boolean().optional(),
  })
  .openapi("StartSandboxResponse");
```

### Step 2: Include `xtermUrl` in the API response

**File**: `apps/www/lib/routes/sandboxes.route.ts` (line \~826)

```typescript
return c.json({
  instanceId: instance.id,
  vscodeUrl: vscodeService.url,
  workerUrl: workerService.url,
  vncUrl: vncService?.url,
  xtermUrl: xtermService?.url,  // ADD THIS
  provider: provider === "pve-lxc" ? "pve-lxc" : "morph",
  vscodePersisted,
});
```

### Step 3: Update cloud-workspace handler to include `vncUrl` and `xtermUrl`

**File**: `apps/server/src/socket-handlers.ts` (lines \~2020-2072)

Extract `vncUrl` and `xtermUrl` from the API response and include them in both the Convex update AND the `vscode-spawned` event:

```typescript
const sandboxId = data.instanceId;
const sandboxProvider = data.provider ?? "morph";
const vscodeBaseUrl = data.vscodeUrl;
const vncUrl = data.vncUrl;      // ADD THIS
const xtermUrl = data.xtermUrl;  // ADD THIS
const workspaceUrl = `${vscodeBaseUrl}?folder=/root/workspace`;

// ... later in updateVSCodeInstance ...
await convex.mutation(api.taskRuns.updateVSCodeInstance, {
  teamSlugOrId,
  id: taskRunId,
  vscode: {
    provider: sandboxProvider,
    containerName: sandboxId,
    status: "running",
    url: vscodeBaseUrl,
    workspaceUrl,
    vncUrl,      // ADD THIS
    xtermUrl,    // ADD THIS
    startedAt: now,
  },
});

// ... later in vscode-spawned event ...
rt.emit("vscode-spawned", {
  instanceId: sandboxId,
  url: vscodeBaseUrl,
  workspaceUrl,
  vncUrl,      // ADD THIS
  xtermUrl,    // ADD THIS
  provider: sandboxProvider,
});
```

### Step 4: Update `VSCodeSpawnedSchema` to include new fields

**File**: `packages/shared/src/socket-schemas.ts` (line \~289)

```typescript
export const VSCodeSpawnedSchema = z.object({
  instanceId: z.string(),
  url: z.string(),
  workspaceUrl: z.string(),
  vncUrl: z.string().optional(),    // ADD THIS
  xtermUrl: z.string().optional(),  // ADD THIS
  provider: z.enum(["docker", "morph", "daytona", "pve-lxc", "other"]),
});
```

### Step 5: Regenerate OpenAPI client

```bash
cd apps/www && bun run generate-openapi-client
```

## Files to Modify

1. `apps/www/lib/routes/sandboxes.route.ts` - Add `xtermUrl` to schema and response
2. `apps/server/src/socket-handlers.ts` - Include `vncUrl` and `xtermUrl` in cloud-workspace handler
3. `packages/shared/src/socket-schemas.ts` - Add optional `vncUrl` and `xtermUrl` to `VSCodeSpawnedSchema`

## Verification

1. Start dev server: `make dev-electron`
2. Create a new cloud-workspace
3. Verify Terminal panel connects successfully (no more "Starting terminal" stuck state)
4. Verify Browser panel (VNC) works correctly
5. Run `bun check` to ensure no type errors

## PR Review Summary
- What Changed:
  - The `StartSandboxResponse` schema and API response in `apps/www/lib/routes/sandboxes.route.ts` were updated to include an optional `xtermUrl`.
  - The `setupSocketHandlers` in `apps/server/src/socket-handlers.ts` now extracts `vncUrl` and `xtermUrl` from the sandbox creation response and includes them in:
    - The Convex `api.taskRuns.updateVSCodeInstance` mutation.
    - The `vscode-spawned` socket event payload.
  - The `VSCodeSpawnedSchema` in `packages/shared/src/socket-schemas.ts` was extended to include optional `vncUrl` and `xtermUrl`.
  - The OpenAPI client types were regenerated to reflect these changes.
- Why It Changed:
  - This resolves an issue where the Cloud-Workspace Terminal panel would not connect because the `xtermUrl` was missing from the `vscode` instance data and `vscode-spawned` event, causing the frontend to be unable to establish a terminal session.
  - The previous cloud-workspace handler was overwriting `vncUrl` and `xtermUrl` data when updating the VSCode instance.
- Review Focus:
  - Carefully verify that the terminal (xterm) connection is stable and responsive across various network conditions.
  - Confirm that the Browser panel (VNC) functionality remains intact and is not negatively impacted by the `vncUrl` propagation changes.
  - Check for any unexpected side effects or regressions in existing workspace functionality.
- Test Plan:
  - Start the development server using `make dev-electron`.
  - Create a new cloud-workspace.
  - Verify that the Terminal panel within the workspace successfully connects and functions.
  - Confirm that the Browser panel (VNC) within the workspace operates correctly.
  - Run `bun check` to ensure there are no new type errors introduced by these schema and code changes.