### PR TITLE
sync: merge upstream/main into fork (2026-02-14)

### DIFF
--- a/packages/cloudrouter/internal/cli/sshproxy.go
+++ b/packages/cloudrouter/internal/cli/sshproxy.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/spf13/cobra"
+)
+
+var sshProxyCmd = &cobra.Command{
+	Use:    "__ssh-proxy",
+	Short:  "Internal: WebSocket-to-stdio SSH proxy",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		wsURL := args[0]
+		return runSSHProxy(wsURL)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(sshProxyCmd)
+}
+
+// runSSHProxy bridges stdin/stdout to a WebSocket connection.
+// This is used as an SSH ProxyCommand to tunnel SSH over WebSocket
+// without depending on external tools like curl.
+func runSSHProxy(wsURL string) error {
+	dialer := websocket.Dialer{
+		HandshakeTimeout:  30 * time.Second,
+		EnableCompression: false,
+	}
+
+	wsConn, _, err := dialer.Dial(wsURL, http.Header{})
+	if err != nil {
+		return fmt.Errorf("WebSocket connect failed: %w", err)
+	}
+	defer wsConn.Close()
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// stdin -> WebSocket
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if n > 0 {
+				if writeErr := wsConn.WriteMessage(websocket.BinaryMessage, buf[:n]); writeErr != nil {
+					return
+				}
+			}
+			if err != nil {
+				wsConn.WriteMessage(websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				return
+			}
+		}
+	}()
+
+	// WebSocket -> stdout
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		for {
+			messageType, data, err := wsConn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if messageType == websocket.BinaryMessage || messageType == websocket.TextMessage {
+				if _, writeErr := os.Stdout.Write(data); writeErr != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	// Wait for WebSocket read side to finish (connection closed)
+	<-done
+	// Also wait briefly for stdin side to clean up
+	stdinDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(stdinDone)
+	}()
+	select {
+	case <-stdinDone:
+	case <-time.After(2 * time.Second):
+	}
+
+	return nil
+}
+
+// getSelfPath returns the path to the currently running executable.
+// Used to construct ProxyCommand for SSH tunneling via __ssh-proxy.
+func getSelfPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine executable path: %w", err)
+	}
+	return exe, nil
+}

--- a/packages/cloudrouter/npm/cloudrouter/bin/cloudrouter
+++ b/packages/cloudrouter/npm/cloudrouter/bin/cloudrouter
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const { execFileSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+// This is a placeholder that gets overwritten by postinstall.
+// If postinstall didn't run (e.g. npx), fall back to lib/cloudrouter binary.
+const libBinary = path.join(__dirname, "..", "lib", "cloudrouter");
+if (fs.existsSync(libBinary)) {
+  try {
+    const result = execFileSync(libBinary, process.argv.slice(2), {
+      stdio: "inherit",
+      env: process.env,
+    });
+    process.exit(0);
+  } catch (e) {
+    process.exit(e.status || 1);
+  }
+} else {
+  console.error("cloudrouter: binary not found. Try reinstalling: npm install -g @manaflow-ai/cloudrouter");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Merge `upstream/main` into `sync/upstream-main-20260214` with a merge commit (no rebase).
- Preserve fork behavior in conflicted fork-owned areas (`packages/cloudrouter/**`, `packages/cmux-devbox/**`, Convex fork surfaces, and website fork customizations).
- Pull in upstream CloudRouter SSH proxy support files that applied cleanly after conflict resolution:
  - `packages/cloudrouter/internal/cli/sshproxy.go`
  - `packages/cloudrouter/npm/cloudrouter/bin/cloudrouter`

## Conflict Decisions
- Kept fork repository metadata where upstream conflicted (`https://github.com/karlorz/cmux.git` for fork-owned packages).
- Kept fork-side Convex schema path and dropped a partial upstream Convex subscription-table addition to avoid schema/type mismatches.

## Verification
- `bun check` passed.
- `./.codex/skills/upstream-sync/scripts/audit-package-repo-links.sh` passed.

## Morph -> PVE-LXC Parity
Range: `origin/main...HEAD`
- Morph hotspot files changed: 0
- PVE-LXC hotspot files changed: 0
- Morph-only alerts: none

## Follow-up Checklist
- [x] No Morph-only parity follow-up required for this merge range.
