### PR TITLE
[Crown] # Fix: Private Repository Auto-Cloning in Custom Environments...

### DIFF
--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -410,6 +410,7 @@ sandboxesRouter.openapi(
         environmentDataVaultKey,
         environmentMaintenanceScript,
         environmentDevScript,
+        environmentSelectedRepos,
       } = await resolveTeamAndSnapshot({
         req: c.req.raw,
         convex,
@@ -422,8 +423,13 @@ sandboxesRouter.openapi(
         ? loadEnvironmentEnvVars(environmentDataVaultKey)
         : Promise.resolve<string | null>(null);
 
+      // Use body.repoUrl if provided, otherwise fall back to first selectedRepo from environment
+      const repoUrl = body.repoUrl ?? environmentSelectedRepos?.[0] ?? null;
+      if (!body.repoUrl && environmentSelectedRepos?.[0]) {
+        console.log(`[sandboxes.start] Using environment selectedRepo: ${repoUrl}`);
+      }
       // Parse repo URL once if provided
-      const parsedRepoUrl = body.repoUrl ? parseGithubRepoUrl(body.repoUrl) : null;
+      const parsedRepoUrl = repoUrl ? parseGithubRepoUrl(repoUrl) : null;
 
       // Load workspace config if we're in cloud mode with a repository (not an environment)
       let workspaceConfig: { maintenanceScript?: string; envVarsContent?: string } | null = null;
@@ -745,7 +751,7 @@ sandboxesRouter.openapi(
       await configureGithubAccess(instance, gitAuthToken);
 
       let repoConfig: HydrateRepoConfig | undefined;
-      if (body.repoUrl) {
+      if (repoUrl) {
         console.log(`[sandboxes.start] Hydrating repo for ${instance.id}`);
         if (!parsedRepoUrl) {
           return c.text("Unsupported repo URL; expected GitHub URL", 400);

--- a/apps/www/lib/routes/sandboxes/snapshot.ts
+++ b/apps/www/lib/routes/sandboxes/snapshot.ts
@@ -28,6 +28,8 @@ export interface SnapshotResolution {
   environmentDataVaultKey?: string;
   environmentMaintenanceScript?: string;
   environmentDevScript?: string;
+  /** Selected repositories from the environment (for auto-cloning) */
+  environmentSelectedRepos?: string[];
 }
 
 /**
@@ -167,6 +169,7 @@ export const resolveTeamAndSnapshot = async ({
       environmentDataVaultKey: environmentDoc.dataVaultKey ?? undefined,
       environmentMaintenanceScript: environmentDoc.maintenanceScript ?? undefined,
       environmentDevScript: environmentDoc.devScript ?? undefined,
+      environmentSelectedRepos: environmentDoc.selectedRepos ?? undefined,
     };
   }
 


### PR DESCRIPTION
## Task

# Fix: Private Repository Auto-Cloning in Custom Environments (PVE-LXC Mode)

## Problem Summary

When creating a custom environment with a private repository (e.g., `karlorz/testing-repo-1`) in PVE-LXC mode, the repository is not automatically cloned into `/root/workspace/`. Users must manually clone using `gh repo clone`.

## Root Cause Analysis

The issue is a **missing data flow** - the `selectedRepos` field stored in custom environments is not passed through to the workspace hydration process:

1. **Environment Creation** (`environments.route.ts`): `selectedRepos` is stored correctly in the environment document
2. **Snapshot Resolution** (`sandboxes/snapshot.ts`): `resolveTeamAndSnapshot()` returns environment metadata but **does NOT return&#32;`selectedRepos`**
3. **Sandbox Start** (`sandboxes.route.ts:426`): Only parses `body.repoUrl` from the request - never reads `selectedRepos` from the resolved environment
4. **Client-side** (`environments.$environmentId.tsx:510-546`): When launching from custom environment, client only passes `environmentId` and `snapshotId` - no `repoUrl`

**Key code paths:**

- `apps/www/lib/routes/sandboxes/snapshot.ts:162-170` - Returns environment data without `selectedRepos`
- `apps/www/lib/routes/sandboxes.route.ts:426` - Only checks `body.repoUrl`, ignoring environment repos
- `apps/client/src/routes/_layout.$teamSlugOrId.environments.$environmentId.tsx:510-546` - Client doesn't pass `repoUrl`

## Implementation Plan

### Step 1: Update `SnapshotResolution` interface to include `selectedRepos`

**File:** `apps/www/lib/routes/sandboxes/snapshot.ts`

Add `selectedRepos?: string[]` to the `SnapshotResolution` interface and ensure it's returned when resolving an environment.

### Step 2: Return `selectedRepos` from `resolveTeamAndSnapshot()`

**File:** `apps/www/lib/routes/sandboxes/snapshot.ts`

In the `environmentId` handling block (lines 141-171), add:

```typescript
environmentSelectedRepos: environmentDoc.selectedRepos ?? undefined,
```

### Step 3: Use `selectedRepos` in sandbox start logic

**File:** `apps/www/lib/routes/sandboxes.route.ts`

After resolving the snapshot, if `body.repoUrl` is not provided but `environmentSelectedRepos` has entries:

1. Use the first repo in `selectedRepos` as the clone target (most environments have a single primary repo)
2. Parse it with `parseGithubRepoUrl()` and proceed with normal cloning flow

```typescript
// After line 419
const { ..., environmentSelectedRepos } = await resolveTeamAndSnapshot(...);

// Replace line 426
const repoUrl = body.repoUrl ?? environmentSelectedRepos?.[0] ?? null;
const parsedRepoUrl = repoUrl ? parseGithubRepoUrl(repoUrl) : null;
```

### Step 4: Handle multiple repos (future consideration)

For environments with multiple `selectedRepos`, the first repo will be cloned into `/root/workspace`. Additional repos could be:

- Cloned into subdirectories (future enhancement)
- Documented as requiring manual cloning

## Files to Modify

| File | Changes |
|------|---------|
| `apps/www/lib/routes/sandboxes/snapshot.ts` | Add `environmentSelectedRepos` to return type and return it |
| `apps/www/lib/routes/sandboxes.route.ts` | Use `environmentSelectedRepos` as fallback for `body.repoUrl` |

## Verification Plan

1. **Local Development Testing:**

- Start dev server: `./scripts/dev.sh`
- Create a custom environment with a private repo selection
- Start a sandbox from that environment
- Verify the repo is automatically cloned into `/root/workspace/`

2. **SSH into the active PVE LXC container (VMID 275):**

```bash
   ssh root@karlws-tailscale
   pct exec 275 -- bash -c "ls -la /root/workspace/"
```

3. **Check server logs for hydration output:**

- Look for `[sandboxes.start] hydration stdout:` entries
- Verify `git clone` is executed with authenticated URL

4. **Run type check:**

```bash
   bun check
```

## PR Review Summary
- What Changed:
  - In `apps/www/lib/routes/sandboxes/snapshot.ts`:
    - The `SnapshotResolution` interface now includes an optional `environmentSelectedRepos?: string[]` field.
    - The `resolveTeamAndSnapshot` function has been updated to return `environmentDoc.selectedRepos` as `environmentSelectedRepos` when resolving an environment.
  - In `apps/www/lib/routes/sandboxes.route.ts`:
    - `environmentSelectedRepos` is now retrieved from the `resolveTeamAndSnapshot` result.
    - The logic for determining the `repoUrl` to clone now prioritizes `body.repoUrl` from the request, falling back to the *first* repository in `environmentSelectedRepos` if `body.repoUrl` is not provided.
    - A `console.log` message is added to indicate when an environment's `selectedRepo` is being used.
    - The `repoConfig` hydration condition was updated from `if (body.repoUrl)` to `if (repoUrl)` to correctly use the resolved URL.
- Review Focus:
  - Verify that `body.repoUrl` correctly overrides `environmentSelectedRepos` when both are present.
  - Confirm that environments without `selectedRepos` or with an empty `selectedRepos` array do not cause errors.
  - The current implementation only clones the *first* selected repository. Review if this behavior aligns with immediate needs, given the 