### PR TITLE
Fix Docker build: Add missing e2b-client workspace package

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -33,6 +33,7 @@ COPY packages/morphcloud-openapi-client/package.json ./packages/morphcloud-opena
 COPY packages/cmux/package.json ./packages/cmux/
 COPY packages/vscode-extension/package.json ./packages/vscode-extension/
 COPY packages/host-screenshot-collector/package.json ./packages/host-screenshot-collector/
+COPY packages/e2b-client/package.json ./packages/e2b-client/
 COPY scripts/package.json ./scripts/
 
 # Install production dependencies
@@ -106,6 +107,7 @@ COPY --from=deps /tmp/deps-to-hoist.txt /tmp/deps-to-hoist.txt
 COPY packages/shared ./packages/shared
 COPY packages/convex ./packages/convex
 COPY packages/www-openapi-client ./packages/www-openapi-client
+COPY packages/e2b-client ./packages/e2b-client
 
 # Copy server source code
 COPY apps/server ./apps/server
@@ -121,7 +123,8 @@ COPY package.json bun.lock .npmrc ./
 RUN rm -rf node_modules/@cmux && mkdir -p node_modules/@cmux \
     && ln -s ../../packages/shared node_modules/@cmux/shared \
     && ln -s ../../packages/convex node_modules/@cmux/convex \
-    && ln -s ../../packages/www-openapi-client node_modules/@cmux/www-openapi-client
+    && ln -s ../../packages/www-openapi-client node_modules/@cmux/www-openapi-client \
+    && ln -s ../../packages/e2b-client node_modules/@cmux/e2b-client
 
 # Auto-hoist packages from .bun/ cache to node_modules root
 # Bun's --production install puts packages in nested .bun/ directory


### PR DESCRIPTION
## Task

# Fix: apps/server Coolify deploy fails — missing @cmux/e2b-client workspace package

## Root Cause

`bun install` in the Docker build fails at Dockerfile line 41 because `packages/convex/package.json` declares a dependency on `@cmux/e2b-client` (workspace:\*), but the Dockerfile never copies `packages/e2b-client/package.json` into the build context. Bun cannot resolve the workspace dependency and errors out.

## Fix

Add the missing COPY line to `apps/server/Dockerfile` (Stage 1: deps).

### File: `apps/server/Dockerfile`

**Change 1** — Add `packages/e2b-client/package.json` to the deps stage (after line 35, alongside the other `packages/*` entries):

```dockerfile
COPY packages/e2b-client/package.json ./packages/e2b-client/
```

**Change 2** — In the production stage, also copy `packages/e2b-client` source and symlink it, since `packages/convex` imports from it at runtime:

After line 108 (`COPY packages/www-openapi-client`):

```dockerfile
COPY packages/e2b-client ./packages/e2b-client
```

After line 124 (the `ln -s` for www-openapi-client):

```
&& ln -s ../../packages/e2b-client node_modules/@cmux/e2b-client
```

## Verification

- Re-deploy on Coolify and confirm the build passes the `bun install` step
- Or locally: `docker compose -f apps/server/docker-compose.yml build` from repo root

## PR Review Summary

- **What Changed**: Updated `apps/server/Dockerfile` to correctly include the `@cmux/e2b-client` workspace package which was causing deployment failures on Coolify. 
  - Added `COPY` command for `packages/e2b-client/package.json` in the dependency stage.
  - Added `COPY` command for the full `packages/e2b-client` source in the production stage.
  - Added a manual symlink in `node_modules/@cmux/e2b-client` to ensure the workspace package is resolvable at runtime.

- **Review Focus**: 
  - Verify that the path `packages/e2b-client` matches the actual folder name in the repository.
  - Confirm that the symlink name `@cmux/e2b-client` matches the package name defined in its `package.json`.

- **Test Plan**: 
  - Run a local Docker build to verify the `bun install` step passes: `docker compose -f apps/server/docker-compose.yml build`.
  - Exec into the built container and verify that `node_modules/@cmux/e2b-client` is a valid symlink pointing to the package source.
  - Deploy to Coolify and confirm the build succeeds.