### PR TITLE
[Crown] ### Tighten Convex Snapshot Maintenance Windows (Orphan 7d→5d...

### DIFF
--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -11,7 +11,7 @@ crons.daily(
   internal.sandboxInstanceMaintenance.pauseOldSandboxInstances
 );
 
-// Stop inactive sandbox instances (paused for >14 days)
+// Stop inactive sandbox instances (paused for >7 days)
 // Runs daily at 21:20 UTC (5:20 AM HKT)
 crons.daily(
   "stop old sandbox instances",

--- a/packages/convex/convex/morphInstanceMaintenance.ts
+++ b/packages/convex/convex/morphInstanceMaintenance.ts
@@ -147,12 +147,12 @@ export const pauseOldMorphInstances = internalAction({
   },
 });
 
-const STOP_DAYS_THRESHOLD = 14; // 2 weeks
+const STOP_DAYS_THRESHOLD = 7; // 7 days
 const STOP_BATCH_SIZE = 5;
 
 /**
- * Stops (deletes) Morph instances that have been inactive for more than 2 weeks.
- * Only stops instances where lastResumedAt is older than 2 weeks (or never resumed).
+ * Stops (deletes) Morph instances that have been inactive for more than 7 days.
+ * Only stops instances where lastResumedAt is older than 7 days (or never resumed).
  * Called by the daily cron job at 5 AM Pacific Time.
  */
 export const stopOldMorphInstances = internalAction({

--- a/packages/convex/convex/sandboxInstanceMaintenance.ts
+++ b/packages/convex/convex/sandboxInstanceMaintenance.ts
@@ -33,8 +33,8 @@ const PAUSE_HOURS_THRESHOLD = 20;
 // Provider-specific threshold for PVE LXC
 // PVE LXC doesn't preserve memory state on pause, so use longer pause threshold
 const PAUSE_DAYS_THRESHOLD_PVE = 3;
-const STOP_DAYS_THRESHOLD = 14; // 2 weeks
-const ORPHAN_MIN_AGE_DAYS = 7;
+const STOP_DAYS_THRESHOLD = 7; // 7 days
+const ORPHAN_MIN_AGE_DAYS = 5;
 const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
 const BATCH_SIZE = 5;
 

--- a/scripts/pve/pve-sandbox-maintenance-dry-run.ts
+++ b/scripts/pve/pve-sandbox-maintenance-dry-run.ts
@@ -61,7 +61,7 @@ type ActivityInfo = {
 };
 
 const PAUSE_HOURS_THRESHOLD = 20;
-const STOP_DAYS_THRESHOLD = 14;
+const STOP_DAYS_THRESHOLD = 7;
 const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
 
 function parseArgs(argv: string[]): Options {


### PR DESCRIPTION
## Task

### Tighten Convex Snapshot Maintenance Windows (Orphan 7d→5d, Stop 14d→7d)

#### Summary

Apply the stop-threshold change you requested on top of the prior orphan-threshold adjustment:

- `ORPHAN_MIN_AGE_DAYS`: `7 -> 5`
- `STOP_DAYS_THRESHOLD`: `14 -> 7`

Because `.env.production` has no maintenance threshold env keys, this is a code-hardcoded update.

#### Public API / Interface / Type Changes

- None.
- No schema, HTTP API, or env contract changes.

#### Exact Code Changes

1. Update unified runtime maintenance thresholds in:

- `/Users/karlchow/Desktop/code/cmux/packages/convex/convex/sandboxInstanceMaintenance.ts`
- Change:
- `STOP_DAYS_THRESHOLD = 14` to `STOP_DAYS_THRESHOLD = 7`
- `ORPHAN_MIN_AGE_DAYS = 7` to `ORPHAN_MIN_AGE_DAYS = 5` (from prior request)
- Keep existing pause thresholds unchanged.

2. Keep comments/docs in sync for active cron behavior in:

- `/Users/karlchow/Desktop/code/cmux/packages/convex/convex/crons.ts`
- Change comment text:
- `paused for >14 days` to `paused for >7 days`

3. Align legacy Morph-only maintenance module for consistency in:

- `/Users/karlchow/Desktop/code/cmux/packages/convex/convex/morphInstanceMaintenance.ts`
- Change:
- `STOP_DAYS_THRESHOLD = 14` to `STOP_DAYS_THRESHOLD = 7`
- Update nearby doc comments from “2 weeks” to “7 days”.

4. Align operator dry-run script output/logic in:

- `/Users/karlchow/Desktop/code/cmux/scripts/pve/pve-sandbox-maintenance-dry-run.ts`
- Change:
- `STOP_DAYS_THRESHOLD = 14` to `STOP_DAYS_THRESHOLD = 7`
- This keeps dry-run candidate reporting consistent with runtime behavior.

#### Validation Plan

1. Static validation

- Run: `bun run typecheck:convex`
- Expect no type errors.

2. Behavior preview (non-mutating)

- Run: `bun scripts/pve/pve-sandbox-maintenance-dry-run.ts --env-file .env.production --mode stop`
- Expect heading to show `Stop candidates (> 7d inactive)`.

3. Deploy

- Run: `bun run convex:deploy:prod`

4. Post-deploy operational check

- Watch next daily stop/cleanup cron logs in Convex production and confirm:
- stopped instances include those inactive `>= 7d`
- orphan cleanup eligibility is `>= 5d` (subject to existing safety checks).

#### Test Cases and Scenarios

1. Stop path

- Paused/stopped instance inactive for 6 days: skipped.
- Paused/stopped instance inactive for 7+ days: stop candidate.

2. Orphan cleanup path

- Orphan age 4 days: skipped as young.
- Orphan age 5+ days: eligible.
- Running orphan: still skipped.
- Unknown creation time orphan: still skipped.

3. Safety invariants unchanged

- Non-production gate still blocks execution.
- Provider availability checks still gate execution.
- Activity-record-based checks remain unchanged.

#### Assumptions and Defaults

- Apply hardcoded constants only; no `.env.production` variable additions.
- Include both active unified maintenance and legacy Morph module to avoid threshold drift across maintenance entrypoints.
- Prior request to set orphan cleanup from 7 to 5 remains in scope with this stop-threshold change.

Implement plan

## PR Review Summary
- **What Changed**:
  - Reduced the threshold for stopping inactive instances from 14 days to 7 days across `sandboxInstanceMaintenance.ts`, `morphInstanceMaintenance.ts`, and the operator dry-run script.
  - Lowered the minimum age for orphan cleanup from 7 days to 5 days in the unified maintenance module.
  - Updated associated comments in `crons.ts` and JSDoc strings in the maintenance modules to reflect the new 7-day policy.
- **Review Focus**:
  - **Consistency**: Verify that all instances of `STOP_DAYS_THRESHOLD` were updated to ensure the legacy Morph module and new unified module don't drift.
  - **Resource Reclamation**: Confirm that a 7-day stop threshold is appropriate for the current workload without causing excessive cold-start issues for users returning after a week.
- **Test Plan**:
  - **Static Check**: Run `bun run typecheck:convex` to ensure no syntax errors were introduced.
  - **Dry Run Validation**: Execute `bun scripts/pve/pve-sandbox-maintenance-dry-run.ts --env-file .env.production --mode stop` and verify that instances inactive for >7 days are correctly flagged.
  - **Live Monitoring**: After deploying with `bun run convex:deploy:prod`, monitor the next daily cron execution to confirm instances previously in the 7-14 day window are now being stopped.