### PR TITLE
[Crown] # Add E2B Lite Template Support

## Goal

Cherry-pick the E2B...

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -470,7 +470,7 @@
       "name": "@cmux/e2b-client",
       "version": "0.1.0",
       "dependencies": {
-        "e2b": "^1.0.7",
+        "e2b": "^2.12.1",
       },
       "devDependencies": {
         "@eslint/js": "^9.34.0",
@@ -3367,6 +3367,8 @@
 
     "docker-modem": ["docker-modem@5.0.6", "", { "dependencies": { "debug": "^4.1.1", "readable-stream": "^3.5.0", "split-ca": "^1.0.1", "ssh2": "^1.15.0" } }, "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ=="],
 
+    "dockerfile-ast": ["dockerfile-ast@0.7.1", "", { "dependencies": { "vscode-languageserver-textdocument": "^1.0.8", "vscode-languageserver-types": "^3.17.3" } }, "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw=="],
+
     "dockerode": ["dockerode@4.0.9", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@grpc/grpc-js": "^1.11.1", "@grpc/proto-loader": "^0.7.13", "docker-modem": "^5.0.6", "protobufjs": "^7.3.2", "tar-fs": "^2.1.4", "uuid": "^10.0.0" } }, "sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
@@ -3387,7 +3389,7 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "e2b": ["e2b@1.13.2", "", { "dependencies": { "@bufbuild/protobuf": "^2.6.2", "@connectrpc/connect": "2.0.0-rc.3", "@connectrpc/connect-web": "2.0.0-rc.3", "compare-versions": "^6.1.0", "openapi-fetch": "^0.9.7", "platform": "^1.3.6" } }, "sha512-m8acE/MzMAJo1A57DakR2X1Sl5Mt1tcQO2aJfygNaQHLXby/4xsjF0UeJUB70jF7xntiR41pAMbZEHnkzrT9tw=="],
+    "e2b": ["e2b@2.12.1", "", { "dependencies": { "@bufbuild/protobuf": "^2.6.2", "@connectrpc/connect": "2.0.0-rc.3", "@connectrpc/connect-web": "2.0.0-rc.3", "chalk": "^5.3.0", "compare-versions": "^6.1.0", "dockerfile-ast": "^0.7.1", "glob": "^11.1.0", "openapi-fetch": "^0.14.1", "platform": "^1.3.6", "tar": "^7.5.4" } }, "sha512-qKYwS0VSZqvtWAT4OrCtOwRhhMlcd359zyFRGAZZ1wpYHHjr9zR872UCoDb/d5jFVUsREcUgktURc47XxfznPg=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
@@ -3683,7 +3685,7 @@
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
-    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+    "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -3935,7 +3937,7 @@
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
-    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+    "jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
@@ -4417,9 +4419,9 @@
 
     "openai": ["openai@6.16.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg=="],
 
-    "openapi-fetch": ["openapi-fetch@0.9.8", "", { "dependencies": { "openapi-typescript-helpers": "^0.0.8" } }, "sha512-zM6elH0EZStD/gSiNlcPrzXcVQ/pZo3BDvC6CDwRDUt1dDzxlshpmQnpD6cZaJ39THaSmwVCxxRrPKNM1hHrDg=="],
+    "openapi-fetch": ["openapi-fetch@0.14.1", "", { "dependencies": { "openapi-typescript-helpers": "^0.0.15" } }, "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A=="],
 
-    "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.8", "", {}, "sha512-1eNjQtbfNi5Z/kFhagDIaIRj6qqDzhjNJKz8cmMW0CVdGwT6e1GLbAfgI0d28VTJa1A8jz82jm/4dG8qNoNS8g=="],
+    "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.15", "", {}, "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="],
 
     "openapi3-ts": ["openapi3-ts@4.5.0", "", { "dependencies": { "yaml": "^2.8.0" } }, "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ=="],
 
@@ -4481,7 +4483,7 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
-    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+    "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -5301,6 +5303,10 @@
 
     "vscode-icons-js": ["vscode-icons-js@11.6.1", "", { "dependencies": { "@types/jasmine": "^3.6.3" } }, "sha512-rht18IFYv117UlqBn6o9j258SOtwhDBmtVrGwdoLPpSj6Z5LKQIzarQDd/tCRWneU68KEX25+nsh48tAoknKNw=="],
 
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "warning": ["warning@4.0.3", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w=="],
@@ -5729,6 +5735,8 @@
 
     "@secretlint/formatter/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "@sentry/bundler-plugin-core/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "@sentry/bundler-plugin-core/magic-string": ["magic-string@0.30.8", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ=="],
 
     "@sentry/bundler-plugin-core/unplugin": ["unplugin@1.0.1", "", { "dependencies": { "acorn": "^8.8.1", "chokidar": "^3.5.3", "webpack-sources": "^3.2.3", "webpack-virtual-modules": "^0.5.0" } }, "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA=="],
@@ -5821,11 +5829,11 @@
 
     "@vscode/test-cli/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
+    "@vscode/test-cli/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "@vscode/test-cli/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@vscode/vsce/cheerio": ["cheerio@1.1.2", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.0.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.12.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg=="],
-
-    "@vscode/vsce/glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
     "@vscode/vsce/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -5838,6 +5846,8 @@
     "app-builder-lib/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "app-builder-lib/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
+    "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -5903,6 +5913,8 @@
 
     "concat-stream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "config-file-ts/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
     "convex/prettier": ["prettier@3.7.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA=="],
@@ -5928,6 +5940,10 @@
     "domutils/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "dotenv-cli/dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
+
+    "e2b/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "e2b/tar": ["tar@7.5.7", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ=="],
 
     "electron/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
 
@@ -5992,8 +6008,6 @@
     "get-source/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "giget/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
-
-    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "globby/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -6133,7 +6147,7 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
@@ -6158,6 +6172,8 @@
     "readdir-glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 
@@ -6559,6 +6575,12 @@
 
     "@secretlint/config-loader/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@sentry/bundler-plugin-core/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "@sentry/bundler-plugin-core/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@sentry/bundler-plugin-core/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
     "@sentry/bundler-plugin-core/unplugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@sentry/bundler-plugin-core/unplugin/webpack-virtual-modules": ["webpack-virtual-modules@0.5.0", "", {}, "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw=="],
@@ -6653,6 +6675,10 @@
 
     "@vscode/test-cli/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "@vscode/test-cli/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "@vscode/test-cli/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
     "@vscode/test-cli/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@vscode/vsce/cheerio/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -6660,12 +6686,6 @@
     "@vscode/vsce/cheerio/htmlparser2": ["htmlparser2@10.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.1", "entities": "^6.0.0" } }, "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g=="],
 
     "@vscode/vsce/cheerio/undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
-
-    "@vscode/vsce/glob/jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
-
-    "@vscode/vsce/glob/minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
-
-    "@vscode/vsce/glob/path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
 
     "ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
 
@@ -6680,6 +6700,12 @@
     "app-builder-lib/tar/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "app-builder-lib/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "archiver-utils/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "archiver-utils/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -6714,6 +6740,12 @@
     "concat-stream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "concat-stream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "config-file-ts/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "config-file-ts/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "config-file-ts/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "convex/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
 
@@ -6802,8 +6834,6 @@
     "giget/tar/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "giget/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "globby/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -6916,6 +6946,12 @@
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "rimraf/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -7219,6 +7255,10 @@
 
     "@octokit/app/@octokit/auth-app/@octokit/auth-oauth-user/@octokit/auth-oauth-device": ["@octokit/auth-oauth-device@8.0.3", "", { "dependencies": { "@octokit/oauth-methods": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw=="],
 
+    "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "@sentry/bundler-plugin-core/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "@sentry/bundler-plugin-core/unplugin/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@sentry/bundler-plugin-core/unplugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -7243,6 +7283,8 @@
 
     "@vscode/test-cli/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "@vscode/test-cli/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "@vscode/vsce/cheerio/dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "@vscode/vsce/cheerio/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
@@ -7251,9 +7293,11 @@
 
     "@vscode/vsce/cheerio/htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "@vscode/vsce/glob/path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
-
     "app-builder-lib/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "archiver-utils/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "cacache/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -7262,6 +7306,10 @@
     "cacache/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "config-file-ts/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "config-file-ts/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "eslint-config-next/typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.50.1", "", { "dependencies": { "@typescript-eslint/types": "8.50.1", "@typescript-eslint/visitor-keys": "8.50.1" } }, "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw=="],
 
@@ -7322,6 +7370,10 @@
     "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "secretlint/read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 

--- a/packages/cloudrouter/cmux-devbox-lite/README.md
+++ b/packages/cloudrouter/cmux-devbox-lite/README.md
@@ -1,0 +1,78 @@
+# cmux-devbox-lite
+
+Lightweight E2B template for cmux sandboxes **without Docker-in-Docker**.
+
+## Features
+
+- **VSCode** (cmux-code fork with OpenVSIX marketplace)
+- **VNC Desktop** (XFCE4 with noVNC web access)
+- **JupyterLab** (with common data science packages)
+- **Chrome CDP** (headless browser automation)
+- **Go Worker Daemon** (API on port 39377)
+- **SSH Server** (token-based auth on port 10000)
+
+## What's NOT Included
+
+- Docker daemon
+- Docker-in-Docker support
+- Container orchestration
+
+## When to Use
+
+Use the **lite** template when you:
+
+- Don't need to run containers inside your sandbox
+- Want faster boot times
+- Want lower resource overhead
+- Are doing code editing, testing, or browser automation
+
+Use the **docker** template when you:
+
+- Need to run Docker containers
+- Are developing containerized applications
+- Need docker-compose support
+
+## Building
+
+```bash
+# Development build (smaller resources)
+bun run build:dev
+
+# Production build (full resources)
+bun run build:prod
+```
+
+## Manual Build
+
+```bash
+cd packages/cloudrouter
+e2b template build --config e2b.lite.toml
+```
+
+## Template Resources
+
+| Mode | vCPUs | Memory | Disk |
+|------|-------|--------|------|
+| Dev  | 4     | 8 GB   | 20 GB |
+| Prod | 4     | 16 GB  | 20 GB |
+
+## Ports
+
+| Port  | Service |
+|-------|---------|
+| 39377 | Worker API |
+| 39378 | VSCode |
+| 39380 | VNC (noVNC) |
+| 8888  | JupyterLab |
+| 9222  | Chrome CDP |
+| 10000 | SSH |
+
+## Authentication
+
+All services use the same auth token (generated at boot):
+
+- **Worker API**: Bearer token
+- **VSCode**: `?tkn=TOKEN` query param
+- **VNC**: `?tkn=TOKEN` query param
+- **Jupyter**: `?token=TOKEN` query param
+- **SSH**: Token as username

--- a/packages/cloudrouter/cmux-devbox-lite/build.dev.ts
+++ b/packages/cloudrouter/cmux-devbox-lite/build.dev.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bun
+/**
+ * Development build script for cmux-devbox-lite E2B template.
+ * Uses the E2B SDK v2 programmatic API to build templates.
+ */
+
+import { buildTemplate } from "./template";
+
+async function main() {
+  console.log("[build.dev] Starting development template build...");
+
+  try {
+    const result = await buildTemplate({
+      mode: "dev",
+      // Dev builds use smaller resources for faster iteration
+      cpuCount: 4,
+      memoryMb: 8192,
+    });
+
+    console.log("[build.dev] Template built successfully!");
+    console.log(`  Template ID: ${result.templateId}`);
+    console.log(`  Build ID: ${result.buildId}`);
+    if (result.logs) {
+      console.log("\n[build.dev] Build logs:");
+      console.log(result.logs);
+    }
+  } catch (error) {
+    console.error("[build.dev] Template build failed:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/cloudrouter/cmux-devbox-lite/build.prod.ts
+++ b/packages/cloudrouter/cmux-devbox-lite/build.prod.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bun
+/**
+ * Production build script for cmux-devbox-lite E2B template.
+ * Uses the E2B SDK v2 programmatic API to build templates.
+ */
+
+import { buildTemplate } from "./template";
+
+async function main() {
+  console.log("[build.prod] Starting production template build...");
+
+  try {
+    const result = await buildTemplate({
+      mode: "prod",
+      // Production builds use full resources
+      cpuCount: 4,
+      memoryMb: 16384,
+    });
+
+    console.log("[build.prod] Template built successfully!");
+    console.log(`  Template ID: ${result.templateId}`);
+    console.log(`  Build ID: ${result.buildId}`);
+    if (result.logs) {
+      console.log("\n[build.prod] Build logs:");
+      console.log(result.logs);
+    }
+  } catch (error) {
+    console.error("[build.prod] Template build failed:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/cloudrouter/cmux-devbox-lite/package.json
+++ b/packages/cloudrouter/cmux-devbox-lite/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "cmux-devbox-lite",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "E2B template builder for cmux-devbox-lite (no Docker-in-Docker)",
+  "scripts": {
+    "build:dev": "bun run build.dev.ts",
+    "build:prod": "bun run build.prod.ts"
+  },
+  "dependencies": {
+    "e2b": "^2.12.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/cloudrouter/cmux-devbox-lite/template.ts
+++ b/packages/cloudrouter/cmux-devbox-lite/template.ts
@@ -1,0 +1,126 @@
+/**
+ * E2B SDK v2 programmatic template definition for cmux-devbox-lite.
+ *
+ * This template provides a lightweight development environment WITHOUT Docker-in-Docker.
+ * Features:
+ * - VSCode (cmux-code fork)
+ * - VNC desktop
+ * - JupyterLab
+ * - Chrome with CDP
+ * - Go worker daemon
+ *
+ * Does NOT include:
+ * - Docker daemon
+ * - Docker-in-Docker support
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// E2B SDK v2 types for template building
+interface TemplateConfig {
+  templateId?: string;
+  templateName: string;
+  dockerfile: string;
+  startCmd: string;
+  readyCmd?: string;
+  cpuCount: number;
+  memoryMb: number;
+  teamId?: string;
+}
+
+interface BuildOptions {
+  mode: "dev" | "prod";
+  cpuCount?: number;
+  memoryMb?: number;
+}
+
+interface BuildResult {
+  templateId: string;
+  buildId: string;
+  logs?: string;
+}
+
+// Template configuration
+const TEMPLATE_NAME = "cmux-devbox-lite";
+const DOCKERFILE_PATH = "../template/e2b.lite.Dockerfile";
+const START_CMD = "/usr/local/bin/start-services-lite.sh";
+const READY_CMD = "curl -sf http://localhost:39377/health || exit 1";
+
+// Team ID from E2B account (same as docker template)
+const TEAM_ID = process.env.E2B_TEAM_ID || "6a135931-2076-4ef8-90e0-d58644927d02";
+
+/**
+ * Build the cmux-devbox-lite template using E2B SDK v2.
+ */
+export async function buildTemplate(options: BuildOptions): Promise<BuildResult> {
+  const { mode, cpuCount = 4, memoryMb = 16384 } = options;
+
+  console.log(`[template] Building ${TEMPLATE_NAME} (${mode} mode)`);
+  console.log(`[template] Resources: ${cpuCount} vCPU, ${memoryMb} MB RAM`);
+
+  // Verify Dockerfile exists
+  const dockerfilePath = path.resolve(__dirname, DOCKERFILE_PATH);
+  if (!fs.existsSync(dockerfilePath)) {
+    throw new Error(`Dockerfile not found at: ${dockerfilePath}`);
+  }
+  console.log(`[template] Dockerfile found: ${dockerfilePath}`);
+
+  // E2B SDK v2 template building
+  // Note: The SDK provides programmatic template building via the API
+  // For now, we use the CLI approach via subprocess
+  const { execSync } = await import("node:child_process");
+
+  // Change to cloudrouter directory where e2b.lite.toml is located
+  const cloudRouterDir = path.resolve(__dirname, "..");
+
+  try {
+    console.log("[template] Running e2b template build...");
+
+    // Build the template using E2B CLI with the lite config
+    const buildOutput = execSync(
+      `e2b template build --config e2b.lite.toml --cpu-count ${cpuCount} --memory-mb ${memoryMb}`,
+      {
+        cwd: cloudRouterDir,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          E2B_API_KEY: process.env.E2B_API_KEY,
+        },
+      }
+    );
+
+    // Parse template ID from build output
+    const templateIdMatch = buildOutput.match(/template[_\s]id[:\s]+([a-z0-9]+)/i);
+    const buildIdMatch = buildOutput.match(/build[_\s]id[:\s]+([a-z0-9-]+)/i);
+
+    return {
+      templateId: templateIdMatch?.[1] || TEMPLATE_NAME,
+      buildId: buildIdMatch?.[1] || `${Date.now()}`,
+      logs: buildOutput,
+    };
+  } catch (error) {
+    // If E2B CLI is not available, provide instructions
+    if (error instanceof Error && error.message.includes("command not found")) {
+      console.error("[template] E2B CLI not found. Install with: npm install -g e2b");
+      console.error("[template] Or use: bunx e2b template build --config e2b.lite.toml");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get the template configuration for manual builds.
+ */
+export function getTemplateConfig(): TemplateConfig {
+  return {
+    templateName: TEMPLATE_NAME,
+    dockerfile: DOCKERFILE_PATH,
+    startCmd: START_CMD,
+    readyCmd: READY_CMD,
+    cpuCount: 4,
+    memoryMb: 16384,
+    teamId: TEAM_ID,
+  };
+}

--- a/packages/cloudrouter/e2b.lite.toml
+++ b/packages/cloudrouter/e2b.lite.toml
@@ -1,0 +1,19 @@
+# This is a config for E2B sandbox template (Lite - no Docker-in-Docker).
+# You can use template ID or template name (cmux-devbox-lite) to create a sandbox:
+
+# Python SDK
+# from e2b import Sandbox, AsyncSandbox
+# sandbox = Sandbox.create("cmux-devbox-lite") # Sync sandbox
+# sandbox = await AsyncSandbox.create("cmux-devbox-lite") # Async sandbox
+
+# JS SDK
+# import { Sandbox } from 'e2b'
+# const sandbox = await Sandbox.create('cmux-devbox-lite')
+
+dockerfile = "template/e2b.lite.Dockerfile"
+template_name = "cmux-devbox-lite"
+start_cmd = "/usr/local/bin/start-services-lite.sh"
+ready_cmd = "curl -sf http://localhost:39377/health || exit 1"
+cpu_count = 4
+memory_mb = 16_384
+team_id = "6a135931-2076-4ef8-90e0-d58644927d02"

--- a/packages/cloudrouter/internal/cli/start.go
+++ b/packages/cloudrouter/internal/cli/start.go
@@ -13,10 +13,11 @@ import (
 
 const (
 	// Preset ID from packages/shared/src/e2b-templates.json (stable identifier)
-	defaultTemplatePresetID = "cmux-devbox-docker"
+	// Using lite template (no Docker-in-Docker) as default for faster boot times
+	defaultTemplatePresetID = "cmux-devbox-lite"
 
 	// Template name in E2B (fallback if template list endpoint is unavailable)
-	defaultTemplateName = "cmux-devbox-docker"
+	defaultTemplateName = "cmux-devbox-lite"
 
 	// Modal preset IDs from packages/shared/src/modal-templates.json
 	modalDefaultPresetID = "cmux-devbox-gpu"

--- a/packages/cloudrouter/template/e2b.lite.Dockerfile
+++ b/packages/cloudrouter/template/e2b.lite.Dockerfile
@@ -1,0 +1,198 @@
+# E2B Dockerfile for cmux devbox template LITE (no Docker-in-Docker)
+# This template is lighter and faster to boot, suitable for most dev tasks
+
+FROM ubuntu:22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system packages (NO Docker dependencies)
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    git \
+    build-essential \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    jq \
+    netcat-openbsd \
+    sudo \
+    python3 \
+    python3-pip \
+    unzip \
+    openssl \
+    rsync \
+    openssh-server \
+    # VNC and desktop environment
+    xfce4 \
+    xfce4-goodies \
+    dbus-x11 \
+    tigervnc-standalone-server \
+    # Fonts for proper rendering
+    fonts-liberation \
+    fonts-dejavu-core \
+    fonts-noto-color-emoji \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure SSH server on port 10000 (since 22 may not be exposed by E2B)
+RUN mkdir -p /var/run/sshd \
+    && sed -i 's/#Port 22/Port 10000/' /etc/ssh/sshd_config \
+    && echo "PermitRootLogin no" >> /etc/ssh/sshd_config \
+    && echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config \
+    && echo "PubkeyAuthentication yes" >> /etc/ssh/sshd_config
+
+# Install Node.js 22 (latest LTS)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g npm@latest agent-browser
+
+# Install Bun globally (accessible to all users, not just root)
+RUN curl -fsSL https://bun.sh/install | bash \
+    && cp /root/.bun/bin/bun /usr/local/bin/bun \
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx
+
+# Install Rust globally (rustup + toolchain accessible to all users)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo sh -s -- -y --default-toolchain stable --no-modify-path \
+    && chmod -R a+rX /usr/local/rustup /usr/local/cargo \
+    && ln -s /usr/local/cargo/bin/* /usr/local/bin/ \
+    && echo 'export RUSTUP_HOME=/usr/local/rustup' >> /etc/profile.d/rust.sh \
+    && echo 'export CARGO_HOME=/usr/local/cargo' >> /etc/profile.d/rust.sh
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH="/usr/local/cargo/bin:${PATH}"
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install cmux-code (VSCode fork with OpenVSIX marketplace support)
+# Fetch latest release from manaflow-ai/vscode-1
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then ARCH="x64"; fi && \
+    RELEASE_URL=$(curl -s https://api.github.com/repos/manaflow-ai/vscode-1/releases/latest | grep "browser_download_url.*vscode-server-linux-${ARCH}-web.tar.gz" | cut -d '"' -f 4) && \
+    wget -q "$RELEASE_URL" -O /tmp/cmux-code.tar.gz && \
+    mkdir -p /app/cmux-code && \
+    tar -xzf /tmp/cmux-code.tar.gz -C /app/cmux-code --strip-components=1 && \
+    rm /tmp/cmux-code.tar.gz && \
+    chmod -R 755 /app/cmux-code
+
+# Install noVNC for web-based VNC access
+RUN git clone --depth=1 https://github.com/novnc/noVNC.git /opt/noVNC \
+    && git clone --depth=1 https://github.com/novnc/websockify.git /opt/noVNC/utils/websockify \
+    && ln -s /opt/noVNC/vnc.html /opt/noVNC/index.html \
+    && chmod -R 755 /opt/noVNC
+
+# Install Chrome for headless browser automation
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create user account (E2B expects a 'user' account)
+# Note: NO docker group since we don't have Docker
+RUN useradd -m -s /bin/bash -u 1000 user \
+    && echo "user:user" | chpasswd
+
+# Setup for user
+RUN mkdir -p /home/user/workspace /home/user/.vnc /home/user/.chrome-data /home/user/.chrome-visible /home/user/.config /home/user/.local/share/applications \
+    && mkdir -p /home/user/.vscode-server-oss/data/User \
+    && mkdir -p /home/user/.vscode-server-oss/data/User/profiles/default-profile \
+    && mkdir -p /home/user/.vscode-server-oss/data/Machine \
+    && mkdir -p /home/user/.vscode-server-oss/extensions \
+    && chown -R user:user /home/user
+
+# Configure cmux-code settings (OpenVSIX marketplace, disable workspace trust)
+# extensions.verifySignature: false is required because OpenVSIX marketplace doesn't support extension signatures
+RUN echo '{ \
+  "workbench.colorTheme": "Default Dark Modern", \
+  "workbench.startupEditor": "none", \
+  "workbench.welcomePage.walkthroughs.openOnInstall": false, \
+  "workbench.tips.enabled": false, \
+  "workbench.secondarySideBar.defaultVisibility": "hidden", \
+  "editor.fontSize": 14, \
+  "editor.tabSize": 2, \
+  "editor.minimap.enabled": false, \
+  "editor.formatOnSave": true, \
+  "files.autoSave": "afterDelay", \
+  "files.autoSaveDelay": 1000, \
+  "terminal.integrated.fontSize": 14, \
+  "terminal.integrated.defaultProfile.linux": "cmux", \
+  "terminal.integrated.shellIntegration.enabled": false, \
+  "security.workspace.trust.enabled": false, \
+  "security.workspace.trust.startupPrompt": "never", \
+  "security.workspace.trust.untrustedFiles": "open", \
+  "security.workspace.trust.emptyWindow": false, \
+  "extensions.verifySignature": false, \
+  "git.openDiffOnClick": true, \
+  "scm.defaultViewMode": "tree", \
+  "settingsSync.ignoredSettings": [] \
+}' > /home/user/.vscode-server-oss/data/User/settings.json \
+    && cp /home/user/.vscode-server-oss/data/User/settings.json /home/user/.vscode-server-oss/data/User/profiles/default-profile/settings.json \
+    && cp /home/user/.vscode-server-oss/data/User/settings.json /home/user/.vscode-server-oss/data/Machine/settings.json \
+    && chown -R user:user /home/user/.vscode-server-oss
+
+# Set up VNC password (empty)
+RUN echo "" | vncpasswd -f > /home/user/.vnc/passwd \
+    && chmod 600 /home/user/.vnc/passwd \
+    && chown user:user /home/user/.vnc/passwd
+
+# Create VNC xstartup script
+COPY worker/xstartup /home/user/.vnc/xstartup
+RUN chmod +x /home/user/.vnc/xstartup \
+    && chown user:user /home/user/.vnc/xstartup
+
+# Create the start services script (Lite version - no Docker)
+COPY worker/start-services-lite.sh /usr/local/bin/start-services-lite.sh
+RUN chmod +x /usr/local/bin/start-services-lite.sh
+
+# Install Go for building worker daemon
+RUN wget -q https://go.dev/dl/go1.24.2.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.24.2.linux-amd64.tar.gz \
+    && rm go1.24.2.linux-amd64.tar.gz
+ENV PATH="/usr/local/go/bin:$PATH"
+
+# Build Go worker daemon (standalone binary, no internal dependencies)
+COPY go.mod go.sum /tmp/worker-build/
+COPY cmd/worker /tmp/worker-build/cmd/worker/
+RUN cd /tmp/worker-build && \
+    go mod download && \
+    go build -ldflags="-s -w" -o /usr/local/bin/worker-daemon ./cmd/worker && \
+    rm -rf /tmp/worker-build
+
+# Install JupyterLab + basic data science packages
+RUN pip3 install --no-cache-dir \
+    jupyterlab \
+    numpy \
+    pandas \
+    matplotlib \
+    requests \
+    httpx \
+    ipywidgets \
+    tqdm \
+    openai \
+    anthropic
+
+# VNC auth proxy and browser agent are now built into the Go worker daemon
+
+# Make sure user can run services - add to sudoers
+RUN echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Set working directory
+WORKDIR /home/user/workspace
+
+# Environment variables
+ENV DISPLAY=:1
+ENV HOME=/home/user
+
+# Expose ports (E2B handles exposure, no nginx needed)
+# Note: 5901 (VNC) and 9222 (Chrome CDP) bind to localhost only for security
+EXPOSE 8888 39377 39378 39380 10000
+
+# Default command
+CMD ["/usr/local/bin/start-services-lite.sh"]

--- a/packages/cloudrouter/worker/start-services-lite.sh
+++ b/packages/cloudrouter/worker/start-services-lite.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Start all services for the cmux E2B sandbox (Lite version - NO Docker)
+# Services: cmux-code (VSCode), Chrome CDP, VNC, noVNC, worker daemon (Go)
+
+echo "[cmux-e2b-lite] Starting services (Lite - no Docker)..."
+
+# Always generate a fresh auth token on startup (security: each instance gets unique token)
+AUTH_TOKEN_FILE="/home/user/.worker-auth-token"
+VSCODE_TOKEN_FILE="/home/user/.vscode-token"
+BOOT_ID_FILE="/home/user/.token-boot-id"
+
+AUTH_TOKEN=$(openssl rand -hex 32)
+# Use printf to avoid trailing newline (VSCode requires exact match)
+printf "%s" "$AUTH_TOKEN" > "$AUTH_TOKEN_FILE"
+chmod 644 "$AUTH_TOKEN_FILE"
+chown user:user "$AUTH_TOKEN_FILE"
+
+echo "[cmux-e2b-lite] Auth token generated: ${AUTH_TOKEN:0:8}..."
+
+# Create VSCode connection token file (same as worker auth, no trailing newline)
+printf "%s" "$AUTH_TOKEN" > "$VSCODE_TOKEN_FILE"
+chmod 644 "$VSCODE_TOKEN_FILE"
+chown user:user "$VSCODE_TOKEN_FILE"
+
+# Save current boot ID so worker-daemon knows not to regenerate token
+BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo "unknown")
+echo "$BOOT_ID" > "$BOOT_ID_FILE"
+chmod 644 "$BOOT_ID_FILE"
+chown user:user "$BOOT_ID_FILE"
+echo "[cmux-e2b-lite] Boot ID saved: ${BOOT_ID:0:8}..."
+
+# SSH server is now handled by Go worker daemon with token-as-username auth
+# No need for system sshd or password setup
+echo "[cmux-e2b-lite] SSH server will be started by Go worker daemon (token-as-username auth)"
+
+# VNC password not needed - auth proxy validates tokens before allowing access
+echo "[cmux-e2b-lite] VNC auth handled by token proxy (no VNC password needed)"
+
+# NO Docker daemon in lite version
+echo "[cmux-e2b-lite] Docker NOT available (use cmux-devbox-docker template if needed)"
+
+# Start D-Bus for desktop environment
+echo "[cmux-e2b-lite] Starting D-Bus..."
+sudo mkdir -p /run/dbus 2>/dev/null || true
+sudo dbus-daemon --system --fork 2>/dev/null || true
+
+# Start VNC server on display :1 (port 5901) - localhost only, auth handled by proxy on 39380
+echo "[cmux-e2b-lite] Starting VNC server on display :1 (localhost only - auth via proxy)..."
+rm -f /tmp/.X1-lock /tmp/.X11-unix/X1 2>/dev/null || true
+vncserver :1 -geometry 1920x1080 -depth 24 -SecurityTypes None -localhost yes 2>/dev/null &
+sleep 3
+
+# VNC auth proxy on port 39380 is now part of the Go worker daemon
+
+# Start cmux-code (our VSCode fork) on port 39378
+# Uses connection-token-file for auth (same token as worker + VNC)
+echo "[cmux-e2b-lite] Starting cmux-code on port 39378 (token-protected)..."
+/app/cmux-code/bin/code-server-oss \
+    --host 0.0.0.0 \
+    --port 39378 \
+    --connection-token-file "$VSCODE_TOKEN_FILE" \
+    --disable-workspace-trust \
+    --disable-telemetry \
+    /home/user/workspace 2>/dev/null &
+
+# Chrome with CDP is started by VNC xstartup (visible browser)
+# CDP will be available on port 9222 once VNC desktop is up
+echo "[cmux-e2b-lite] Chrome CDP will be available on port 9222 (started via VNC)"
+
+# Create agent-browser wrapper that auto-connects to Chrome CDP on first use
+cat > /usr/local/bin/ab << 'WRAPPER_EOF'
+#!/bin/bash
+# Auto-connect to Chrome CDP if not already connected
+if [ ! -S "$HOME/.agent-browser/default.sock" ] || ! agent-browser get url >/dev/null 2>&1; then
+  mkdir -p "$HOME/.agent-browser"
+  agent-browser connect 9222 >/dev/null 2>&1
+fi
+exec agent-browser "$@"
+WRAPPER_EOF
+chmod +x /usr/local/bin/ab
+
+# Start JupyterLab on port 8888 (token-protected, same auth token)
+echo "[cmux-e2b-lite] Starting JupyterLab on port 8888..."
+jupyter lab --ip=0.0.0.0 --port=8888 --no-browser \
+    --ServerApp.token="$AUTH_TOKEN" \
+    --ServerApp.root_dir=/home/user/workspace \
+    --allow-root 2>/dev/null &
+
+# Start worker daemon on port 39377 (Go binary)
+echo "[cmux-e2b-lite] Starting worker daemon on port 39377..."
+/usr/local/bin/worker-daemon &
+
+echo "[cmux-e2b-lite] All services started!"
+echo "[cmux-e2b-lite] Services:"
+echo "  - VSCode:  http://localhost:39378?tkn=$AUTH_TOKEN"
+echo "  - Jupyter: http://localhost:8888?token=$AUTH_TOKEN"
+echo "  - Worker:  http://localhost:39377 (use Bearer token)"
+echo "  - VNC:     http://localhost:39380?tkn=$AUTH_TOKEN"
+echo "  - Chrome:  http://localhost:9222"
+echo ""
+echo "[cmux-e2b-lite] NOTE: Docker is NOT available in this template."
+echo "[cmux-e2b-lite] Use cmux-devbox-docker template if you need Docker."
+echo ""
+echo "[cmux-e2b-lite] Auth token stored at: $AUTH_TOKEN_FILE"
+echo "[cmux-e2b-lite] VSCode and VNC use ?tkn=, Jupyter uses ?token= for authentication"
+
+# Keep running
+tail -f /dev/null

--- a/packages/e2b-client/package.json
+++ b/packages/e2b-client/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "e2b": "^1.0.7"
+    "e2b": "^2.12.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",

--- a/packages/shared/src/e2b-templates.json
+++ b/packages/shared/src/e2b-templates.json
@@ -1,7 +1,22 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-02-13T00:00:00Z",
+  "updatedAt": "2026-02-15T00:00:00Z",
   "templates": [
+    {
+      "templateId": "cmux-devbox-lite",
+      "label": "Lite (4 vCPU / 16 GB, no Docker)",
+      "cpu": "4 vCPU",
+      "memory": "16 GB RAM",
+      "disk": "20 GB SSD",
+      "versions": [
+        {
+          "version": 1,
+          "e2bTemplateId": "cmux-devbox-lite",
+          "capturedAt": "2026-02-15T00:00:00Z"
+        }
+      ],
+      "description": "Lightweight E2B workspace without Docker-in-Docker. Faster boot, lower overhead."
+    },
     {
       "templateId": "cmux-devbox-low",
       "label": "Low (4 vCPU / 16 GB)",

--- a/packages/shared/src/e2b-templates.ts
+++ b/packages/shared/src/e2b-templates.ts
@@ -116,18 +116,19 @@ export const DEFAULT_E2B_TEMPLATE_ID: E2BTemplateId =
   highPreset?.id ?? firstPreset.id;
 
 /**
- * Size tiers for E2B templates: low, mid, high.
- * Default is "high" (cmux-devbox-docker).
+ * Size tiers for E2B templates: lite, low, mid, high.
+ * Default is "lite" (cmux-devbox-lite - no Docker-in-Docker).
  */
-export type E2BSizeTier = "low" | "mid" | "high";
+export type E2BSizeTier = "lite" | "low" | "mid" | "high";
 
 const E2B_SIZE_TIER_PRESET_IDS: Record<E2BSizeTier, string> = {
+  lite: "cmux-devbox-lite",
   low: "cmux-devbox-low",
   mid: "cmux-devbox-mid",
   high: "cmux-devbox-docker",
 };
 
-export const DEFAULT_E2B_SIZE_TIER: E2BSizeTier = "high";
+export const DEFAULT_E2B_SIZE_TIER: E2BSizeTier = "lite";
 
 /**
  * Get the latest E2B template ID for a size tier.

--- a/scripts/setup-e2b-template-lite.sh
+++ b/scripts/setup-e2b-template-lite.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Build script for E2B Lite Template
+# Usage: ./scripts/setup-e2b-template-lite.sh [--prod|--dev]
+#
+# This creates a lightweight E2B template WITHOUT Docker-in-Docker.
+# Useful for tasks that don't require running containers inside the sandbox.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Parse arguments
+BUILD_MODE="dev"
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --prod)
+            BUILD_MODE="prod"
+            shift
+            ;;
+        --dev)
+            BUILD_MODE="dev"
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--prod|--dev]"
+            echo ""
+            echo "Options:"
+            echo "  --dev   Build template in development mode (default)"
+            echo "  --prod  Build template in production mode"
+            echo ""
+            echo "This script builds the cmux-devbox-lite E2B template."
+            echo "The lite template does NOT include Docker-in-Docker, making it:"
+            echo "  - Faster to boot"
+            echo "  - Smaller image size"
+            echo "  - Lower resource overhead"
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+log_info "Building E2B Lite Template (mode: $BUILD_MODE)"
+
+# Check for required tools
+if ! command -v bun &> /dev/null; then
+    log_error "bun is not installed. Please install bun first."
+    exit 1
+fi
+
+if ! command -v e2b &> /dev/null; then
+    log_warn "E2B CLI not found, will use bunx e2b"
+    E2B_CMD="bunx e2b"
+else
+    E2B_CMD="e2b"
+fi
+
+# Navigate to cmux-devbox-lite package
+cd "$PROJECT_ROOT/packages/cloudrouter/cmux-devbox-lite"
+
+log_info "Installing dependencies..."
+bun install
+
+log_info "Building template with SDK v2..."
+if [ "$BUILD_MODE" = "prod" ]; then
+    bun run build:prod
+else
+    bun run build:dev
+fi
+
+log_success "E2B Lite Template build complete!"
+log_info ""
+log_info "Template Details:"
+log_info "  - Name: cmux-devbox-lite"
+log_info "  - Features: VSCode, VNC, JupyterLab, Worker Daemon"
+log_info "  - Excludes: Docker-in-Docker"
+log_info ""
+log_info "To use this template:"
+log_info "  cloudrouter start --template cmux-devbox-lite"
+log_info ""
+log_info "Or set as default in Convex:"
+log_info "  Update packages/shared/src/e2b-templates.ts DEFAULT_E2B_SIZE_TIER to 'lite'"


### PR DESCRIPTION
## Task

# Add E2B Lite Template Support

## Goal

Cherry-pick the E2B lite template infrastructure onto main. This adds `scripts/setup-e2b-template-lite.sh` and all supporting files so users can build and use the lightweight E2B devbox template.

**Scope**: Template building/setup only. No web app sandbox start changes. No v2 devbox API.

## What Changes (all from existing local commits)

### New Files to Add

| File | Description |
|------|-------------|
| `scripts/setup-e2b-template-lite.sh` | Build script for lite E2B template |
| `packages/cloudrouter/cmux-devbox-lite/package.json` | Template builder package |
| `packages/cloudrouter/cmux-devbox-lite/build.dev.ts` | Dev build script |
| `packages/cloudrouter/cmux-devbox-lite/build.prod.ts` | Prod build script |
| `packages/cloudrouter/cmux-devbox-lite/template.ts` | Template definition (SDK v2 programmatic) |
| `packages/cloudrouter/cmux-devbox-lite/README.md` | Template docs |
| `packages/cloudrouter/cmux-devbox-lite/package-lock.json` | Lock file |
| `packages/cloudrouter/e2b.lite.toml` | E2B config for lite template |
| `packages/cloudrouter/template/e2b.lite.Dockerfile` | Lite Dockerfile (no Docker-in-Docker) |
| `packages/cloudrouter/worker/start-services-lite.sh` | Lite service startup script |

### Modified Files

| File | Change |
|------|--------|
| `packages/e2b-client/package.json` | Upgrade `e2b` from `^1.0.7` to `^2.12.1` |
| `packages/e2b-client/src/index.ts` | E2B SDK v2 API (list, getInfo, pause, autoPause, CommandExitError handling) |
| `packages/shared/src/e2b-templates.json` | Add `cmux-devbox-lite` template entry |
| `packages/shared/src/e2b-templates.ts` | Add "lite" size tier, change default to lite |
| `packages/cloudrouter/internal/cli/start.go` | Change default preset from `cmux-devbox-docker` to `cmux-devbox-lite` |

### NOT Included (out of scope)

- `apps/www/lib/routes/sandboxes.route.ts` - No changes to web app sandbox start
- `apps/www/lib/routes/devbox.route.ts` - No v2 devbox API
- `apps/server/src/agentSpawner.ts` - No server-side E2B changes
- `apps/server/src/vscode/*` - No VSCode instance E2B changes
- `packages/convex/convex/taskRuns.ts` - No Convex schema changes
- `packages/shared/src/socket-schemas.ts` - No socket schema changes

## Implementation Steps

1. **Stage only the E2B lite template files** from the existing local commits
2. **Verify** `bun check` passes
3. **Verify** `bun install` resolves with e2b v2
4. **Commit** with descriptive message
5. **Create PR** targeting `karlorz/cmux:main`

## Verification

1. `bun check` passes
2. `bun install` succeeds (e2b v2 resolves)
3. `scripts/setup-e2b-template-lite.sh` exists and is executable
4. E2B templates JSON includes `cmux-devbox-lite`
5. Default template is now lite in `e2b-templates.ts` and `start.go`
6. No changes to `sandboxes.route.ts` or server-side code

## PR Review Summary
- **What Changed**:
  - Added a new `cmux-devbox-lite` E2B template infrastructure that excludes Docker-in-Docker for significantly faster boot times.
  - Upgraded the `e2b` SDK from `v1.x` to `v2.12.1` in `packages/e2b-client`.
  - Refactored `E2BInstance` and `E2BClient` to use SDK v2 programmatic APIs, including `Sandbox.list()` pagination, `getInfo()`, and `betaPause()`.
  - Changed the default template preset to `cmux-devbox-lite` in the Go CLI (`start.go`) and shared configuration (`e2b-templates.ts`).
  - Added supporting build scripts (`setup-e2b-template-lite.sh`, `build.dev.ts`) and configuration files (`e2b.lite.toml`, `e2b.lite.Dockerfile`).
- **Review Focus**:
  - **SDK Migration**: Review `packages/e2b-client/src/index.ts` carefully. The `pause()` and `resume()` logic now relies on E2B's native beta features rather than just extending timeouts.
  - **Default Switch**: Confirm that defaulting to a non-Docker environment is acceptable for standard CLI users.
  - **Token Generation**: Verify the security of the auth token generation logic in `start-services-lite.sh`, which is shared across VSCode, VNC, and Jupyter.
- **Test Plan**:
  - Run `bun install` and `bun check` to ensure SDK v2 types are resolved correctly.
  - Execute `./scripts/setup-e2b-template-lite.sh --dev` to build the template.
  - Verify the default template by running `cloudrouter start` and checking if it utilizes the `lite` preset.