### PR TITLE
Switch OpenAI migration target to gpt-5.2-codex and update tests

### DIFF
--- a/packages/shared/src/providers/openai/environment.test.ts
+++ b/packages/shared/src/providers/openai/environment.test.ts
@@ -100,7 +100,7 @@ approval_mode = "full"`);
 });
 
 describe("getOpenAIEnvironment", () => {
-  it("generates managed model migrations targeting gpt-5.3-codex", async () => {
+  it("generates managed model migrations targeting gpt-5.2-codex", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "cmux-openai-home-"));
     const previousHome = process.env.HOME;
     process.env.HOME = homeDir;
@@ -121,13 +121,13 @@ describe("getOpenAIEnvironment", () => {
       );
       expect(toml).toContain('notify = ["/root/lifecycle/codex-notify.sh"]');
       expect(toml).toContain("[notice.model_migrations]");
-      expect(toml).toContain('"gpt-5-codex" = "gpt-5.3-codex"');
-      expect(toml).toContain('"gpt-5" = "gpt-5.3-codex"');
-      expect(toml).toContain('"o3" = "gpt-5.3-codex"');
-      expect(toml).toContain('"o4-mini" = "gpt-5.3-codex"');
-      expect(toml).toContain('"gpt-4.1" = "gpt-5.3-codex"');
-      expect(toml).toContain('"gpt-5-codex-mini" = "gpt-5.3-codex"');
-      expect(toml).not.toContain('"gpt-5.2-codex" =');
+      expect(toml).toContain('"gpt-5-codex" = "gpt-5.2-codex"');
+      expect(toml).toContain('"gpt-5" = "gpt-5.2-codex"');
+      expect(toml).toContain('"o3" = "gpt-5.2-codex"');
+      expect(toml).toContain('"o4-mini" = "gpt-5.2-codex"');
+      expect(toml).toContain('"gpt-4.1" = "gpt-5.2-codex"');
+      expect(toml).toContain('"gpt-5-codex-mini" = "gpt-5.2-codex"');
+      expect(toml).not.toContain('"gpt-5.3-codex" =');
     } finally {
       process.env.HOME = previousHome;
       await rm(homeDir, { recursive: true, force: true });
@@ -151,7 +151,7 @@ model = "gpt-5"
 model_reasoning_effort = "high"
 
 [notice.model_migrations]
-"o3" = "gpt-5.2-codex"
+"o3" = "gpt-5.3-codex"
 
 [some_section]
 foo = "bar"
@@ -177,8 +177,8 @@ foo = "bar"
       expect(toml).not.toContain('model = "gpt-5"');
       expect(toml).not.toContain('model_reasoning_effort = "high"');
 
-      expect(toml).not.toContain('"o3" = "gpt-5.2-codex"');
-      expect(toml).toContain('"o3" = "gpt-5.3-codex"');
+      expect(toml).not.toContain('"o3" = "gpt-5.3-codex"');
+      expect(toml).toContain('"o3" = "gpt-5.2-codex"');
 
       const noticeSections = toml.match(/\[notice\.model_migrations\]/g) ?? [];
       expect(noticeSections).toHaveLength(1);

--- a/packages/shared/src/providers/openai/environment.ts
+++ b/packages/shared/src/providers/openai/environment.ts
@@ -65,7 +65,7 @@ export function stripFilteredConfigKeys(toml: string): string {
 }
 
 // Target model for migrations - change this when a new latest model is released
-const MIGRATION_TARGET_MODEL = "gpt-5.3-codex";
+const MIGRATION_TARGET_MODEL = "gpt-5.2-codex";
 
 // Models to migrate (legacy models and models without model_reasoning_effort support)
 const MODELS_TO_MIGRATE = [


### PR DESCRIPTION
## Task

### Switch OpenAI Migration Target to gpt-5.2-codex

  #### Summary

  Change the managed OpenAI notice.model\_migrations target from gpt-5.3-codex to
  gpt-5.2-codex in the environment generator, and update tests so they validate
  the new target behavior consistently.

  #### Implementation Plan

1. Update the migration target constant in /Users/karlchow/Desktop/code/cmux/
     packages/shared/src/providers/openai/environment.ts:68.

- Change const MIGRATION\_TARGET\_MODEL = "gpt-5.3-codex"; to const
    MIGRATION\_TARGET\_MODEL = "gpt-5.2-codex";.
- Keep migration generation logic unchanged (generateModelMigrations() still
    maps every model in MODELS\_TO\_MIGRATE to the single managed target).

2. Refresh test expectations in /Users/karlchow/Desktop/code/cmux/packages/
     shared/src/providers/openai/environment.test.ts.

- In the test currently named “generates managed model migrations targeting gpt-
    5.3-codex”, rename to reference gpt-5.2-codex.
- Update all toContain expectations for migrated values from gpt-5.3-codex to
    gpt-5.2-codex.
- Flip the negative check from not.toContain('"gpt-5.2-codex" =') to
    not.toContain('"gpt-5.3-codex" =').

3. Keep replacement behavior test meaningful in /Users/karlchow/Desktop/code/
     cmux/packages/shared/src/providers/openai/environment.test.ts.

- In fixture input for existing [notice.model\_migrations], set old mapping to
    gpt-5.3-codex so the test verifies real replacement.
- Assert output no longer contains gpt-5.3-codex and does contain gpt-5.2-codex.

4. Validate with focused tests.

- Run: cd /Users/karlchow/Desktop/code/cmux/packages/shared && bun test src/
    providers/openai/environment.test.ts
- Success criterion: all tests pass, especially both getOpenAIEnvironment
    migration tests.

  #### Public APIs / Interfaces / Types

- No public API, type, or interface changes.
- Behavior change is internal to generated TOML contents in
    getOpenAIEnvironment.

  #### Test Cases and Scenarios

- Managed migration generation points legacy models to gpt-5.2-codex.
- Existing user [notice.model\_migrations] section is stripped and replaced with
    exactly one managed section.
- Notify hook insertion and filtered key behavior remain unchanged.

  #### Assumptions and Defaults

- “Fallback to gpt-5.2-codex” is interpreted as a direct target switch (not
    runtime conditional fallback logic).
- Scope is limited to OpenAI environment migration generation and its tests.
- No changes to model lists in /Users/karlchow/Desktop/code/cmux/packages/
    shared/src/providers/openai/configs.ts are included in this task.