### PR TITLE
feat: Add Cloudflare Worker edge router for PVE-LXC preview URLs

### DIFF
--- a/apps/edge-router-pvelxc/package.json
+++ b/apps/edge-router-pvelxc/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cmux/edge-router-pvelxc",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "4"
+  }
+}

--- a/apps/edge-router-pvelxc/src/index.ts
+++ b/apps/edge-router-pvelxc/src/index.ts
@@ -1,0 +1,705 @@
+// Edge Router for PVE-LXC sandboxes on alphasolves.com
+// Based on apps/edge-router/src/index.ts but modified for PVE-LXC URL patterns
+
+// Service worker content for PVE-LXC
+const SERVICE_WORKER_JS = `
+
+function isLoopbackHostname(hostname) {
+  if (!hostname) {
+    return false;
+  }
+
+  if (hostname === 'localhost' || hostname === '0.0.0.0') {
+    return true;
+  }
+
+  if (hostname === '::1' || hostname === '[::1]' || hostname === '::') {
+    return true;
+  }
+
+  return /^127(?:\\.\\d{1,3}){3}$/.test(hostname);
+}
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  // Check if request is to localhost or a loopback IP with a port
+  if (isLoopbackHostname(url.hostname) && url.port) {
+    // Get the instance ID from the current page's subdomain
+    const currentHost = self.location.hostname;
+    const instanceMatch = currentHost.match(/port-\\d+-pvelxc-([^.]+)\\.alphasolves\\.com/);
+
+    if (instanceMatch) {
+      const instanceId = instanceMatch[1];
+      // Redirect to port-PORT-pvelxc-[instanceId].alphasolves.com
+      const redirectUrl = \`https://port-\${url.port}-pvelxc-\${instanceId}.alphasolves.com\${url.pathname}\${url.search}\`;
+
+      // Create new headers, but let the browser handle Host header
+      const headers = new Headers(event.request.headers);
+      headers.delete('Host');
+      headers.set('Host', 'alphasolves.com');
+      headers.delete('X-Forwarded-Host');
+      headers.delete('X-Forwarded-For');
+      headers.delete('X-Real-IP');
+
+      // Create a completely new request to avoid any caching or DNS issues
+      const newRequest = new Request(redirectUrl, {
+        method: event.request.method,
+        headers: headers,
+        body: event.request.method !== 'GET' && event.request.method !== 'HEAD'
+          ? event.request.body
+          : undefined,
+        mode: 'cors',
+        credentials: event.request.credentials,
+        redirect: 'follow',
+      });
+
+      event.respondWith(fetch(newRequest));
+      return;
+    }
+  }
+
+  // For all other requests, proceed normally
+});`;
+
+// Function to rewrite JavaScript code
+function rewriteJavaScript(
+  code: string,
+  isExternalFile: boolean = false
+): string {
+  // Skip if it's our injected code
+  if (code.includes("__CMUX_NO_REWRITE__")) {
+    return code;
+  }
+
+  // For external files, we need to ensure __cmuxLocation exists first
+  const prefix = isExternalFile
+    ? `
+// Injected by cmux proxy - ensure __cmuxLocation exists
+(function() {
+  if (typeof window === 'undefined') return;
+
+  // If __cmuxLocation already exists, we're done
+  if (window.__cmuxLocation && window.__cmuxLocation.href) return;
+
+  // Create a temporary __cmuxLocation that uses real location
+  if (!window.__cmuxLocation) {
+    window.__cmuxLocation = window.location;
+  }
+
+  // Also ensure document.__cmuxLocation exists
+  if (typeof document !== 'undefined' && !document.__cmuxLocation) {
+    Object.defineProperty(document, '__cmuxLocation', {
+      get: function() {
+        return window.__cmuxLocation || window.location;
+      },
+      configurable: true
+    });
+  }
+})();
+`
+    : "";
+
+  // Replace various patterns of location access
+  let modified = code
+    .replace(/\bwindow\.location\b/g, "window.__cmuxLocation")
+    .replace(/\bdocument\.location\b/g, "document.__cmuxLocation");
+
+  if (!isExternalFile) {
+    modified = modified.replace(/\blocation\b/g, (match, offset) => {
+      const before = modified.substring(Math.max(0, offset - 20), offset);
+      const after = modified.substring(
+        offset + match.length,
+        Math.min(modified.length, offset + match.length + 10)
+      );
+
+      if (/\b(const|let|var)\s+$/.test(before)) return match;
+      if (/[{,]\s*$/.test(before) && /\s*[:},]/.test(after)) return match;
+      if (/\(\s*$/.test(before) || /^\s*[,)]/.test(after)) return match;
+      if (/\.\s*$/.test(before)) return match;
+      if (/^\s*:/.test(after)) return match;
+      if (/__cmux$/.test(before)) return match;
+
+      return "__cmuxLocation";
+    });
+  }
+
+  modified = modified
+    .replace(/window\.__cmux__cmuxLocation/g, "window.__cmuxLocation")
+    .replace(/document\.__cmux__cmuxLocation/g, "document.__cmuxLocation")
+    .replace(/__cmux__cmuxLocation/g, "__cmuxLocation");
+
+  return prefix + modified;
+}
+
+const REWRITTEN_RESPONSE_IGNORED_HEADERS = [
+  "content-encoding",
+  "content-length",
+  "transfer-encoding",
+  "content-md5",
+  "content-digest",
+  "etag",
+];
+
+function sanitizeRewrittenResponseHeaders(source: Headers): Headers {
+  const headers = new Headers(source);
+  for (const header of REWRITTEN_RESPONSE_IGNORED_HEADERS) {
+    headers.delete(header);
+  }
+  return headers;
+}
+
+function stripCSPHeaders(source: Headers): Headers {
+  const headers = new Headers(source);
+  headers.delete("content-security-policy");
+  headers.delete("content-security-policy-report-only");
+  return headers;
+}
+
+function addPermissiveCORS(headers: Headers): Headers {
+  headers.set("access-control-allow-origin", "*");
+  headers.set(
+    "access-control-allow-methods",
+    "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD"
+  );
+  headers.set("access-control-allow-headers", "*");
+  headers.set("access-control-expose-headers", "*");
+  headers.set("access-control-allow-credentials", "true");
+  headers.set("access-control-max-age", "86400");
+  return headers;
+}
+
+class ScriptRewriter {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  element(_element: any) {
+    // Currently no-op
+  }
+}
+
+class MetaCSPRewriter {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  element(element: any) {
+    const httpEquiv = element.getAttribute("http-equiv");
+    if (httpEquiv?.toLowerCase() === "content-security-policy") {
+      element.remove();
+    }
+  }
+}
+
+class HeadRewriter {
+  private skipServiceWorker: boolean;
+
+  constructor(skipServiceWorker: boolean = false) {
+    this.skipServiceWorker = skipServiceWorker;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  element(element: any) {
+    // Config script with localhost interceptors for PVE-LXC
+    element.prepend(
+      `<script data-cmux-injected="true">
+// __CMUX_NO_REWRITE__ - This marker prevents this script from being rewritten
+window.cmuxConfig = {
+  provider: "pvelxc"
+};
+
+// Store the real location object (before any rewriting happens)
+const __realLocation = window.location;
+
+// Determine if a hostname should be treated as loopback/local
+function isLoopbackHostname(hostname) {
+  if (!hostname) {
+    return false;
+  }
+
+  if (hostname === 'localhost' || hostname === '0.0.0.0') {
+    return true;
+  }
+
+  if (hostname === '::1' || hostname === '[::1]' || hostname === '::') {
+    return true;
+  }
+
+  return /^127(?:\\.\\d{1,3}){3}$/.test(hostname);
+}
+
+// Function to replace loopback URLs with alphasolves.com proxy
+function replaceLocalhostUrl(url) {
+  try {
+    const urlObj = new URL(url, __realLocation.href);
+    if (isLoopbackHostname(urlObj.hostname) && urlObj.port) {
+      const currentHost = __realLocation.hostname;
+      const instanceMatch = currentHost.match(/port-\\d+-pvelxc-([^.]+)\\.alphasolves\\.com/);
+
+      if (instanceMatch) {
+        const instanceId = instanceMatch[1];
+        urlObj.protocol = 'https:';
+        urlObj.hostname = \`port-\${urlObj.port}-pvelxc-\${instanceId}.alphasolves.com\`;
+        urlObj.port = '';
+        return urlObj.toString();
+      }
+    }
+    return url;
+  } catch {
+    return url;
+  }
+}
+
+// Create our proxy location object that intercepts everything
+const __cmuxLocation = new Proxy({}, {
+  get(target, prop) {
+    if (prop === Symbol.toStringTag) {
+      return 'Location';
+    }
+    if (prop === Symbol.toPrimitive) {
+      return function(hint) {
+        return __realLocation.href;
+      };
+    }
+
+    if (prop === 'assign') {
+      return function(url) {
+        const newUrl = replaceLocalhostUrl(url);
+        return __realLocation.assign(newUrl);
+      };
+    }
+    if (prop === 'replace') {
+      return function(url) {
+        const newUrl = replaceLocalhostUrl(url);
+        return __realLocation.replace(newUrl);
+      };
+    }
+    if (prop === 'reload') {
+      return function() {
+        return __realLocation.reload.apply(__realLocation, arguments);
+      };
+    }
+
+    if (prop === 'toString') {
+      return function() {
+        return __realLocation.toString();
+      };
+    }
+    if (prop === 'valueOf') {
+      return function() {
+        return __realLocation.valueOf();
+      };
+    }
+
+    const locationProps = [
+      'href', 'origin', 'protocol', 'host', 'hostname', 'port',
+      'pathname', 'search', 'hash', 'username', 'password', 'searchParams'
+    ];
+
+    if (locationProps.includes(prop)) {
+      return __realLocation[prop];
+    }
+
+    const value = __realLocation[prop];
+    if (value !== undefined) {
+      if (typeof value === 'function') {
+        return value.bind(__realLocation);
+      }
+      return value;
+    }
+
+    return undefined;
+  },
+  set(target, prop, value) {
+    if (prop === 'href') {
+      const newUrl = replaceLocalhostUrl(value);
+      __realLocation.href = newUrl;
+      return true;
+    }
+
+    const settableProps = ['hash', 'search', 'pathname', 'port', 'hostname', 'host', 'protocol'];
+    if (settableProps.includes(prop)) {
+      __realLocation[prop] = value;
+      return true;
+    }
+
+    return true;
+  },
+  has(target, prop) {
+    return prop in __realLocation;
+  },
+  ownKeys(target) {
+    return Object.keys(__realLocation);
+  },
+  getOwnPropertyDescriptor(target, prop) {
+    return Object.getOwnPropertyDescriptor(__realLocation, prop);
+  }
+});
+
+window.__cmuxLocation = __cmuxLocation;
+window.__cmuxLocationProxy = __cmuxLocation;
+
+try {
+  Object.defineProperty(window, '__cmuxLocation', {
+    value: __cmuxLocation,
+    writable: false,
+    configurable: true
+  });
+} catch (e) {
+  // Already defined
+}
+
+try {
+  if (window.parent && window.parent !== window) {
+    window.parent.__cmuxLocation = __cmuxLocation;
+  }
+} catch (e) {
+  // Cross-origin
+}
+
+try {
+  if (window.top && window.top !== window) {
+    window.top.__cmuxLocation = __cmuxLocation;
+  }
+} catch (e) {
+  // Cross-origin
+}
+
+const originalGetElementById = document.getElementById;
+if (originalGetElementById) {
+  document.getElementById = function(id) {
+    const element = originalGetElementById.call(this, id);
+    if (element && element.tagName === 'IFRAME') {
+      try {
+        if (element.contentWindow) {
+          element.contentWindow.__cmuxLocation = __cmuxLocation;
+        }
+      } catch (e) {
+        // Cross-origin or not ready
+      }
+    }
+    return element;
+  };
+}
+
+try {
+  Object.defineProperty(document, 'location', {
+    get() { return __cmuxLocation; },
+    set(value) {
+      const newUrl = replaceLocalhostUrl(value);
+      __realLocation.href = newUrl;
+    },
+    configurable: true
+  });
+} catch (e) {
+}
+
+document.__cmuxLocation = __cmuxLocation;
+
+try {
+  Object.defineProperty(window, 'location', {
+    get() { return __cmuxLocation; },
+    set(value) {
+      if (typeof value === 'string') {
+        const newUrl = replaceLocalhostUrl(value);
+        __realLocation.href = newUrl;
+      } else {
+        __realLocation = value;
+      }
+    },
+    configurable: true
+  });
+} catch (e) {
+  // Expected to fail in most browsers
+}
+
+// Intercept window.open
+const originalOpen = window.open;
+window.open = function(url, ...args) {
+  const newUrl = replaceLocalhostUrl(url);
+  return originalOpen.call(this, newUrl, ...args);
+};
+
+// Intercept anchor tag clicks
+document.addEventListener('click', function(e) {
+  const target = e.target.closest('a');
+  if (target && target.href) {
+    const originalHref = target.getAttribute('href');
+    const newUrl = replaceLocalhostUrl(target.href);
+    if (newUrl !== target.href) {
+      e.preventDefault();
+      window.location.href = newUrl;
+    }
+  }
+}, true);
+
+// Intercept form submissions
+document.addEventListener('submit', function(e) {
+  const form = e.target;
+  if (form && form.action) {
+    const newAction = replaceLocalhostUrl(form.action);
+    if (newAction !== form.action) {
+      form.action = newAction;
+    }
+  }
+}, true);
+
+// Intercept history.pushState and history.replaceState
+const originalPushState = history.pushState;
+history.pushState = function(state, title, url) {
+  if (url) {
+    const newUrl = replaceLocalhostUrl(url);
+    return originalPushState.call(this, state, title, newUrl);
+  }
+  return originalPushState.apply(this, arguments);
+};
+
+const originalReplaceState = history.replaceState;
+history.replaceState = function(state, title, url) {
+  if (url) {
+    const newUrl = replaceLocalhostUrl(url);
+    return originalReplaceState.call(this, state, title, newUrl);
+  }
+  return originalReplaceState.apply(this, arguments);
+};
+
+function startMutationObserver() {
+  if (!document.body) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', startMutationObserver);
+    }
+    return;
+  }
+
+  const observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'onclick') {
+        const element = mutation.target;
+        const onclickStr = element.getAttribute('onclick');
+        if (onclickStr && onclickStr.includes('localhost')) {
+          console.warn('Detected onclick with localhost:', onclickStr);
+        }
+      }
+    });
+  });
+
+  observer.observe(document.body, {
+    attributes: true,
+    attributeFilter: ['onclick'],
+    subtree: true,
+    childList: true
+  });
+}
+
+startMutationObserver();
+</script>`,
+      { html: true }
+    );
+
+    // Service worker registration script (conditional)
+    if (!this.skipServiceWorker) {
+      element.prepend(
+        `<script data-cmux-injected="true">
+// __CMUX_NO_REWRITE__ - This marker prevents this script from being rewritten
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/proxy-sw.js', { scope: '/' }).catch(console.error);
+}
+</script>`,
+        { html: true }
+      );
+    }
+  }
+}
+
+const LOOPBACK_V4_REGEX = /^127(?:\.\d{1,3}){3}$/;
+
+function isLoopbackHostnameValue(hostname: string | null | undefined): boolean {
+  if (!hostname) {
+    return false;
+  }
+
+  const normalized = hostname.toLowerCase();
+
+  if (normalized === "localhost" || normalized === "0.0.0.0") {
+    return true;
+  }
+
+  if (normalized === "::1" || normalized === "[::1]" || normalized === "::") {
+    return true;
+  }
+
+  return LOOPBACK_V4_REGEX.test(normalized);
+}
+
+function rewriteLoopbackRedirect(
+  response: Response,
+  buildProxyHost: (port: string) => string | null
+): Response {
+  const location = response.headers.get("location");
+  if (!location) {
+    return response;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(location);
+  } catch {
+    return response;
+  }
+
+  if (!isLoopbackHostnameValue(parsed.hostname)) {
+    return response;
+  }
+
+  const port = parsed.port;
+  const proxyHost = buildProxyHost(port);
+  if (!proxyHost) {
+    return response;
+  }
+
+  parsed.protocol = "https:";
+  parsed.hostname = proxyHost;
+  parsed.port = "";
+
+  const rewritten = parsed.toString();
+  if (rewritten === location) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set("location", rewritten);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const host = url.hostname.toLowerCase();
+
+    // Only process PVE-LXC preview URLs
+    // Pattern: port-{PORT}-pvelxc-{INSTANCE}.alphasolves.com
+    const pvelxcMatch = host.match(
+      /^port-(\d+)-pvelxc-([^.]+)\.alphasolves\.com$/
+    );
+
+    if (!pvelxcMatch) {
+      // PASS-THROUGH: Not a PVE-LXC preview URL
+      // CF Tunnel, Caddy, other services handle these
+      return fetch(request);
+    }
+
+    const [, port, instanceId] = pvelxcMatch;
+
+    // Serve the service worker file
+    if (url.pathname === "/proxy-sw.js") {
+      return new Response(SERVICE_WORKER_JS, {
+        headers: {
+          "content-type": "application/javascript",
+          "cache-control": "no-cache",
+        },
+      });
+    }
+
+    // Handle OPTIONS preflight for VS Code port (39378)
+    if (port === "39378" && request.method === "OPTIONS") {
+      return new Response(null, {
+        status: 204,
+        headers: addPermissiveCORS(new Headers()),
+      });
+    }
+
+    // Prevent infinite loops
+    const isAlreadyProxied = request.headers.get("X-Cmux-Proxied") === "true";
+    if (isAlreadyProxied) {
+      return new Response("Loop detected in proxy", { status: 508 });
+    }
+
+    // Forward to the same URL (CF Tunnel handles final routing)
+    const target = new URL(url.pathname + url.search, `https://${host}`);
+
+    const headers = new Headers(request.headers);
+    headers.set("X-Cmux-Proxied", "true");
+
+    const outbound = new Request(target, {
+      method: request.method,
+      headers: headers,
+      body: request.body,
+      redirect: "manual",
+    });
+
+    // WebSocket upgrades must be returned directly without modification
+    const upgradeHeader = request.headers.get("Upgrade");
+    if (upgradeHeader?.toLowerCase() === "websocket") {
+      return fetch(outbound);
+    }
+
+    let response = await fetch(outbound);
+
+    response = rewriteLoopbackRedirect(response, (redirectPort) => {
+      if (!redirectPort || !/^\d+$/.test(redirectPort)) {
+        return null;
+      }
+      return `port-${redirectPort}-pvelxc-${instanceId}.alphasolves.com`;
+    });
+
+    const contentType = response.headers.get("content-type") || "";
+    const skipServiceWorker = port === "39378";
+
+    // Apply HTMLRewriter to HTML responses
+    if (contentType.includes("text/html")) {
+      let responseHeaders = stripCSPHeaders(response.headers);
+      if (skipServiceWorker) {
+        responseHeaders = addPermissiveCORS(responseHeaders);
+      }
+      const rewriter = new HTMLRewriter()
+        .on("head", new HeadRewriter(skipServiceWorker))
+        .on("script", new ScriptRewriter());
+
+      if (skipServiceWorker) {
+        rewriter.on("meta", new MetaCSPRewriter());
+      }
+
+      return rewriter.transform(
+        new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: responseHeaders,
+        })
+      );
+    }
+
+    // Rewrite JavaScript files
+    if (contentType.includes("javascript") || url.pathname.endsWith(".js")) {
+      const text = await response.text();
+      const rewritten = rewriteJavaScript(text, true);
+      let sanitizedHeaders = sanitizeRewrittenResponseHeaders(response.headers);
+      sanitizedHeaders = stripCSPHeaders(sanitizedHeaders);
+      if (skipServiceWorker) {
+        sanitizedHeaders = addPermissiveCORS(sanitizedHeaders);
+      }
+      return new Response(rewritten, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: sanitizedHeaders,
+      });
+    }
+
+    let responseHeaders = stripCSPHeaders(response.headers);
+    if (skipServiceWorker) {
+      responseHeaders = addPermissiveCORS(responseHeaders);
+    }
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  },
+};

--- a/apps/edge-router-pvelxc/wrangler.toml
+++ b/apps/edge-router-pvelxc/wrangler.toml
@@ -1,0 +1,16 @@
+name = "alphasolves-edge-router"
+main = "src/index.ts"
+compatibility_date = "2024-09-01"
+account_id = "331b116e6a1d98ccf73b5c4f0b2ba56d"  # Uncomment and set your CF account ID
+
+# Catch ALL subdomains, filter at runtime
+# (CF doesn't support infix wildcards like port-*-pvelxc-*)
+routes = [
+  { pattern = "*.alphasolves.com/*", zone_name = "alphasolves.com" },
+]
+
+[observability.logs]
+enabled = true
+
+[placement]
+mode = "smart"

--- a/bun.lock
+++ b/bun.lock
@@ -215,6 +215,13 @@
         "wrangler": "^3.80.0",
       },
     },
+    "apps/edge-router-pvelxc": {
+      "name": "@cmux/edge-router-pvelxc",
+      "version": "0.0.0",
+      "devDependencies": {
+        "wrangler": "4",
+      },
+    },
     "apps/preview-proxy": {
       "name": "bun-react-template",
       "version": "0.1.0",
@@ -854,6 +861,8 @@
     "@cmux/convex": ["@cmux/convex@workspace:packages/convex"],
 
     "@cmux/edge-router": ["@cmux/edge-router@workspace:apps/edge-router"],
+
+    "@cmux/edge-router-pvelxc": ["@cmux/edge-router-pvelxc@workspace:apps/edge-router-pvelxc"],
 
     "@cmux/host-screenshot-collector": ["@cmux/host-screenshot-collector@workspace:packages/host-screenshot-collector"],
 
@@ -1671,6 +1680,12 @@
 
     "@playwright/mcp": ["@playwright/mcp@0.0.44", "", { "dependencies": { "playwright": "1.57.0-alpha-2025-10-24", "playwright-core": "1.57.0-alpha-2025-10-24" }, "bin": { "mcp-server-playwright": "cli.js" } }, "sha512-QkJd/qUxbw9MY5Vy5TMC6EmK2VSTBJ0+NOx/wTat5W7ycj8s19tweYRJI+33Ix8SMdf6aaG9pIaY0AZGfnK0oA=="],
 
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
     "@posthog/ai": ["@posthog/ai@7.5.3", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.2", "@google/genai": "^1.34.0", "@langchain/core": "^1.1.8", "@posthog/core": "1.13.0", "langchain": "^1.2.3", "openai": "^6.15.0", "uuid": "^11.1.0", "zod": "^4.1.13" }, "peerDependencies": { "@ai-sdk/provider": "^2.0.0 || ^3.0.0", "posthog-node": "^5.0.0" }, "optionalPeers": ["@ai-sdk/provider"] }, "sha512-pcHKDyQHfvDCSZSm9xh/dM+Z8ILmZWJJoSm9m1OwIQIF/t7BGyn1Ap7X3jVCDUw2W4/p+4Oh0M9ntwqUUD2/gg=="],
 
     "@posthog/core": ["@posthog/core@1.9.0", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-j7KSWxJTUtNyKynLt/p0hfip/3I46dWU2dk+pt7dKRoz2l5CYueHuHK4EO7Wlgno5yo1HO4sc4s30MXMTICHJw=="],
@@ -2316,6 +2331,8 @@
     "@smithy/uuid": ["@smithy/uuid@1.1.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw=="],
 
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
@@ -3328,6 +3345,8 @@
     "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
 
@@ -5217,6 +5236,8 @@
 
     "youch": ["youch@3.3.4", "", { "dependencies": { "cookie": "^0.7.1", "mustache": "^4.2.0", "stacktracey": "^2.1.8" } }, "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg=="],
 
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
     "yup": ["yup@1.7.1", "", { "dependencies": { "property-expr": "^2.0.5", "tiny-case": "^1.0.3", "toposort": "^2.0.2", "type-fest": "^2.19.0" } }, "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw=="],
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
@@ -5262,6 +5283,8 @@
     "@cloudflare/kv-asset-handler/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "@cmux/convex/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "@cmux/edge-router-pvelxc/wrangler": ["wrangler@4.62.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.12.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.0", "miniflare": "4.20260131.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260131.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260131.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-DogP9jifqw85g33BqwF6m21YBW5J7+Ep9IJLgr6oqHU0RkA79JMN5baeWXdmnIWZl+VZh6bmtNtR+5/Djd32tg=="],
 
     "@cmux/scripts/morphcloud": ["morphcloud@0.0.18", "", { "dependencies": { "ignore": "^7.0.0", "node-ssh": "^13.2.0", "undici": "^7.12.0", "uuid": "^11.1.0" } }, "sha512-k3kxdvmwUQbRM5RBJp/UMXQKOqZBBy+BVo/jgNLuNp8yLBq5CJqGAK3O0oZewwKUK2/UL4LyHkwJxBNf7gy0kg=="],
 
@@ -5442,6 +5465,12 @@
     "@octokit/oauth-app/@octokit/auth-oauth-app": ["@octokit/auth-oauth-app@9.0.3", "", { "dependencies": { "@octokit/auth-oauth-device": "^8.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg=="],
 
     "@octokit/oauth-app/@octokit/auth-oauth-user": ["@octokit/auth-oauth-user@6.0.2", "", { "dependencies": { "@octokit/auth-oauth-device": "^8.0.3", "@octokit/oauth-methods": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A=="],
+
+    "@poppinss/colors/kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "@poppinss/dumper/@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "@posthog/ai/@posthog/core": ["@posthog/core@1.13.0", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-knjncrk7qRmssFRbGzBl1Tunt21GRpe0Wv+uVelyL0Rh7PdQUsgguulzXFTps8hA6wPwTU4kq85qnbAJ3eH6Wg=="],
 
@@ -6034,6 +6063,18 @@
     "@cmux/convex/vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "@cmux/convex/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.12.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "^1.20260115.0" }, "optionalPeers": ["workerd"] }, "sha512-NK4vN+2Z/GbfGS4BamtbbVk1rcu5RmqaYGiyHJQrA09AoxdZPHDF3W/EhgI0YSK8p3vRo/VNCtbSJFPON7FWMQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare": ["miniflare@4.20260131.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.18.2", "workerd": "1.20260131.0", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-CtObRzlAzOUpCFH+MgImykxmDNKthrgIYtC+oLC3UGpve6bGLomKUW4u4EorTvzlQFHe66/9m/+AYbBbpzG0mQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/workerd": ["workerd@1.20260131.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260131.0", "@cloudflare/workerd-darwin-arm64": "1.20260131.0", "@cloudflare/workerd-linux-64": "1.20260131.0", "@cloudflare/workerd-linux-arm64": "1.20260131.0", "@cloudflare/workerd-windows-64": "1.20260131.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-4zZxOdWeActbRfydQQlj7vZ2ay01AjjNC4K3stjmWC3xZHeXeN3EAROwsWE83SZHhtw4rn18srrhtXoQvQMw3Q=="],
 
     "@cmux/scripts/morphcloud/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -6723,6 +6764,76 @@
 
     "@cmux/convex/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260131.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-+1X4qErc715NUhJZNhtlpuCxajhD5YNre7Cz50WPMmj+BMUrh9h7fntKEadtrUo5SM2YONY7CDzK7wdWbJJBVA=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260131.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-M84mXR8WEMEBuX4/dL2IQ4wHV/ALwYjx9if5ePZR8rdbD7if/fkEEoMBq0bGS/1gMLRqqCZLstabxHV+g92NNg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260131.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SWzr48bCL9y5wjkj23tXS6t/6us99EAH9T5TAscMV0hfJFZQt97RY/gaHKyRRjFv6jfJZvk7d4g+OmGeYBnwcg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260131.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-mL0kLPGIBJRPeHS3+erJ2t5dJT3ODhsKvR9aA4BcsY7M30/QhlgJIF6wsgwNisTJ23q8PbobZNHBUKIe8l/E9A=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260131.0", "", { "os": "win32", "cpu": "x64" }, "sha512-hoQqTFBpP1zntP2OQSpt5dEWbd9vSBliK+G7LmDXjKitPkmkRFo2PB4P9aBRE1edPAIO/fpdoJv928k2HaAn4A=="],
+
     "@cmux/server/electron/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@cmux/server/octokit/@octokit/app/@octokit/auth-unauthenticated": ["@octokit/auth-unauthenticated@5.0.1", "", { "dependencies": { "@octokit/request-error": "^5.0.0", "@octokit/types": "^12.0.0" } }, "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg=="],
@@ -6890,6 +7001,46 @@
     "wrap-ansi-cjs/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@cmux/edge-router-pvelxc/wrangler/miniflare/youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "@cmux/server/octokit/@octokit/app/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@20.0.0", "", {}, "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="],
 


### PR DESCRIPTION
## Summary

Add edge router at `apps/edge-router-pvelxc/` to enable localhost URL rewriting for PVE-LXC sandboxes when using "Open in new tab" (web mode / external browser).

## Problem

In web mode, preview iframes load content from `https://port-5173-pvelxc-xxx.alphasolves.com`, but the app inside tries to fetch from `http://localhost:3000/api/...` which **fails** because `localhost` refers to the user's browser machine, not the sandbox.

| Mode | localhost Handling | Works? |
|------|-------------------|--------|
| Electron | Proxy intercepts & rewrites | ✅ |
| Web (new tab) | No proxy exists | ❌ → ✅ with this PR |

## Solution

Deploy a Cloudflare Worker edge router for `*.alphasolves.com` that:

1. **Runtime filtering**: Only processes `port-{PORT}-pvelxc-{INSTANCE}.alphasolves.com` URLs
2. **JS injection**: Injects `replaceLocalhostUrl()` and `__cmuxLocation` proxy into HTML
3. **Service Worker**: Registers `/proxy-sw.js` to intercept fetch requests to localhost
4. **Pass-through**: All other traffic (Caddy, CF Tunnel, other services) passes through unchanged

### Architecture

```
Browser → CF Worker (*.alphasolves.com)
             ↓ (matches port-*-pvelxc-*?)
             ↓ YES: Inject JS interceptors
             ↓ NO:  Pass-through
          CF Tunnel → LXC Container

Result: localhost:3000 → port-3000-pvelxc-xxx.alphasolves.com
```

### Cloudflare Route Constraint

CF doesn't support infix wildcards like `port-*-pvelxc-*.alphasolves.com/*`, so we use `*.alphasolves.com/*` and filter at runtime.

## Files

- `apps/edge-router-pvelxc/src/index.ts` - Main worker code (~670 lines)
- `apps/edge-router-pvelxc/wrangler.toml` - CF Worker config
- `apps/edge-router-pvelxc/package.json` - Package config

## Deployment

```bash
cd apps/edge-router-pvelxc
bunx wrangler login
bunx wrangler deploy
```

## Test plan

- [x] Deploy worker: `bunx wrangler deploy`
- [x] Verify pass-through: `curl -I https://pve.alphasolves.com` (works as before)
- [x] Verify JS injection: `window.__cmuxLocation` exists in DevTools
- [x] Verify localhost rewriting: `replaceLocalhostUrl('http://localhost:3000/api')` returns correct URL
- [x] Verify Service Worker: Activated at scope `/`
- [ ] Test "Open in new tab" from cmux UI with real API calls