### PR TITLE
[Crown] # Plan: Add IS\_SANDBOX=1 Environment Variable to Sandbox Bui...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1106,6 +1106,8 @@ RUN chmod +x /usr/local/bin/envctl /usr/local/bin/envd /usr/local/bin/cmux-proxy
   printf 'export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"\n' > /etc/profile.d/local-bin.sh && \
   chmod +x /etc/profile.d/local-bin.sh
 
+COPY configs/profile.d/cmux-env.sh /etc/profile.d/cmux-env.sh
+
 # Install tmux configuration for better mouse scrolling behavior
 COPY configs/tmux.conf /etc/tmux.conf
 

--- a/configs/profile.d/cmux-env.sh
+++ b/configs/profile.d/cmux-env.sh
@@ -1,0 +1,3 @@
+# cmux sandbox environment variables
+# Auto-loaded on shell startup via /etc/profile.d/
+export IS_SANDBOX=1

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -2974,6 +2974,7 @@ export RUSTUP_HOME=/usr/local/rustup
 export CARGO_HOME=/usr/local/cargo
 export PATH="/usr/local/bin:/usr/local/cargo/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH"
 EOF
+        install -Dm0644 {repo}/configs/profile.d/cmux-env.sh /etc/profile.d/cmux-env.sh
         if ! grep -q "alias g='git'" /root/.bashrc 2>/dev/null; then
           echo "alias g='git'" >> /root/.bashrc
         fi

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1711,6 +1711,7 @@ export RUSTUP_HOME=/usr/local/rustup
 export CARGO_HOME=/usr/local/cargo
 export PATH="/usr/local/bin:/usr/local/cargo/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH"
 EOF
+        install -Dm0644 {repo}/configs/profile.d/cmux-env.sh /etc/profile.d/cmux-env.sh
         if ! grep -q "alias g='git'" /root/.bashrc 2>/dev/null; then
           echo "alias g='git'" >> /root/.bashrc
         fi


### PR DESCRIPTION
## Task

# Plan: Add IS\_SANDBOX=1 Environment Variable to Sandbox Builds (v1)

## Summary

Create a **new shared config file** `/etc/profile.d/cmux-env.sh` for cmux environment variables (starting with `IS_SANDBOX=1`). This file will be auto-loaded on shell startup across all sandbox providers.

## Existing /etc/profile.d Pattern

The codebase already uses `/etc/profile.d/cmux-*.sh` files:

| File | Purpose | Exists |
|------|---------|--------|
| `/etc/profile.d/cmux-paths.sh` | PATH, RUSTUP, CARGO exports | Yes |
| `/etc/profile.d/cmux-extensions.sh` | IDE extension install hook | Yes (runtime) |
| `/etc/profile.d/nvm.sh` | Node version manager | Yes |
| `/etc/profile.d/cmux-env.sh` | Shared cmux env vars (IS\_SANDBOX) | **NEW** |

## Implementation

### Step 1: Create config file template

**New file:** `configs/profile.d/cmux-env.sh`

```bash
# cmux sandbox environment variables
# Auto-loaded on shell startup via /etc/profile.d/
export IS_SANDBOX=1
```

### Step 2: Install in Docker build

**File:** `Dockerfile` (after line \~1106)

```dockerfile
COPY configs/profile.d/cmux-env.sh /etc/profile.d/cmux-env.sh
```

### Step 3: Install in Morph snapshot

**File:** `scripts/snapshot.py` (in configure-zsh task around line 1708)

Add installation of cmux-env.sh:

```bash
install -Dm0644 {repo}/configs/profile.d/cmux-env.sh /etc/profile.d/cmux-env.sh
```

### Step 4: Install in PVE LXC snapshot

**File:** `scripts/snapshot-pvelxc.py` (in configure-zsh task around line 2971)

Add installation of cmux-env.sh:

```bash
install -Dm0644 {repo}/configs/profile.d/cmux-env.sh /etc/profile.d/cmux-env.sh
```

## Files to Create/Modify

1. **NEW:** `configs/profile.d/cmux-env.sh` - Shared env file with `IS_SANDBOX=1`
2. `Dockerfile` - COPY the new file to `/etc/profile.d/`
3. `scripts/snapshot.py` - Install the new file during snapshot build
4. `scripts/snapshot-pvelxc.py` - Install the new file during snapshot build

## Current IS\_SANDBOX=1 Coverage (systemd scope - already done)

| Provider | Location | Status |
|----------|----------|--------|
| Bubblewrap | `packages/sandbox/src/bubblewrap.rs` | Runtime injection |
| Docker | `configs/systemd/cmux-worker.service:13` | systemd service |
| Docker (host) | `configs/systemd-host/cmux.env:6` | systemd service |

## Verification

```bash
# After implementation, verify in any sandbox:
bash -lc 'echo $IS_SANDBOX'     # Should output: 1
cat /etc/profile.d/cmux-env.sh  # Should show: export IS_SANDBOX=1

# Rebuild Docker image
docker build -t cmux .

# Rebuild PVE LXC snapshot
uv run --env-file .env ./scripts/snapshot-pvelxc.py --template-vmid 9000

# Rebuild Morph snapshot
uv run --env-file .env ./scripts/snapshot.py
```

## Implementation Steps

### 1. Morph Snapshot Script

**File:** `scripts/snapshot.py` (line 1709-1713)

Add `IS_SANDBOX=1` to existing `/etc/profile.d/cmux-paths.sh`:

```python
# Before (current):
cat <<'EOF' > /etc/profile.d/cmux-paths.sh
export RUSTUP_HOME=/usr/local/rustup
export CARGO_HOME=/usr/local/cargo
export PATH="/usr/local/bin:/usr/local/cargo/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH"
EOF

# After (add IS_SANDBOX=1):
cat <<'EOF' > /etc/profile.d/cmux-paths.sh
export RUSTUP_HOME=/usr/local/rustup
export CARGO_HOME=/usr/local/cargo
export PATH="/usr/local/bin:/usr/local/cargo/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH"
export IS_SANDBOX=1
EOF
```

### 2. PVE LXC Snapshot Script

**File:** `scripts/snapshot-pvelxc.py` (line 2972-2976)

Same change as Morph - add `IS_SANDBOX=1` to `/etc/profile.d/cmux-paths.sh`:

```python
cat <<'EOF' > /etc/profile.d/cmux-paths.sh
export RUSTUP_HOME=/usr/local/rustup
export CARGO_HOME=/usr/local/cargo
export PATH="/usr/local/bin:/usr/local/cargo/bin:$HOME/.local/bin:$HOME/.bun/bin:$PATH"
export IS_SANDBOX=1
EOF
```

### 3. Docker Dockerfile

**File:** `Dockerfile` (line 1106)

Add `IS_SANDBOX=1` to `/etc/profile.d/local-bin.sh`:

```dockerfile
# Before:
printf 'export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"\n' > /etc/profile.d/local-bin.sh

# After:
printf 'export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"\nexport IS_SANDBOX=1\n' > /etc/profile.d/local-bin.sh
```

## Files to Modify

1. `scripts/snapshot.py:1709-1713` - Add IS\_SANDBOX=1 to cmux-paths.sh
2. `scripts/snapshot-pvelxc.py:2972-2976` - Add IS\_SANDBOX=1 to cmux-paths.sh
3. `Dockerfile:1106` - Add IS\_SANDBOX=1 to local-bin.sh

## Verification

```bash
# Rebuild Docker image
docker build -t cmux .

# Rebuild PVE LXC snapshot
uv run --env-file .env ./scripts/snapshot-pvelxc.py --template-vmid 9000

# Rebuild Morph snapshot
uv run --env-file .env ./scripts/snapshot.py

# Verify in running sandbox (all providers)
bash -lc 'echo $IS_SANDBOX'  # Should output: 1
cat /etc/profile.d/cmux-paths.sh | grep IS_SANDBOX  # Should show: export IS_SANDBOX=1


implement plan but skip sandbox rebuild verify
```