### PR TITLE
chore: quick-win upstream sync (release v1.0.260)

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmux/client",
-  "version": "1.0.258",
+  "version": "1.0.260",
   "description": "cmux client application",
   "author": "cmux",
   "type": "module",


### PR DESCRIPTION
Includes cherry-pick of 041a5dea2 (release v1.0.260). b3651aae9 was skipped because equivalent Opus 4.6 Bedrock mapping is already present on main via 2c4fe36a3; upstream hash not re-picked to avoid redundant/conflicting patch.