### PR TITLE
[Crown] # Plan: Fix cmux-pty Terminal Echoing Raw ANSI Escape Sequenc...

### DIFF
--- a/crates/cmux-pty/src/main.rs
+++ b/crates/cmux-pty/src/main.rs
@@ -738,18 +738,10 @@ async fn spawn_pty_reader(
                 read_count += 1;
                 total_bytes_read += n;
 
-                // Process through virtual terminal emulator for state tracking
-                let responses = session.process_terminal(&buf[..n]);
-                if !responses.is_empty() {
-                    for response in responses {
-                        if let Err(e) = session.write_input_bytes(response) {
-                            error!(
-                                "[reader:{}] Failed to send terminal response: {}",
-                                session_id, e
-                            );
-                        }
-                    }
-                }
+                // Process through virtual terminal emulator for state tracking only.
+                // Responses (OSC 10/11/12 color queries, CPR cursor reports, etc.) are
+                // discarded - xterm.js on the client handles these directly.
+                let _ = session.process_terminal(&buf[..n]);
 
                 // Apply DaFilter to raw bytes to remove DA query/response sequences
                 let filtered_bytes = {


### PR DESCRIPTION
## Task

# Plan: Fix cmux-pty Terminal Echoing Raw ANSI Escape Sequences

## Problem Summary

The cmux-pty terminal is displaying raw ANSI escape sequence responses like:

```
# 11;rgb:f8f8/f8f8/f8f81R11;rgb:f8f8/f8f8/f8f81R
```

These are **terminal query responses** that should be consumed by the querying application but are instead being echoed back as visible text.

### Components of the Strange Output:

1. `11;rgb:f8f8/f8f8/f8f8` - OSC 11 (background color query) response
2. `1R` - CPR (Cursor Position Report) response `ESC[row;colR`

---

## Why cmux-pty Exists (vs Using Plain zsh/bash)

cmux-pty transforms a raw PTY into a **managed, observable, programmable terminal service**. Key features that would be lost with plain VS Code terminal:

### 1. Server-Side Terminal State & Content Capture

- **VirtualTerminal** parses ANSI sequences server-side, extracts clean text grid
- `/sessions/:id/capture` endpoint returns processed terminal content (AI agents can read what's on screen)
- Plain zsh: No programmatic way to read terminal content without screenshots

### 2. Multi-Client Synchronization

- Multiple editors/clients can attach to same terminal session
- All clients see real-time state updates via WebSocket broadcast
- Plain zsh: Each VS Code window has isolated terminal

### 3. AI Agent Integration

- Metadata tagging: mark terminals as `{"managed": true, "type": "agent"}`
- Programmatic input: `ptyClient.sendInput()` sends commands
- Programmatic capture: `ptyClient.captureScreen()` reads output
- Plain zsh: No API for AI agents to interact programmatically

### 4. Session Persistence & Management

- Sessions survive page refreshes, reconnections
- Session ordering, renaming, metadata updates
- Plain zsh: Terminal state lost on disconnect

### 5. Process Signal Control

- Send SIGUSR1/SIGUSR2 to PTY child processes (theme change notifications)
- Plain zsh: No signal control from remote client

### 6. DA Query Filtering (Nested Terminal Safety)

- Filters DA1/DA2 capability queries to prevent feedback loops
- Enables running terminal emulators inside cmux-pty
- Plain zsh: Risk of infinite loops with nested terminals

---

## Root Cause Analysis

The data flow in `crates/cmux-pty/src/main.rs` (line 742-751):

```rust
let responses = session.process_terminal(&buf[..n]);
if !responses.is_empty() {
    for response in responses {
        if let Err(e) = session.write_input_bytes(response) {  // <-- BUG!
            error!("Failed to send terminal response: {}", e);
        }
    }
}
```

**The Bug:** Terminal query responses (OSC 11, CPR, etc.) generated by `VirtualTerminal` are written back to **PTY input** (shell's stdin), causing the shell to echo them as text.

**Why plain zsh/bash works:** When using VS Code's built-in terminal, xterm.js handles OSC/CPR queries directly. The queries never reach cmux-pty's VirtualTerminal.

---

## Files to Modify

| File | Change |
|------|--------|
| `crates/cmux-pty/src/main.rs` | Remove writing terminal responses back to PTY |

## Implementation (Recommended)

The `VirtualTerminal` is for **state tracking** (scrollback, content snapshots), not as a terminal emulator that applications communicate with. VS Code's xterm.js is the actual terminal emulator.

**Fix:** Discard responses from VirtualTerminal:

```rust
// In the reader loop (line ~742-751)
// Change from:
let responses = session.process_terminal(&buf[..n]);
if !responses.is_empty() { ... write responses ... }

// To:
let _ = session.process_terminal(&buf[..n]); // State tracking only, discard responses
```

---

## Context7 References

### xterm.js Custom Handlers (Source: /xtermjs/xterm.js)

- `terminal.parser.registerCsiHandler()` - register custom CSI sequence handlers
- `terminal.parser.registerOscHandler()` - register custom OSC sequence handlers
- xterm.js handles escape sequences client-side; cmux-pty should NOT duplicate this

### VS Code Shell Integration (Source: /microsoft/vscode-docs)

- VS Code uses **OSC 633** (custom sequences) for shell integration
- Sequences: `OSC 633;A ST` (prompt start), `OSC 633;B ST` (command start), etc.
- These are handled by VS Code, not cmux-pty

---

## Verification

1. After the fix, open a cmux-pty terminal in VS Code
2. Run commands (`gh auth status`, `ls`, `cd`)
3. Verify no garbage characters appear
4. Verify capture endpoint still returns terminal content

## Risk Assessment

**Low risk** - The responses being discarded are:

- OSC 10/11/12 color queries - handled by xterm.js
- CPR cursor position reports - handled by xterm.js

cmux-pty's **unique features remain intact**:

- Content capture via VirtualTerminal grid state
- Scrollback buffer management
- Session management & metadata
- Multi-client broadcasting
- DA query filtering

---

## Completed Tasks

- [x] **Update Obsidian Note** - Added to `/Users/karlchow/Documents/obsidian_vault/2️⃣-Drafts/cmux-pty-terminal-vscode-integration.md`:
- "Why cmux-pty vs Plain zsh/bash" section with feature comparison table
- "Known Issue: Escape Sequence Echo (2026-02)" section with root cause and fix
- "Context7 References (2026-02)" section with xterm.js and VS Code docs

---

## Task: Fix Escape Sequence Bug

**Status:** TO BE IMPLEMENTED

### Step 1: Edit Code

**File:** `crates/cmux-pty/src/main.rs` (line \~742-751)

```rust
// Change from:
let responses = session.process_terminal(&buf[..n]);
if !responses.is_empty() {
    for response in responses {
        if let Err(e) = session.write_input_bytes(response) {
            error!("[reader:{}] Failed to send terminal response: {}", session_id, e);
        }
    }
}

// To:
let _ = session.process_terminal(&buf[..n]); // State tracking only, discard responses
```

### Step 2: Build & Test

```bash
cd /Users/karlchow/Desktop/code/cmux
cargo clippy -p cmux-pty   # Check for warnings
cargo fmt -p cmux-pty      # Format code
cargo test -p cmux-pty     # Run tests
```

### Step 3: Rebuild & Restart

```bash
./scripts/reload.sh        # Rebuild CLI, Docker container, restart dev server
```

### Step 4: Verify

1. Open a cmux-pty terminal in VS Code remote sandbox
2. Run commands (`gh auth status`, `ls`, `cd`)
3. Confirm no garbage characters like `11;rgb:f8f8/f8f8/f8f81R` appear

## PR Review Summary
- **What Changed**: Modified the PTY reader loop in `crates/cmux-pty/src/main.rs` to discard responses from `session.process_terminal`. Previously, terminal query responses (such as OSC 10/11/12 and CPR) were being written back to the PTY input (stdin), causing the shell to echo them as raw ANSI text.
- **Review Focus**: Ensure that calling `session.process_terminal` without handling its return value doesn't negatively impact features beyond the terminal echo bug. Specifically, verify that the `VirtualTerminal` still correctly updates its internal state grid, as this is required for the AI capture functionality.
- **Test Plan**:
  1. Open a `cmux-pty` terminal in VS Code and execute several commands (e.g., `ls`, `gh auth status`).
  2. Confirm that no raw ANSI strings like `11;rgb:f8f8/f8f8/f8f81R` appear in the output.
  3. Call the `/sessions/:id/capture` endpoint to verify that the terminal's text state is still being tracked and returned correctly.
- **Follow-ups**: None; this change successfully isolates state tracking from terminal-emulator response generation.