### PR TITLE
[Crown] # Plan: Replace Global Environment Variables Textarea with Ke...

### DIFF
--- a/apps/client/src/components/EnvVarsKeyValueGrid.tsx
+++ b/apps/client/src/components/EnvVarsKeyValueGrid.tsx
@@ -9,12 +9,18 @@ type EnvVarsKeyValueGridProps = {
   envVars: EnvVar[];
   onUpdate: (updater: (prev: EnvVar[]) => EnvVar[]) => void;
   disabled?: boolean;
+  title?: string;
+  description?: string;
+  footerRight?: React.ReactNode;
 };
 
 export function EnvVarsKeyValueGrid({
   envVars,
   onUpdate,
   disabled = false,
+  title,
+  description,
+  footerRight,
 }: EnvVarsKeyValueGridProps) {
   const [areEnvValuesHidden, setAreEnvValuesHidden] = useState(true);
   const [activeEnvValueIndex, setActiveEnvValueIndex] = useState<number | null>(
@@ -64,11 +70,23 @@ export function EnvVarsKeyValueGrid({
   );
 
   return (
-    <div className="space-y-1.5" onPasteCapture={handleEnvPaste}>
-      <div className="flex flex-wrap items-center justify-end gap-2">
+    <div className="space-y-1 pt-1" onPasteCapture={handleEnvPaste}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          {title && (
+            <p className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+              {title}
+            </p>
+          )}
+          {description && (
+            <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
+              {description}
+            </p>
+          )}
+        </div>
         <button
           type="button"
-          className="inline-flex items-center gap-1 rounded-md border border-neutral-300 bg-white px-2 py-1 text-xs font-medium text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
+          className="inline-flex items-center gap-1 rounded-md border border-neutral-200 bg-white px-2 py-1 text-[11px] font-medium text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
           onClick={() => {
             setActiveEnvValueIndex(null);
             setAreEnvValuesHidden((previous) => !previous);
@@ -97,7 +115,7 @@ export function EnvVarsKeyValueGrid({
 
       <div className="space-y-1.5">
         <div
-          className="grid gap-2 text-xs font-medium text-neutral-600 dark:text-neutral-400 items-center"
+          className="grid gap-2 text-[11px] font-medium text-neutral-600 dark:text-neutral-400 items-center"
           style={{ gridTemplateColumns: "3fr 7fr 36px" }}
         >
           <span>Key</span>
@@ -189,10 +207,10 @@ export function EnvVarsKeyValueGrid({
         </div>
       </div>
 
-      <div className="flex items-start pt-1">
+      <div className="flex items-start justify-between gap-2 pt-1 pb-1">
         <button
           type="button"
-          className="inline-flex items-center gap-1 text-xs text-neutral-500 transition-colors hover:text-neutral-700 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-400 dark:hover:text-neutral-200"
+          className="inline-flex items-center gap-1 text-[11px] text-neutral-500 transition-colors hover:text-neutral-700 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-400 dark:hover:text-neutral-200"
           onClick={() =>
             onUpdate((prev) => [
               ...prev,
@@ -208,6 +226,7 @@ export function EnvVarsKeyValueGrid({
           <Plus className="h-3.5 w-3.5" />
           Add variable
         </button>
+        {footerRight}
       </div>
     </div>
   );


### PR DESCRIPTION
## Task

# Plan: Replace Global Environment Variables Textarea with Key-Value Pair Input

## Goal

Replace the textarea-based environment variables editor on the environment details page with the same key-value pair grid used in the Per-Repository Configuration (WorkspaceSetupPanel).

## Approach

1. Create a new `EnvVarsKeyValueGrid` component (copying the pattern from WorkspaceSetupPanel)
2. Use it in the environment details page (replacing the textarea)
3. **Do NOT touch WorkspaceSetupPanel** - leave it and the dashboard untouched

Adopt the "always editable" pattern (no Edit/View toggle) with Save/Discard buttons and an "Unsaved changes" indicator.

## Files to Change

### 1. CREATE `apps/client/src/components/EnvVarsKeyValueGrid.tsx`

New component copying the key-value grid pattern from WorkspaceSetupPanel (lines 341-493). The component will:

- Accept props: `envVars: EnvVar[]`, `onUpdate: (updater) => void`, `disabled?: boolean`
- Manage internal state: `areEnvValuesHidden`, `activeEnvValueIndex`
- Include: paste handler (`onPasteCapture` using `parseEnvBlock`), Reveal/Hide toggle, Key/Value grid rows, remove buttons, "Add variable" button
- Use `MASKED_ENV_VALUE = "••••••••••••••••"` for masking

Reuse existing utilities:

- `parseEnvBlock` from `@/lib/parseEnvBlock`
- `EnvVar` from `@/types/environment`

### 2. MODIFY `apps/client/src/routes/_layout.$teamSlugOrId.environments.$environmentId.tsx`

**State changes (around lines 161-163):**

- Remove: `isEditingEnvVars`, `envVarsDraft` (string), `showEnvVars`
- Add: `envVars: EnvVar[]` state, `updateEnvVars` callback, `hasInitializedEnvVarsRef`
- Add: `currentEnvContent` memo (via `formatEnvVarsContent`), `normalizedServerContent` memo, `hasEnvVarsChanges` boolean
- Add imports: `useCallback`, `useMemo`, `useRef`, `EnvVarsKeyValueGrid`, `parseEnvBlock`, `ensureInitialEnvVars`, `EnvVar`, `formatEnvVarsContent`

**Sync effect (around lines 230-234):**

- Replace string-based sync with `parseEnvBlock` -> `ensureInitialEnvVars` flow
- Use `hasInitializedEnvVarsRef` to only sync once on mount (prevent background refetch from overwriting edits)

**Handler functions (around lines 324-373):**

- Remove: `handleStartEditingEnvVars`, `handleCancelEnvVars`, `maskEnvVarsContent`
- Replace `handleSaveEnvVars`: serialize `currentEnvContent` to API, reset init ref, refetch
- Add `handleDiscardEnvVars`: reset init ref, refetch from server

**UI section (lines 1028-1142):**

- Remove: textarea (`ScriptTextareaField`), Edit/Add button, Show/Hide button, `<pre>` read-only view
- Add: `<EnvVarsKeyValueGrid>` component, Save button (disabled when no changes), Discard button (shown when changes exist), "Unsaved changes" indicator
- Keep: header with KeyRound icon and description text, loading state

### NOT changed

- `apps/client/src/components/WorkspaceSetupPanel.tsx` - untouched (used by dashboard and env setup flow)

## Verification

1. Run `bun check` to verify TypeScript compilation
2. Test on `localhost:5173/dev/environments/{id}`:

- Load with existing env vars -> key-value rows appear
- Load with no env vars -> one empty row
- Edit key/value -> "Unsaved changes" appears, Save becomes enabled
- Save -> API call succeeds, toast shown
- Discard -> reverts to server state
- Paste `.env` block into a key field -> auto-parses into rows
- Reveal/Hide toggle -> masks/shows values
- Add/remove variable rows

3. Verify dashboard workspace config is unaffected (WorkspaceSetupPanel not modified)

## PR Review Summary
- What Changed:
  - A new `EnvVarsKeyValueGrid` component was created in `apps/client/src/components/EnvVarsKeyValueGrid.tsx`. This component provides a key-value pair input grid for environment variables, including features like 'Reveal/Hide' values, 'Add variable' button, and `.env` block paste handling.
  - The `EnvironmentDetailsPage` (`apps/client/src/routes/_layout.$teamSlugOrId.environments.$environmentId.tsx`) was refactored to replace the old textarea-based environment variable editor with the new `EnvVarsKeyValueGrid`.
  - State management for environment variables on the `EnvironmentDetailsPage` was updated: removed `isEditingEnvVars`, `envVarsDraft`, `showEnvVars`, and added `envVars` (array of `EnvVar`), `hasInitializedEnvVarsRef`, `currentEnvContent` (memoized), `normalizedServerEnvContent` (memoized), and `hasEnvVarsChanges` (boolean).
  - The initial synchronization of environment variables on mount was updated to use `parseEnvBlock` and `ensureInitialEnvVars` to populate the new `envVars` state.
  - `handleSaveEnvVars` was modified to serialize the `envVars` state to `envVarsContent` for the API, and `handleDiscardEnvVars` was added to reset changes by refetching from the server.
  - The UI for environment variables on the `EnvironmentDetailsPage` was completely revamped: `ScriptTextareaField`, 'Edit', 'Add', 'Show', 'Hide' buttons, and the read-only `<pre>` view were removed. They were replaced by the `<EnvVarsKeyValueGrid>`, a 'Save' button (enabled when `hasEnvVarsChanges`), a 'Discard' button (shown when `hasEnvVarsChanges`), and an 'Unsaved changes' indicator.
  - The `WorkspaceSetupPanel.tsx` component was explicitly not modified, preserving its existing functionality on the dashboard.

- Review Focus:
  - Verify the `EnvVarsKeyValueGrid` correctly parses and displays existing environment variables from the server.
  - Carefully review the `onPasteCapture` logic within `EnvVarsKeyValueGrid` for handling `.env` blocks, especially for scenarios involving duplicate keys or malformed input.
  - Test the state synchronization and change detection (`hasEnvVarsChanges`) to ensure 'Save' and 'Discard' buttons behave as expected under various editing scenarios (add, remove, modify key/value).
  - Confirm that the 'Reveal/Hide' toggle functions correctly and does not inadvertently expose sensitive information or interfere with editing.
  - Ensure the `ensureInitialEnvVars` logic correctly handles both empty and populated server responses without overwriting user edits during background refetches.

- Test Plan:
  - Navigate to `localhost:5173/dev/environments/{id}` for an environment with existing variables: Confirm they load correctly into the key-value grid.
  - For an environment with no variables: Verify one empty row appears initially.
  - Edit a key or value in the grid: Observe the 'Unsaved changes' indicator appear and the 'Save' button enable. Save the changes and confirm persistence after refresh.
  - Make changes and then click 'Discard': Verify all edits are reverted to the server's last saved state.
  - Paste a multi-line `.env` block (e.g., `KEY1=value1\nKEY2=value2`) into a key field: Confirm it auto-parses into multiple key-value rows.
  - Toggle the 'Reveal' and 'Hide' button: Ensure values are masked/unmasked correctly and editing still functions when values are masked.
  - Add new variables using the 'Add variable' button and remove existing ones using the 'Minus' button.
  - Verify that the dashboard workspace configuration (using `WorkspaceSetupPanel`) remains unchanged and fully functional.