### PR TITLE
[Crown] # Fix: Task Read Status Issue - Spurious Agent-Stopped Notifi...

### DIFF
--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -223,17 +223,6 @@ exit 0`;
           ],
         },
       ],
-      Notification: [
-        {
-          matcher: ".*",
-          hooks: [
-            {
-              type: "command",
-              command: `${claudeLifecycleDir}/stop-hook.sh`,
-            },
-          ],
-        },
-      ],
     },
     env: {
       CLAUDE_CODE_ENABLE_TELEMETRY: 0,


### PR DESCRIPTION
## Task

# Fix: Task Read Status Issue - Spurious Agent-Stopped Notifications

## Problem Summary

Tasks revert to "unread" repeatedly while viewing. The `Notification` hook fires multiple times, calling `agent-stopped` API repeatedly.

## ROOT CAUSE CONFIRMED

### Evidence from Hook Log (`/root/lifecycle/claude-hook.log`)

The stop hook fired **5 times in 9 minutes** for the same completed task:

```
12:11:12 - ns79gv84rwb192ammf5mnhtf5h80c8vw (first completion)
12:12:17 - ns79gv84rwb192ammf5mnhtf5h80c8vw (spurious)
12:15:22 - ns79gv84rwb192ammf5mnhtf5h80c8vw (spurious)
12:18:47 - ns79gv84rwb192ammf5mnhtf5h80c8vw (spurious)
12:19:57 - ns79gv84rwb192ammf5mnhtf5h80c8vw (spurious)
```

### The Culprit: Notification Hook

File: `packages/shared/src/providers/anthropic/environment.ts` lines 226-236

```json
"Notification": [
  {
    "matcher": ".*",
    "hooks": [{ "type": "command", "command": "/root/lifecycle/claude/stop-hook.sh" }]
  }
]
```

Every Claude notification (toast) triggers the same stop-hook.sh, which calls `/api/notifications/agent-stopped` and marks the task unread again.

## Related Fix (PR #196 - Not Yet Merged)

File: `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.tsx`

- PR #196 changes `document.hasFocus()` to `document.visibilityState === "visible"`
- This fixes the Electron WebContentsView focus issue (different problem)
- **Should be merged** - it's a separate valid fix for mark-as-read not working when focus is in embedded preview

## Solution: Remove the Notification Hook

The `Stop` hook is sufficient - the `Notification` hook is causing spurious triggers.

### File to Modify

`packages/shared/src/providers/anthropic/environment.ts` lines 226-236

### Change

Remove the entire `Notification` hook block from the `hooks` object:

```typescript
// BEFORE
hooks: {
  Stop: [...],
  Notification: [  // DELETE THIS ENTIRE BLOCK
    {
      matcher: ".*",
      hooks: [{ type: "command", command: `${claudeLifecycleDir}/stop-hook.sh` }]
    }
  ]
}

// AFTER
hooks: {
  Stop: [...]
  // Notification hook removed
}
```

### After Code Change

Rebuild snapshots to apply the new settings.json:

```bash
# For PVE LXC
gh workflow run "Weekly PVE LXC Snapshot" --repo karlorz/cmux --ref main

# For Morph (production)
gh workflow run "Daily Morph Snapshot" --repo karlorz/cmux --ref main
```

## Verification - Immediate Test on Current LXC

### Step 1: Apply fix directly to running sandbox

```bash
# SSH to PVE and edit settings.json in container 296
ssh root@karlws-tailscale "pct exec 296 -- cat /root/.claude/settings.json" > /tmp/settings-before.json

# Remove Notification hook and write back
ssh root@karlws-tailscale 'pct exec 296 -- bash -c "cat > /root/.claude/settings.json" << '\''EOF'\''
{
  "alwaysThinkingEnabled": true,
  "apiKeyHelper": "/root/lifecycle/claude/secrets/anthropic_key_helper.sh",
  "hooks": {
    "Stop": [
      {
        "hooks": [
          {
            "type": "command",
            "command": "/root/lifecycle/claude/stop-hook.sh"
          }
        ]
      }
    ]
  },
  "env": {
    "CLAUDE_CODE_ENABLE_TELEMETRY": 0,
    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": 1,
    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": 1,
    "ANTHROPIC_BASE_URL": "https://bold-bandicoot-96.convex.site/api/anthropic",
    "ANTHROPIC_CUSTOM_HEADERS": "x-cmux-token:...\nx-cmux-source:cmux"
  }
}
EOF'
```

### Step 2: Clear hook log and restart Claude Code

```bash
# Clear the hook log
ssh root@karlws-tailscale "pct exec 296 -- rm /root/lifecycle/claude-hook.log"

# Kill any running claude process (it will be restarted when user sends message)
ssh root@karlws-tailscale "pct exec 296 -- pkill -f 'claude' || true"
```

### Step 3: Test - VERIFIED ✓

Hook log after fix shows only ONE trigger at 12:32:28:

```
[CMUX Stop Hook] Script started at Mon Feb  2 12:32:28 PM UTC 2026
[CMUX Stop Hook] API calls completed at Mon Feb  2 12:32:30 PM UTC 2026
```

After 60 seconds wait - still only one entry. **FIX WORKS!**

### Step 4: Apply permanent fix (PR #196 already merged)

1. Edit `packages/shared/src/providers/anthropic/environment.ts` - remove Notification hook (lines 226-236)
2. Run `bun check`
3. Commit changes
4. Rebuild snapshots

## PR Review Summary
- What Changed:
  - The `Notification` hook has been completely removed from the `hooks` object in `packages/shared/src/providers/anthropic/environment.ts`.
  - This change eliminates the configuration that caused the `/root/lifecycle/claude/stop-hook.sh` script to be executed whenever a Claude notification occurred.
- Review Focus:
  - Verify that no other legitimate functionality relied on the `Notification` hook for state updates or cleanup actions.
  - Confirm that the `Stop` hook correctly captures all necessary agent lifecycle events without any regressions.
- Test Plan:
  - Navigate to and view a completed Claude task in the UI.
  - Monitor the `/root/lifecycle/claude-hook.log` file on the sandbox/LXC.
  - Confirm that the `stop-hook.sh` script is triggered only once upon actual task completion and *not* repeatedly when viewing the task or receiving subsequent notifications.
  - Ensure that the task's read status remains 