### PR TITLE
[Crown] # Fix: Private Repository Auto-Cloning in PVE LXC Sandboxes

...

### DIFF
--- a/apps/www/lib/utils/pve-lxc-client.ts
+++ b/apps/www/lib/utils/pve-lxc-client.ts
@@ -632,7 +632,7 @@ export class PveLxcClient {
     const effectiveTimeoutMs = timeoutMs ?? 300000;
 
     const body = JSON.stringify({
-      command: `HOME=/root XDG_RUNTIME_DIR=/run/user/0 ${command}`,
+      command: `export HOME=/root XDG_RUNTIME_DIR=/run/user/0; ${command}`,
       timeout_ms: effectiveTimeoutMs,
     });
 


### PR DESCRIPTION
## Task

# Fix: Private Repository Auto-Cloning in PVE LXC Sandboxes

## Problem

Private repositories fail to clone to PVE LXC sandboxes with the error:

```
To get started with GitHub CLI, please run: gh auth login
```

## Root Cause

In `apps/www/lib/utils/pve-lxc-client.ts` line 635, environment variables are set using shell prefix notation:

```typescript
command: `HOME=/root XDG_RUNTIME_DIR=/run/user/0 ${command}`,
```

When commands contain `&&` (like `mkdir -p /root/workspace && cd /root/workspace && gh repo clone ...`), the `HOME=/root` prefix only applies to the **first command** in the pipeline. Subsequent commands (`gh repo clone`) run without `HOME` being set, causing `gh` CLI to fail to find its config at `/root/.config/gh/hosts.yml`.

**Verified**: Changing to `export HOME=/root XDG_RUNTIME_DIR=/run/user/0;` fixes the issue.

## Solution

### File: `apps/www/lib/utils/pve-lxc-client.ts`

**Line 635** - Change from:

```typescript
command: `HOME=/root XDG_RUNTIME_DIR=/run/user/0 ${command}`,
```

To:

```typescript
command: `export HOME=/root XDG_RUNTIME_DIR=/run/user/0; ${command}`,
```

## Verification

1. Start the dev server: `./scripts/dev.sh`
2. Create a new sandbox with a private repository (e.g., `karlorz/testing-repo-1`)
3. Verify the repository is cloned to `/root/workspace/` in the container
4. Run `bun check` to ensure no type errors

## PR Review Summary
- What Changed:
  - In `apps/www/lib/utils/pve-lxc-client.ts`, line 635, the command prefix for setting `HOME` and `XDG_RUNTIME_DIR` was changed from `HOME=/root XDG_RUNTIME_DIR=/run/user/0 ${command}` to `export HOME=/root XDG_RUNTIME_DIR=/run/user/0; ${command}`.
  - This modification ensures that the `HOME` and `XDG_RUNTIME_DIR` environment variables are properly exported and persist across multiple commands chained with `&&` within the LXC sandbox, resolving an issue where `gh CLI` failed to locate its configuration.
- Review Focus:
  - Verify that this change correctly resolves the private repository auto-cloning issue in PVE LXC sandboxes without introducing regressions for other commands executed within the sandboxes.
  - Confirm that the `export` keyword functions as expected across different shell environments or command structures that might be passed to this utility.
- Test Plan:
  - Start the dev server: `./scripts/dev.sh`
  - Create a new sandbox using a private repository (e.g., `karlorz/testing-repo-1`).
  - Confirm that the private repository successfully clones to `/root/workspace/` within the container.
  - Run `bun check` to ensure no type errors were introduced.