### PR TITLE
chore: quick-win upstream sync (release v1.0.260)

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@cmux/client",
-  "version": "1.0.258",
+  "version": "1.0.260",
   "description": "cmux client application",
   "author": "cmux",
   "type": "module",
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/karlorz/cmux.git"
+    "url": "https://github.com/manaflow-ai/cmux.git"
   },
   "main": "./out/main/index.js",
   "scripts": {
@@ -131,7 +131,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "lodash.isequal": "^4.5.0",
     "lucide-react": "^0.525.0",
-    "monaco-editor": "^0.55.1",
+    "monaco-editor": "^0.53.0",
     "ms": "^2.1.3",
     "node-forge": "^1.3.1",
     "posthog-js": "^1.297.2",
@@ -176,10 +176,10 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@types/semver": "^7.7.1",
-    "@vitejs/plugin-react": "^5.1.2",
+    "@vitejs/plugin-react": "^4.5.2",
     "electron": "38.0.0",
     "electron-builder": "^26.0.12",
-    "electron-vite": "^5.0.0",
+    "electron-vite": "^4.0.0",
     "eslint": "^9.29.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
@@ -187,7 +187,7 @@
     "node-abi": "^4.14.0",
     "npm-run-all": "^4.1.5",
     "png2icons": "^2.0.1",
-    "rolldown-vite": "^7.3.1",
+    "rolldown-vite": "^7.1.7",
     "tw-animate-css": "^1.3.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.34.1",


### PR DESCRIPTION
Includes cherry-pick of 041a5dea2 (release v1.0.260). b3651aae9 was skipped because equivalent Opus 4.6 Bedrock mapping is already present on main via 2c4fe36a3.