### PR TITLE
Fix stale Git diff data on initial load

### DIFF
--- a/apps/client/src/queries/git-diff.ts
+++ b/apps/client/src/queries/git-diff.ts
@@ -80,6 +80,7 @@ export function gitDiffQueryOptions({
       });
     },
     staleTime: 10_000,
+    refetchOnMount: "always",
     enabled: Boolean(canonicalHeadRef) && Boolean(repoKey.trim()),
   });
 }


### PR DESCRIPTION
## Task

# Fix: Git Diff Showing Stale Data on Initial Load

## Problem Statement

The Git diff view initially shows **+10953 -546** changes across many unrelated files when the actual commit only changed **2 files**. After web mode fetches the task, Electron also shows the correct result.

## Root Cause Analysis (Updated)

The Electron app (built with `.env.production`) connects to the **same production www server** as web mode. Both share the same cache. The issue is:

1. **Stale-while-revalidate behavior**: React Query shows stale cached data immediately while fetching fresh data in background
2. **Initial cache miss**: On first load, Electron may show outdated cached diff data
3. **Cache sync delay**: Once web fetches fresh data, Electron eventually gets it too

## Key Evidence

- Web mode shows correct diff immediately
- Electron shows wrong diff initially, then corrects after web fetches
- Both apps share same production backend (Convex + www server)

## Fix Options

### Option 1: Reduce staleTime in git-diff query (Quick Fix)

The git-diff query has `staleTime: 10_000` (10 seconds). Reducing this or using `staleTime: 0` would force immediate refetch.

**File:** `apps/client/src/queries/git-diff.ts:82`

### Option 2: Add Manual Refresh Button (Better UX)

Add a refresh button that invalidates the query cache and refetches with `forceRefresh: true`.

**Files to modify:**

- `apps/client/src/components/TaskRunGitDiffPanel.tsx` - Add refresh button
- `apps/client/src/queries/git-diff.ts` - Already supports `forceRefresh`

### Option 3: Invalidate cache on task/run change (Proper Fix)

When navigating to a different task or run, invalidate the git-diff cache to ensure fresh data.

## Actual Finding: Refresh Button Already Exists!

The refresh button **already exists** in `task-detail-header.tsx:235-250`:

- Component: `AdditionsAndDeletions`
- Shows the +/- counts with a refresh icon button
- Already uses `forceRefresh: true` (line 176)
- Already invalidates the query cache (line 182)

**The issue is**: Initial load shows stale cached data. Users need to manually click refresh.

## Root Cause Identified

The `gitDiffQueryOptions` in `git-diff.ts:82` has:

```ts
staleTime: 10_000,  // 10 seconds
```

Combined with React Query's default caching behavior, this means:

1. On initial load, if cached data exists, it's shown immediately
2. Fresh data is fetched in background
3. But if the cached data is stale/wrong, users see wrong counts until refresh

## Recommended Fix: Auto-refresh on task/run navigation

**Option A**: Reduce `staleTime` to 0 for git-diff queries (force immediate refetch)
**Option B**: Invalidate git-diff cache when navigating to a new task/run
**Option C**: Add `refetchOnMount: 'always'` to ensure fresh data on component mount

## Critical Files

| File | Purpose |
|------|---------|
| `apps/client/src/queries/git-diff.ts:82` | Change staleTime or add refetchOnMount |
| `apps/client/src/components/task-detail-header.tsx` | Has existing refresh button |
| `apps/client/src/components/TaskRunGitDiffPanel.tsx` | Uses git-diff query |

## Implementation Plan

### Option A: Quick Fix - Set staleTime to 0

**File:** `apps/client/src/queries/git-diff.ts:82`

```ts
// Change from:
staleTime: 10_000,

// To:
staleTime: 0,  // Always refetch on mount
```

**Pros**: Simple one-line change
**Cons**: More network requests, may affect performance

### Option B: Add refetchOnMount: 'always' (Recommended)

**File:** `apps/client/src/queries/git-diff.ts`

```ts
return queryOptions({
  // ... existing options
  staleTime: 10_000,
  refetchOnMount: 'always',  // <-- Add this
});
```

**Pros**: Only refetches on mount, keeps staleTime for other scenarios
**Cons**: Still makes request every mount

### Option C: Invalidate cache on task/run change

**File:** `apps/client/src/components/TaskRunGitDiffPanel.tsx`

Add useEffect to invalidate git-diff cache when selectedRunId changes:

```tsx
const queryClient = useQueryClient();

useEffect(() => {
  queryClient.invalidateQueries({ queryKey: ["git-diff"] });
}, [selectedRunId, queryClient]);
```

**Pros**: Only invalidates when actually needed
**Cons**: Slightly more complex

## Verification

1. **Before fix**: Open Electron, navigate to a task, see stale diff counts
2. **Apply Option B fix**: Add `refetchOnMount: 'always'`
3. **Run&#32;`bun check`**: Ensure no type errors
4. **Test in Electron**: Open same task, should see correct counts immediately
5. **Test refresh button**: Still works as backup
6. **Test web mode**: Ensure no regression

## PR Review Summary
- **What Changed**: Updated `gitDiffQueryOptions` in `apps/client/src/queries/git-diff.ts` to include `refetchOnMount: "always"`. This ensures that a fresh Git diff is fetched every time the component mounts, preventing users from seeing stale cached data on initial load.
- **Review Focus**: Evaluate the performance impact of increased network requests. Since `refetchOnMount` is set to `always`, the `git-diff` query will trigger a background fetch every time the panel is viewed, regardless of the 10-second `staleTime`.
- **Test Plan**: 
1. Launch the Electron app and navigate to a task with known diff counts; verify correct counts appear immediately.
2. Navigate between different tasks/runs to ensure the diff data refreshes correctly on each mount.
3. Verify the manual refresh button in `task-detail-header.tsx` still functions as a backup for force-refreshing data.
4. Run `bun check` to ensure no TypeScript regressions.