### PR TITLE
[Crown] # Plan: Fix PVE-LXC Activity Recording + Safe Orphan Cleanup
...

### DIFF
--- a/packages/convex/convex/crons.ts
+++ b/packages/convex/convex/crons.ts
@@ -27,6 +27,13 @@ crons.daily(
   internal.sandboxInstanceMaintenance.cleanupOrphanedContainers
 );
 
+// Clean up orphaned PVE templates daily at 22:00 UTC
+crons.daily(
+  "cleanup orphaned pve templates",
+  { hourUTC: 22, minuteUTC: 0 },
+  internal.sandboxInstanceMaintenance.cleanupOrphanedPveTemplates
+);
+
 // Recover crown evaluations stuck in pending/in_progress state
 // Runs every hour to detect evaluations that failed without proper error handling
 crons.interval(

--- a/packages/convex/convex/environments.ts
+++ b/packages/convex/convex/environments.ts
@@ -247,6 +247,25 @@ export const remove = authMutation({
   },
 });
 
+/**
+ * Get all template VMIDs that are in use by environment snapshot versions.
+ * Used by maintenance cron to avoid deleting templates that are still needed.
+ */
+export const getUsedTemplateVmidsInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const versions = await ctx.db.query("environmentSnapshotVersions").collect();
+
+    const vmids: number[] = [];
+    for (const version of versions) {
+      if (version.templateVmid !== undefined) {
+        vmids.push(version.templateVmid);
+      }
+    }
+    return vmids;
+  },
+});
+
 export const getByIdInternal = internalQuery({
   args: {
     id: v.id("environments"),


### PR DESCRIPTION
## Task

# Plan: Fix PVE-LXC Activity Recording + Safe Orphan Cleanup

## Problem Summary

When creating a custom environment from a running PVE-LXC container, the `createTemplateFromContainer` method leaves behind **orphaned source templates** with VMID < 9000.

### Current Workflow (creates orphans):

1. Stop source container (VMID 330, hostname `pvelxc-xxx`)
2. Convert source to template (VMID 330 is now a template)
3. Linked clone to VMID 9001 (template range)
4. Convert linked clone to template
5. Return VMID 9001 as final template
6. **BUG: Source template (VMID 330) is left behind!**

### Result:

The containers visible in PVE (VMIDs 330, 343, 402, 431, etc.) are **templates** created as intermediate steps but never deleted.

## Solution Overview

1. **Fix the bug**: Delete source template after successful linked clone in `createTemplateFromContainer`
2. **Add cron cleanup**: Add orphaned template cleanup to the maintenance cron for existing orphans

---

## Part 1: Fix Template Creation Bug

### File: `packages/pve-lxc-client/src/index.ts`

**Add Step 5 after line 1023** (after linked clone is converted to template):

```typescript
      // Step 5: Delete the source template (no longer needed after linked clone)
      console.log(
        `[PveLxcClient] Deleting source template ${sourceVmid} (linked clone ${linkedCloneVmid} is now the template)`
      );
      try {
        await this.deleteContainer(sourceVmid);
      } catch (deleteError) {
        // Non-fatal: the new template is created, source just couldn't be cleaned up
        console.warn(
          `[PveLxcClient] Failed to delete source template ${sourceVmid} (non-fatal):`,
          deleteError instanceof Error ? deleteError.message : deleteError
        );
      }
```

---

## Part 2: Add Cron Cleanup for Orphaned Templates

### File: `packages/pve-lxc-client/src/index.ts`

**Add new method to list orphaned templates** (after `instances.list` around line 1617):

```typescript
  /**
   * List orphaned templates with VMID < 9000.
   * These are intermediate templates created during custom environment saving
   * that were not properly cleaned up.
   */
  async listOrphanedTemplates(): Promise<Array<{ vmid: number; hostname: string }>> {
    const node = await this.getNode();
    const containers = await this.apiRequest<PveContainerStatus[]>(
      "GET",
      `/api2/json/nodes/${node}/lxc`
    );

    const orphans: Array<{ vmid: number; hostname: string }> = [];
    for (const container of containers) {
      const hostname = container.name || "";
      // Orphaned templates:
      // - Have cmux-* or pvelxc-* prefix (cmux-managed)
      // - Are templates (template === 1)
      // - Have VMID < 9000 (not in protected template range)
      // - Exclude base templates (VMID 100-199)
      if (
        (hostname.startsWith("cmux-") || hostname.startsWith("pvelxc-")) &&
        container.template === 1 &&
        container.vmid >= 200 &&
        container.vmid < 9000
      ) {
        orphans.push({ vmid: container.vmid, hostname });
      }
    }

    return orphans;
  }

  /**
   * Delete a template by VMID.
   */
  async deleteTemplate(vmid: number): Promise<void> {
    const node = await this.getNode();
    const upid = await this.apiRequest<string>(
      "DELETE",
      `/api2/json/nodes/${node}/lxc/${vmid}`
    );
    await this.waitForTaskNormalized(upid, `delete template ${vmid}`);
  }
```

### File: `packages/convex/convex/sandboxInstanceMaintenance.ts`

**Add to PVE provider client** (around line 125, in `createPveLxcProviderClient`):

```typescript
    // Add method to list orphaned templates
    listOrphanedTemplates: async (): Promise<Array<{ vmid: number; hostname: string }>> => {
      return pveClient.listOrphanedTemplates();
    },

    // Add method to delete templates
    deleteTemplate: async (vmid: number): Promise<void> => {
      return pveClient.deleteTemplate(vmid);
    },
```

**Add new cleanup function** (after `cleanupOrphanedContainers`, around line 782):

```typescript
/**
 * Clean up orphaned PVE templates with VMID < 9000.
 * These are intermediate templates created during custom environment saving
 * that were not properly cleaned up (bug fix in createTemplateFromContainer).
 *
 * Safety: Only deletes templates that:
 * - Have cmux-* or pvelxc-* hostname prefix
 * - Are templates (not running containers)
 * - Have VMID in range 200-8999 (excludes base templates 100-199 and protected 9000+)
 * - Are NOT referenced by any environmentSnapshotVersions record
 */
export const cleanupOrphanedPveTemplates = internalAction({
  args: {},
  handler: async (ctx) => {
    // Only run in production
    if (env.CONVEX_IS_PRODUCTION !== "true") {
      console.log("[sandboxMaintenance:templateCleanup] Skipping: not in production");
      return;
    }

    console.log("[sandboxMaintenance:templateCleanup] Starting orphaned template cleanup...");

    // Only run for PVE-LXC provider
    const pveApiUrl = process.env.PVE_API_URL;
    const pveApiToken = process.env.PVE_API_TOKEN;
    const pveNode = process.env.PVE_NODE;

    if (!pveApiUrl || !pveApiToken) {
      console.log("[sandboxMaintenance:templateCleanup] Skipping: PVE not configured");
      return;
    }

    const pveClient = new PveLxcClient({
      apiUrl: pveApiUrl,
      apiToken: pveApiToken,
      node: pveNode,
      verifyTls:
        process.env.PVE_VERIFY_TLS === "1" ||
        process.env.PVE_VERIFY_TLS?.toLowerCase() === "true",
    });

    try {
      const orphanedTemplates = await pveClient.listOrphanedTemplates();
      console.log(
        `[sandboxMaintenance:templateCleanup] Found ${orphanedTemplates.length} orphaned templates`
      );

      if (orphanedTemplates.length === 0) {
        return;
      }

      // Get all template VMIDs that are actually in use by environments
      const usedTemplateVmids = await ctx.runQuery(
        internal.environments.getUsedTemplateVmidsInternal
      );
      const usedVmidSet = new Set(usedTemplateVmids);

      let totalCleaned = 0;
      let totalSkipped = 0;

      for (const orphan of orphanedTemplates) {
        // Skip if this template is referenced by an environment
        if (usedVmidSet.has(orphan.vmid)) {
          console.log(
            `[sandboxMaintenance:templateCleanup] Skipping template ${orphan.vmid} (${orphan.hostname}): in use by environment`
          );
          totalSkipped++;
          continue;
        }

        try {
          console.log(
            `[sandboxMaintenance:templateCleanup] Deleting orphaned template ${orphan.vmid} (${orphan.hostname})`
          );
          await pveClient.deleteTemplate(orphan.vmid);
          totalCleaned++;
        } catch (error) {
          console.error(
            `[sandboxMaintenance:templateCleanup] Failed to delete template ${orphan.vmid}:`,
            error
          );
        }
      }

      console.log(
        `[sandboxMaintenance:templateCleanup] Finished: ${totalCleaned} deleted, ${totalSkipped} skipped`
      );
    } catch (error) {
      console.error("[sandboxMaintenance:templateCleanup] Error:", error);
    }
  },
});
```

### File: `packages/convex/convex/environments.ts`

**Add internal query** to get used template VMIDs:

```typescript
/**
 * Get all template VMIDs that are in use by environment snapshot versions.
 * Used by maintenance cron to avoid deleting templates that are still needed.
 */
export const getUsedTemplateVmidsInternal = internalQuery({
  args: {},
  handler: async (ctx) => {
    const versions = await ctx.db
      .query("environmentSnapshotVersions")
      .collect();

    const vmids: number[] = [];
    for (const version of versions) {
      if (version.templateVmid !== undefined) {
        vmids.push(version.templateVmid);
      }
    }
    return vmids;
  },
});
```

### File: `packages/convex/convex/crons.ts`

**Add cron job** (after line 28):

```typescript
// Clean up orphaned PVE templates daily at 22:00 UTC
crons.daily(
  "cleanupOrphanedPveTemplates",
  { hourUTC: 22, minuteUTC: 0 },
  internal.sandboxInstanceMaintenance.cleanupOrphanedPveTemplates
);
```

---

## Files to Modify Summary

| File | Changes |
|------|---------|
| `packages/pve-lxc-client/src/index.ts` | Add Step 5 to delete source template; Add `listOrphanedTemplates()` and `deleteTemplate()` methods |
| `packages/convex/convex/sandboxInstanceMaintenance.ts` | Add `cleanupOrphanedPveTemplates` action |
| `packages/convex/convex/environments.ts` | Add `getUsedTemplateVmidsInternal` query |
| `packages/convex/convex/crons.ts` | Add daily cron for template cleanup |

---

## Verification

1. **Test template creation fix**:

- Create a custom environment from a running PVE container
- Verify source VMID is deleted after success
- Only VMID >= 9000 template should remain

2. **Test cron cleanup**:

```bash
   # Run manually via Convex dashboard or CLI
   bunx convex run sandboxInstanceMaintenance:cleanupOrphanedPveTemplates
```

3. **Check PVE after cleanup**:

```bash
   pvesh get /nodes/<node>/lxc --output-format json | \
     jq '[.[] | select(.vmid >= 200 and .vmid < 9000 and .template == 1)] | length'
   # Should be 0 after cleanup
```

4. **Run&#32;`bun check`** after all changes

---

## Safety Measures

1. **Template deletion is non-fatal** in createTemplateFromContainer - main template still created on failure
2. **Cron checks environmentSnapshotVersions** - won't delete templates actually in use
3. **VMID range 200-8999** - excludes base templates (100-199) and protected range (9000+)
4. **Production only** - cron skips in development
5. **Comprehensive logging** - all decisions logged for audit

Implement plan

## PR Review Summary
- **What Changed**: Fixed PVE-LXC activity recording to prevent orphaned templates. Added a final step to `createTemplateFromContainer` to delete source templates after cloning, and implemented a daily maintenance cron job (`cleanupOrphanedPveTemplates`) that cross-references active `environmentSnapshotVersions` to safely prune unused templates from Proxmox.
- **Review Focus**: Verify the safety of the VMID exclusion range (200-8999) to ensure base templates (100-199) and protected templates (9000+) are never touched. Review the `getUsedTemplateVmidsInternal` query for potential performance bottlenecks if the versions table becomes extremely large.
- **Test Plan**: 1. Manually create a custom environment from an LXC container and confirm the intermediate source VMID is deleted upon success. 2. Manually trigger the maintenance action via `bunx convex run sandboxInstanceMaintenance:cleanupOrphanedPveTemplates` and verify in Proxmox that orphaned `cmux-` or `pvelxc-` templates are removed while those in use by the DB remain.