### PR TITLE
[Crown] # Fix: Task Read Status Issue - Race Condition with Agent-Sto...

### DIFF
--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1227,6 +1227,18 @@ const convexSchema = defineSchema({
     .index("by_team_user", ["teamId", "userId"]) // Get unread runs for a user in a team
     .index("by_task_user", ["taskId", "userId"]), // Get unread runs for a task
 
+  // Track users actively viewing tasks (for race condition prevention)
+  // Used to prevent marking tasks as unread when user is actively viewing them
+  activeTaskViewers: defineTable({
+    taskId: v.id("tasks"),
+    userId: v.string(),
+    teamId: v.string(),
+    lastHeartbeatAt: v.number(), // For staleness detection (60s threshold)
+  })
+    .index("by_task_user", ["taskId", "userId"])
+    .index("by_user", ["userId"])
+    .index("by_team_user", ["teamId", "userId"]),
+
   // Track Morph instance activity for cleanup cron decisions
   // DEPRECATED: Use sandboxInstanceActivity for new code (provider-agnostic)
   morphInstanceActivity: defineTable({


### PR DESCRIPTION
## Task

# Fix: Task Read Status Issue - Race Condition with Agent-Stopped Notifications

## Problem Summary

Tasks revert to "unread" even while the user is actively viewing them. This happens because:

1. User views task → task marked as read
2. Agent stops → `createAgentStoppedNotification` creates new unread entry
3. Task appears unread again (race condition)

## Previous Fix (Already Implemented)

File: `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx`

- Lines 70-90: Changed from `document.hasFocus()` to `document.visibilityState === "visible"`
- This fixed the Electron WebContentsView focus issue but NOT the race condition

## New Issue: Race Condition

The `createAgentStoppedNotification` mutation ALWAYS inserts into `unreadTaskRuns`:

- File: `packages/convex/convex/notifications_http.ts` lines 154-170
- No check if user is currently viewing the task
- Frontend's auto-mark-as-read effect runs AFTER the notification is created

## Solution: Skip Unread Marking if Task is Currently Being Viewed

### Approach: Track Active Viewers

Add a table to track which users are actively viewing which tasks, then check this before marking as unread.

### Files to Modify

1. **`packages/convex/convex/schema.ts`**

- Add new table `activeTaskViewers` with fields:
    - `taskId: v.id("tasks")`
    - `userId: v.string()`
    - `lastHeartbeatAt: v.number()` (for cleanup/expiry)
- Add index `by_task_user` for fast lookup

2. **`packages/convex/convex/taskNotifications.ts`**

- Add `registerActiveViewer` mutation - called when user opens task
- Add `unregisterActiveViewer` mutation - called when user leaves task
- Add `isActivelyViewing` internal query - checks if user is viewing task

3. **`packages/convex/convex/notifications_http.ts`** (lines 154-170)

- Before inserting into `unreadTaskRuns`, check `isActivelyViewing`
- If user is actively viewing, skip the unread insertion
- Still create the notification entry (for history), just don't mark unread

4. **`apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx`**

- On mount: call `registerActiveViewer`
- On unmount: call `unregisterActiveViewer`
- Use heartbeat (every 30s) to keep viewer status alive

### Alternative: Simpler Approach (No Backend Changes)

Keep the current behavior but make the frontend more aggressive:

- Instead of reacting to `hasUnread` changes, poll and mark as read every few seconds
- Cons: More API calls, still brief flicker

## Implementation Plan: Track Active Viewers

### Step 1: Add Schema (`packages/convex/convex/schema.ts`)

```ts
activeTaskViewers: defineTable({
  taskId: v.id("tasks"),
  userId: v.string(),
  lastHeartbeatAt: v.number(),
})
  .index("by_task_user", ["taskId", "userId"])
  .index("by_user", ["userId"])
```

### Step 2: Add Mutations (`packages/convex/convex/taskNotifications.ts`)

```ts
// Register viewer (upsert with heartbeat)
export const registerActiveViewer = authMutation({...})

// Unregister viewer (delete row)
export const unregisterActiveViewer = authMutation({...})

// Internal: check if viewing (with 60s staleness threshold)
export const isActivelyViewing = internalQuery({...})
```

### Step 3: Modify Notification Creation (`packages/convex/convex/notifications_http.ts`)

At line 154-170, before inserting into `unreadTaskRuns`:

```ts
// Check if user is actively viewing this task
const isViewing = await ctx.runQuery(
  internal.taskNotifications.isActivelyViewing,
  { taskId: args.taskId, userId: args.userId }
);

// Only mark as unread if NOT actively viewing
if (!isViewing && !existing) {
  await ctx.db.insert("unreadTaskRuns", {...});
}
```

### Step 4: Frontend Integration (`apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx`)

```tsx
// Register on mount, heartbeat every 30s, unregister on unmount
useEffect(() => {
  if (!taskId) return;

  // Register immediately
  registerViewer({ teamSlugOrId, taskId });

  // Heartbeat every 30s
  const interval = setInterval(() => {
    registerViewer({ teamSlugOrId, taskId });
  }, 30000);

  // Cleanup on unmount
  return () => {
    clearInterval(interval);
    unregisterViewer({ teamSlugOrId, taskId });
  };
}, [taskId, teamSlugOrId]);
```

### Step 5: Deploy Convex Schema

Run `bunx convex dev` to push schema changes.

## Verification

1. Start dev-electron: `make dev-electron`
2. Open a task with a running agent
3. Wait for agent to stop (triggers agent-stopped notification)
4. **Verify**: Task does NOT show unread indicator while viewing
5. Navigate away from task
6. Trigger another agent stop
7. **Verify**: Task now shows unread (user was not viewing)
8. Navigate back to task
9. **Verify**: Task marked as read again

## PR Review Summary
- **What Changed:**
    - This PR addresses a race condition where tasks were incorrectly marked as unread by agent-stopped notifications even when the user was actively viewing them.
    - A new Convex table, `activeTaskViewers`, was added (`packages/convex/convex/schema.ts`) to track which `userId` is viewing which `taskId` within a `teamId`, using a `lastHeartbeatAt` timestamp for staleness.
    - Three new Convex functions were introduced in `packages/convex/convex/taskNotifications.ts`:
        - `registerActiveViewer`: An `authMutation` that upserts/updates a viewer's heartbeat for a given task.
        - `unregisterActiveViewer`: An `authMutation` that deletes a viewer's record when they leave a task.
        - `isActivelyViewing`: An `internalQuery` that checks if a user is currently viewing a task based on the `activeTaskViewers` table and a 60-second staleness threshold.
    - The `createAgentStoppedNotification` `internalMutation` in `packages/convex/convex/notifications_http.ts` was modified to call `isActivelyViewing`. It now only inserts an entry into `unreadTaskRuns` if the user is *not* actively viewing the task.
    - The frontend component `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx` was updated to:
        - Use `useMutation` for `registerActiveViewer` and `unregisterActiveViewer`.
        - Utilize a `useEffect` hook to call `registerViewer` on component mount, send a heartbeat every 30 seconds, and call `unregisterViewer` on unmount.

- **Review Focus:**
    - **Heartbeat Logic**: Ensure the 30-second client-side heartbeat interval works robustly with the 60-second server-side staleness threshold in `isActivelyViewing` to prevent false negatives (tasks appearing unread while viewing).
    - **Error Handling**: Review the client-side `catch` blocks for `registerViewer` and `unregisterViewer` to ensure they handle failures gracefully without disrupting the user experience.
    - **Unregistration Reliability**: Consider edge cases where `unregisterViewer` might fail (e.g., browser crash, network loss) and how `activeTaskViewers` entries might be cleaned up if they become stale indefinitely (though `lastHeartbeatAt` is present, there's no explicit server-side cleanup mechanism shown).

- **Test Plan:**
    1. Start the Electron development environment: `make dev-electron`.
    2. Navigate to and open a specific task that has an agent running.
    3. Wait for the agent associated with that task to stop.
    4. **Verify**: While still viewing the task, confirm that no unread indicator appears for that task in the task list or sidebar.
    5. Navigate away from the task (e.g., to another task or a different page).
    6. Trigger another agent stop for the *same* task (e.g., by restarting the agent and letting it stop again).
    7. **Verify**: Now that you are *not* viewing the task, confirm that an unread indicator appears for the task.
    8. Navigate back to the task and open it.
    9. **Verify**: The task should be marked as read again after opening.