### PR TITLE
[Crown] # Settings Page Refactor - Codex App Style

## Overview

Refa...

### DIFF
--- a/apps/client/src/components/settings/SettingRow.tsx
+++ b/apps/client/src/components/settings/SettingRow.tsx
@@ -1,0 +1,41 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+interface SettingRowProps {
+  label: ReactNode;
+  description?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  noBorder?: boolean;
+}
+
+export function SettingRow({
+  label,
+  description,
+  children,
+  className,
+  noBorder = false,
+}: SettingRowProps) {
+  return (
+    <div
+      className={clsx(
+        "flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6",
+        !noBorder && "border-b border-neutral-200 dark:border-neutral-800",
+        className
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+          {label}
+        </p>
+        {description ? (
+          <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+            {description}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="w-full sm:w-auto sm:flex-shrink-0">{children}</div>
+    </div>
+  );
+}

--- a/apps/client/src/components/settings/SettingSection.tsx
+++ b/apps/client/src/components/settings/SettingSection.tsx
@@ -1,0 +1,37 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+interface SettingSectionProps {
+  title: ReactNode;
+  description?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function SettingSection({
+  title,
+  description,
+  children,
+  className,
+}: SettingSectionProps) {
+  return (
+    <section
+      className={clsx(
+        "overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950",
+        className
+      )}
+    >
+      <header className="border-b border-neutral-200 px-4 py-3 dark:border-neutral-800">
+        <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+          {title}
+        </h2>
+        {description ? (
+          <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+            {description}
+          </p>
+        ) : null}
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/apps/client/src/components/settings/SettingSegmented.tsx
+++ b/apps/client/src/components/settings/SettingSegmented.tsx
@@ -1,0 +1,51 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+import { SettingRow } from "./SettingRow";
+
+interface SegmentedOption {
+  value: string;
+  label: string;
+}
+
+interface SettingSegmentedProps {
+  label: ReactNode;
+  description?: ReactNode;
+  value: string;
+  options: SegmentedOption[];
+  onValueChange: (value: string) => void;
+  noBorder?: boolean;
+}
+
+export function SettingSegmented({
+  label,
+  description,
+  value,
+  options,
+  onValueChange,
+  noBorder,
+}: SettingSegmentedProps) {
+  return (
+    <SettingRow label={label} description={description} noBorder={noBorder}>
+      <div className="inline-flex w-full items-center rounded-lg border border-neutral-200 bg-white p-1 dark:border-neutral-700 dark:bg-neutral-900 sm:w-auto">
+        {options.map((option) => {
+          const active = option.value === value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onValueChange(option.value)}
+              className={clsx(
+                "flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors sm:flex-none",
+                active
+                  ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900"
+                  : "text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800"
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </SettingRow>
+  );
+}

--- a/apps/client/src/components/settings/SettingSelect.tsx
+++ b/apps/client/src/components/settings/SettingSelect.tsx
@@ -1,0 +1,51 @@
+import { ChevronDown } from "lucide-react";
+import type { ReactNode } from "react";
+import { SettingRow } from "./SettingRow";
+
+interface SettingSelectOption {
+  value: string;
+  label: string;
+}
+
+interface SettingSelectProps {
+  id: string;
+  label: ReactNode;
+  description?: ReactNode;
+  value: string;
+  options: SettingSelectOption[];
+  onValueChange: (value: string) => void;
+  noBorder?: boolean;
+}
+
+export function SettingSelect({
+  id,
+  label,
+  description,
+  value,
+  options,
+  onValueChange,
+  noBorder,
+}: SettingSelectProps) {
+  return (
+    <SettingRow label={label} description={description} noBorder={noBorder}>
+      <div className="relative w-full sm:w-64">
+        <select
+          id={id}
+          value={value}
+          onChange={(event) => onValueChange(event.target.value)}
+          className="w-full appearance-none rounded-lg border border-neutral-300 bg-white px-3 py-2 pr-9 text-sm text-neutral-900 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+        >
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral-500 dark:text-neutral-400"
+          aria-hidden
+        />
+      </div>
+    </SettingRow>
+  );
+}

--- a/apps/client/src/components/settings/SettingSwitch.tsx
+++ b/apps/client/src/components/settings/SettingSwitch.tsx
@@ -1,0 +1,38 @@
+import { Switch } from "@heroui/react";
+import type { ReactNode } from "react";
+import { SettingRow } from "./SettingRow";
+
+interface SettingSwitchProps {
+  label: ReactNode;
+  description?: ReactNode;
+  isSelected: boolean;
+  onValueChange: (value: boolean) => void;
+  ariaLabel: string;
+  isDisabled?: boolean;
+  noBorder?: boolean;
+}
+
+export function SettingSwitch({
+  label,
+  description,
+  isSelected,
+  onValueChange,
+  ariaLabel,
+  isDisabled,
+  noBorder,
+}: SettingSwitchProps) {
+  return (
+    <SettingRow label={label} description={description} noBorder={noBorder}>
+      <div className="flex justify-start sm:justify-end">
+        <Switch
+          aria-label={ariaLabel}
+          size="sm"
+          color="primary"
+          isSelected={isSelected}
+          isDisabled={isDisabled}
+          onValueChange={onValueChange}
+        />
+      </div>
+    </SettingRow>
+  );
+}

--- a/apps/client/src/components/settings/SettingsSidebar.tsx
+++ b/apps/client/src/components/settings/SettingsSidebar.tsx
@@ -1,0 +1,258 @@
+import {
+  disableDragPointerEvents,
+  restoreDragPointerEvents,
+} from "@/lib/drag-pointer-events";
+import { isElectron } from "@/lib/electron";
+import { Link } from "@tanstack/react-router";
+import clsx from "clsx";
+import { ArrowLeft, KeyRound, Settings } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+
+export type SettingsSection = "general" | "ai-providers";
+
+interface SettingsSidebarProps {
+  teamSlugOrId: string;
+  activeSection: SettingsSection;
+  onSectionChange: (section: SettingsSection) => void;
+}
+
+interface SettingsSidebarNavItem {
+  label: string;
+  section: SettingsSection;
+  icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+}
+
+const navItems: SettingsSidebarNavItem[] = [
+  {
+    label: "General",
+    section: "general",
+    icon: Settings,
+  },
+  {
+    label: "AI Providers",
+    section: "ai-providers",
+    icon: KeyRound,
+  },
+];
+
+export function SettingsSidebar({
+  teamSlugOrId,
+  activeSection,
+  onSectionChange,
+}: SettingsSidebarProps) {
+  const DEFAULT_WIDTH = 256;
+  const MIN_WIDTH = 240;
+  const MAX_WIDTH = 600;
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerLeftRef = useRef<number>(0);
+  const rafIdRef = useRef<number | null>(null);
+  const [width, setWidth] = useState<number>(() => {
+    const stored = localStorage.getItem("sidebarWidth");
+    const parsed = stored ? Number.parseInt(stored, 10) : DEFAULT_WIDTH;
+    if (Number.isNaN(parsed)) return DEFAULT_WIDTH;
+    return Math.min(Math.max(parsed, MIN_WIDTH), MAX_WIDTH);
+  });
+  const [isResizing, setIsResizing] = useState(false);
+  const [isHidden, setIsHidden] = useState(() => {
+    const stored = localStorage.getItem("sidebarHidden");
+    return stored === "true";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("sidebarWidth", String(width));
+  }, [width]);
+
+  useEffect(() => {
+    localStorage.setItem("sidebarHidden", String(isHidden));
+  }, [isHidden]);
+
+  useEffect(() => {
+    if (isElectron && window.cmux?.on) {
+      const off = window.cmux.on("shortcut:sidebar-toggle", () => {
+        setIsHidden((prev) => !prev);
+      });
+      return () => {
+        if (typeof off === "function") off();
+      };
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.ctrlKey &&
+        event.shiftKey &&
+        !event.altKey &&
+        !event.metaKey &&
+        (event.code === "KeyS" || event.key.toLowerCase() === "s")
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        setIsHidden((prev) => !prev);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, []);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === "sidebarHidden" && event.newValue !== null) {
+        setIsHidden(event.newValue === "true");
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  const onMouseMove = useCallback((event: MouseEvent) => {
+    if (rafIdRef.current != null) return;
+    rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      const containerLeft = containerLeftRef.current;
+      const clientX = event.clientX;
+      const newWidth = Math.min(
+        Math.max(clientX - containerLeft, MIN_WIDTH),
+        MAX_WIDTH
+      );
+      setWidth(newWidth);
+    });
+  }, []);
+
+  const stopResizing = useCallback(() => {
+    setIsResizing(false);
+    document.body.style.cursor = "";
+    document.body.classList.remove("select-none");
+    document.body.classList.remove("cmux-sidebar-resizing");
+    if (rafIdRef.current != null) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+    }
+    restoreDragPointerEvents();
+    window.removeEventListener("mousemove", onMouseMove);
+    window.removeEventListener("mouseup", stopResizing);
+  }, [onMouseMove]);
+
+  const startResizing = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsResizing(true);
+      document.body.style.cursor = "col-resize";
+      document.body.classList.add("select-none");
+      document.body.classList.add("cmux-sidebar-resizing");
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect();
+        containerLeftRef.current = rect.left;
+      }
+      disableDragPointerEvents();
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", stopResizing);
+    },
+    [onMouseMove, stopResizing]
+  );
+
+  useEffect(() => {
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", stopResizing);
+    };
+  }, [onMouseMove, stopResizing]);
+
+  const resetWidth = useCallback(() => setWidth(DEFAULT_WIDTH), []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative flex h-dvh shrink-0 grow snap-always snap-start flex-col bg-neutral-50 pr-1 dark:bg-neutral-900/50 md:w-auto md:snap-align-none"
+      style={
+        {
+          display: isHidden ? "none" : "flex",
+          width: undefined,
+          minWidth: undefined,
+          maxWidth: undefined,
+          userSelect: isResizing ? ("none" as const) : undefined,
+          "--sidebar-width": `${width}px`,
+        } as CSSProperties
+      }
+    >
+      <div
+        className={`h-[38px] flex items-center shrink-0 pr-2 ${isElectron ? "" : "pl-3"}`}
+        style={{ WebkitAppRegion: "drag" } as CSSProperties}
+      >
+        {isElectron && <div className="w-[80px]" />}
+        <Link
+          to="/$teamSlugOrId/dashboard"
+          params={{ teamSlugOrId }}
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-neutral-700 transition-colors hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+          style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+          <span>Back to app</span>
+        </Link>
+      </div>
+
+      <nav className="flex grow flex-col overflow-hidden pb-8">
+        <div className="px-4 pb-2 pt-2">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+            Settings
+          </h2>
+        </div>
+        <ul className="flex flex-col gap-px">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const isActive = activeSection === item.section;
+            return (
+              <li key={item.section}>
+                <button
+                  type="button"
+                  data-active={isActive ? "true" : undefined}
+                  onClick={() => onSectionChange(item.section)}
+                  className={clsx(
+                    "pointer-default cursor-default group ml-2 flex w-[calc(100%-16px)] items-center gap-2 rounded-sm pl-2 pr-2 py-1 text-left text-[13px] text-neutral-900 select-none hover:bg-neutral-200/45 dark:text-neutral-100 dark:hover:bg-neutral-800/45",
+                    isActive &&
+                      "bg-neutral-200/75 text-black dark:bg-neutral-800/65 dark:text-white"
+                  )}
+                >
+                  <Icon
+                    className={clsx(
+                      "size-[15px] text-neutral-500 group-hover:text-neutral-800 dark:group-hover:text-neutral-100",
+                      isActive && "text-neutral-900 dark:text-neutral-100"
+                    )}
+                    aria-hidden
+                  />
+                  <span>{item.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        title="Drag to resize"
+        onMouseDown={startResizing}
+        onDoubleClick={resetWidth}
+        className="absolute right-0 top-0 h-full cursor-col-resize"
+        style={
+          {
+            width: "14px",
+            transform: "translateX(7px)",
+            background: "transparent",
+            zIndex: "var(--z-sidebar-resize-handle)",
+          } as CSSProperties
+        }
+      />
+    </div>
+  );
+}

--- a/apps/client/src/components/settings/sections/AIProvidersSection.tsx
+++ b/apps/client/src/components/settings/sections/AIProvidersSection.tsx
@@ -1,0 +1,427 @@
+import { ProviderStatusSettings } from "@/components/provider-status-settings";
+import { SettingSection } from "@/components/settings/SettingSection";
+import {
+  ANTHROPIC_BASE_URL_KEY,
+  API_KEY_TO_BASE_URL,
+  type ProviderBaseUrlKey,
+} from "@cmux/shared";
+import { Switch } from "@heroui/react";
+import { ChevronDown, Eye, EyeOff, ExternalLink } from "lucide-react";
+import type { MutableRefObject } from "react";
+
+export interface ProviderInfo {
+  url?: string;
+  helpText?: string;
+}
+
+export type ConnectionTestResult = {
+  status: "success" | "error";
+  message: string;
+  details?: {
+    statusCode?: number;
+    responseTime?: number;
+    endpoint: string;
+    modelsFound?: number;
+  };
+};
+
+interface ApiKeyDefinition {
+  envVar: string;
+  displayName: string;
+  description?: string;
+}
+
+interface AIProvidersSectionProps {
+  apiKeys: ApiKeyDefinition[];
+  providerInfoByEnvVar: Record<string, ProviderInfo>;
+  apiKeyModelsByEnv: Record<string, string[]>;
+  apiKeyValues: Record<string, string>;
+  originalApiKeyValues: Record<string, string>;
+  showKeys: Record<string, boolean>;
+  showBaseUrls: boolean;
+  baseUrlValues: Record<string, string>;
+  isTestingConnection: Record<string, boolean>;
+  connectionTestResults: Record<string, ConnectionTestResult | null>;
+  bypassAnthropicProxy: boolean;
+  expandedUsedList: Record<string, boolean>;
+  overflowUsedList: Record<string, boolean>;
+  usedListRefs: MutableRefObject<Record<string, HTMLSpanElement | null>>;
+  showProviderStatus: boolean;
+  onApiKeyChange: (envVar: string, value: string) => void;
+  onToggleShowKey: (envVar: string) => void;
+  onToggleShowBaseUrls: () => void;
+  onBaseUrlChange: (baseUrlKey: ProviderBaseUrlKey, value: string) => void;
+  onTestBaseUrlConnection: (
+    baseUrlKey: ProviderBaseUrlKey,
+    apiKeyEnvVar: string
+  ) => void;
+  onBypassAnthropicProxyChange: (value: boolean) => void;
+  onToggleUsedList: (envVar: string) => void;
+}
+
+function getApiKeyPlaceholder(key: ApiKeyDefinition): string {
+  if (key.envVar === "CLAUDE_CODE_OAUTH_TOKEN") {
+    return "sk-ant-oat01-...";
+  }
+  if (key.envVar === "ANTHROPIC_API_KEY") {
+    return "sk-ant-api03-...";
+  }
+  if (key.envVar === "OPENAI_API_KEY") {
+    return "sk-proj-...";
+  }
+  if (key.envVar === "OPENROUTER_API_KEY") {
+    return "sk-or-v1-...";
+  }
+  return `Enter your ${key.displayName}`;
+}
+
+export function AIProvidersSection({
+  apiKeys,
+  providerInfoByEnvVar,
+  apiKeyModelsByEnv,
+  apiKeyValues,
+  originalApiKeyValues,
+  showKeys,
+  showBaseUrls,
+  baseUrlValues,
+  isTestingConnection,
+  connectionTestResults,
+  bypassAnthropicProxy,
+  expandedUsedList,
+  overflowUsedList,
+  usedListRefs,
+  showProviderStatus,
+  onApiKeyChange,
+  onToggleShowKey,
+  onToggleShowBaseUrls,
+  onBaseUrlChange,
+  onTestBaseUrlConnection,
+  onBypassAnthropicProxyChange,
+  onToggleUsedList,
+}: AIProvidersSectionProps) {
+  return (
+    <div className="space-y-4">
+      <SettingSection title="AI Provider Authentication">
+        <div className="p-4">
+          {apiKeys.length === 0 ? (
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              No API keys are required for the configured agents.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              <div>
+                <div className="mb-1 flex items-center justify-between gap-3">
+                  <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                    API Key Authentication
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={onToggleShowBaseUrls}
+                    className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {showBaseUrls ? "Hide more" : "Show more"}
+                    <ChevronDown
+                      className={`h-3.5 w-3.5 transition-transform ${
+                        showBaseUrls ? "rotate-180" : ""
+                      }`}
+                    />
+                  </button>
+                </div>
+                <div className="space-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+                  <p>You can authenticate providers in two ways:</p>
+                  <ul className="ml-4 list-disc space-y-0.5">
+                    <li>
+                      Sign in using a provider CLI (Claude Code, Codex CLI,
+                      Gemini CLI, Amp, Opencode).
+                    </li>
+                    <li>
+                      Or enter API keys here and cmux will use them directly.
+                    </li>
+                  </ul>
+                </div>
+              </div>
+
+              {apiKeys.map((key) => {
+                const providerInfo = providerInfoByEnvVar[key.envVar];
+                const usedModels = apiKeyModelsByEnv[key.envVar] ?? [];
+                const baseUrlKey = API_KEY_TO_BASE_URL[key.envVar];
+                const baseUrlValue = baseUrlKey
+                  ? baseUrlValues[baseUrlKey.envVar] || ""
+                  : "";
+                const hasBaseUrlValue = baseUrlValue.trim().length > 0;
+                const connectionResult = baseUrlKey
+                  ? connectionTestResults[baseUrlKey.envVar]
+                  : null;
+
+                return (
+                  <div
+                    key={key.envVar}
+                    className="space-y-2 rounded-lg border border-neutral-200 p-3 dark:border-neutral-800"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <label
+                          htmlFor={key.envVar}
+                          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+                        >
+                          {key.displayName}
+                        </label>
+                        {providerInfo?.helpText ? (
+                          <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+                            {providerInfo.helpText}
+                          </p>
+                        ) : null}
+
+                        {usedModels.length > 0 ? (
+                          <div className="mt-1">
+                            <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                              Used for agents:{" "}
+                              <span className="inline-flex min-w-0 items-center gap-1 align-middle">
+                                <span
+                                  ref={(element) => {
+                                    usedListRefs.current[key.envVar] = element;
+                                  }}
+                                  className={`min-w-0 font-medium ${
+                                    expandedUsedList[key.envVar]
+                                      ? "whitespace-normal break-words"
+                                      : "truncate"
+                                  }`}
+                                >
+                                  {usedModels.join(", ")}
+                                </span>
+                                {overflowUsedList[key.envVar] ? (
+                                  <button
+                                    type="button"
+                                    onClick={() => onToggleUsedList(key.envVar)}
+                                    className="flex-none text-[10px] text-blue-600 hover:underline dark:text-blue-400"
+                                  >
+                                    {expandedUsedList[key.envVar]
+                                      ? "Hide more"
+                                      : "Show more"}
+                                  </button>
+                                ) : null}
+                              </span>
+                            </p>
+                          </div>
+                        ) : null}
+                      </div>
+
+                      {providerInfo?.url ? (
+                        <a
+                          href={providerInfo.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 whitespace-nowrap text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+                        >
+                          Get key
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      ) : null}
+                    </div>
+
+                    <div className="md:w-[min(100%,480px)] md:flex-shrink-0">
+                      {key.envVar === "CODEX_AUTH_JSON" ? (
+                        <div className="relative">
+                          {showKeys[key.envVar] ? (
+                            <textarea
+                              id={key.envVar}
+                              value={apiKeyValues[key.envVar] || ""}
+                              onChange={(event) =>
+                                onApiKeyChange(key.envVar, event.target.value)
+                              }
+                              rows={4}
+                              className="w-full resize-y rounded-lg border border-neutral-300 bg-white px-3 py-2 pr-10 font-mono text-xs text-neutral-900 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+                              placeholder='{"tokens": {"id_token": "...", "access_token": "...", "refresh_token": "...", "account_id": "..."}, "last_refresh": "..."}'
+                            />
+                          ) : (
+                            <div
+                              onClick={() => onToggleShowKey(key.envVar)}
+                              className="h-[82px] w-full cursor-pointer rounded-lg border border-neutral-300 bg-white px-3 py-2 pr-10 font-mono text-xs text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+                            >
+                              {apiKeyValues[key.envVar] ? (
+                                "••••••••••••••••••••••••••••••••"
+                              ) : (
+                                <span className="text-neutral-400">
+                                  Click to edit
+                                </span>
+                              )}
+                            </div>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => onToggleShowKey(key.envVar)}
+                            className="absolute right-2 top-2 p-1 text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+                            aria-label={
+                              showKeys[key.envVar] ? "Hide value" : "Show value"
+                            }
+                          >
+                            {showKeys[key.envVar] ? (
+                              <EyeOff className="h-5 w-5" />
+                            ) : (
+                              <Eye className="h-5 w-5" />
+                            )}
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="relative">
+                          <input
+                            type={showKeys[key.envVar] ? "text" : "password"}
+                            id={key.envVar}
+                            value={apiKeyValues[key.envVar] || ""}
+                            onChange={(event) =>
+                              onApiKeyChange(key.envVar, event.target.value)
+                            }
+                            className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 pr-10 font-mono text-xs text-neutral-900 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+                            placeholder={getApiKeyPlaceholder(key)}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => onToggleShowKey(key.envVar)}
+                            className="absolute inset-y-0 right-0 flex items-center pr-3 text-neutral-500"
+                            aria-label={
+                              showKeys[key.envVar] ? "Hide value" : "Show value"
+                            }
+                          >
+                            {showKeys[key.envVar] ? (
+                              <EyeOff className="h-5 w-5" />
+                            ) : (
+                              <Eye className="h-5 w-5" />
+                            )}
+                          </button>
+                        </div>
+                      )}
+
+                      {originalApiKeyValues[key.envVar] ? (
+                        <div className="mt-1 flex items-center gap-1">
+                          <svg
+                            className="h-3 w-3 text-green-500 dark:text-green-400"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M5 13l4 4L19 7"
+                            />
+                          </svg>
+                          <span className="text-xs text-green-600 dark:text-green-400">
+                            API key configured
+                          </span>
+                        </div>
+                      ) : null}
+
+                      {showBaseUrls && baseUrlKey ? (
+                        <div className="mt-3 space-y-2 border-t border-neutral-200 pt-3 dark:border-neutral-800">
+                          <label
+                            htmlFor={baseUrlKey.envVar}
+                            className="block text-xs font-medium text-neutral-700 dark:text-neutral-300"
+                          >
+                            {baseUrlKey.displayName}
+                          </label>
+                          <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
+                            {baseUrlKey.description}
+                            {baseUrlKey.envVar === ANTHROPIC_BASE_URL_KEY.envVar
+                              ? " Enter the base URL without the /v1 suffix. Example: https://my-proxy.example.com"
+                              : ""}
+                          </p>
+
+                          <div className="flex flex-col gap-2 sm:flex-row">
+                            <input
+                              id={baseUrlKey.envVar}
+                              type="text"
+                              value={baseUrlValue}
+                              onChange={(event) =>
+                                onBaseUrlChange(baseUrlKey, event.target.value)
+                              }
+                              className="flex-1 rounded-lg border border-neutral-300 bg-white px-3 py-2 font-mono text-xs text-neutral-900 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+                              placeholder={baseUrlKey.placeholder}
+                              autoComplete="off"
+                            />
+                            <button
+                              type="button"
+                              onClick={() =>
+                                onTestBaseUrlConnection(baseUrlKey, key.envVar)
+                              }
+                              disabled={
+                                !hasBaseUrlValue ||
+                                !apiKeyValues[key.envVar]?.trim() ||
+                                isTestingConnection[baseUrlKey.envVar]
+                              }
+                              className="rounded-lg border border-neutral-300 bg-white px-3 py-2 text-xs text-neutral-700 hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                            >
+                              {isTestingConnection[baseUrlKey.envVar]
+                                ? "Testing..."
+                                : "Test Connection"}
+                            </button>
+                          </div>
+
+                          {connectionResult ? (
+                            <div
+                              className={`mt-1 rounded-lg px-2 py-1.5 text-[11px] ${
+                                connectionResult.status === "success"
+                                  ? "bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-400"
+                                  : "bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-400"
+                              }`}
+                            >
+                              <span className="font-medium">
+                                {connectionResult.status === "success"
+                                  ? "Success: "
+                                  : "Error: "}
+                              </span>
+                              {connectionResult.message}
+                              {connectionResult.details?.endpoint ? (
+                                <div className="mt-1 text-neutral-500 dark:text-neutral-400">
+                                  Tested: {connectionResult.details.endpoint}
+                                  {connectionResult.details.responseTime !==
+                                  undefined
+                                    ? ` (${connectionResult.details.responseTime}ms)`
+                                    : ""}
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : null}
+
+                          {baseUrlKey.envVar === ANTHROPIC_BASE_URL_KEY.envVar &&
+                          hasBaseUrlValue ? (
+                            <div className="mt-2 flex items-start justify-between gap-3 rounded-lg border border-neutral-200 px-3 py-2 dark:border-neutral-800">
+                              <div>
+                                <p className="text-xs font-medium text-neutral-800 dark:text-neutral-200">
+                                  Bypass cmux Anthropic proxy
+                                </p>
+                                <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
+                                  When enabled, Claude connects directly to your
+                                  custom Anthropic endpoint.
+                                </p>
+                              </div>
+                              <Switch
+                                aria-label="Bypass cmux Anthropic proxy"
+                                size="sm"
+                                color="primary"
+                                isSelected={bypassAnthropicProxy}
+                                onValueChange={onBypassAnthropicProxyChange}
+                              />
+                            </div>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </SettingSection>
+
+      {showProviderStatus ? (
+        <SettingSection title="Provider Status">
+          <div className="p-4">
+            <ProviderStatusSettings />
+          </div>
+        </SettingSection>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/client/src/components/settings/sections/GeneralSection.tsx
+++ b/apps/client/src/components/settings/sections/GeneralSection.tsx
@@ -1,0 +1,603 @@
+import { env } from "@/client-env";
+import { ContainerSettings } from "@/components/ContainerSettings";
+import { EditorSettingsSection } from "@/components/EditorSettingsSection";
+import { SettingRow } from "@/components/settings/SettingRow";
+import { SettingSection } from "@/components/settings/SettingSection";
+import { SettingSegmented } from "@/components/settings/SettingSegmented";
+import { SettingSelect } from "@/components/settings/SettingSelect";
+import { SettingSwitch } from "@/components/settings/SettingSwitch";
+import { useOnboardingOptional } from "@/contexts/onboarding";
+import { isElectron } from "@/lib/electron";
+import { WWW_ORIGIN } from "@/lib/wwwOrigin";
+import { useUser } from "@stackframe/react";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { HelpCircle } from "lucide-react";
+import { useCallback, useState } from "react";
+import { z } from "zod";
+
+const GitHubUserSchema = z.object({
+  login: z.string(),
+});
+
+type HeatmapColors = {
+  line: { start: string; end: string };
+  token: { start: string; end: string };
+};
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface GeneralSectionProps {
+  teamSlugOrId: string;
+  isSaving: boolean;
+  teamName: string;
+  originalTeamName: string;
+  teamNameError: string;
+  validateName: (value: string) => string;
+  onTeamNameChange: (value: string) => void;
+  onSaveTeamName: () => void;
+  teamSlug: string;
+  originalTeamSlug: string;
+  teamSlugError: string;
+  validateSlug: (value: string) => string;
+  onTeamSlugChange: (value: string) => void;
+  onSaveTeamSlug: () => void;
+  selectedTheme: "light" | "dark" | "system";
+  onThemeChange: (theme: "light" | "dark" | "system") => void;
+  autoPrEnabled: boolean;
+  onAutoPrEnabledChange: (value: boolean) => void;
+  heatmapModel: string;
+  onHeatmapModelChange: (value: string) => void;
+  heatmapModelOptions: Option[];
+  heatmapThreshold: number;
+  onHeatmapThresholdChange: (value: number) => void;
+  heatmapTooltipLanguage: string;
+  onHeatmapTooltipLanguageChange: (value: string) => void;
+  tooltipLanguageOptions: Option[];
+  heatmapColors: HeatmapColors;
+  onHeatmapColorsChange: (colors: HeatmapColors) => void;
+  worktreePath: string;
+  onWorktreePathChange: (value: string) => void;
+  onContainerSettingsChange: (data: {
+    maxRunningContainers: number;
+    reviewPeriodMinutes: number;
+    autoCleanupEnabled: boolean;
+    stopImmediatelyOnCompletion: boolean;
+    minContainersToKeep: number;
+  }) => void;
+}
+
+function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
+
+function ConnectedAccountsSection({ teamSlugOrId }: { teamSlugOrId: string }) {
+  const user = useUser({ or: "return-null" });
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  const { data: githubAccount, isLoading: isCheckingConnection } = useQuery({
+    queryKey: ["github-connection", user?.id],
+    queryFn: async () => {
+      if (!user) return { connected: false, username: null };
+      const account = await user.getConnectedAccount("github");
+      if (!account) return { connected: false, username: null };
+
+      try {
+        const token = await account.getAccessToken();
+        if (!token.accessToken) return { connected: true, username: null };
+
+        const response = await fetch("https://api.github.com/user", {
+          headers: { Authorization: `Bearer ${token.accessToken}` },
+        });
+
+        if (!response.ok) return { connected: true, username: null };
+
+        const parsed = GitHubUserSchema.safeParse(await response.json());
+        if (!parsed.success) return { connected: true, username: null };
+
+        return { connected: true, username: parsed.data.login };
+      } catch (error) {
+        console.error("Failed to fetch GitHub username:", error);
+        return { connected: true, username: null };
+      }
+    },
+    enabled: !!user,
+  });
+
+  const githubConnected = isCheckingConnection
+    ? null
+    : (githubAccount?.connected ?? false);
+  const githubUsername = githubAccount?.username ?? null;
+
+  const handleConnectGitHub = useCallback(async () => {
+    if (!user) return;
+
+    setIsConnecting(true);
+    try {
+      if (isElectron) {
+        const oauthUrl = `${WWW_ORIGIN}/handler/connect-github?team=${encodeURIComponent(teamSlugOrId)}`;
+        window.open(oauthUrl, "_blank", "noopener,noreferrer");
+        return;
+      }
+
+      await user.getConnectedAccount("github", { or: "redirect" });
+    } catch (error) {
+      console.error("Failed to connect GitHub:", error);
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [teamSlugOrId, user]);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <SettingSection
+      title="Connected Accounts"
+      description="Connect accounts to enable private repositories and higher API limits."
+    >
+      <SettingRow
+        label={
+          <span className="inline-flex items-center gap-2">
+            <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
+              <GitHubIcon className="h-4 w-4 text-neutral-700 dark:text-neutral-300" />
+            </span>
+            GitHub
+          </span>
+        }
+        description={
+          githubConnected === null
+            ? "Checking account status..."
+            : githubConnected
+              ? `Connected${githubUsername ? ` as @${githubUsername}` : ""}`
+              : "Required for private repository access and improved GitHub API limits"
+        }
+        noBorder
+      >
+        {githubConnected === false ? (
+          <button
+            type="button"
+            onClick={() => void handleConnectGitHub()}
+            disabled={isConnecting}
+            className="rounded-md bg-neutral-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200"
+          >
+            {isConnecting ? "Connecting..." : "Connect"}
+          </button>
+        ) : githubConnected === true ? (
+          <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+            Connected
+          </span>
+        ) : null}
+      </SettingRow>
+    </SettingSection>
+  );
+}
+
+function OnboardingTourSection({ teamSlugOrId }: { teamSlugOrId: string }) {
+  const onboarding = useOnboardingOptional();
+  const navigate = useNavigate();
+
+  const handleStartTour = useCallback(async () => {
+    if (!onboarding) return;
+
+    onboarding.resetOnboarding();
+
+    try {
+      await navigate({
+        to: "/$teamSlugOrId/dashboard",
+        params: { teamSlugOrId },
+      });
+    } catch (error) {
+      console.error("Failed to navigate to dashboard for onboarding:", error);
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 100);
+    });
+
+    onboarding.startOnboarding();
+  }, [navigate, onboarding, teamSlugOrId]);
+
+  return (
+    <SettingSection title="Getting Started">
+      <SettingRow
+        label={
+          <span className="inline-flex items-center gap-2">
+            <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
+              <HelpCircle className="h-4 w-4" aria-hidden />
+            </span>
+            Product Tour
+          </span>
+        }
+        description="Take a guided tour of cmux to learn the workflow and major features."
+        noBorder
+      >
+        <button
+          type="button"
+          onClick={() => void handleStartTour()}
+          className="rounded-md bg-blue-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-600"
+        >
+          Start Tour
+        </button>
+      </SettingRow>
+    </SettingSection>
+  );
+}
+
+export function GeneralSection({
+  teamSlug,
+  teamSlugError,
+  teamName,
+  teamNameError,
+  heatmapModel,
+  heatmapColors,
+  isSaving,
+  selectedTheme,
+  heatmapThreshold,
+  worktreePath,
+  autoPrEnabled,
+  originalTeamSlug,
+  originalTeamName,
+  teamSlugOrId,
+  validateName,
+  validateSlug,
+  heatmapModelOptions,
+  heatmapTooltipLanguage,
+  tooltipLanguageOptions,
+  onTeamSlugChange,
+  onTeamNameChange,
+  onThemeChange,
+  onSaveTeamSlug,
+  onSaveTeamName,
+  onWorktreePathChange,
+  onAutoPrEnabledChange,
+  onContainerSettingsChange,
+  onHeatmapModelChange,
+  onHeatmapColorsChange,
+  onHeatmapThresholdChange,
+  onHeatmapTooltipLanguageChange,
+}: GeneralSectionProps) {
+  return (
+    <div className="space-y-4">
+      <SettingSection title="Team">
+        <SettingRow
+          label="Team Name"
+          description="How your team is displayed across cmux."
+        >
+          <div className="w-full space-y-2 sm:w-[26rem]">
+            <input
+              type="text"
+              id="teamName"
+              value={teamName}
+              onChange={(event) => onTeamNameChange(event.target.value)}
+              placeholder="Your Team"
+              aria-invalid={teamNameError ? true : undefined}
+              aria-describedby={teamNameError ? "team-name-error" : undefined}
+              className={`w-full rounded-lg border bg-white px-3 py-2 text-sm text-neutral-900 focus:border-transparent focus:outline-none focus:ring-2 dark:bg-neutral-900 dark:text-neutral-100 ${
+                teamNameError
+                  ? "border-red-500 focus:ring-red-500"
+                  : "border-neutral-300 focus:ring-blue-500 dark:border-neutral-700"
+              }`}
+            />
+            {teamNameError ? (
+              <p
+                id="team-name-error"
+                className="text-xs text-red-600 dark:text-red-500"
+              >
+                {teamNameError}
+              </p>
+            ) : null}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                className="rounded-md bg-neutral-900 px-3 py-1.5 text-sm text-white disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900"
+                disabled={
+                  isSaving ||
+                  teamName.trim() === originalTeamName.trim() ||
+                  Boolean(teamNameError) ||
+                  validateName(teamName) !== ""
+                }
+                onClick={onSaveTeamName}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </SettingRow>
+
+        <SettingRow
+          label="Team URL"
+          description="Set the slug used in links. Lowercase letters, numbers, and hyphens only."
+          noBorder
+        >
+          <div className="w-full space-y-2 sm:w-[26rem]">
+            <div
+              className={`inline-flex w-full items-center overflow-hidden rounded-lg border bg-white dark:bg-neutral-900 ${
+                teamSlugError
+                  ? "border-red-500"
+                  : "border-neutral-300 dark:border-neutral-700"
+              }`}
+            >
+              <span className="select-none border-r border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-500 dark:border-neutral-700 dark:bg-neutral-800/60 dark:text-neutral-400">
+                cmux.dev/
+              </span>
+              <input
+                id="teamSlug"
+                aria-label="Team slug"
+                type="text"
+                value={teamSlug}
+                onChange={(event) => onTeamSlugChange(event.target.value)}
+                placeholder="your-team"
+                aria-invalid={teamSlugError ? true : undefined}
+                aria-describedby={teamSlugError ? "team-slug-error" : undefined}
+                className="min-w-0 flex-1 border-0 bg-transparent px-3 py-2 text-sm text-neutral-900 outline-none focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 dark:text-neutral-100"
+              />
+            </div>
+            {teamSlugError ? (
+              <p
+                id="team-slug-error"
+                className="text-xs text-red-600 dark:text-red-500"
+              >
+                {teamSlugError}
+              </p>
+            ) : null}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                className="rounded-md bg-neutral-900 px-3 py-1.5 text-sm text-white disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900"
+                disabled={
+                  isSaving ||
+                  teamSlug.trim() === originalTeamSlug.trim() ||
+                  Boolean(teamSlugError) ||
+                  validateSlug(teamSlug) !== ""
+                }
+                onClick={onSaveTeamSlug}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </SettingRow>
+      </SettingSection>
+
+      <ConnectedAccountsSection teamSlugOrId={teamSlugOrId} />
+
+      <SettingSection title="Appearance">
+        <SettingSegmented
+          label="Theme"
+          description="Choose how cmux looks."
+          value={selectedTheme}
+          options={[
+            { value: "light", label: "Light" },
+            { value: "dark", label: "Dark" },
+            { value: "system", label: "System" },
+          ]}
+          onValueChange={(value) =>
+            onThemeChange(value as "light" | "dark" | "system")
+          }
+          noBorder
+        />
+      </SettingSection>
+
+      <OnboardingTourSection teamSlugOrId={teamSlugOrId} />
+
+      <SettingSection title="Crown Evaluator">
+        <SettingSwitch
+          label="Auto-create pull request with the best diff"
+          description="After all agents finish, automatically create a pull request with the winning solution."
+          ariaLabel="Auto-create pull request with the best diff"
+          isSelected={autoPrEnabled}
+          onValueChange={onAutoPrEnabledChange}
+          noBorder
+        />
+      </SettingSection>
+
+      <SettingSection title="Diff Heatmap Review">
+        <SettingSelect
+          id="heatmapModel"
+          label="Review Model"
+          description="AI model used to analyze diffs and highlight risky lines."
+          value={heatmapModel}
+          onValueChange={onHeatmapModelChange}
+          options={heatmapModelOptions}
+        />
+
+        <SettingSelect
+          id="heatmapTooltipLanguage"
+          label="Tooltip Language"
+          description="Language used in heatmap review comments."
+          value={heatmapTooltipLanguage}
+          onValueChange={onHeatmapTooltipLanguageChange}
+          options={tooltipLanguageOptions}
+        />
+
+        <SettingRow
+          label={`Visibility Threshold: ${Math.round(heatmapThreshold * 100)}%`}
+          description="Show highlights only for lines above this confidence threshold."
+        >
+          <div className="w-full sm:w-80">
+            <input
+              type="range"
+              id="heatmapThreshold"
+              min="0"
+              max="1"
+              step="0.05"
+              value={heatmapThreshold}
+              onChange={(event) =>
+                onHeatmapThresholdChange(Number.parseFloat(event.target.value))
+              }
+              className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-neutral-200 accent-blue-600 dark:bg-neutral-700"
+            />
+          </div>
+        </SettingRow>
+
+        <SettingRow
+          label="Heatmap Colors"
+          description="Customize line and token gradient colors."
+          noBorder
+        >
+          <div className="grid w-full gap-4 sm:w-[30rem] sm:grid-cols-2">
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
+                Line Background
+              </p>
+              <div className="flex items-center gap-2">
+                <span className="w-8 text-xs text-neutral-500 dark:text-neutral-400">
+                  Low
+                </span>
+                <input
+                  type="color"
+                  value={heatmapColors.line.start}
+                  onChange={(event) =>
+                    onHeatmapColorsChange({
+                      ...heatmapColors,
+                      line: {
+                        ...heatmapColors.line,
+                        start: event.target.value,
+                      },
+                    })
+                  }
+                  className="h-8 w-8 cursor-pointer rounded border border-neutral-300 dark:border-neutral-600"
+                />
+                <span className="font-mono text-xs text-neutral-500 dark:text-neutral-400">
+                  {heatmapColors.line.start}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-8 text-xs text-neutral-500 dark:text-neutral-400">
+                  High
+                </span>
+                <input
+                  type="color"
+                  value={heatmapColors.line.end}
+                  onChange={(event) =>
+                    onHeatmapColorsChange({
+                      ...heatmapColors,
+                      line: {
+                        ...heatmapColors.line,
+                        end: event.target.value,
+                      },
+                    })
+                  }
+                  className="h-8 w-8 cursor-pointer rounded border border-neutral-300 dark:border-neutral-600"
+                />
+                <span className="font-mono text-xs text-neutral-500 dark:text-neutral-400">
+                  {heatmapColors.line.end}
+                </span>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
+                Token Highlight
+              </p>
+              <div className="flex items-center gap-2">
+                <span className="w-8 text-xs text-neutral-500 dark:text-neutral-400">
+                  Low
+                </span>
+                <input
+                  type="color"
+                  value={heatmapColors.token.start}
+                  onChange={(event) =>
+                    onHeatmapColorsChange({
+                      ...heatmapColors,
+                      token: {
+                        ...heatmapColors.token,
+                        start: event.target.value,
+                      },
+                    })
+                  }
+                  className="h-8 w-8 cursor-pointer rounded border border-neutral-300 dark:border-neutral-600"
+                />
+                <span className="font-mono text-xs text-neutral-500 dark:text-neutral-400">
+                  {heatmapColors.token.start}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-8 text-xs text-neutral-500 dark:text-neutral-400">
+                  High
+                </span>
+                <input
+                  type="color"
+                  value={heatmapColors.token.end}
+                  onChange={(event) =>
+                    onHeatmapColorsChange({
+                      ...heatmapColors,
+                      token: {
+                        ...heatmapColors.token,
+                        end: event.target.value,
+                      },
+                    })
+                  }
+                  className="h-8 w-8 cursor-pointer rounded border border-neutral-300 dark:border-neutral-600"
+                />
+                <span className="font-mono text-xs text-neutral-500 dark:text-neutral-400">
+                  {heatmapColors.token.end}
+                </span>
+              </div>
+            </div>
+
+            <div className="sm:col-span-2">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                Preview
+              </p>
+              <div
+                className="mt-1 h-4 rounded"
+                style={{
+                  background: `linear-gradient(to right, ${heatmapColors.line.start}, ${heatmapColors.line.end})`,
+                }}
+              />
+            </div>
+          </div>
+        </SettingRow>
+      </SettingSection>
+
+      {!env.NEXT_PUBLIC_WEB_MODE ? (
+        <SettingSection title="Worktree Location">
+          <SettingRow
+            label="Custom Worktree Path"
+            description="Specify where to store git worktrees. Leave empty to use the default ~/cmux location."
+            noBorder
+          >
+            <div className="w-full sm:w-[30rem]">
+              <input
+                type="text"
+                id="worktreePath"
+                value={worktreePath}
+                onChange={(event) => onWorktreePathChange(event.target.value)}
+                className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
+                placeholder="~/my-custom-worktrees"
+                autoComplete="off"
+              />
+              <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                Default location: ~/cmux
+              </p>
+            </div>
+          </SettingRow>
+        </SettingSection>
+      ) : null}
+
+      {!env.NEXT_PUBLIC_WEB_MODE ? (
+        <SettingSection title="Container Management">
+          <div className="p-4">
+            <ContainerSettings
+              teamSlugOrId={teamSlugOrId}
+              onDataChange={onContainerSettingsChange}
+            />
+          </div>
+        </SettingSection>
+      ) : (
+        <EditorSettingsSection teamSlugOrId={teamSlugOrId} />
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -1,64 +1,45 @@
 import { env } from "@/client-env";
-import { ContainerSettings } from "@/components/ContainerSettings";
-import { EditorSettingsSection } from "@/components/EditorSettingsSection";
 import { FloatingPane } from "@/components/floating-pane";
-import { ProviderStatusSettings } from "@/components/provider-status-settings";
+import { GeneralSection } from "@/components/settings/sections/GeneralSection";
+import {
+  AIProvidersSection,
+  type ConnectionTestResult,
+  type ProviderInfo,
+} from "@/components/settings/sections/AIProvidersSection";
 import { useTheme } from "@/components/theme/use-theme";
 import { TitleBar } from "@/components/TitleBar";
-import { useOnboardingOptional } from "@/contexts/onboarding";
-import { ChevronDown, HelpCircle } from "lucide-react";
 import { api } from "@cmux/convex/api";
 import type { Doc } from "@cmux/convex/dataModel";
 import { AGENT_CONFIGS, type AgentConfig } from "@cmux/shared/agentConfig";
 import {
   ALL_BASE_URL_KEYS,
   ANTHROPIC_BASE_URL_KEY,
-  API_KEY_TO_BASE_URL,
   type ProviderBaseUrlKey,
 } from "@cmux/shared";
 import { API_KEY_MODELS_BY_ENV } from "@cmux/shared/model-usage";
 import { convexQuery } from "@convex-dev/react-query";
-import { Switch } from "@heroui/react";
-import { useUser } from "@stackframe/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { useConvex } from "convex/react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { isElectron } from "@/lib/electron";
 import { cachedGetUser } from "@/lib/cachedGetUser";
 import { stackClientApp } from "@/lib/stack";
 import { WWW_ORIGIN } from "@/lib/wwwOrigin";
 import { toast } from "sonner";
 import { z } from "zod";
 
-const GitHubUserSchema = z.object({
-  login: z.string(),
-});
-
 export const Route = createFileRoute("/_layout/$teamSlugOrId/settings")({
   component: SettingsComponent,
+  validateSearch: z.object({
+    section: z.enum(["general", "ai-providers"]).default("general"),
+  }),
 });
-
-interface ProviderInfo {
-  url?: string;
-  helpText?: string;
-}
 
 type HeatmapColors = {
   line: { start: string; end: string };
   token: { start: string; end: string };
 };
 
-type ConnectionTestResult = {
-  status: "success" | "error";
-  message: string;
-  details?: {
-    statusCode?: number;
-    responseTime?: number;
-    endpoint: string;
-    modelsFound?: number;
-  };
-};
 
 const createDefaultHeatmapColors = (): HeatmapColors => ({
   line: { start: "#fefce8", end: "#f8e1c9" },
@@ -106,180 +87,9 @@ const PROVIDER_INFO: Record<string, ProviderInfo> = {
   },
 };
 
-function GitHubIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-    </svg>
-  );
-}
-
-function ConnectedAccountsSection({ teamSlugOrId }: { teamSlugOrId: string }) {
-  const user = useUser({ or: "return-null" });
-  const [isConnecting, setIsConnecting] = useState(false);
-
-  const { data: githubAccount, isLoading: isCheckingConnection } = useQuery({
-    queryKey: ["github-connection", user?.id],
-    queryFn: async () => {
-      if (!user) return { connected: false, username: null };
-      const account = await user.getConnectedAccount("github");
-      if (!account) return { connected: false, username: null };
-      try {
-        const token = await account.getAccessToken();
-        if (!token.accessToken) return { connected: true, username: null };
-        const response = await fetch("https://api.github.com/user", {
-          headers: { Authorization: `Bearer ${token.accessToken}` },
-        });
-        if (!response.ok) return { connected: true, username: null };
-        const parsed = GitHubUserSchema.safeParse(await response.json());
-        if (!parsed.success) return { connected: true, username: null };
-        return { connected: true, username: parsed.data.login };
-      } catch (err) {
-        console.error("Failed to fetch GitHub username:", err);
-        return { connected: true, username: null };
-      }
-    },
-    enabled: !!user,
-  });
-
-  const githubConnected = isCheckingConnection ? null : (githubAccount?.connected ?? false);
-  const githubUsername = githubAccount?.username ?? null;
-
-  const handleConnectGitHub = useCallback(async () => {
-    if (!user) return;
-    setIsConnecting(true);
-    try {
-      if (isElectron) {
-        // In Electron, open OAuth flow in system browser
-        // The www endpoint will handle OAuth and return via deep link
-        const oauthUrl = `${WWW_ORIGIN}/handler/connect-github?team=${encodeURIComponent(teamSlugOrId)}`;
-        window.open(oauthUrl, "_blank", "noopener,noreferrer");
-        return;
-      }
-
-      // In web, use Stack Auth's redirect (page navigates away)
-      await user.getConnectedAccount("github", { or: "redirect" });
-    } catch (error) {
-      console.error("Failed to connect GitHub:", error);
-    } finally {
-      setIsConnecting(false);
-    }
-  }, [user, teamSlugOrId]);
-
-  if (!user) return null;
-
-  return (
-    <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-      <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-        <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-          Connected Accounts
-        </h2>
-        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-          Connect accounts to enable additional features like private repo access
-        </p>
-      </div>
-      <div className="p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="w-9 h-9 bg-neutral-100 dark:bg-neutral-800 rounded-lg flex items-center justify-center">
-              <GitHubIcon className="w-4.5 h-4.5 text-neutral-700 dark:text-neutral-300" />
-            </div>
-            <div>
-              <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                GitHub
-              </p>
-              {githubConnected === null ? (
-                <p className="text-xs text-neutral-500 dark:text-neutral-400">Checking...</p>
-              ) : githubConnected ? (
-                <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                  Connected{githubUsername ? ` as @${githubUsername}` : ""}
-                </p>
-              ) : (
-                <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                  Required for private repo access and higher API rate limits
-                </p>
-              )}
-            </div>
-          </div>
-          {githubConnected === false && (
-            <button
-              onClick={handleConnectGitHub}
-              disabled={isConnecting}
-              className="px-3 py-1.5 text-xs font-medium text-white bg-neutral-900 dark:bg-neutral-100 dark:text-neutral-900 rounded-md hover:bg-neutral-800 dark:hover:bg-neutral-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {isConnecting ? "Connecting..." : "Connect"}
-            </button>
-          )}
-          {githubConnected === true && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400">
-              Connected
-            </span>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function OnboardingTourSection({ teamSlugOrId }: { teamSlugOrId: string }) {
-  const onboarding = useOnboardingOptional();
-  const navigate = useNavigate();
-
-  const handleStartTour = useCallback(async () => {
-    if (!onboarding) return;
-    onboarding.resetOnboarding();
-    try {
-      await navigate({
-        to: "/$teamSlugOrId/dashboard",
-        params: { teamSlugOrId },
-      });
-    } catch (error) {
-      console.error("Failed to navigate to dashboard for onboarding:", error);
-      return;
-    }
-    // Small delay to ensure reset completes before starting
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 100);
-    });
-    onboarding.startOnboarding();
-  }, [navigate, onboarding, teamSlugOrId]);
-
-  return (
-    <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-      <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-        <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-          Getting Started
-        </h2>
-      </div>
-      <div className="p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-start gap-3">
-            <div className="w-9 h-9 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center flex-shrink-0">
-              <HelpCircle className="w-4.5 h-4.5 text-blue-600 dark:text-blue-400" />
-            </div>
-            <div>
-              <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                Product Tour
-              </p>
-              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-                Take a guided tour of cmux to learn about its features and how to get the most out of it.
-              </p>
-            </div>
-          </div>
-          <button
-            onClick={handleStartTour}
-            className="px-3 py-1.5 text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 rounded-md transition-colors flex-shrink-0"
-          >
-            Start Tour
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function SettingsComponent() {
   const { teamSlugOrId } = Route.useParams();
+  const { section } = Route.useSearch();
   const { resolvedTheme, setTheme } = useTheme();
   const convex = useConvex();
   const [apiKeyValues, setApiKeyValues] = useState<Record<string, string>>({});
@@ -314,9 +124,6 @@ function SettingsComponent() {
   const [autoPrEnabled, setAutoPrEnabled] = useState<boolean>(false);
   const [originalAutoPrEnabled, setOriginalAutoPrEnabled] =
     useState<boolean>(false);
-  // const [isSaveButtonVisible, setIsSaveButtonVisible] = useState(true);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const saveButtonRef = useRef<HTMLDivElement>(null);
   const usedListRefs = useRef<Record<string, HTMLSpanElement | null>>({});
   const [expandedUsedList, setExpandedUsedList] = useState<
     Record<string, boolean>
@@ -958,1034 +765,95 @@ function SettingsComponent() {
     }
   };
 
+  const activeSection = section;
+  const selectedTheme = resolvedTheme;
+
   return (
     <FloatingPane header={<TitleBar title="Settings" />}>
-      <div
-        ref={scrollContainerRef}
-        className="flex flex-col grow overflow-auto select-none relative"
-      >
-        <div className="p-6 max-w-3xl">
-          {/* Header */}
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
-              Settings
-            </h1>
-            <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
-              Manage your workspace preferences and configuration
-            </p>
-          </div>
-
-          {/* Settings Sections */}
-          <div className="space-y-4">
-            {/* Team name */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  Team Name
-                </h2>
-              </div>
-              <div className="p-4">
-                <div>
-                  <label
-                    htmlFor="teamName"
-                    className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-                  >
-                    Display Name
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3">
-                    How your team is displayed across cmux.
-                  </p>
-                  <input
-                    type="text"
-                    id="teamName"
-                    value={teamName}
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      setTeamName(v);
-                      setTeamNameError(validateName(v));
-                    }}
-                    placeholder="Your Team"
-                    aria-invalid={teamNameError ? true : undefined}
-                    aria-describedby={
-                      teamNameError ? "team-name-error" : undefined
-                    }
-                    className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 ${teamNameError
-                        ? "border-red-500 focus:ring-red-500"
-                        : "border-neutral-300 dark:border-neutral-700 focus:ring-blue-500"
-                      }`}
-                  />
-                  {teamNameError && (
-                    <p
-                      id="team-name-error"
-                      className="mt-2 text-xs text-red-600 dark:text-red-500"
-                    >
-                      {teamNameError}
-                    </p>
-                  )}
-                </div>
-
-                {/* URL Preview removed
-                <div className="pt-2">
-                  <label className="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Preview</label>
-                  <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 overflow-hidden">
-                    <div className="flex items-center gap-3 px-3 sm:px-4 h-9 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50/70 dark:bg-neutral-900/70">
-                      window controls
-                      <div className="flex items-center gap-1.5">
-                        <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f56]" aria-hidden />
-                        <span className="h-2.5 w-2.5 rounded-full bg-[#ffbd2e]" aria-hidden />
-                        <span className="h-2.5 w-2.5 rounded-full bg-[#27c93f]" aria-hidden />
-                      </div>
-                      <div className="flex-1 flex items-center justify-center">
-                        <div className="flex items-center gap-2 min-w-0 max-w-full px-3 h-7 rounded-full border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-xs sm:text-sm text-neutral-700 dark:text-neutral-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] dark:shadow-none">
-                          <svg className="h-3.5 w-3.5 text-green-600 dark:text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                            <path d="M10 13a5 5 0 0 1 7 7l-7-7z"></path>
-                            <path d="M14.5 12.5a5 5 0 1 0-7 7"></path>
-                          </svg>
-                          <span className="truncate">
-                            {`https://cmux.dev/${(teamSlug || "your-team").replace(/^\/+/, "")}/dashboard`}
-                          </span>
-                        </div>
-                      </div>
-                      <div className="w-6" aria-hidden />
-                    </div>
-                    <div className="p-3 text-xs text-neutral-500 dark:text-neutral-400">
-                      This is how your workspace URL appears once the slug is saved.
-                    </div>
-                  </div>
-                </div>
-                */}
-              </div>
-              <div className="px-4 py-3 border-t border-neutral-200 dark:border-neutral-800 flex items-center justify-end">
-                <button
-                  className="px-3 py-1.5 text-sm rounded-md bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900 disabled:opacity-50"
-                  disabled={
-                    isSaving ||
-                    teamName.trim() === originalTeamName.trim() ||
-                    Boolean(teamNameError) ||
-                    validateName(teamName) !== ""
-                  }
-                  onClick={() => void saveTeamName()}
-                >
-                  Save
-                </button>
-              </div>
-            </div>
-
-            {/* Team URL */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  Team URL
-                </h2>
-              </div>
-              <div className="p-4">
-                <div>
-                  <label
-                    htmlFor="teamSlug"
-                    className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-                  >
-                    URL Slug
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3">
-                    Set the slug used in links, e.g. /your-team/dashboard.
-                    Lowercase letters, numbers, and hyphens. 3–48 characters.
-                  </p>
-                  <div
-                    className={`inline-flex items-center w-full rounded-lg bg-white dark:bg-neutral-900 border ${teamSlugError
-                        ? "border-red-500"
-                        : "border-neutral-300 dark:border-neutral-700"
-                      }`}
-                  >
-                    <span
-                      aria-hidden
-                      className="px-3 py-2 text-sm text-neutral-500 dark:text-neutral-400 select-none bg-neutral-50 dark:bg-neutral-800/50 border-r border-neutral-200 dark:border-neutral-700 rounded-l-lg"
-                    >
-                      cmux.dev/
-                    </span>
-                    <input
-                      id="teamSlug"
-                      aria-label="Team slug"
-                      type="text"
-                      value={teamSlug}
-                      onChange={(e) => {
-                        const v = e.target.value.toLowerCase();
-                        setTeamSlug(v);
-                        setTeamSlugError(validateSlug(v));
-                      }}
-                      placeholder="your-team"
-                      aria-invalid={teamSlugError ? true : undefined}
-                      aria-describedby={
-                        teamSlugError ? "team-slug-error" : undefined
-                      }
-                      className="flex-1 bg-transparent border-0 outline-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset px-3 py-2 text-sm text-neutral-900 dark:text-neutral-100 rounded-r-lg"
-                    />
-                  </div>
-                  {teamSlugError && (
-                    <p
-                      id="team-slug-error"
-                      className="mt-2 text-xs text-red-600 dark:text-red-500"
-                    >
-                      {teamSlugError}
-                    </p>
-                  )}
-                </div>
-              </div>
-              <div className="px-4 py-3 border-t border-neutral-200 dark:border-neutral-800 flex items-center justify-end">
-                <button
-                  className="px-3 py-1.5 text-sm rounded-md bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900 disabled:opacity-50"
-                  disabled={
-                    isSaving ||
-                    teamSlug.trim() === originalTeamSlug.trim() ||
-                    Boolean(teamSlugError) ||
-                    validateSlug(teamSlug) !== ""
-                  }
-                  onClick={() => void saveTeamSlug()}
-                >
-                  Save
-                </button>
-              </div>
-            </div>
-
-            {/* Connected Accounts */}
-            <ConnectedAccountsSection teamSlugOrId={teamSlugOrId} />
-
-            {/* Appearance */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  Appearance
-                </h2>
-              </div>
-              <div className="p-4">
-                <div>
-                  <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
-                    Theme
-                  </label>
-                  <div className="grid grid-cols-3 gap-2">
-                    <button
-                      onClick={() => setTheme("light")}
-                      className={`p-2 border-2 ${resolvedTheme === "light" ? "border-blue-500 bg-neutral-50 dark:bg-neutral-800" : "border-neutral-200 dark:border-neutral-700"} rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-300 transition-colors`}
-                    >
-                      Light
-                    </button>
-                    <button
-                      onClick={() => setTheme("dark")}
-                      className={`p-2 border-2 ${resolvedTheme === "dark" ? "border-blue-500 bg-neutral-50 dark:bg-neutral-800" : "border-neutral-200 dark:border-neutral-700"} rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-300 transition-colors`}
-                    >
-                      Dark
-                    </button>
-                    <button
-                      onClick={() => setTheme("system")}
-                      className={`p-2 border-2 ${resolvedTheme === "system" ? "border-blue-500 bg-neutral-50 dark:bg-neutral-800" : "border-neutral-200 dark:border-neutral-700"} rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-300 transition-colors`}
-                    >
-                      System
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Onboarding Tour */}
-            <OnboardingTourSection teamSlugOrId={teamSlugOrId} />
-
-            {/* Crown Evaluator */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  Crown Evaluator
-                </h2>
-              </div>
-              <div className="p-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                      Auto-create pull request with the best diff
-                    </label>
-                    <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-                      After all agents finish, automatically create a pull request with the
-                      winning agent's solution.
-                    </p>
-                  </div>
-                  <Switch
-                    aria-label="Auto-create pull request with the best diff"
-                    size="sm"
-                    color="primary"
-                    isSelected={autoPrEnabled}
-                    onValueChange={setAutoPrEnabled}
-                  />
-                </div>
-              </div>
-            </div>
-
-            {/* Heatmap Review Settings */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  Diff Heatmap Review
-                </h2>
-              </div>
-              <div className="p-4 space-y-6">
-                {/* Model Selector */}
-                <div>
-                  <label
-                    htmlFor="heatmapModel"
-                    className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-                  >
-                    Review Model
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3">
-                    Select the AI model used to analyze diffs and highlight areas that need attention.
-                  </p>
-                  <div className="relative">
-                    <select
-                      id="heatmapModel"
-                      value={heatmapModel}
-                      onChange={(e) => setHeatmapModel(e.target.value)}
-                      className="w-full appearance-none px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 text-sm"
-                    >
-                      {HEATMAP_MODEL_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <ChevronDown
-                      className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral-500 dark:text-neutral-400"
-                      aria-hidden
-                    />
-                  </div>
-                </div>
-
-                {/* Tooltip Language Selector */}
-                <div>
-                  <label
-                    htmlFor="heatmapTooltipLanguage"
-                    className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-                  >
-                    Tooltip Language
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3">
-                    Language for the review comments shown in heatmap tooltips.
-                  </p>
-                  <div className="relative">
-                    <select
-                      id="heatmapTooltipLanguage"
-                      value={heatmapTooltipLanguage}
-                      onChange={(e) => setHeatmapTooltipLanguage(e.target.value)}
-                      className="w-full appearance-none px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 text-sm"
-                    >
-                      {TOOLTIP_LANGUAGE_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <ChevronDown
-                      className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral-500 dark:text-neutral-400"
-                      aria-hidden
-                    />
-                  </div>
-                </div>
-
-                {/* Threshold Slider */}
-                <div>
-                  <label
-                    htmlFor="heatmapThreshold"
-                    className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-                  >
-                    Visibility Threshold: {Math.round(heatmapThreshold * 100)}%
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3">
-                    Only show highlights for lines with a review score above this threshold.
-                  </p>
-                  <input
-                    type="range"
-                    id="heatmapThreshold"
-                    min="0"
-                    max="1"
-                    step="0.05"
-                    value={heatmapThreshold}
-                    onChange={(e) => setHeatmapThreshold(Number.parseFloat(e.target.value))}
-                    className="w-full h-2 bg-neutral-200 dark:bg-neutral-700 rounded-lg appearance-none cursor-pointer accent-blue-600"
-                  />
-                </div>
-
-                {/* Color Settings */}
-                <div>
-                  <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
-                    Heatmap Colors
-                  </label>
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3">
-                    Customize the gradient colors for line and token highlighting.
-                  </p>
-                  <div className="grid grid-cols-2 gap-4">
-                    {/* Line Background Colors */}
-                    <div className="space-y-2">
-                      <span className="text-xs font-medium text-neutral-600 dark:text-neutral-400">Line Background</span>
-                      <div className="flex items-center gap-2">
-                        <label className="text-xs text-neutral-500 dark:text-neutral-400 w-10">Low</label>
-                        <input
-                          type="color"
-                          value={heatmapColors.line.start}
-                          onChange={(e) => setHeatmapColors((prev) => ({
-                            ...prev,
-                            line: { ...prev.line, start: e.target.value }
-                          }))}
-                          className="w-8 h-8 rounded border border-neutral-300 dark:border-neutral-600 cursor-pointer"
-                        />
-                        <span className="text-xs font-mono text-neutral-500">{heatmapColors.line.start}</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className="text-xs text-neutral-500 dark:text-neutral-400 w-10">High</label>
-                        <input
-                          type="color"
-                          value={heatmapColors.line.end}
-                          onChange={(e) => setHeatmapColors((prev) => ({
-                            ...prev,
-                            line: { ...prev.line, end: e.target.value }
-                          }))}
-                          className="w-8 h-8 rounded border border-neutral-300 dark:border-neutral-600 cursor-pointer"
-                        />
-                        <span className="text-xs font-mono text-neutral-500">{heatmapColors.line.end}</span>
-                      </div>
-                    </div>
-                    {/* Token Highlight Colors */}
-                    <div className="space-y-2">
-                      <span className="text-xs font-medium text-neutral-600 dark:text-neutral-400">Token Highlight</span>
-                      <div className="flex items-center gap-2">
-                        <label className="text-xs text-neutral-500 dark:text-neutral-400 w-10">Low</label>
-                        <input
-                          type="color"
-                          value={heatmapColors.token.start}
-                          onChange={(e) => setHeatmapColors((prev) => ({
-                            ...prev,
-                            token: { ...prev.token, start: e.target.value }
-                          }))}
-                          className="w-8 h-8 rounded border border-neutral-300 dark:border-neutral-600 cursor-pointer"
-                        />
-                        <span className="text-xs font-mono text-neutral-500">{heatmapColors.token.start}</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className="text-xs text-neutral-500 dark:text-neutral-400 w-10">High</label>
-                        <input
-                          type="color"
-                          value={heatmapColors.token.end}
-                          onChange={(e) => setHeatmapColors((prev) => ({
-                            ...prev,
-                            token: { ...prev.token, end: e.target.value }
-                          }))}
-                          className="w-8 h-8 rounded border border-neutral-300 dark:border-neutral-600 cursor-pointer"
-                        />
-                        <span className="text-xs font-mono text-neutral-500">{heatmapColors.token.end}</span>
-                      </div>
-                    </div>
-                  </div>
-                  {/* Preview Gradient */}
-                  <div className="mt-4">
-                    <span className="text-xs text-neutral-500 dark:text-neutral-400">Preview</span>
-                    <div
-                      className="mt-1 h-4 rounded"
-                      style={{
-                        background: `linear-gradient(to right, ${heatmapColors.line.start}, ${heatmapColors.line.end})`
-                      }}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Worktree Path - hidden in web mode */}
-            {!env.NEXT_PUBLIC_WEB_MODE && (
-              <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-                <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                  <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                    Worktree Location
-                  </h2>
-                </div>
-                <div className="p-4">
-                  <div>
-                    <label
-                      htmlFor="worktreePath"
-                      className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
-                    >
-                      Custom Worktree Path
-                    </label>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3">
-                      Specify where to store git worktrees. Leave empty to use the
-                      default location. You can use ~ for your home directory.
-                    </p>
-                    <input
-                      type="text"
-                      id="worktreePath"
-                      value={worktreePath}
-                      onChange={(e) => setWorktreePath(e.target.value)}
-                      className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100"
-                      placeholder="~/my-custom-worktrees"
-                      autoComplete="off"
-                    />
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-2">
-                      Default location: ~/cmux
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* AI Provider Authentication */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  AI Provider Authentication
-                </h2>
-              </div>
-              <div className="p-4">
-                {/* OAuth Providers Notice TODO: this is not valid */}
-                <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg hidden">
-                  <div className="flex items-start gap-2">
-                    <svg
-                      className="w-4 h-4 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                        OAuth-based providers (Gemini, AMP)
-                      </p>
-                      <p className="text-xs text-blue-700 dark:text-blue-300">
-                        These providers use OAuth authentication. When you first
-                        run them, they'll open a browser for you to authorize
-                        access. No API keys needed.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                {/* API Keys Section */}
-                <div className="space-y-3">
-                  {apiKeys.length === 0 ? (
-                    <p className="text-sm text-neutral-500 dark:text-neutral-400">
-                      No API keys required for the configured agents.
-                    </p>
-                  ) : (
-                    <>
-                      <div className="mb-3">
-                        <div className="flex items-center justify-between gap-3 mb-1">
-                          <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                            API Key Authentication
-                          </h3>
-                          <button
-                            type="button"
-                            onClick={() => setShowBaseUrls((prev) => !prev)}
-                            className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
-                          >
-                            {showBaseUrls ? "Hide more" : "Show more"}
-                            <ChevronDown
-                              className={`h-3.5 w-3.5 transition-transform ${showBaseUrls ? "rotate-180" : ""}`}
-                            />
-                          </button>
-                        </div>
-                        <div className="text-xs text-neutral-500 dark:text-neutral-400 space-y-1">
-                          <p>You can authenticate providers in two ways:</p>
-                          <ul className="list-disc ml-4 space-y-0.5">
-                            <li>
-                              Start a coding CLI (Claude Code, Codex CLI, Gemini
-                              CLI, Amp, Opencode) and complete its sign-in; cmux
-                              reuses that authentication.
-                            </li>
-                            <li>
-                              Or enter API keys here and cmux will use them
-                              directly.
-                            </li>
-                          </ul>
-                        </div>
-                      </div>
-
-                      {/* Group API keys by provider for better organization */}
-                      {apiKeys.map((key) => {
-                        const providerInfo = PROVIDER_INFO[key.envVar];
-                        const usedModels = apiKeyModelsByEnv[key.envVar] ?? [];
-                        const baseUrlKey = API_KEY_TO_BASE_URL[key.envVar];
-                        const baseUrlValue = baseUrlKey
-                          ? baseUrlValues[baseUrlKey.envVar] || ""
-                          : "";
-                        const hasBaseUrlValue = baseUrlValue.trim().length > 0;
-                        const connectionResult = baseUrlKey
-                          ? connectionTestResults[baseUrlKey.envVar]
-                          : null;
-
-                        return (
-                          <div
-                            key={key.envVar}
-                            className="border border-neutral-200 dark:border-neutral-800 rounded-lg p-3 space-y-2"
-                          >
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-start justify-between">
-                                <div className="min-w-0">
-                                  <label
-                                    htmlFor={key.envVar}
-                                    className="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
-                                  >
-                                    {key.displayName}
-                                  </label>
-                                  {providerInfo?.helpText && (
-                                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-                                      {providerInfo.helpText}
-                                    </p>
-                                  )}
-                                  {usedModels.length > 0 && (
-                                    <div className="mt-1 space-y-1">
-                                      <div className="flex items-center gap-2 min-w-0">
-                                        <p className="text-xs text-neutral-500 dark:text-neutral-400 flex-1 min-w-0">
-                                          Used for agents:{" "}
-                                          <span className="inline-flex items-center gap-1 min-w-0 align-middle w-full">
-                                            <span
-                                              ref={(el) => {
-                                                usedListRefs.current[
-                                                  key.envVar
-                                                ] = el;
-                                              }}
-                                              className={`font-medium min-w-0 ${expandedUsedList[key.envVar]
-                                                  ? "flex-1 whitespace-normal break-words"
-                                                  : "flex-1 truncate"
-                                                }`}
-                                            >
-                                              {usedModels.join(", ")}
-                                            </span>
-                                            {overflowUsedList[key.envVar] && (
-                                              <a
-                                                href="#"
-                                                onClick={(e) => {
-                                                  e.preventDefault();
-                                                  setExpandedUsedList(
-                                                    (prev) => ({
-                                                      ...prev,
-                                                      [key.envVar]:
-                                                        !prev[key.envVar],
-                                                    })
-                                                  );
-                                                }}
-                                                className="flex-none text-[10px] text-blue-600 hover:underline dark:text-blue-400"
-                                              >
-                                                {expandedUsedList[key.envVar]
-                                                  ? "Hide more"
-                                                  : "Show more"}
-                                              </a>
-                                            )}
-                                          </span>
-                                        </p>
-                                      </div>
-                                    </div>
-                                  )}
-                                </div>
-                                {providerInfo?.url && (
-                                  <a
-                                    href={providerInfo.url}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 flex items-center gap-1 whitespace-nowrap"
-                                  >
-                                    Get key
-                                    <svg
-                                      className="w-3 h-3"
-                                      fill="none"
-                                      stroke="currentColor"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth={2}
-                                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                                      />
-                                    </svg>
-                                  </a>
-                                )}
-                              </div>
-                            </div>
-
-                            <div className="md:w-[min(100%,480px)] md:flex-shrink-0 self-start">
-                              {key.envVar === "CODEX_AUTH_JSON" ? (
-                                <div className="relative">
-                                  {showKeys[key.envVar] ? (
-                                    <textarea
-                                      id={key.envVar}
-                                      value={apiKeyValues[key.envVar] || ""}
-                                      onChange={(e) =>
-                                        handleApiKeyChange(
-                                          key.envVar,
-                                          e.target.value
-                                        )
-                                      }
-                                      rows={4}
-                                      className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs resize-y"
-                                      placeholder='{"tokens": {"id_token": "...", "access_token": "...", "refresh_token": "...", "account_id": "..."}, "last_refresh": "..."}'
-                                    />
-                                  ) : (
-                                    <div
-                                      onClick={() => toggleShowKey(key.envVar)}
-                                      className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs cursor-pointer h-[82px]"
-                                    >
-                                      {apiKeyValues[key.envVar] ? "••••••••••••••••••••••••••••••••" : <span className="text-neutral-400">{"Click to edit"}</span>}
-                                    </div>
-                                  )}
-                                  <button
-                                    type="button"
-                                    onClick={() => toggleShowKey(key.envVar)}
-                                    className="absolute top-2 right-2 p-1 text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
-                                  >
-                                    {showKeys[key.envVar] ? (
-                                      <svg
-                                        className="h-5 w-5"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          strokeWidth={2}
-                                          d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                                        />
-                                      </svg>
-                                    ) : (
-                                      <svg
-                                        className="h-5 w-5"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          strokeWidth={2}
-                                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                                        />
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          strokeWidth={2}
-                                          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                                        />
-                                      </svg>
-                                    )}
-                                  </button>
-                                </div>
-                              ) : (
-                                <div className="relative">
-                                  <input
-                                    type={
-                                      showKeys[key.envVar] ? "text" : "password"
-                                    }
-                                    id={key.envVar}
-                                    value={apiKeyValues[key.envVar] || ""}
-                                    onChange={(e) =>
-                                      handleApiKeyChange(
-                                        key.envVar,
-                                        e.target.value
-                                      )
-                                    }
-                                    className="w-full px-3 py-2 pr-10 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs"
-                                    placeholder={
-                                      key.envVar === "CLAUDE_CODE_OAUTH_TOKEN"
-                                        ? "sk-ant-oat01-..."
-                                        : key.envVar === "ANTHROPIC_API_KEY"
-                                          ? "sk-ant-api03-..."
-                                          : key.envVar === "OPENAI_API_KEY"
-                                            ? "sk-proj-..."
-                                            : key.envVar === "OPENROUTER_API_KEY"
-                                              ? "sk-or-v1-..."
-                                              : `Enter your ${key.displayName}`
-                                    }
-                                  />
-                                  <button
-                                    type="button"
-                                    onClick={() => toggleShowKey(key.envVar)}
-                                    className="absolute inset-y-0 right-0 pr-3 flex items-center text-neutral-500"
-                                  >
-                                    {showKeys[key.envVar] ? (
-                                      <svg
-                                        className="h-5 w-5"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          strokeWidth={2}
-                                          d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                                        />
-                                      </svg>
-                                    ) : (
-                                      <svg
-                                        className="h-5 w-5"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          strokeWidth={2}
-                                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                                        />
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          strokeWidth={2}
-                                          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                                        />
-                                      </svg>
-                                    )}
-                                  </button>
-                                </div>
-                              )}
-                              {originalApiKeyValues[key.envVar] && (
-                                <div className="flex items-center gap-1 mt-1">
-                                  <svg
-                                    className="w-3 h-3 text-green-500 dark:text-green-400"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      strokeWidth={2}
-                                      d="M5 13l4 4L19 7"
-                                    />
-                                  </svg>
-                                  <span className="text-xs text-green-600 dark:text-green-400">
-                                    API key configured
-                                  </span>
-                                </div>
-                              )}
-
-                              {showBaseUrls && baseUrlKey && (
-                                <div className="mt-3 pt-3 border-t border-neutral-200 dark:border-neutral-800 space-y-2">
-                                  <label
-                                    htmlFor={baseUrlKey.envVar}
-                                    className="block text-xs font-medium text-neutral-700 dark:text-neutral-300"
-                                  >
-                                    {baseUrlKey.displayName}
-                                  </label>
-                                  <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
-                                    {baseUrlKey.description}
-                                    {baseUrlKey.envVar === ANTHROPIC_BASE_URL_KEY.envVar && (
-                                      <>
-                                        {" "}
-                                        Enter the base URL without the /v1
-                                        suffix. Example:
-                                        {" "}
-                                        https://my-proxy.example.com
-                                      </>
-                                    )}
-                                  </p>
-                                  <div className="flex flex-col sm:flex-row gap-2">
-                                    <input
-                                      id={baseUrlKey.envVar}
-                                      type="text"
-                                      value={baseUrlValue}
-                                      onChange={(e) =>
-                                        handleBaseUrlChange(
-                                          baseUrlKey,
-                                          e.target.value
-                                        )
-                                      }
-                                      className="flex-1 px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 font-mono text-xs"
-                                      placeholder={baseUrlKey.placeholder}
-                                      autoComplete="off"
-                                    />
-                                    <button
-                                      type="button"
-                                      onClick={() =>
-                                        void testBaseUrlConnection(
-                                          baseUrlKey,
-                                          key.envVar
-                                        )
-                                      }
-                                      disabled={
-                                        !hasBaseUrlValue ||
-                                        !apiKeyValues[key.envVar]?.trim() ||
-                                        isTestingConnection[baseUrlKey.envVar]
-                                      }
-                                      className="px-3 py-2 text-xs rounded-lg border border-neutral-300 dark:border-neutral-700 text-neutral-700 dark:text-neutral-200 bg-white dark:bg-neutral-900 hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed"
-                                    >
-                                      {isTestingConnection[baseUrlKey.envVar]
-                                        ? "Testing..."
-                                        : "Test Connection"}
-                                    </button>
-                                  </div>
-
-                                  {connectionResult && (
-                                    <div
-                                      className={`mt-1 rounded-lg px-2 py-1.5 text-[11px] ${connectionResult.status === "success"
-                                        ? "bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400"
-                                        : "bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400"
-                                        }`}
-                                    >
-                                      <span className="font-medium">
-                                        {connectionResult.status === "success"
-                                          ? "Success: "
-                                          : "Error: "}
-                                      </span>
-                                      {connectionResult.message}
-                                      {connectionResult.details?.endpoint && (
-                                        <div className="mt-1 text-neutral-500 dark:text-neutral-400">
-                                          Tested: {connectionResult.details.endpoint}
-                                          {connectionResult.details.responseTime !==
-                                            undefined && (
-                                              <> ({connectionResult.details.responseTime}ms)</>
-                                            )}
-                                        </div>
-                                      )}
-                                    </div>
-                                  )}
-
-                                  {baseUrlKey.envVar === ANTHROPIC_BASE_URL_KEY.envVar &&
-                                    hasBaseUrlValue && (
-                                      <div className="mt-2 flex items-start justify-between gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 px-3 py-2">
-                                        <div>
-                                          <p className="text-xs font-medium text-neutral-800 dark:text-neutral-200">
-                                            Bypass cmux Anthropic proxy
-                                          </p>
-                                          <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
-                                            When enabled, Claude connects directly
-                                            to your custom Anthropic endpoint.
-                                          </p>
-                                        </div>
-                                        <Switch
-                                          aria-label="Bypass cmux Anthropic proxy"
-                                          size="sm"
-                                          color="primary"
-                                          isSelected={bypassAnthropicProxy}
-                                          onValueChange={setBypassAnthropicProxy}
-                                        />
-                                      </div>
-                                    )}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {/* Provider Status - hidden in web mode */}
-            {!env.NEXT_PUBLIC_WEB_MODE && (
-              <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-                <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                  <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                    Provider Status
-                  </h2>
-                </div>
-                <div className="p-4">
-                  <ProviderStatusSettings />
-                </div>
-              </div>
-            )}
-
-            {/* Container Settings - hidden in web mode */}
-            {!env.NEXT_PUBLIC_WEB_MODE && (
-              <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800">
-                <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                  <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                    Container Management
-                  </h2>
-                </div>
-                <div className="p-4">
-                  <ContainerSettings
-                    teamSlugOrId={teamSlugOrId}
-                    onDataChange={handleContainerSettingsChange}
-                  />
-                </div>
-              </div>
-            )}
-
-            {/* Editor Settings Sync - web mode only */}
-            {env.NEXT_PUBLIC_WEB_MODE && (
-              <EditorSettingsSection teamSlugOrId={teamSlugOrId} />
-            )}
-
-            {/* Notifications */}
-            <div className="bg-white dark:bg-neutral-950 rounded-lg border border-neutral-200 dark:border-neutral-800 hidden">
-              <div className="px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
-                <h2 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                  Notifications
-                </h2>
-              </div>
-              <div className="p-4 space-y-3">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                      Email Notifications
-                    </p>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                      Receive updates about your workspace via email
-                    </p>
-                  </div>
-                  <Switch
-                    aria-label="Email Notifications"
-                    size="sm"
-                    isSelected
-                    isDisabled
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                      Desktop Notifications
-                    </p>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                      Get notified about important updates on desktop
-                    </p>
-                  </div>
-                  <Switch
-                    aria-label="Desktop Notifications"
-                    size="sm"
-                    isSelected={false}
-                    isDisabled
-                  />
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                      Weekly Digest
-                    </p>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                      Summary of your workspace activity
-                    </p>
-                  </div>
-                  <Switch
-                    aria-label="Weekly Digest"
-                    size="sm"
-                    isSelected
-                    isDisabled
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
+      <div className="relative flex grow flex-col overflow-auto select-none">
+        <div className="max-w-4xl p-6">
+          {activeSection === "general" ? (
+            <GeneralSection
+              teamSlugOrId={teamSlugOrId}
+              isSaving={isSaving}
+              teamName={teamName}
+              originalTeamName={originalTeamName}
+              teamNameError={teamNameError}
+              validateName={validateName}
+              onTeamNameChange={(value) => {
+                setTeamName(value);
+                setTeamNameError(validateName(value));
+              }}
+              onSaveTeamName={() => {
+                void saveTeamName();
+              }}
+              teamSlug={teamSlug}
+              originalTeamSlug={originalTeamSlug}
+              teamSlugError={teamSlugError}
+              validateSlug={validateSlug}
+              onTeamSlugChange={(value) => {
+                const normalized = value.toLowerCase();
+                setTeamSlug(normalized);
+                setTeamSlugError(validateSlug(normalized));
+              }}
+              onSaveTeamSlug={() => {
+                void saveTeamSlug();
+              }}
+              selectedTheme={selectedTheme}
+              onThemeChange={setTheme}
+              autoPrEnabled={autoPrEnabled}
+              onAutoPrEnabledChange={setAutoPrEnabled}
+              heatmapModel={heatmapModel}
+              onHeatmapModelChange={setHeatmapModel}
+              heatmapModelOptions={HEATMAP_MODEL_OPTIONS}
+              heatmapThreshold={heatmapThreshold}
+              onHeatmapThresholdChange={setHeatmapThreshold}
+              heatmapTooltipLanguage={heatmapTooltipLanguage}
+              onHeatmapTooltipLanguageChange={setHeatmapTooltipLanguage}
+              tooltipLanguageOptions={TOOLTIP_LANGUAGE_OPTIONS}
+              heatmapColors={heatmapColors}
+              onHeatmapColorsChange={setHeatmapColors}
+              worktreePath={worktreePath}
+              onWorktreePathChange={setWorktreePath}
+              onContainerSettingsChange={handleContainerSettingsChange}
+            />
+          ) : (
+            <AIProvidersSection
+              apiKeys={apiKeys}
+              providerInfoByEnvVar={PROVIDER_INFO}
+              apiKeyModelsByEnv={apiKeyModelsByEnv}
+              apiKeyValues={apiKeyValues}
+              originalApiKeyValues={originalApiKeyValues}
+              showKeys={showKeys}
+              showBaseUrls={showBaseUrls}
+              baseUrlValues={baseUrlValues}
+              isTestingConnection={isTestingConnection}
+              connectionTestResults={connectionTestResults}
+              bypassAnthropicProxy={bypassAnthropicProxy}
+              expandedUsedList={expandedUsedList}
+              overflowUsedList={overflowUsedList}
+              usedListRefs={usedListRefs}
+              showProviderStatus={!env.NEXT_PUBLIC_WEB_MODE}
+              onApiKeyChange={handleApiKeyChange}
+              onToggleShowKey={toggleShowKey}
+              onToggleShowBaseUrls={() => setShowBaseUrls((prev) => !prev)}
+              onBaseUrlChange={handleBaseUrlChange}
+              onTestBaseUrlConnection={(baseUrlKey, apiKeyEnvVar) => {
+                void testBaseUrlConnection(baseUrlKey, apiKeyEnvVar);
+              }}
+              onBypassAnthropicProxyChange={setBypassAnthropicProxy}
+              onToggleUsedList={(envVar) => {
+                setExpandedUsedList((prev) => ({
+                  ...prev,
+                  [envVar]: !prev[envVar],
+                }));
+              }}
+            />
+          )}
         </div>
       </div>
 
-      {/* Footer Save bar */}
       <div
-        ref={saveButtonRef}
         className="sticky bottom-0 border-t border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 supports-[backdrop-filter]:dark:bg-neutral-900/60"
       >
         <div className="max-w-3xl mx-auto px-6 py-3 flex items-center justify-end gap-3">


### PR DESCRIPTION
## Task

# Settings Page Refactor - Codex App Style

## Overview

Refactor the settings page from card-based layout to Codex app style. The **main sidebar is completely replaced** by settings navigation when on the settings page.

## Key Design Decisions

1. **Replace main sidebar** - When on settings page, hide the main sidebar (Home, Environments, etc.) and show settings sidebar instead
2. **Two sections only**: General (all settings except AI) and AI Providers
3. **Client-side state** for section switching (not nested routes)
4. **Hybrid save approach** - global Save for most settings, individual Save for Team Name/URL

## File Structure

```
apps/client/src/components/settings/
├── SettingsSidebar.tsx         # Replaces main sidebar on settings page
├── SettingRow.tsx              # Base row: label + description on left, control on right
├── SettingSwitch.tsx           # Row with toggle switch
├── SettingSelect.tsx           # Row with dropdown
├── SettingSegmented.tsx        # Row with segmented control (Light/Dark/System)
├── SettingSection.tsx          # Section container with header
└── sections/
    ├── GeneralSection.tsx      # All settings except AI Providers
    └── AIProvidersSection.tsx  # API Keys, Base URLs
```

## Implementation Steps

### Phase 1: Create SettingsSidebar Component

1. **Create&#32;`apps/client/src/components/settings/SettingsSidebar.tsx`**

- Same structure as main Sidebar (width, resizing, hidden state)
- "Back to app" link at top using ArrowLeft icon -> `/$teamSlugOrId/dashboard`
- Two nav items using SidebarNavLink pattern:
    - **General** (Settings icon) - active when `activeSection === 'general'`
    - **AI Providers** (Key icon) - active when `activeSection === 'ai-providers'`
- Props: `teamSlugOrId`, `activeSection`, `onSectionChange`

### Phase 2: Modify Parent Layout to Swap Sidebars

2. **Modify&#32;`apps/client/src/routes/_layout.$teamSlugOrId.tsx`**

- Import `useLocation` from TanStack Router
- Detect if current route matches `/settings` path
- Import `SettingsSidebar`
- Conditionally render:
    - If on settings: `<SettingsSidebar />`
    - Otherwise: `<Sidebar />`
- Pass `activeSection` and `onSectionChange` from URL search params or context

### Phase 3: Create Section Components

3. **Create&#32;`apps/client/src/components/settings/sections/GeneralSection.tsx`**

- Contains all settings EXCEPT AI Providers:
    - Team Name (with individual Save)
    - Team URL (with individual Save)
    - Connected Accounts (GitHub)
    - Appearance (Theme - Light/Dark/System)
    - Onboarding Tour
    - Crown Evaluator (Auto-PR toggle)
    - Heatmap Review settings
    - Worktree Location (hidden in web mode)
    - Container Settings (hidden in web mode)
    - Editor Settings (web mode only)

4. **Create&#32;`apps/client/src/components/settings/sections/AIProvidersSection.tsx`**

- API Key Authentication section
- All API keys with show/hide toggles
- Base URL settings (Show more/Hide more)
- Bypass Anthropic Proxy toggle
- Connection test functionality

### Phase 4: Create Shared Row Components

5. **Create&#32;`apps/client/src/components/settings/SettingRow.tsx`**

- Base row with label + description on left, children (control) on right
- Border-bottom divider between rows

6. **Create&#32;`apps/client/src/components/settings/SettingSection.tsx`**

- Section container with title header
- Wraps multiple SettingRow components

### Phase 5: Refactor Main Settings Route

7. **Refactor&#32;`apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx`**

- Keep all existing state and data fetching logic
- Add `activeSection` state: `'general' | 'ai-providers'`
- Replace card-based layout with:
    - Conditional rendering of GeneralSection or AIProvidersSection
- Remove FloatingPane sidebar (now handled by parent layout)
- Keep TitleBar with "Settings" title
- Keep global "Save Changes" footer button

## Key Files to Modify

| File | Action |
|------|--------|
| `apps/client/src/routes/_layout.$teamSlugOrId.tsx` | Add conditional sidebar rendering |
| `apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx` | Refactor to use section components |
| `apps/client/src/components/settings/SettingsSidebar.tsx` | Create new |
| `apps/client/src/components/settings/SettingRow.tsx` | Create new |
| `apps/client/src/components/settings/SettingSection.tsx` | Create new |
| `apps/client/src/components/settings/sections/GeneralSection.tsx` | Create new |
| `apps/client/src/components/settings/sections/AIProvidersSection.tsx` | Create new |

## Existing Components to Reuse

- `apps/client/src/components/ContainerSettings.tsx` - Import into GeneralSection
- `apps/client/src/components/EditorSettingsSection.tsx` - Import into GeneralSection
- `apps/client/src/components/sidebar/SidebarNavLink.tsx` - Reuse pattern for SettingsSidebar nav items

## Styling Guidelines

- Colors: `neutral` (not gray)
- Light mode: bg-white, border-neutral-200
- Dark mode: bg-neutral-950, border-neutral-800
- Sidebar: bg-neutral-50 dark:bg-neutral-900/50
- Text: text-neutral-900 dark:text-neutral-100

## Verification

1. Run `bun check` after changes
2. Test in browser:

- Navigate to settings page
- Click each sidebar section
- Verify all settings display correctly
- Test Save functionality for each section
- Test in both light and dark mode
- Test in web mode vs desktop mode (some sections hidden)

implement all tasks

## PR Review Summary
- **What Changed**:
  - Replaced the primary sidebar with a `SettingsSidebar` specifically for the `/settings` route.
  - Refactored settings content into two main components: `GeneralSection` and `AIProvidersSection`.
  - Introduced a modular settings UI toolkit (`SettingRow`, `SettingSection`, `SettingSegmented`, `SettingSelect`, `SettingSwitch`).
  - Updated route validation to include a `section` search parameter for navigation.
- **Review Focus**:
  - Sidebar persistence logic (width/hidden state) and the `requestAnimationFrame` resizing implementation in `SettingsSidebar.tsx`.
  - Logic in `_layout.$teamSlugOrId.tsx` that detects the settings path for sidebar swapping.
  - Proper filtering of environment-specific settings (web vs. desktop mode) within the new sections.
- **Test Plan**:
  - Open Settings: verify global sidebar is replaced and "Back to app" returns to dashboard.
  - Switch sections: verify content updates and URL search params reflect the selection.
  - Resize sidebar: confirm width persists in local storage after a refresh.
  - Test "Save" buttons for Team Name/URL to ensure individual saves still function alongside the global footer.