### PR TITLE
[Crown] # Fix Preview Config Page for PVE LXC Sandbox Provider

## Pr...

### DIFF
--- a/apps/www/components/preview/preview-configure-client.tsx
+++ b/apps/www/components/preview/preview-configure-client.tsx
@@ -23,8 +23,8 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { formatEnvVarsContent } from "@cmux/shared/utils/format-env-vars-content";
-import { DEFAULT_PREVIEW_CONFIGURE_SNAPSHOT_ID } from "@cmux/shared";
 import clsx from "clsx";
+import type { SandboxConfig } from "@cmux/shared";
 import {
   FrameworkPresetSelect,
   getFrameworkPresetConfig,
@@ -84,6 +84,8 @@ type PreviewConfigureClientProps = {
   initialMaintenanceScript?: string | null;
   initialDevScript?: string | null;
   startAtConfigureEnvironment?: boolean;
+  sandboxConfig: SandboxConfig;
+  initialSnapshotId: MachinePresetId;
 };
 
 function normalizeVncUrl(url: string): string | null {
@@ -425,6 +427,8 @@ export function PreviewConfigureClient({
   initialMaintenanceScript,
   initialDevScript,
   startAtConfigureEnvironment = false,
+  sandboxConfig,
+  initialSnapshotId,
 }: PreviewConfigureClientProps) {
   const initialEnvPrefilled = useMemo(
     () =>
@@ -488,7 +492,7 @@ export function PreviewConfigureClient({
   const [hasTouchedEnvVars, setHasTouchedEnvVars] = useState(false);
   const [frameworkPreset, setFrameworkPreset] = useState<FrameworkPreset>("other");
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<MachinePresetId>(
-    DEFAULT_PREVIEW_CONFIGURE_SNAPSHOT_ID
+    initialSnapshotId
   );
   const [maintenanceScript, setMaintenanceScript] = useState("");
   const [devScript, setDevScript] = useState("");
@@ -732,7 +736,7 @@ export function PreviewConfigureClient({
           repoUrl: `https://github.com/${repo}`,
           branch: "main",
           ttlSeconds: 3600,
-          snapshotId: selectedSnapshotId,
+          ...(selectedSnapshotId ? { snapshotId: selectedSnapshotId } : {}),
         }),
       });
 
@@ -1555,6 +1559,8 @@ export function PreviewConfigureClient({
 
         {/* Machine Size Preset */}
         <MachinePresetSelect
+          provider={sandboxConfig.provider}
+          presets={sandboxConfig.presets}
           value={selectedSnapshotId}
           onValueChange={setSelectedSnapshotId}
         />


### PR DESCRIPTION
## Task

# Fix Preview Config Page for PVE LXC Sandbox Provider

## Problem

The Preview Config page (`/preview/configure`) fails with:

```
Forbidden: Instance provider does not match active sandbox provider
```

## Root Cause Analysis

### Error Location

The error is thrown in `apps/www/lib/routes/environments.route.ts`:

- **Line 291-296**: CREATE ENVIRONMENT endpoint (`POST /environments`)
- **Line 1035-1040**: CREATE SNAPSHOT VERSION endpoint (`POST /environments/{id}/snapshots`)

```typescript
const provider = getActiveSandboxProvider().provider;
const instanceProvider = detectInstanceProvider(body.instanceId);
if (instanceProvider !== "other" && instanceProvider !== provider) {
  return c.text(
    "Forbidden: Instance provider does not match active sandbox provider",
    403
  );
}
```

### Provider Detection Logic

In `apps/www/lib/utils/sandbox-provider.ts`:

```typescript
const detectInstanceProvider = (instanceId: string) => {
  if (instanceId.startsWith("morphvm_")) return "morph";
  if (instanceId.startsWith("pvelxc-")) return "pve-lxc";
  if (instanceId.startsWith("pvevm-")) return "pve-vm";
  return "other";
};
```

### The Mismatch

- User's `.env`: `SANDBOX_PROVIDER=pve-lxc`
- Preview Config UI: Tries to use Morph snapshots (`morphvm_*` IDs)
- Result: `pve-lxc !== morph` → 403 Forbidden

## Key Finding

**PVE LXC IS supported** for preview configs. The infrastructure exists:

- PVE LXC snapshots stored with `snapshotProvider: "pve-lxc"`
- Preview configs link to environments via `environmentId`
- Snapshot resolution handles multiple providers

**The issue**: The Preview Config UI (`preview-configure-client.tsx`) may be hardcoded to show/use only Morph snapshots.

---

## Solutions

### Option A: Fix Preview Config UI to Support PVE LXC (Full Fix)

1. Update `preview-configure-client.tsx` to detect active provider
2. Show appropriate snapshot options based on provider
3. Use correct snapshot IDs when provisioning

### Option B: Create Preview Config via API (Workaround)

Skip the UI and create preview config directly via:

1. Convex database insert
2. Or API call with correct PVE LXC environment ID

### Option C: Switch to Morph for Preview Testing (Quick Test)

Temporarily change `.env` to `SANDBOX_PROVIDER=morph` for testing the opt-in flags.

---

## Files to Modify (Option A)

| File | Change |
|------|--------|
| `apps/www/components/preview/preview-configure-client.tsx` | Detect provider, show correct snapshots |
| `apps/www/lib/routes/preview.route.ts` | Ensure PVE LXC snapshots are returned |
| `apps/www/app/(preview)/preview/configure/page.tsx` | Pass provider info to client |

---

## Implementation Plan (Option A: Full Fix)

### Problem Summary

The `MachinePresetSelect` component is **hardcoded to show only Morph presets**. It doesn't check the active sandbox provider or use the existing `PVE_LXC_SNAPSHOT_PRESETS`.

### What Already Works

- Backend supports multi-provider provisioning
- `resolveTeamAndSnapshot()` handles both Morph and PVE LXC
- `UI_VISIBLE_PRESET_IDS_BY_PROVIDER` already defines presets per provider
- PVE LXC presets exist: `["4vcpu_8gb_32gb", "6vcpu_8gb_40gb"]`

### Files to Modify

#### 1. `apps/www/lib/routes/sandboxes.route.ts`

Add new endpoint to return available presets based on active provider:

```typescript
// GET /api/sandboxes/presets
// Returns: { provider: string, presets: SandboxPreset[] }
```

#### 2. `apps/www/components/preview/machine-preset-select.tsx`

- Remove hardcoded `MORPH_SNAPSHOT_PRESETS` import
- Fetch presets from new API endpoint
- Accept `provider` prop to filter presets
- Use `filterVisiblePresets()` from `sandbox-presets.ts`

#### 3. `apps/www/components/preview/preview-configure-client.tsx`

- Fetch active provider on mount
- Pass provider to `MachinePresetSelect`
- Update default snapshot ID based on provider

#### 4. `apps/www/app/(preview)/preview/configure/page.tsx` (optional)

- Pass provider info from server-side if needed

### Implementation Steps

1. **Add API Endpoint** (`sandboxes.route.ts`):

```typescript
   app.openapi(
     createRoute({
       method: "get",
       path: "/sandboxes/presets",
       responses: { 200: { ... } },
     }),
     async (c) => {
       const { provider } = getActiveSandboxProvider();
       const presets = provider === "pve-lxc"
         ? PVE_LXC_SNAPSHOT_PRESETS
         : MORPH_SNAPSHOT_PRESETS;
       const visible = filterVisiblePresets(presets, provider);
       return c.json({ provider, presets: visible });
     }
   );
```

2. **Update MachinePresetSelect**:

- Add `provider` prop
- Import both `MORPH_SNAPSHOT_PRESETS` and `PVE_LXC_SNAPSHOT_PRESETS`
- Select presets based on provider
- Use `UI_VISIBLE_PRESET_IDS_BY_PROVIDER[provider]` for filtering

3. **Update PreviewConfigureClient**:

- Fetch `/api/sandboxes/presets` on mount
- Store provider and presets in state
- Pass to `MachinePresetSelect`
- Set appropriate default snapshot ID

### Verification

1. Set `SANDBOX_PROVIDER=pve-lxc` in `.env`
2. Run `./scripts/setup-convex-env.sh`
3. Navigate to `/preview/configure`
4. Verify PVE LXC presets are shown (not Morph)
5. Complete preview config setup without error
6. Test with a PR to verify screenshot workflow

---

## Status: Ready for Implementation

## PR Review Summary

- **What Changed**:
  - **Provider-Aware Configuration**: The Preview Config page now detects the active sandbox provider (Morph or PVE LXC) on the server and passes this context to the client.
  - **Dynamic Presets**: Refactored `MachinePresetSelect` to dynamically display and filter machine sizes based on the active provider using a new mapping: `ALLOWED_PRESET_IDS_BY_PROVIDER`.
  - **Snapshot Initialization**: Implemented `getPreviewDefaultSnapshotId` to intelligently select default snapshots (e.g., preferring the 6 vCPU 'performance' preset for PVE LXC).
  - **API Integration**: Updated the environment creation payload to include provider-appropriate `snapshotId` values, fixing the 403 Forbidden error caused by provider mismatches.

- **Review Focus**:
  - **Provider Mapping**: Verify the preset IDs in `ALLOWED_PRESET_IDS_BY_PROVIDER` for PVE LXC match the IDs defined in the infrastructure/database.
  - **Edge Cases**: Ensure the fallback logic in `getDefaultPresetId` is safe if a provider returns no presets.
  - **PVE-VM Support**: Note that `pve-vm` currently returns empty sets; confirm if this is intentional for this phase.

- **Test Plan**:
  - **LXC Validation**: Set `SANDBOX_PROVIDER=pve-lxc` in `.env`, navigate to `/preview/configure`, and verify that PVE-specific machine sizes (e.g., 6 vCPU, 8GB RAM) appear.
  - **Morph Regression**: Set `SANDBOX_PROVIDER=morph` and verify the UI correctly switches back to Morph-specific presets.
  - **End-to-End**: Complete a preview configuration flow and verify the resulting `POST /environments` request contains the correct snapshot ID for the selected provider.