### PR TITLE
[Crown] # Fix: Task Read Status Not Updating in Electron App

## Prob...

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx
@@ -67,24 +67,26 @@ function TaskDetailPage() {
     taskId,
   });
 
-  // Mark as read when viewing AND focused, triggers when unread state changes
+  // Mark as read when viewing AND visible, triggers when unread state changes
+  // Uses Page Visibility API instead of document.hasFocus() to work correctly
+  // in Electron where focus may be in embedded WebContentsView (VSCode/VNC preview)
   useEffect(() => {
     if (!taskId || !hasUnread) return;
 
-    const markReadIfFocused = () => {
-      if (document.hasFocus()) {
+    const markReadIfVisible = () => {
+      if (document.visibilityState === "visible") {
         setTaskReadState(taskId, true).catch((err) => {
           console.error("Failed to mark task notifications as read:", err);
         });
       }
     };
 
-    // Mark as read immediately if focused
-    markReadIfFocused();
+    // Mark as read immediately if visible
+    markReadIfVisible();
 
-    // Handle user returning to the page
-    window.addEventListener("focus", markReadIfFocused);
-    return () => window.removeEventListener("focus", markReadIfFocused);
+    // Handle user returning to the page (tab becomes visible again)
+    document.addEventListener("visibilitychange", markReadIfVisible);
+    return () => document.removeEventListener("visibilitychange", markReadIfVisible);
   }, [hasUnread, taskId, setTaskReadState]);
 
   // Get the deepest matched child to extract runId if present


### PR DESCRIPTION
## Task

# Fix: Task Read Status Not Updating in Electron App

## Problem

Tasks stay marked as "unread" even when viewing them in the Electron app because `document.hasFocus()` returns `false` when focus is in the embedded VSCode/VNC preview (WebContentsView).

## Root Cause

- `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx` lines 71-88
- The auto-read effect uses `document.hasFocus()` to determine if the window is focused
- In Electron, when the user is interacting with the embedded VSCode/VNC preview, the main document doesn't have focus - the embedded WebContentsView does
- `document.hasFocus()` returns `false`, so `markReadIfFocused()` doesn't mark as read

## Solution

Replace `document.hasFocus()` with a more robust focus detection that works in Electron's multi-webcontents environment.

### Option A: Use Electron Window Focus (Recommended)

Check if the Electron window is focused rather than the document. The Electron main process already tracks window focus.

**Files to modify:**

1. `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx`

- Import `isElectron` from `@/lib/electron`
- Create a custom hook or helper that:
    - In Electron: subscribes to window focus events via IPC (already exists as `ELECTRON_WINDOW_FOCUS_EVENT`)
    - In browser: uses `document.hasFocus()`

2. May need to add IPC handler in `apps/client/electron/main/index.ts` if not already exposing window focus state

### Option B: Always Mark as Read When Viewing (Simpler)

Remove the focus check entirely - if the user is on the task page, mark as read.

**Change:**

```tsx
// Before:
if (document.hasFocus()) {
  setTaskReadState(taskId, true)...
}

// After:
setTaskReadState(taskId, true)...
```

**Pros:** Simple, always works
**Cons:** Marks as read even when window is minimized/hidden

### Option C: Use Page Visibility API

Use `document.visibilityState === "visible"` instead of `document.hasFocus()`.

**Change:**

```tsx
// Before:
if (document.hasFocus()) {

// After:
if (document.visibilityState === "visible") {
```

**Pros:** Works across browser/Electron, simpler than IPC
**Cons:** Marks as read when tab is visible but user may not be looking

## Recommended Approach

**Option C** - Use Page Visibility API. It's the simplest fix that works in both browser and Electron environments.

## Files to Modify

1. `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx` (lines 75, 86-87)

## Verification

1. Start the Electron app: `make dev-electron`
2. Open a task with a running agent
3. Wait for the agent to stop
4. Verify the task is automatically marked as read (no unread indicator)
5. Interact with the VSCode/VNC preview
6. Trigger another agent stop
7. Verify the task is still marked as read automatically

## PR Review Summary
- What Changed:
    - Modified `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx` to fix an issue where tasks were not being marked as read in the Electron app.
    - Replaced the `document.hasFocus()` check with `document.visibilityState === "visible"` in the `useEffect` hook responsible for marking tasks as read.
    - Updated the event listener from `window.addEventListener("focus", ...)` to `document.addEventListener("visibilitychange", ...)`.
    - Renamed the internal helper function from `markReadIfFocused` to `markReadIfVisible` to reflect the new logic.
    - This change ensures that tasks are marked as read when the document/tab is visible, addressing the problem where `document.hasFocus()` returned `false` when focus was in an embedded VSCode/VNC preview in Electron.
- Review Focus:
    - Verify that tasks are consistently marked as read in the Electron app, especially when interacting with embedded WebContentsView (VSCode/VNC previews).
    - Confirm there are no regressions in task read status behavior in standard browser environments.
    - Check edge cases where the Electron window might be visible but not actively focused by the user (e.g., in the background but not minimized) to ensure correct read state updates.
- Test Plan:
    - **Electron App:**
        1. Run `make dev-electron`.
        2. Open an unread task. Verify it immediately marks as read.
        3. Within a task, interact with an embedded VSCode/VNC preview. Ensure the task remains marked as read.
        4. Minimize the Electron app with an unread task open, then restore it. Verify the task is marked as read upon restoration.
    - **Browser App:**
        1. Open an unread task in a browser tab.
        2. Open another tab and switch focus away from the task tab.
        3. Switch back to the task tab. Verify it's marked as read.
        4. Confirm tasks are not marked as read if the tab is in the background and never brought to the foreground.