### PR TITLE
[Crown] # Fix: VNC Reconnection Steals Focus from Workspace Panel

##...

### DIFF
--- a/packages/shared/src/components/vnc-viewer.tsx
+++ b/packages/shared/src/components/vnc-viewer.tsx
@@ -316,10 +316,28 @@ export const VncViewer = forwardRef<VncViewerHandle, VncViewerProps>(
         if (isUnmountedRef.current) return;
 
         const wsUrl = urlRef.current;
+
+        // Save focus before RFB creation - noVNC appends a new canvas which can steal focus
+        const previouslyFocused = document.activeElement;
+        const containerEl = containerRef.current;
+        const focusWasOutsideVnc =
+          previouslyFocused &&
+          previouslyFocused !== containerEl &&
+          !containerEl.contains(previouslyFocused);
+
         const rfb = new RFB(containerRef.current, wsUrl, {
           credentials: undefined,
           wsProtocols: ["binary"],
         });
+
+        // Restore focus if it was outside VNC container before RFB creation
+        if (focusWasOutsideVnc && previouslyFocused instanceof HTMLElement) {
+          try {
+            previouslyFocused.focus({ preventScroll: true });
+          } catch (e) {
+            console.error("[VncViewer] Failed to restore focus:", e);
+          }
+        }
 
         rfb.scaleViewport = scaleViewport;
         rfb.clipViewport = clipViewport;
@@ -980,7 +998,7 @@ export const VncViewer = forwardRef<VncViewerHandle, VncViewerProps>(
           ref={containerRef}
           className="absolute inset-0"
           style={{ background }}
-          tabIndex={0}
+          tabIndex={-1}
           data-drag-disable-pointer
         />
 


### PR DESCRIPTION
## Task

# Fix: VNC Reconnection Steals Focus from Workspace Panel

## Problem

When the Browser panel's VNC connection drops and auto-reconnects, it steals focus from the Workspace panel (OpenVSCode iframe), interrupting typing.

## Root Cause

In `packages/shared/src/components/vnc-viewer.tsx`, the `connectInternal` function (line 298) creates a new `RFB` instance on every reconnection:

```typescript
const rfb = new RFB(containerRef.current, wsUrl, { ... });
```

The noVNC library appends a new `<div>` containing a `<canvas>` into the container. Because the container has `tabIndex={0}` (line 983), this DOM insertion can cause browsers to shift focus to the container, stealing it from other panels.

This happens on:

- Auto-reconnect after unclean disconnect (exponential backoff, every 1-30s)
- Manual browser reload events (`disconnect()` + `connect()`)
- URL prop changes triggering reconnect (line 854-859)

The existing `iframeFocusGuard.ts` only protects against `HTMLIFrameElement` focus steals, not canvas/div elements.

## Fix (single file: `packages/shared/src/components/vnc-viewer.tsx`)

### Change 1: Save/restore focus around RFB creation in `connectInternal`

After line 318 (`const wsUrl = urlRef.current;`), before `new RFB(...)`:

- Capture `document.activeElement`
- Check if focus is outside the VNC container
- After RFB creation, restore focus if it was outside

```typescript
// Before RFB creation:
const previouslyFocused = document.activeElement;
const containerEl = containerRef.current;
const focusWasOutsideVnc =
    previouslyFocused &&
    previouslyFocused !== containerEl &&
    !containerEl.contains(previouslyFocused);

const rfb = new RFB(containerRef.current, wsUrl, { ... });

// After RFB creation:
if (focusWasOutsideVnc && previouslyFocused instanceof HTMLElement) {
    try {
        previouslyFocused.focus({ preventScroll: true });
    } catch (e) {
        console.error("[VncViewer] Failed to restore focus:", e);
    }
}
```

### Change 2: Change container `tabIndex` from `0` to `-1}` (line 983)

- `tabIndex={0}` makes the container a tab stop and amplifies implicit focus shifts
- `tabIndex={-1}` keeps it programmatically focusable but removes it from tab order
- `focusOnClick` still works because it calls `rfbRef.current.focus()` explicitly

## What stays unchanged

- `iframeFocusGuard.ts` - extending it would be too broad
- `browser-reload-events.ts` - benefits automatically from the connectInternal fix
- `focusOnClick` behavior - only fires on user interaction, not during reconnection

## Verification

1. Run `bun check` after changes
2. Open a task with both Workspace and Browser panels visible
3. Click into Workspace (VSCode) and type continuously
4. Force VNC disconnect (kill VNC server or wait for natural disconnect)
5. Confirm: typing in VSCode is NOT interrupted during reconnection
6. After VNC reconnects, click Browser panel - confirm VNC input works
7. Test Tab key navigation - VNC container should not be a tab stop

## PR Review Summary
- What Changed:
  - **VNC Focus Stealing Fix (`packages/shared/src/components/vnc-viewer.tsx`):**
    - **Focus Preservation/Restoration:** Within the `connectInternal` function, logic was added to save the currently focused element *before* a new `RFB` instance is created. After the `RFB` instance is initialized, if the focus was originally outside the VNC container, it is now programmatically restored to its previous location using `previouslyFocused.focus({ preventScroll: true })`.
    - **`tabIndex` Adjustment:** The `tabIndex` attribute of the VNC viewer's main container `div` was changed from `0` to `-1`. This removes the VNC container from the default tab navigation order, while still allowing it to be programmatically focused.
- Review Focus:
  - **Focus Restoration Edge Cases:** Verify that the focus restoration logic (`previouslyFocused.focus()`) reliably restores focus across various scenarios and browsers, especially if the originally focused element is no longer valid or accessible when reconnection occurs.
  - **Keyboard Accessibility:** Ensure that changing `tabIndex` to `-1` does not negatively impact any other keyboard navigation or accessibility features within the VNC viewer or its interaction with other panels.
- Test Plan:
  1. Run `bun check`.
  2. Open a task that displays both the Workspace (VSCode) and Browser panels.
  3. Click into the Workspace panel and continuously type.
  4. Force a VNC disconnect (e.g., kill the VNC server or wait for a natural disconnect).
  5. **Confirm:** Typing in VSCode should NOT be interrupted during the VNC reconnection process.
  6. After VNC successfully reconnects, click into the Browser panel and confirm that VNC input functions correctly.
  7. Test `Tab` key navigation: Verify that the VNC container is no longer a tab stop when tabbing through the UI.