### PR TITLE
[Crown] # Lazy Fetch for Archived Tasks Optimization Plan

## Problem...

### DIFF
--- a/packages/convex/convex/migrations/normalizeIsArchived.ts
+++ b/packages/convex/convex/migrations/normalizeIsArchived.ts
@@ -1,0 +1,64 @@
+/**
+ * Migration to normalize isArchived field on tasks table.
+ * Converts undefined -> false so we can efficiently use the by_team_user_archived index.
+ *
+ * Run this migration after deploying the schema update that adds the
+ * by_team_user_archived index.
+ *
+ * Usage:
+ *   1. Deploy schema with new index: bun run convex:deploy
+ *   2. Run migration until complete:
+ *      bunx convex run migrations/normalizeIsArchived:migrateTasksIsArchived
+ *   3. Repeat step 2 until it returns { processed: 0, hasMore: false }
+ */
+import { internalMutation } from "../_generated/server";
+
+/**
+ * Batch migration to normalize isArchived field on tasks.
+ * Processes 100 tasks at a time to avoid transaction timeouts.
+ *
+ * @returns { processed: number, hasMore: boolean }
+ *   - processed: number of tasks updated in this batch
+ *   - hasMore: true if more batches remain
+ */
+export const migrateTasksIsArchived = internalMutation({
+  handler: async (ctx) => {
+    // Find tasks where isArchived is undefined (not yet normalized)
+    const tasks = await ctx.db
+      .query("tasks")
+      .filter((q) => q.eq(q.field("isArchived"), undefined))
+      .take(100);
+
+    const now = Date.now();
+    for (const task of tasks) {
+      await ctx.db.patch(task._id, { isArchived: false, updatedAt: now });
+    }
+
+    return { processed: tasks.length, hasMore: tasks.length === 100 };
+  },
+});
+
+/**
+ * Batch migration to normalize isArchived field on taskRuns.
+ * Processes 100 taskRuns at a time to avoid transaction timeouts.
+ *
+ * @returns { processed: number, hasMore: boolean }
+ *   - processed: number of taskRuns updated in this batch
+ *   - hasMore: true if more batches remain
+ */
+export const migrateTaskRunsIsArchived = internalMutation({
+  handler: async (ctx) => {
+    // Find taskRuns where isArchived is undefined (not yet normalized)
+    const taskRuns = await ctx.db
+      .query("taskRuns")
+      .filter((q) => q.eq(q.field("isArchived"), undefined))
+      .take(100);
+
+    const now = Date.now();
+    for (const run of taskRuns) {
+      await ctx.db.patch(run._id, { isArchived: false, updatedAt: now });
+    }
+
+    return { processed: taskRuns.length, hasMore: taskRuns.length === 100 };
+  },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -177,6 +177,7 @@ const convexSchema = defineSchema({
     .index("by_created", ["createdAt"])
     .index("by_user", ["userId", "createdAt"])
     .index("by_team_user", ["teamId", "userId"])
+    .index("by_team_user_archived", ["teamId", "userId", "isArchived"])
     .index("by_team_user_activity", ["teamId", "userId", "lastActivityAt"])
     .index("by_pinned", ["pinned", "teamId", "userId"])
     .index("by_team_user_preview", ["teamId", "userId", "isPreview"])


### PR DESCRIPTION
## Task

# Lazy Fetch for Archived Tasks Optimization Plan

## Problem Summary

The following Convex queries are fetching all tasks (archived or not) and filtering client-side:

| Function | Current Behavior | Bandwidth Impact |
|----------|------------------|------------------|
| `tasks.get` | Filters `isArchived` post-index | 1.66 GB |
| `tasks.getWithNotificationOrder` | Filters `isArchived` post-index | 1.01 GB |
| `tasks.getTasksWithTaskRuns` | Filters `isArchived` post-index | 892.55 MB |
| `taskRuns.getByTask` | Queries all runs for a task | Depends on task |

### Current Index Structure

```ts
// tasks table indexes (schema.ts:177-185)
.index("by_team_user", ["teamId", "userId"])           // Most queries use this
.index("by_team_user_activity", ["teamId", "userId", "lastActivityAt"])
```

**Issue:** `isArchived` is NOT in the index - queries must scan all tasks then filter, wasting bandwidth.

### Why `.filter()` Consumes Full Bandwidth (Critical)

From Convex documentation:

> **"`.filter()`&#32;evaluates on every document in the index range rather than using the index itself"**

This means the current pattern:

```ts
ctx.db.query("tasks")
  .withIndex("by_team_user", (idx) => idx.eq("teamId", t).eq("userId", u))
  .filter((q) => q.neq(q.field("isArchived"), true))  // ⚠️ READS ALL DOCS
  .collect()
```

**Reads 100% of documents** matching `(teamId, userId)`, then filters in memory.

- If user has 100 tasks (80 active, 20 archived)
- **Current:** Reads 100 documents → returns 80 (wastes 20% bandwidth)
- **With index:** Reads only 80 documents → returns 80 (no waste)

**Conclusion:** Adding `isArchived` to index is the ONLY way to reduce bandwidth.

---

## Proposed Solution: Add `isArchived` to Index

### Option 1: Compound Index (Recommended)

Add a new index that includes `isArchived`:

```ts
// New index for efficient archived filtering
.index("by_team_user_archived", ["teamId", "userId", "isArchived"])
```

**Benefits:**

- Index can directly skip archived documents
- No scan of archived tasks at all
- Works with existing query patterns

**Caveat:** Convex doesn't support inequality on indexed fields after equality. Since we filter `isArchived !== true` (not equals), we'd need to:

- Query twice: `isArchived: false` + `isArchived: undefined`
- OR: Normalize `isArchived` to always be `true`/`false` (migration required)

### Option 2: Use Existing Paginated Queries

The codebase already has paginated variants that aren't being used:

- `tasks.getPaginated`
- `tasks.getWithNotificationOrderPaginated`
- `tasks.getArchivedPaginated`

Switch frontend from `.collect()` queries to paginated queries.

---

## Implementation Plan

### Phase 1: Schema/Index Update

**File:** `packages/convex/convex/schema.ts`

Add compound index for archived filtering:

```ts
// Line 179, add after by_team_user
.index("by_team_user_archived", ["teamId", "userId", "isArchived"])
```

### Phase 2: Update Query Functions

**File:** `packages/convex/convex/tasks.ts`

#### 2.1 Update `tasks.get` (line 98)

```ts
// Change from:
let q = ctx.db
  .query("tasks")
  .withIndex("by_team_user", ...)
  .filter((qq) => qq.neq(qq.field("isArchived"), true));

// To: Use new index with explicit isArchived values
const nonArchivedTasks = await ctx.db
  .query("tasks")
  .withIndex("by_team_user_archived", (idx) =>
    idx.eq("teamId", teamId).eq("userId", userId).eq("isArchived", false)
  )
  .collect();

const undefinedArchivedTasks = await ctx.db
  .query("tasks")
  .withIndex("by_team_user_archived", (idx) =>
    idx.eq("teamId", teamId).eq("userId", userId)
  )
  .filter((qq) => qq.eq(qq.field("isArchived"), undefined))
  .collect();

const tasks = [...nonArchivedTasks, ...undefinedArchivedTasks];
```

**After migration completes:** Use single query:

```ts
const tasks = await ctx.db
  .query("tasks")
  .withIndex("by_team_user_archived", (idx) =>
    idx.eq("teamId", teamId).eq("userId", userId).eq("isArchived", false)
  )
  .collect();
```

#### 2.2 Apply same pattern to:

- `tasks.getWithNotificationOrder` (line 224)
- `tasks.getTasksWithTaskRuns` (line 509)
- `tasks.getPinned` (line 462)

### Phase 3: Migration (Required)

Normalize `isArchived` field to always be `boolean` instead of `boolean | undefined`:

**File:** `packages/convex/convex/migrations/normalizeIsArchived.ts`

```ts
// Batch migration to set isArchived: false where undefined
export const normalizeIsArchived = internalMutation({
  handler: async (ctx) => {
    const tasks = await ctx.db
      .query("tasks")
      .filter((q) => q.eq(q.field("isArchived"), undefined))
      .take(100);

    for (const task of tasks) {
      await ctx.db.patch(task._id, { isArchived: false });
    }

    return { processed: tasks.length, hasMore: tasks.length === 100 };
  },
});
```

---

## Files to Modify

| File | Changes |
|------|---------|
| `packages/convex/convex/schema.ts` | Add `by_team_user_archived` index |
| `packages/convex/convex/tasks.ts` | Update queries to use new index |
| `packages/convex/convex/migrations/` | Add normalization migration (new file) |

---

## Verification

1. **Deploy schema change** - `bun run convex:deploy:prod`
2. **Run migration** - Execute `normalizeIsArchived` until complete
3. **Update queries** - Switch to single-query pattern using new index
4. **Deploy query changes** - `bun run convex:deploy:prod`
5. **Run&#32;`bun check`** - Verify no type errors
6. **Monitor dashboard** - Check bandwidth metrics after 24h
7. **Expected impact:** 30-50% reduction in `tasks.*` query bandwidth

---

## Frontend Usage Analysis

### Query Usage Summary

| Query | Usage Count | Key Files |
|-------|-------------|-----------|
| `tasks.get` | 8 files | `useArchiveTask.ts`, `dashboard.tsx`, `TaskList.tsx`, `TaskTree.tsx`, `TaskItem.tsx` |
| `tasks.getWithNotificationOrder` | 2 files | `_layout.$teamSlugOrId.tsx`, `workspaces.tsx` |
| `tasks.getTasksWithTaskRuns` | 1 file | `CommandBar.tsx` |
| `taskRuns.getByTask` | 11 files | Widely used for task details and optimistic updates |

### Critical: Optimistic Update Cache Keys

The frontend uses `localStore.getQuery` / `localStore.setQuery` for optimistic updates. These depend on **exact parameter matching**:

```ts
// apps/client/src/hooks/useArchiveTask.ts
localStore.getQuery(api.tasks.get, { teamSlugOrId, archived: false })
localStore.getQuery(api.tasks.get, { teamSlugOrId, archived: true })
```

**Requirement:** Query signatures and parameter variants MUST remain unchanged for cache coherency.

### Parameter Variants in Use

| Query | Parameter Variants |
|-------|-------------------|
| `tasks.get` | `{}`, `{archived: false}`, `{archived: true}`, `{excludeLocalWorkspaces: true}` |
| `tasks.getWithNotificationOrder` | `{}`, `{excludeLocalWorkspaces: true}` |
| `tasks.getTasksWithTaskRuns` | `{archived: false}` (hardcoded) |

---

## Breaking Change Risk Assessment

| Risk Level | Area | Mitigation |
|------------|------|------------|
| **NONE** | API Signatures | Query parameters unchanged - only internal index usage changes |
| **NONE** | Return Types | Same projected fields returned |
| **NONE** | Cache Keys | Parameter variants preserved |
| **LOW** | Query Behavior | After migration, `isArchived: undefined` becomes `false` - same semantic meaning |

**Conclusion:** This optimization is **backward compatible** - no frontend changes required.

---

## Context7 API Documentation Verification

Verified against Context7 docs for `/karlorz/cmux`:

| Endpoint | `archived` param | `isArchived` in response |
|----------|-----------------|--------------------------|
| `GET /api/tasks/get` | Required boolean | Optional `isArchived?: boolean` |
| `GET /api/tasks/getWithNotificationOrder` | Required boolean | Same as above |
| `GET /api/taskRuns/getForTask` | `includeArchived` boolean | N/A (task runs don't expose this) |

**API Contract Compliance:**

- `isArchived` field remains `optional` in response type (no schema change)
- Migration normalizes `undefined` → `false` which maintains backward compatibility
- All documented parameter variants remain supported

---

## Notes

- `taskRuns.getByTask` already filters by task, so `isArchived` optimization is less impactful there
- The `archived: true` parameter in queries already works correctly - this optimizes the default `archived: false` case
- Paginated queries (`getPaginated`, `getArchivedPaginated`) remain as options for very large task lists

## PR Review Summary
- **What Changed:**
  - Added a new Convex index `by_team_user_archived` to `packages/convex/convex/schema.ts` for the `tasks` table, including `teamId`, `userId`, and `isArchived`.
  - Modified `tasks.ts` functions (`tasks.get`, `tasks.getWithNotificationOrder`, `tasks.getTasksWithTaskRuns`, `tasks.getPinned`, `tasks.getArchivedPaginated`) to leverage the new `by_team_user_archived` index.
  - Queries for non-archived tasks now perform two lookups: one for `isArchived: false` using the new index and another for `isArchived: undefined` using the old `by_team_user` index to handle pre-migration data. This temporary dual query will be removed post-migration.
  - Queries for explicitly archived tasks (`args.archived === true`) now directly use the new index with `isArchived: true`.
  - Introduced a new internal migration file `packages/convex/convex/migrations/normalizeIsArchived.ts` with `migrateTasksIsArchived` and `migrateTaskRunsIsArchived` mutations. These mutations normalize the `isArchived` field from `undefined` to `false` in batches for both `tasks` and `taskRuns` tables.

- **Review Focus:**
  - Verify the correctness of the new indexed queries, especially the temporary dual-query logic for handling `isArchived: undefined` and `isArchived: false` during the migration period.
  - Ensure all existing filters (e.g., `isPreview`, `linkedFromCloudTaskRunId`, `isLocalWorkspace`, `projectFullName`) are correctly applied and no tasks are unintentionally excluded or included.
  - Confirm the `normalizeIsArchived` migration effectively updates all relevant documents without data loss or unexpected side effects.
  - Pay close attention to the `tasks.getPinned` query, which was also updated but not explicitly detailed in the problem summary, to ensure its logic remains correct.

- **Test Plan:**
  1. **Deploy Schema:** Run `bun run convex:deploy:prod` to apply the new index.
  2. **Run Migration:** Execute `bunx convex run migrations/normalizeIsArchived:migrateTasksIsArchived` repeatedly until it reports `{ processed: 0, hasMore: false }`. Repeat for `migrateTaskRunsIsArchived`.
  3. **Frontend Validation:** Navigate through the application to verify that all task lists (Dashboard, Task Tree, Command Bar, Notification Order) display active and archived tasks correctly.
  4. **Archiving/Unarchiving:** Test archiving and unarchiving tasks to ensure state changes are reflected accurately and immediately via optimistic updates.
  5. **Convex Dashboard:** Monitor bandwidth metrics for `tasks.get`, `tasks.getWithNotificationOrder`, and `tasks.getTasksWithTaskRuns` to confirm the expected 30-50% reduction post-migration.

- **Follow-ups:**
  - After the `normalizeIsArchived` migration is fully completed and verified, remove the temporary query logic for `isArchived: undefined` from `packages/convex/convex/tasks.ts` to simplify the code and rely solely on the `isArchived: false` index lookup for non-archived tasks.