### PR TITLE
Fix git diff for new tasks; use starting commit SHA

### DIFF
--- a/apps/client/src/components/TaskPanelFactory.tsx
+++ b/apps/client/src/components/TaskPanelFactory.tsx
@@ -624,7 +624,7 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
     }
 
     case "gitDiff": {
-      const { task, selectedRun, TaskRunGitDiffPanel, teamSlugOrId, taskId } = props;
+      const { task, taskRuns, selectedRun, TaskRunGitDiffPanel, teamSlugOrId, taskId } = props;
       if (!TaskRunGitDiffPanel || !teamSlugOrId || !taskId) return null;
 
       return panelWrapper(
@@ -634,6 +634,7 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
           <TaskRunGitDiffPanel
             key={selectedRun?._id}
             task={task}
+            taskRuns={taskRuns}
             selectedRun={selectedRun}
             teamSlugOrId={teamSlugOrId}
             taskId={taskId}
@@ -698,6 +699,7 @@ export const RenderPanel = React.memo(RenderPanelComponent, (prevProps, nextProp
   // For gitDiff panel, check task and selectedRun changes
   if (prevProps.type === "gitDiff") {
     if (prevProps.task?._id !== nextProps.task?._id ||
+      prevProps.taskRuns !== nextProps.taskRuns ||
       prevProps.selectedRun?._id !== nextProps.selectedRun?._id ||
       prevProps.teamSlugOrId !== nextProps.teamSlugOrId ||
       prevProps.taskId !== nextProps.taskId) {

--- a/apps/client/src/components/TaskRunGitDiffPanel.tsx
+++ b/apps/client/src/components/TaskRunGitDiffPanel.tsx
@@ -11,25 +11,47 @@ import { api } from "@cmux/convex/api";
 
 export interface TaskRunGitDiffPanelProps {
   task: Doc<"tasks"> | null | undefined;
+  taskRuns?: TaskRunWithChildren[] | null | undefined;
   selectedRun: TaskRunWithChildren | null | undefined;
   teamSlugOrId: string;
   taskId: Id<"tasks">;
   selectedRunId: Id<"taskRuns"> | null | undefined;
 }
 
-export function TaskRunGitDiffPanel({ task, selectedRun, teamSlugOrId, taskId, selectedRunId }: TaskRunGitDiffPanelProps) {
+export function TaskRunGitDiffPanel({
+  task,
+  taskRuns,
+  selectedRun,
+  teamSlugOrId,
+  taskId,
+  selectedRunId,
+}: TaskRunGitDiffPanelProps) {
   // Check for cloud/local workspace (no GitHub repo to diff against)
   const isCloudOrLocalWorkspace = task?.isCloudWorkspace || task?.isLocalWorkspace;
 
-  // When baseBranch is not set, pass undefined to let native code auto-detect
-  // the default branch (via refs/remotes/origin/HEAD → origin/main → origin/master)
+  // Find parent run if this is a child run (for comparing against parent's branch)
+  const parentRun = useMemo(() => {
+    if (!selectedRun?.parentRunId || !taskRuns) return null;
+    return taskRuns.find((run) => run._id === selectedRun.parentRunId) ?? null;
+  }, [selectedRun?.parentRunId, taskRuns]);
+
+  // Determine base ref for diff comparison with priority:
+  // 1. Parent run's branch (for child runs)
+  // 2. Starting commit SHA (for new tasks in custom environments)
+  // 3. Task's base branch (explicit user choice)
   const normalizedBaseBranch = useMemo(() => {
+    if (parentRun?.newBranch) {
+      return normalizeGitRef(parentRun.newBranch);
+    }
+    if (selectedRun?.startingCommitSha) {
+      return selectedRun.startingCommitSha;
+    }
     const candidate = task?.baseBranch;
     if (candidate && candidate.trim()) {
       return normalizeGitRef(candidate);
     }
     return undefined;
-  }, [task?.baseBranch]);
+  }, [parentRun?.newBranch, selectedRun?.startingCommitSha, task?.baseBranch]);
 
   const normalizedHeadBranch = useMemo(
     () => normalizeGitRef(selectedRun?.newBranch),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -188,6 +188,7 @@ const convexSchema = defineSchema({
   taskRuns: defineTable({
     taskId: v.id("tasks"),
     parentRunId: v.optional(v.id("taskRuns")), // For tree structure
+    startingCommitSha: v.optional(v.string()), // Commit SHA when run started (for diff baseline)
     prompt: v.string(), // The prompt that will be passed to claude
     agentName: v.optional(v.string()), // Name of the agent that ran this task (e.g., "claude/sonnet-4")
     summary: v.optional(v.string()), // Markdown summary of the run

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -2235,6 +2235,31 @@ export const getRunningContainersByCleanupPriority = authQuery({
   },
 });
 
+// Update starting commit SHA (for diff baseline in custom environments)
+export const updateStartingCommitSha = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    id: v.id("taskRuns"),
+    startingCommitSha: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const run = await ctx.db.get(args.id);
+    if (!run) {
+      throw new Error("Task run not found");
+    }
+    if (run.teamId !== teamId || run.userId !== userId) {
+      throw new Error("Unauthorized");
+    }
+
+    await ctx.db.patch(args.id, {
+      startingCommitSha: args.startingCommitSha,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
 export const createForPreview = internalMutation({
   args: {
     taskId: v.id("tasks"),


### PR DESCRIPTION
## Task

# Fix: Git Diff Shows Too Many Files for New Tasks in Custom Environments

## Problem Summary

For NEW tasks (no parent run) in custom environments, the git diff shows all accumulated changes since diverging from `main`, rather than just the changes made during the specific run.

**User's requirement:** "Only this run's changes" - diff should show only what was changed during this specific task run.

## Solution: Track Starting Commit SHA

Capture the commit SHA when the sandbox starts (after hydration but before the agent runs). This becomes the baseline for diff comparison.

---

## Files to Modify

1. `packages/convex/convex/schema.ts` - Add `startingCommitSha` field
2. `packages/convex/convex/taskRuns.ts` - Add mutation to update the field
3. `apps/www/lib/routes/sandboxes.route.ts` - Capture commit SHA after hydration
4. `apps/client/src/components/TaskRunGitDiffPanel.tsx` - Use startingCommitSha as baseRef
5. `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx` - Same update (loader + component)
6. `apps/client/src/components/task-detail-header.tsx` - Update for AdditionsAndDeletions component

---

## Implementation Steps

### Step 1: Add Schema Field

**File:** `packages/convex/convex/schema.ts` (after line 190, near `parentRunId`)

```typescript
startingCommitSha: v.optional(v.string()), // Commit SHA when run started (for diff baseline)
```

### Step 2: Add Mutation to Update Starting Commit

**File:** `packages/convex/convex/taskRuns.ts` (add at end of file)

```typescript
// Update starting commit SHA (for diff baseline in custom environments)
export const updateStartingCommitSha = authMutation({
  args: {
    teamSlugOrId: v.string(),
    id: v.id("taskRuns"),
    startingCommitSha: v.string(),
  },
  handler: async (ctx, args) => {
    const userId = ctx.identity.subject;
    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
    const run = await ctx.db.get(args.id);
    if (!run) {
      throw new Error("Task run not found");
    }
    if (run.teamId !== teamId || run.userId !== userId) {
      throw new Error("Unauthorized");
    }

    await ctx.db.patch(args.id, {
      startingCommitSha: args.startingCommitSha,
      updatedAt: Date.now(),
    });
  },
});
```

### Step 3: Capture Commit SHA During Sandbox Start

**File:** `apps/www/lib/routes/sandboxes.route.ts` (after line 811, after hydration completes)

Insert after `await hydrateWorkspace(...)` block and before "Update status to running":

```typescript
// Capture starting commit SHA for diff baseline (after hydration, before agent runs)
if (body.taskRunId) {
  console.log(
    "[sandboxes.start] Capturing starting commit SHA for taskRunId:",
    body.taskRunId,
  );
  try {
    const execResult = await instance.exec(
      "git -C /root/workspace rev-parse HEAD",
    );
    console.log(
      "[sandboxes.start] git rev-parse HEAD result:",
      { exit_code: execResult.exit_code, stdout: execResult.stdout?.substring(0, 50) },
    );
    if (execResult.exit_code === 0 && execResult.stdout) {
      const startingCommitSha = execResult.stdout.trim();
      console.log(
        "[sandboxes.start] Starting commit SHA:",
        startingCommitSha,
        "length:",
        startingCommitSha.length,
      );
      if (startingCommitSha.length === 40) {
        console.log(
          "[sandboxes.start] Saving startingCommitSha to Convex:",
          startingCommitSha,
        );
        void convex
          .mutation(api.taskRuns.updateStartingCommitSha, {
            teamSlugOrId: body.teamSlugOrId,
            id: body.taskRunId as Id<"taskRuns">,
            startingCommitSha,
          })
          .catch((error) => {
            console.error(
              "[sandboxes.start] Failed to update starting commit SHA:",
              error,
            );
          });
      }
    }
  } catch (error) {
    console.error(
      "[sandboxes.start] Failed to capture starting commit SHA:",
      error,
    );
  }
}
```

### Step 4: Update TaskRunGitDiffPanel.tsx

**File:** `apps/client/src/components/TaskRunGitDiffPanel.tsx`

Replace lines 20-32 (the existing `normalizedBaseBranch` logic) with:

```typescript
export function TaskRunGitDiffPanel({ task, taskRuns, selectedRun, teamSlugOrId, taskId, selectedRunId }: TaskRunGitDiffPanelProps) {
  // Check for cloud/local workspace (no GitHub repo to diff against)
  const isCloudOrLocalWorkspace = task?.isCloudWorkspace || task?.isLocalWorkspace;

  // Find parent run if this is a child run (for comparing against parent's branch)
  const parentRun = useMemo(() => {
    if (!selectedRun?.parentRunId || !taskRuns) return null;
    return taskRuns.find((run) => run._id === selectedRun.parentRunId) ?? null;
  }, [selectedRun?.parentRunId, taskRuns]);

  // Determine base ref for diff comparison with priority:
  // 1. Parent run's branch (for child runs)
  // 2. Starting commit SHA (for new tasks in custom environments)
  // 3. Task's base branch (explicit user choice)
  const normalizedBaseBranch = useMemo(() => {
    // Priority 1: Parent run's branch (for child runs)
    if (parentRun?.newBranch) {
      return normalizeGitRef(parentRun.newBranch);
    }
    // Priority 2: Starting commit SHA (for new tasks in custom environments)
    if (selectedRun?.startingCommitSha) {
      return selectedRun.startingCommitSha; // Direct SHA, no normalization needed
    }
    // Priority 3: Task's base branch
    const candidate = task?.baseBranch;
    if (candidate && candidate.trim()) {
      return normalizeGitRef(candidate);
    }
    return undefined;
  }, [parentRun?.newBranch, selectedRun?.startingCommitSha, task?.baseBranch]);
```

Also update the interface to include `taskRuns`:

```typescript
export interface TaskRunGitDiffPanelProps {
  task: Doc<"tasks"> | null | undefined;
  taskRuns?: TaskRunWithChildren[] | null | undefined;
  selectedRun: TaskRunWithChildren | null | undefined;
  teamSlugOrId: string;
  taskId: Id<"tasks">;
  selectedRunId: Id<"taskRuns"> | null | undefined;
}
```

### Step 5: Update diff.tsx Route (Loader)

**File:** `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx`

Replace lines 315-319 (loader's baseRefForDiff logic) with:

```typescript
        // Find parent run if this is a child run
        const parentTaskRun = selectedTaskRun.parentRunId
          ? taskRuns.find((run) => run._id === selectedTaskRun.parentRunId)
          : null;

        // Determine base ref for diff comparison with priority:
        // 1. Parent run's branch (for child runs)
        // 2. Starting commit SHA (for new tasks in custom environments)
        // 3. Task's base branch (explicit user choice)
        let baseRefForDiff: string | undefined;
        if (parentTaskRun?.newBranch) {
          baseRefForDiff = normalizeGitRef(parentTaskRun.newBranch);
        } else if (selectedTaskRun.startingCommitSha) {
          baseRefForDiff = selectedTaskRun.startingCommitSha; // Direct SHA
        } else if (task.baseBranch) {
          baseRefForDiff = normalizeGitRef(task.baseBranch);
        }
```

### Step 6: Update diff.tsx Route (Component)

**File:** `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.diff.tsx`

Replace lines 570-574 (component's baseRefForHeatmap logic) with:

```typescript
  // Find parent run if this is a child run (for comparing against parent's branch)
  const parentRun = useMemo(() => {
    if (!selectedRun?.parentRunId || !taskRuns) return null;
    return taskRuns.find((run) => run._id === selectedRun.parentRunId) ?? null;
  }, [selectedRun?.parentRunId, taskRuns]);

  // Determine base ref for diff comparison with priority:
  // 1. Parent run's branch (for child runs)
  // 2. Starting commit SHA (for new tasks in custom environments)
  // 3. Task's base branch (explicit user choice)
  const baseRefForHeatmap = useMemo(() => {
    if (parentRun?.newBranch) {
      return normalizeGitRef(parentRun.newBranch);
    }
    if (selectedRun?.startingCommitSha) {
      return selectedRun.startingCommitSha; // Direct SHA
    }
    return task?.baseBranch ? normalizeGitRef(task.baseBranch) : undefined;
  }, [parentRun?.newBranch, selectedRun?.startingCommitSha, task?.baseBranch]);
```

### Step 7: Update task-detail-header.tsx

**File:** `apps/client/src/components/task-detail-header.tsx`

Replace lines 292-300 (the normalizedBaseBranch logic) with:

```typescript
  // Find parent run if this is a child run (for comparing against parent's branch)
  const parentRun = useMemo(() => {
    if (!selectedRun?.parentRunId || !taskRuns) return null;
    return taskRuns.find((run) => run._id === selectedRun.parentRunId) ?? null;
  }, [selectedRun?.parentRunId, taskRuns]);

  // Determine base ref for diff comparison with priority:
  // 1. Parent run's branch (for child runs)
  // 2. Starting commit SHA (for new tasks in custom environments)
  // 3. Task's base branch (explicit user choice)
  const normalizedBaseBranch = useMemo(() => {
    // Priority 1: Parent run's branch (for child runs)
    if (parentRun?.newBranch) {
      return normalizeGitRef(parentRun.newBranch);
    }
    // Priority 2: Starting commit SHA (for new tasks in custom environments)
    if (selectedRun?.startingCommitSha) {
      return selectedRun.startingCommitSha; // Direct SHA, no normalization needed
    }
    // Priority 3: Task's base branch (explicit user choice)
    const candidate = task?.baseBranch;
    if (candidate && candidate.trim()) {
      return normalizeGitRef(candidate);
    }
    return undefined;
  }, [parentRun?.newBranch, selectedRun?.startingCommitSha, task?.baseBranch]);
```

---

## Verification

1. Run `bun check` to ensure no type errors
2. Start dev server with `./scripts/dev.sh`
3. Create a new task in a custom environment (not spawned from another run)
4. Let the agent make some changes
5. Check www.log for: `[sandboxes.start] Saving startingCommitSha to Convex: <sha>`
6. Check electron.log for: `baseRef=Some("<sha>")` in git\_diff calls
7. Verify diff shows only changes from this run (small number of files), not all accumulated history

---

## Edge Cases

- If `startingCommitSha` capture fails, falls back to current merge-base behavior (no regression)
- For tasks with explicit `baseBranch` set, use that (user's explicit choice)
- For child runs, use parent's branch as base (existing behavior preserved)