### PR TITLE
[Crown] # Plan: Clone Single Repo Directly to /root/workspace

## Con...

### DIFF
--- a/apps/www/lib/routes/morph.route.ts
+++ b/apps/www/lib/routes/morph.route.ts
@@ -855,7 +855,8 @@ morphRouter.openapi(
           const rootRepoMatchesSelected =
             hasRootRepo &&
             rootRepoRemote !== "no-remote" &&
-            rootRepoRemote.includes(selectedRepo);
+            (rootRepoRemote.endsWith(`/${selectedRepo}.git`) ||
+              rootRepoRemote.endsWith(`/${selectedRepo}`));
 
           if (hasRootRepo && !rootRepoMatchesSelected) {
             console.log(
@@ -984,7 +985,13 @@ morphRouter.openapi(
                 () => sandboxInstance.exec(`rm -rf /root/workspace/${existingName}`)
               );
               removedRepos.push(existingName);
-            } else if (existingUrl && !existingUrl.includes(selectedRepo)) {
+            } else if (
+              existingUrl &&
+              !(
+                existingUrl.endsWith(`/${selectedRepo}.git`) ||
+                existingUrl.endsWith(`/${selectedRepo}`)
+              )
+            ) {
               console.log(
                 `Repository ${existingName} points to different remote, removing for re-clone`
               );


### PR DESCRIPTION
## Task

# Plan: Clone Single Repo Directly to /root/workspace

## Context

When creating a custom environment with a single repository, the repo is cloned to `/root/workspace/repo-name` (as a subdirectory). Many coding agents (Claude Code, Codex, Gemini CLI, etc.) expect the repo to be at the workspace root `/root/workspace`. When only one repo is selected, the clone should go directly to `/root/workspace` instead of a subdirectory.

The multi-repo subdirectory layout should remain unchanged when 2+ repos are selected.

## File to Modify

- `apps/www/lib/routes/morph.route.ts` (lines 778-950) -- the `setup-instance` route handler

This endpoint handles BOTH Morph Cloud and PVE LXC providers (line 572: `getActiveSandboxProvider()`, line 584: `if (provider === "pve-lxc")`). The clone logic at lines 778-950 runs identically for both providers, so the fix covers both.

No other files need changes. The frontend, sandboxes.route.ts (task run path), and hydrateRepoScript.ts already handle single repos correctly.

## Implementation

### 1. Add root-level repo detection (after line 807)

After the existing validation block, detect whether `/root/workspace` itself is a git repo:

```typescript
const isSingleRepo = selectedRepos.length === 1;

// Check if workspace root itself has a git repo (single-repo layout)
const rootRepoCheck = await Sentry.startSpan(
  { name: "instance.exec (check root repo)", op: "sandbox.exec" },
  () => sandboxInstance.exec(
    'if [ -d "/root/workspace/.git" ]; then git -C /root/workspace remote get-url origin 2>/dev/null || echo "no-remote"; else echo "no-git"; fi'
  )
);
const rootRepoRemote = rootRepoCheck.stdout.trim();
const hasRootRepo = rootRepoRemote !== "no-git";
```

### 2. Branch cleanup logic by repo count

**Single-repo path** (new):

- Remove any leftover subdirectory repos (from a previous multi-repo layout)
- If root `.git` remote doesn't match the selected repo, clear workspace

**Multi-repo path** (modified):

- If root `.git` exists (from a previous single-repo layout), clear workspace before doing existing subdirectory scan/cleanup

### 3. Branch clone logic by repo count

**Single-repo** (`selectedRepos.length === 1`):

- `git clone https://github.com/${repo}.git . 2>&1` (clone into current dir)
- Same retry logic (3 attempts) and auth error detection as existing code
- On retry cleanup: `rm -rf /root/workspace/.git /root/workspace/* /root/workspace/.[!.]* 2>/dev/null || true`

**Multi-repo** (`selectedRepos.length > 1`):

- Existing logic unchanged (lines 857-949)

### 4. Full restructured flow (lines 778-950)

```
if (selectedRepos && selectedRepos.length > 0) {
  const isSingleRepo = selectedRepos.length === 1;

  // Validation (EXISTING, unchanged)
  // Root repo detection (NEW)

  if (isSingleRepo) {
    // Remove subdirectory repos from previous multi-repo layout (NEW)
    // Handle root repo remote mismatch (NEW)
    // Clone directly to /root/workspace with `git clone ... .` (NEW)
  } else {
    // Clear root .git if transitioning from single-repo (NEW)
    // Existing subdirectory scan/cleanup (EXISTING)
    // Existing per-owner clone loop (EXISTING)
  }
}
```

### Edge Cases

| Scenario | Behavior |
|----------|----------|
| Fresh snapshot, 1 repo | Clone directly to `/root/workspace` |
| Same single repo already at root | Skip clone (remote matches) |
| Different single repo at root | Clear workspace, clone new repo |
| Multi-repo layout -> 1 repo | Remove subdirs, clone to root |
| Single-repo layout -> multi-repo | Clear root `.git`, then subdirectory cloning |
| Multi-repo -> multi-repo | Existing logic (unchanged) |

## Verification

1. Run `bun check` to verify no type errors
2. Test manually:

- Create custom environment with 1 repo: verify cloned to `/root/workspace` (not subdirectory)
- Create custom environment with 2+ repos: verify each in `/root/workspace/{repoName}`

## PR Review Summary
- What Changed:
  - Refactored the `setup-instance` route handler in `apps/www/lib/routes/morph.route.ts` to differentiate between single and multiple selected repositories.
  - For a single selected repository, the system now clones the repository directly into `/root/workspace` using `git clone ... .`.
  - For multiple selected repositories, the existing logic for cloning each repository into its own subdirectory (`/root/workspace/{repoName}`) remains in place.
  - Introduced a `rootRepoCheck` to detect if `/root/workspace` itself contains a Git repository.
  - Implemented cleanup and re-cloning logic to handle transitions between single-repo and multi-repo layouts, ensuring the workspace is correctly prepared (e.g., clearing the root `.git` if switching from single to multi-repo, or removing subdirectory repos if switching from multi to single-repo).
  - Defined a `clearWorkspaceCmd` for robust workspace clearing during these transitions or upon failed single-repo clone retries.
- Review Focus:
  - Verify the correctness and robustness of the `rootRepoCheck` command and its subsequent logic for detecting existing root-level repositories.
  - Carefully review the workspace clearing logic (`clearWorkspaceCmd`) to ensure it prevents unintended data loss during layout transitions while correctly preparing the sandbox.
  - Confirm that the retry mechanism and authentication error handling for the new single-repo clone path (`git clone ... .`) functions consistently and correctly.
  - Ensure that the cleanup process for subdirectory repositories when transitioning from a multi-repo layout to a single-repo layout is effective.
- Test Plan:
  - Run `bun check` to verify no type errors.
  - Create a custom environment with a **single repository** and confirm it is cloned directly to `/root/workspace` (no subdirectory).
  - Create a custom environment with **two or more repositories** and confirm each is cloned into its own subdirectory (e.g., `/root/workspace/repo-name`).
  - Test switching from a single-repo environment to a multi-repo environment, verifying the workspace is cleared and new repos are in subdirectories.
  - Test switching from a multi-repo environment to a single-repo environment, verifying subdirectories are removed and the new single repo is at the root.
  - Test re-creating an environment with the *same* single repository (should skip cloning if remote matches) and with a *different* single repository (should clear and re-clone).