### PR TITLE
[Crown] # Plan: Fix Deep Link Protocol Not Using NEXT\_PUBLIC\_CMUX\_...

### DIFF
--- a/apps/www/app/(home)/handler/connect-github/page.tsx
+++ b/apps/www/app/(home)/handler/connect-github/page.tsx
@@ -1,4 +1,5 @@
 import { stackServerApp } from "@/lib/utils/stack";
+import { env } from "@/lib/utils/www-env";
 import { ConnectGitHubClient } from "./ConnectGitHubClient";
 
 export const dynamic = "force-dynamic";
@@ -29,9 +30,10 @@ export default async function ConnectGitHubPage({
 
   if (githubAccount) {
     // Already connected - redirect to deep link immediately
+    const protocol = env.NEXT_PUBLIC_CMUX_PROTOCOL ?? "cmux-next";
     const deepLinkHref = teamSlugOrId
-      ? `cmux://github-connect-complete?team=${encodeURIComponent(teamSlugOrId)}`
-      : `cmux://github-connect-complete`;
+      ? `${protocol}://github-connect-complete?team=${encodeURIComponent(teamSlugOrId)}`
+      : `${protocol}://github-connect-complete`;
 
     // Use client component to trigger deep link
     return <ConnectGitHubClient href={deepLinkHref} alreadyConnected />;


### PR DESCRIPTION
## Task

# Plan: Fix Deep Link Protocol Not Using NEXT\_PUBLIC\_CMUX\_PROTOCOL

## Problem

The `/handler/connect-github` page hardcodes `cmux://` protocol in deep links instead of using the `NEXT_PUBLIC_CMUX_PROTOCOL` environment variable. This prevents fork deployments from customizing the protocol.

**Affected file:** `apps/www/app/(home)/handler/connect-github/page.tsx` (lines 32-34)

**Current buggy code:**

```typescript
const deepLinkHref = teamSlugOrId
  ? `cmux://github-connect-complete?team=${encodeURIComponent(teamSlugOrId)}`
  : `cmux://github-connect-complete`;
```

## Solution

Import `env` from `@/lib/utils/www-env` and use `NEXT_PUBLIC_CMUX_PROTOCOL` with fallback to `"cmux-next"` (consistent with other pages).

## Changes

### File: `apps/www/app/(home)/handler/connect-github/page.tsx`

1. Add import at line 2:

```typescript
   import { env } from "@/lib/utils/www-env";
```

2. Update lines 31-34 to use env variable:

```typescript
   if (githubAccount) {
     // Already connected - redirect to deep link immediately
     const protocol = env.NEXT_PUBLIC_CMUX_PROTOCOL ?? "cmux-next";
     const deepLinkHref = teamSlugOrId
       ? `${protocol}://github-connect-complete?team=${encodeURIComponent(teamSlugOrId)}`
       : `${protocol}://github-connect-complete`;
```

## Verification

1. Set `NEXT_PUBLIC_CMUX_PROTOCOL=test-protocol` in `.env`
2. Access `http://localhost:9779/handler/connect-github?team=0dev` with GitHub already connected
3. Verify the deep link uses `test-protocol://` instead of `cmux://`
4. Run `bun check` to ensure no type errors

## PR Review Summary
- What Changed:
  - In `apps/www/app/(home)/handler/connect-github/page.tsx`, the hardcoded `cmux://` deep link protocol has been replaced with a dynamic protocol.
  - An import for `env` from `@/lib/utils/www-env` was added.
  - The deep link generation now uses `env.NEXT_PUBLIC_CMUX_PROTOCOL` and falls back to `"cmux-next"` if the environment variable is not set. This ensures fork deployments can customize the deep link protocol.
- Review Focus:
  - Verify that the `NEXT_PUBLIC_CMUX_PROTOCOL` is correctly read and applied in both deep link variations (with and without the `team` query parameter).
  - Confirm the fallback protocol `"cmux-next"` is appropriate if the environment variable is undefined.
  - Ensure no unintended side effects on the `ConnectGitHubClient` component.
- Test Plan:
  - Set `NEXT_PUBLIC_CMUX_PROTOCOL=test-protocol` in your `.env` file.
  - Access `http://localhost:9779/handler/connect-github?team=0dev` with a GitHub account already connected.
  - Verify that the generated deep link uses `test-protocol://` instead of `cmux://`.
  - Access `http://localhost:9779/handler/connect-github` (without a team) with a GitHub account already connected and verify the deep link uses `test-protocol://`.
  - Remove `NEXT_PUBLIC_CMUX_PROTOCOL` from `.env` and repeat the above steps, ensuring the deep link uses the fallback `cmux-next://`.
  - Run `bun check` to confirm no type errors were introduced.