### PR TITLE
Add Claude Opus 4.6 model with Bedrock mappings

### DIFF
--- a/packages/convex/convex/bedrock_utils.ts
+++ b/packages/convex/convex/bedrock_utils.ts
@@ -33,6 +33,8 @@ export const BEDROCK_INFERENCE_PROFILE: "us" | "global" = "us";
  * The prefix (us/global) is applied dynamically based on BEDROCK_INFERENCE_PROFILE.
  */
 const BASE_MODELS = {
+  // Claude 4.6 models
+  "opus-4-6": "anthropic.claude-opus-4-6-v1",
   // Claude 4.5 models
   "sonnet-4-5": "anthropic.claude-sonnet-4-5-20250929-v1:0",
   "opus-4-5": "anthropic.claude-opus-4-5-20251101-v1:0",
@@ -62,6 +64,9 @@ function withPrefix(baseModel: string): string {
  * Uses the configured BEDROCK_INFERENCE_PROFILE prefix.
  */
 export const MODEL_MAP: Record<string, string> = {
+  // Opus 4.6 variants
+  "claude-opus-4-6": withPrefix(BASE_MODELS["opus-4-6"]),
+  "claude-4-6-opus": withPrefix(BASE_MODELS["opus-4-6"]),
   // Sonnet 4.5 variants
   "claude-sonnet-4-5-20250929": withPrefix(BASE_MODELS["sonnet-4-5"]),
   "claude-sonnet-4-5": withPrefix(BASE_MODELS["sonnet-4-5"]),

--- a/packages/shared/src/agentConfig.ts
+++ b/packages/shared/src/agentConfig.ts
@@ -5,6 +5,7 @@ import type {
 
 import { AMP_CONFIG, AMP_GPT_5_CONFIG } from "./providers/amp/configs";
 import {
+  CLAUDE_OPUS_4_6_CONFIG,
   CLAUDE_OPUS_4_5_CONFIG,
   CLAUDE_SONNET_4_5_CONFIG,
   CLAUDE_HAIKU_4_5_CONFIG,
@@ -111,6 +112,7 @@ export interface AgentConfig {
 }
 
 export const AGENT_CONFIGS: AgentConfig[] = [
+  CLAUDE_OPUS_4_6_CONFIG,
   CLAUDE_OPUS_4_5_CONFIG,
   CLAUDE_SONNET_4_5_CONFIG,
   CLAUDE_HAIKU_4_5_CONFIG,

--- a/packages/shared/src/providers/anthropic/configs.ts
+++ b/packages/shared/src/providers/anthropic/configs.ts
@@ -58,6 +58,25 @@ function createApplyClaudeApiKeys(): NonNullable<AgentConfig["applyApiKeys"]> {
   };
 }
 
+export const CLAUDE_OPUS_4_6_CONFIG: AgentConfig = {
+  name: "claude/opus-4.6",
+  command: "claude",
+  args: [
+    "--allow-dangerously-skip-permissions",
+    "--dangerously-skip-permissions",
+    "--model",
+    "claude-opus-4-6",
+    "--ide",
+    "$PROMPT",
+  ],
+  environment: getClaudeEnvironment,
+  checkRequirements: checkClaudeRequirements,
+  // User-configurable: OAuth token (preferred) or API key; falls back to platform proxy
+  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
+  applyApiKeys: createApplyClaudeApiKeys(),
+  completionDetector: startClaudeCompletionDetector,
+};
+
 export const CLAUDE_OPUS_4_5_CONFIG: AgentConfig = {
   name: "claude/opus-4.5",
   command: "claude",

--- a/packages/shared/src/utils/anthropic.ts
+++ b/packages/shared/src/utils/anthropic.ts
@@ -8,6 +8,7 @@ export const CMUX_ANTHROPIC_PROXY_PLACEHOLDER_API_KEY =
  * AWS Bedrock model IDs for Claude models.
  * Used by code review heatmap feature.
  */
+export const ANTHROPIC_MODEL_OPUS_46 = "global.anthropic.claude-opus-4-6-v1";
 export const ANTHROPIC_MODEL_OPUS_45 =
   "global.anthropic.claude-opus-4-5-20251101-v1:0";
 export const ANTHROPIC_MODEL_HAIKU_45 =


### PR DESCRIPTION
## Task

# Plan: Sync GPT 5.3 Codex & Opus 4.6 from Upstream

## Context

- Fork: `karlorz/cmux` (current `main`)
- Upstream: `manaflow-ai/cmux` (112 commits ahead)
- Key upstream commits:
- `940ef0e93` - feat: Add gpt-5.3-codex and claude-opus-4-6 models
- `b3651aae9` - feat: Add claude-opus-4-6 to AWS Bedrock model mappings

## Current State

### GPT 5.3 Codex - Already implemented, no changes needed

Fork already has all 5 GPT 5.3 Codex configs in `packages/shared/src/providers/openai/configs.ts:8-109` and they are registered in `agentConfig.ts:117-121`. The only upstream difference is a `bunx` command migration which we are **not** adopting. No changes required.

### Opus 4.6 - New, needs to be added

Fork does not have Opus 4.6. We will add it following the fork's existing patterns (using `command: "claude"`, matching the existing opus-4.5/sonnet-4.5/haiku-4.5 configs).

## Changes

### 1. Add Claude Opus 4.6 config

**File:** `packages/shared/src/providers/anthropic/configs.ts`

- Add new `CLAUDE_OPUS_4_6_CONFIG` export before `CLAUDE_OPUS_4_5_CONFIG` (line 61)
- Use `command: "claude"` (matching fork's existing pattern, NOT upstream's `bunx`)
- Model: `"claude-opus-4-6"`
- Same args pattern as existing opus-4.5 config

```ts
export const CLAUDE_OPUS_4_6_CONFIG: AgentConfig = {
  name: "claude/opus-4.6",
  command: "claude",
  args: [
    "--allow-dangerously-skip-permissions",
    "--dangerously-skip-permissions",
    "--model",
    "claude-opus-4-6",
    "--ide",
    "$PROMPT",
  ],
  environment: getClaudeEnvironment,
  checkRequirements: checkClaudeRequirements,
  apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
  applyApiKeys: createApplyClaudeApiKeys(),
  completionDetector: startClaudeCompletionDetector,
};
```

### 2. Register Opus 4.6 in agent config

**File:** `packages/shared/src/agentConfig.ts`

- Add `CLAUDE_OPUS_4_6_CONFIG` to import from `"./providers/anthropic/configs"` (line 8)
- Add `CLAUDE_OPUS_4_6_CONFIG` as first entry in `AGENT_CONFIGS` array (before `CLAUDE_OPUS_4_5_CONFIG`, line 113)

### 3. Add Opus 4.6 Bedrock mapping

**File:** `packages/convex/convex/bedrock_utils.ts`

- Add to `BASE_MODELS` object: `"opus-4-6": "anthropic.claude-opus-4-6-v1"`
- Add to `MODEL_MAP` object: `"claude-opus-4-6"` and `"claude-4-6-opus"` variants

### 4. Add Opus 4.6 Bedrock model constant

**File:** `packages/shared/src/utils/anthropic.ts`

- Add `ANTHROPIC_MODEL_OPUS_46 = "global.anthropic.claude-opus-4-6-v1"` before the existing OPUS\_45 constant

## Files NOT changed

- `packages/shared/src/providers/openai/configs.ts` - GPT 5.3 already correct
- `configs/ide-deps.json` - No bunx migration, so no version bump needed
- `packages/shared/src/morph-snapshots.json` - Fork uses separate snapshots
- `packages/shared/src/providers/opencode/configs.ts` - Unrelated changes

## Verification

1. Run `bun check` to verify no type errors
2. Confirm `CLAUDE_OPUS_4_6_CONFIG` is exported and registered in `AGENT_CONFIGS`
3. Confirm Bedrock mappings compile correctly