### PR TITLE
fix: enable preview URLs for PVE-LXC sandbox provider

### DIFF
--- a/apps/client/src/components/TaskTree.tsx
+++ b/apps/client/src/components/TaskTree.tsx
@@ -98,7 +98,7 @@ type TaskRunStatus = "pending" | "running" | "completed" | "failed" | "skipped";
  * Feature flag to show/hide preview URLs in the sidebar.
  * Set to true to re-enable preview URLs and "Add preview URL" button.
  */
-const SHOW_PREVIEW_URLS = false;
+const SHOW_PREVIEW_URLS = true;
 
 function getStatusIcon(status: TaskRunStatus): ReactElement {
   switch (status) {

--- a/apps/client/src/components/environment/EnvironmentSetupFlow.tsx
+++ b/apps/client/src/components/environment/EnvironmentSetupFlow.tsx
@@ -123,7 +123,7 @@ export function EnvironmentSetupFlow({
   );
   const [maintenanceScript, setMaintenanceScript] = useState(initialMaintenanceScript);
   const [devScript, setDevScript] = useState(initialDevScript);
-  const [exposedPorts] = useState(initialExposedPorts);
+  const [exposedPorts, setExposedPorts] = useState(initialExposedPorts);
 
   // Error state
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -490,6 +490,7 @@ export function EnvironmentSetupFlow({
       maintenanceScript={maintenanceScript}
       devScript={devScript}
       envVars={envVars}
+      exposedPorts={exposedPorts}
       vscodeUrl={vscodeUrl}
       vncWebsocketUrl={vncWebsocketUrl}
       isSaving={createEnvironmentMutation.isPending}
@@ -498,6 +499,7 @@ export function EnvironmentSetupFlow({
       onMaintenanceScriptChange={handleMaintenanceScriptChange}
       onDevScriptChange={handleDevScriptChange}
       onEnvVarsChange={handleEnvVarsChange}
+      onExposedPortsChange={setExposedPorts}
       onConfigStepChange={handleConfigStepChange}
       onSave={handleSaveEnvironment}
       onBack={handleBackToInitialSetup}

--- a/apps/client/src/components/environment/EnvironmentWorkspaceConfig.tsx
+++ b/apps/client/src/components/environment/EnvironmentWorkspaceConfig.tsx
@@ -57,6 +57,7 @@ interface EnvironmentWorkspaceConfigProps {
   maintenanceScript: string;
   devScript: string;
   envVars: EnvVar[];
+  exposedPorts: string;
   vscodeUrl?: string;
   vncWebsocketUrl?: string;
   isSaving: boolean;
@@ -65,6 +66,7 @@ interface EnvironmentWorkspaceConfigProps {
   onMaintenanceScriptChange: (value: string) => void;
   onDevScriptChange: (value: string) => void;
   onEnvVarsChange: (updater: (prev: EnvVar[]) => EnvVar[]) => void;
+  onExposedPortsChange: (value: string) => void;
   onConfigStepChange?: (step: ConfigStep) => void;
   onSave: () => void;
   onBack: () => void;
@@ -90,6 +92,7 @@ export function EnvironmentWorkspaceConfig({
   maintenanceScript,
   devScript,
   envVars,
+  exposedPorts,
   vscodeUrl,
   vncWebsocketUrl,
   isSaving,
@@ -98,6 +101,7 @@ export function EnvironmentWorkspaceConfig({
   onMaintenanceScriptChange,
   onDevScriptChange,
   onEnvVarsChange,
+  onExposedPortsChange,
   onConfigStepChange,
   onSave,
   onBack,
@@ -630,6 +634,31 @@ export function EnvironmentWorkspaceConfig({
             })}
           </div>
         )}
+
+        {/* Exposed Ports (always visible, not a numbered step) */}
+        <details className="group" open>
+          <summary
+            className={clsx(
+              "flex items-center gap-2 cursor-pointer text-[13px] font-medium text-neutral-900 dark:text-neutral-100 list-none",
+              isSaving && "cursor-not-allowed opacity-60"
+            )}
+          >
+            <ChevronDown className="h-3.5 w-3.5 text-neutral-400 transition-transform -rotate-90 group-open:rotate-0" />
+            Exposed Ports
+          </summary>
+          <div className="mt-3 pl-5 space-y-2">
+            <input
+              type="text"
+              value={exposedPorts}
+              onChange={(e) => onExposedPortsChange(e.target.value)}
+              placeholder="3000, 5173, 8080"
+              className="w-full rounded-md border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 py-2 text-sm text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-neutral-300 dark:focus:ring-neutral-700"
+            />
+            <p className="text-xs text-neutral-400">
+              Comma-separated list of ports for preview URLs (e.g., dev server port)
+            </p>
+          </div>
+        </details>
 
         {/* Step 3: Run Scripts */}
         {isStepVisible("run-scripts") && (

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -532,8 +532,8 @@ export async function spawnAgent(
       `VSCode instance spawned for agent ${agent.name}: ${vscodeUrl}`
     );
 
-    if (options.isCloudMode && vscodeInstance instanceof CmuxVSCodeInstance) {
-      console.log("[AgentSpawner] [isCloudMode] Setting up devcontainer");
+    if (vscodeInstance instanceof CmuxVSCodeInstance) {
+      console.log("[AgentSpawner] Setting up devcontainer");
       void vscodeInstance
         .setupDevcontainer()
         .catch((err) =>


### PR DESCRIPTION
## Summary
- Enable `SHOW_PREVIEW_URLS` flag in TaskTree.tsx to show preview URLs in task tree sidebar
- Add "Exposed Ports" field to Environment Setup Flow UI
- Fix PVE-LXC preview URLs not appearing by:
  - Calling `setupDevcontainer()` for all sandbox providers (not just Morph)
  - Getting `environmentId` from taskRun instead of instance metadata (PVE-LXC doesn't persist metadata)
  - Skipping `reloadInstance()` after exposing services for PVE-LXC (prevents wiping in-memory services)

## Test plan
- [x] Create environment with `exposedPorts: [3000, 5173]` via UI
- [x] Start new task using the environment
- [x] Verify "Preview (port 3000)" and "Preview (port 5173)" appear in task tree
- [x] Click preview URL and verify it loads in Browser panel