### PR TITLE
[Crown] # Plan: Fix Server Deploy Failure + Worker Test Timeouts

## ...

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -34,7 +34,6 @@ COPY packages/cmux/package.json ./packages/cmux/
 COPY packages/vscode-extension/package.json ./packages/vscode-extension/
 COPY packages/host-screenshot-collector/package.json ./packages/host-screenshot-collector/
 COPY packages/e2b-client/package.json ./packages/e2b-client/
-COPY packages/modal-client/package.json ./packages/modal-client/
 COPY scripts/package.json ./scripts/
 
 # Install production dependencies
@@ -109,7 +108,6 @@ COPY packages/shared ./packages/shared
 COPY packages/convex ./packages/convex
 COPY packages/www-openapi-client ./packages/www-openapi-client
 COPY packages/e2b-client ./packages/e2b-client
-COPY packages/modal-client ./packages/modal-client
 
 # Copy server source code
 COPY apps/server ./apps/server
@@ -126,8 +124,7 @@ RUN rm -rf node_modules/@cmux && mkdir -p node_modules/@cmux \
     && ln -s ../../packages/shared node_modules/@cmux/shared \
     && ln -s ../../packages/convex node_modules/@cmux/convex \
     && ln -s ../../packages/www-openapi-client node_modules/@cmux/www-openapi-client \
-    && ln -s ../../packages/e2b-client node_modules/@cmux/e2b-client \
-    && ln -s ../../packages/modal-client node_modules/@cmux/modal-client
+    && ln -s ../../packages/e2b-client node_modules/@cmux/e2b-client
 
 # Auto-hoist packages from .bun/ cache to node_modules root
 # Bun's --production install puts packages in nested .bun/ directory

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    testTimeout: 15_000,
+  },
+});


### PR DESCRIPTION
## Task

# Plan: Fix Server Deploy Failure + Worker Test Timeouts

## Issue 1: Server Deployment Failure (blocking)

**Root cause:** The Dockerfile at `apps/server/Dockerfile` references `packages/modal-client` which was deleted in the upstream sync (commit `173dfed61` — "remove modal-client wrapper, use official Modal SDK directly"). No TS code imports `@cmux/modal-client` anymore.

**The Dockerfile has 3 stale references:**

1. **Line 37** (deps stage): `COPY packages/modal-client/package.json ./packages/modal-client/`
2. **Line 112** (production stage): `COPY packages/modal-client ./packages/modal-client`
3. **Line 130** (symlink step): `&& ln -s ../../packages/modal-client node_modules/@cmux/modal-client`

**Fix:** Remove all 3 lines from `apps/server/Dockerfile`.

### Files to modify

- `apps/server/Dockerfile` — remove lines 37, 112, and the `modal-client` symlink from line 130

---

## Issue 2: Worker Test Timeouts (non-blocking, flaky)

**Root cause:** 4 tests in `apps/worker/scripts/` timeout at vitest's default 5000ms because they create bare git repos with remote push/fetch operations in `beforeEach`, then run shell scripts that also do git fetch/merge-base/diff. Total execution exceeds 5s.

**Failing tests:**

- `collect-crown-diff.base-override.test.ts`
- `collect-crown-diff.dev-default.test.ts`
- `collect-crown-diff.origin.test.ts`
- `collect-relevant-diff.base-override.test.ts`

**Passing tests** (local-only git, no remote ops) complete in 1-2s.

**Fix:** Create `apps/worker/vitest.config.ts` with `testTimeout: 15_000`. The workspace glob at `vitest.workspace.ts` (`apps/*/vitest.config.ts`) will auto-discover it. This follows the existing pattern from `packages/convex/vitest.config.ts`.

### Files to create

- `apps/worker/vitest.config.ts`:

```ts
import { defineConfig } from "vitest/config";

export default defineConfig({
  test: {
    environment: "node",
    testTimeout: 15_000,
  },
});
```

---

## Verification

1. Run `bun check` to verify no type errors
2. Run `bun run --filter @cmux/worker test` to verify all worker tests pass
3. Rebuild the server Docker image locally to verify the Dockerfile fix:
   `docker build -f apps/server/Dockerfile .` (or redeploy via Coolify)

Implement plan

## PR Review Summary
- What Changed:
  - **`apps/server/Dockerfile`:** Removed all three stale references to `packages/modal-client` (COPY instructions and a symlink) as this package was deleted upstream and is no longer used.
  - **`apps/worker/vitest.config.ts`:** Added a new Vitest configuration file for the worker app, setting `testTimeout` to 15,000ms (15 seconds). This addresses recurring timeouts for worker tests involving git operations.
- Review Focus:
  - **Server Dockerfile Cleanup:** Confirm that removing `modal-client` references from the Dockerfile does not introduce any unforeseen build or runtime issues, although the original request states no TS code imports it.
  - **Worker Test Timeout:** Ensure that 15,000ms is a sufficient and appropriate timeout for the worker tests and doesn't just mask underlying performance problems, especially for the git-heavy tests.
- Test Plan:
  - Run `bun check` to verify no type errors.
  - Execute worker tests with `bun run --filter @cmux/worker test` to confirm all tests pass, including the previously timing-out ones.
  - Build the server Docker image locally using `docker build -f apps/server/Dockerfile .` to validate the Dockerfile changes, or perform a full server redeployment.