### PR TITLE
[Crown] # Plan: Refactor cmux Sidebar with Codex App UI Features

## ...

### DIFF
--- a/apps/client/src/components/MainContentHeader.tsx
+++ b/apps/client/src/components/MainContentHeader.tsx
@@ -1,0 +1,48 @@
+import { Link } from "@tanstack/react-router";
+import clsx from "clsx";
+import { PanelLeft, Plus } from "lucide-react";
+
+interface MainContentHeaderProps {
+  onToggleSidebar: () => void;
+  teamSlugOrId: string;
+}
+
+const buttonClassName = clsx(
+  "w-[28px] h-[28px] flex items-center justify-center rounded-lg",
+  "border border-neutral-200 dark:border-neutral-800",
+  "bg-white dark:bg-black",
+  "text-neutral-600 dark:text-neutral-400",
+  "hover:bg-neutral-100 dark:hover:bg-neutral-900",
+  "hover:text-neutral-800 dark:hover:text-neutral-200",
+  "transition-colors cursor-default"
+);
+
+/**
+ * Floating header shown in the main content area when the sidebar is hidden.
+ * Contains toggle sidebar button and new task button.
+ */
+export function MainContentHeader({
+  onToggleSidebar,
+  teamSlugOrId,
+}: MainContentHeaderProps) {
+  return (
+    <div className="absolute top-2 left-2 z-10 flex flex-col gap-1">
+      <button
+        onClick={onToggleSidebar}
+        className={buttonClassName}
+        title="Toggle sidebar (Ctrl+Shift+S)"
+      >
+        <PanelLeft className="w-4 h-4" aria-hidden="true" />
+      </button>
+      <Link
+        to="/$teamSlugOrId/dashboard"
+        params={{ teamSlugOrId }}
+        activeOptions={{ exact: true }}
+        className={buttonClassName}
+        title="New task"
+      >
+        <Plus className="w-4 h-4" aria-hidden="true" />
+      </Link>
+    </div>
+  );
+}

--- a/apps/client/src/components/sidebar/SidebarFilterMenu.tsx
+++ b/apps/client/src/components/sidebar/SidebarFilterMenu.tsx
@@ -1,0 +1,140 @@
+import { Menu } from "@base-ui-components/react/menu";
+import clsx from "clsx";
+import { Check, ListFilter, MoreHorizontal } from "lucide-react";
+import type { OrganizeMode, SectionPreferences, ShowFilter, SortBy } from "./sidebar-types";
+
+interface SidebarFilterMenuProps {
+  preferences: SectionPreferences;
+  onOrganizeModeChange: (mode: OrganizeMode) => void;
+  onSortByChange: (sort: SortBy) => void;
+  onShowFilterChange: (filter: ShowFilter) => void;
+}
+
+const radioItemClassName = clsx(
+  "grid cursor-default grid-cols-[0.75rem_1fr] items-center gap-2 py-1.5 pr-6 pl-2.5 text-xs leading-4 outline-none select-none",
+  "data-[highlighted]:relative data-[highlighted]:z-0",
+  "data-[highlighted]:text-neutral-900 dark:data-[highlighted]:text-neutral-100",
+  "data-[highlighted]:before:absolute data-[highlighted]:before:inset-x-1 data-[highlighted]:before:inset-y-0",
+  "data-[highlighted]:before:z-[-1] data-[highlighted]:before:rounded-sm",
+  "data-[highlighted]:before:bg-neutral-100 dark:data-[highlighted]:before:bg-neutral-800"
+);
+
+const labelClassName = "px-2.5 py-1.5 text-[10px] font-semibold text-neutral-500 dark:text-neutral-500 uppercase tracking-wide";
+
+const popupClassName = clsx(
+  "origin-[var(--transform-origin)] rounded-md bg-white dark:bg-black py-1 min-w-[160px]",
+  "text-neutral-900 dark:text-neutral-100",
+  "shadow-lg shadow-neutral-200 dark:shadow-neutral-950",
+  "outline outline-neutral-200 dark:outline-neutral-800",
+  "transition-[transform,scale,opacity]",
+  "data-[ending-style]:scale-90 data-[ending-style]:opacity-0",
+  "data-[starting-style]:scale-90 data-[starting-style]:opacity-0"
+);
+
+const iconButtonClassName = clsx(
+  "p-1 flex items-center justify-center rounded",
+  "text-neutral-500 dark:text-neutral-400",
+  "hover:text-neutral-700 dark:hover:text-neutral-200",
+  "hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50",
+  "transition-colors"
+);
+
+export function SidebarFilterMenu({
+  preferences,
+  onOrganizeModeChange,
+  onSortByChange,
+  onShowFilterChange,
+}: SidebarFilterMenuProps) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {/* Filter icon - Show filter options */}
+      <Menu.Root>
+        <Menu.Trigger
+          className={iconButtonClassName}
+          title="Filter"
+        >
+          <ListFilter className="w-3.5 h-3.5" aria-hidden="true" />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner sideOffset={4} side="bottom" align="end" className="outline-none z-[var(--z-popover)]">
+            <Menu.Popup className={popupClassName}>
+              <div className={labelClassName}>Show</div>
+              <Menu.RadioGroup
+                value={preferences.showFilter}
+                onValueChange={(val) => onShowFilterChange(val as ShowFilter)}
+              >
+                <Menu.RadioItem value="all" className={radioItemClassName}>
+                  <Menu.RadioItemIndicator className="col-start-1">
+                    <Check className="w-3 h-3" />
+                  </Menu.RadioItemIndicator>
+                  <span className="col-start-2">All threads</span>
+                </Menu.RadioItem>
+                <Menu.RadioItem value="relevant" className={radioItemClassName}>
+                  <Menu.RadioItemIndicator className="col-start-1">
+                    <Check className="w-3 h-3" />
+                  </Menu.RadioItemIndicator>
+                  <span className="col-start-2">Relevant</span>
+                </Menu.RadioItem>
+              </Menu.RadioGroup>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
+
+      {/* Organize icon - Organize and sort options */}
+      <Menu.Root>
+        <Menu.Trigger
+          className={iconButtonClassName}
+          title="Organize"
+        >
+          <MoreHorizontal className="w-3.5 h-3.5" aria-hidden="true" />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner sideOffset={4} side="bottom" align="end" className="outline-none z-[var(--z-popover)]">
+            <Menu.Popup className={popupClassName}>
+              <div className={labelClassName}>Organize</div>
+              <Menu.RadioGroup
+                value={preferences.organizeMode}
+                onValueChange={(val) => onOrganizeModeChange(val as OrganizeMode)}
+              >
+                <Menu.RadioItem value="by-project" className={radioItemClassName}>
+                  <Menu.RadioItemIndicator className="col-start-1">
+                    <Check className="w-3 h-3" />
+                  </Menu.RadioItemIndicator>
+                  <span className="col-start-2">By project</span>
+                </Menu.RadioItem>
+                <Menu.RadioItem value="chronological" className={radioItemClassName}>
+                  <Menu.RadioItemIndicator className="col-start-1">
+                    <Check className="w-3 h-3" />
+                  </Menu.RadioItemIndicator>
+                  <span className="col-start-2">Chronological list</span>
+                </Menu.RadioItem>
+              </Menu.RadioGroup>
+
+              <div className="my-1 mx-2 border-t border-neutral-200 dark:border-neutral-800" />
+
+              <div className={labelClassName}>Sort by</div>
+              <Menu.RadioGroup
+                value={preferences.sortBy}
+                onValueChange={(val) => onSortByChange(val as SortBy)}
+              >
+                <Menu.RadioItem value="created" className={radioItemClassName}>
+                  <Menu.RadioItemIndicator className="col-start-1">
+                    <Check className="w-3 h-3" />
+                  </Menu.RadioItemIndicator>
+                  <span className="col-start-2">Created</span>
+                </Menu.RadioItem>
+                <Menu.RadioItem value="updated" className={radioItemClassName}>
+                  <Menu.RadioItemIndicator className="col-start-1">
+                    <Check className="w-3 h-3" />
+                  </Menu.RadioItemIndicator>
+                  <span className="col-start-2">Updated</span>
+                </Menu.RadioItem>
+              </Menu.RadioGroup>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
+    </div>
+  );
+}

--- a/apps/client/src/components/sidebar/SidebarProjectGroup.tsx
+++ b/apps/client/src/components/sidebar/SidebarProjectGroup.tsx
@@ -1,0 +1,86 @@
+import clsx from "clsx";
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+import { OTHER_GROUP_KEY } from "./sidebar-types";
+
+interface SidebarProjectGroupProps<T> {
+  groupKey: string;
+  displayName: string;
+  items: T[];
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  renderItem: (item: T, index: number) => ReactNode;
+  /** Number of items to show initially before "Show more" (default: 5) */
+  initialDisplayCount?: number;
+  className?: string;
+}
+
+export function SidebarProjectGroup<T>({
+  groupKey,
+  displayName,
+  items,
+  isCollapsed,
+  onToggleCollapse,
+  isExpanded,
+  onToggleExpand,
+  renderItem,
+  initialDisplayCount = 5,
+  className,
+}: SidebarProjectGroupProps<T>) {
+  const isOtherGroup = groupKey === OTHER_GROUP_KEY;
+  const visibleItems = isExpanded ? items : items.slice(0, initialDisplayCount);
+  const remainingCount = items.length - initialDisplayCount;
+  const showExpandButton = !isExpanded && remainingCount > 0;
+
+  return (
+    <div className={clsx("flex flex-col", className)}>
+      {/* Group header with chevron */}
+      <button
+        onClick={onToggleCollapse}
+        className={clsx(
+          "flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-sm",
+          "text-neutral-600 dark:text-neutral-400",
+          "hover:bg-neutral-200/45 dark:hover:bg-neutral-800/45",
+          "cursor-default select-none transition-colors"
+        )}
+      >
+        <ChevronRight
+          className={clsx(
+            "w-3 h-3 transition-transform",
+            !isCollapsed && "rotate-90"
+          )}
+          aria-hidden="true"
+        />
+        <span className={clsx(isOtherGroup && "italic")}>{displayName}</span>
+        <span className="text-neutral-400 dark:text-neutral-500 ml-1">
+          ({items.length})
+        </span>
+      </button>
+
+      {/* Group items */}
+      {!isCollapsed && (
+        <div className="flex flex-col">
+          {visibleItems.map((item, index) => renderItem(item, index))}
+
+          {/* Show more button */}
+          {showExpandButton && (
+            <button
+              onClick={onToggleExpand}
+              className={clsx(
+                "ml-5 px-2 py-1 text-xs rounded-sm text-left",
+                "text-neutral-500 dark:text-neutral-500",
+                "hover:text-neutral-700 dark:hover:text-neutral-300",
+                "hover:bg-neutral-200/45 dark:hover:bg-neutral-800/45",
+                "cursor-default select-none transition-colors"
+              )}
+            >
+              Show more ({remainingCount})
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/sidebar/SidebarPullRequestSection.tsx
+++ b/apps/client/src/components/sidebar/SidebarPullRequestSection.tsx
@@ -1,0 +1,38 @@
+import { SidebarSectionHeader } from "./SidebarSectionHeader";
+import { SidebarPullRequestList } from "./SidebarPullRequestList";
+import { useSidebarPreferences } from "./useSidebarPreferences";
+import { SIDEBAR_PR_PREFS_KEY } from "./sidebar-types";
+
+interface SidebarPullRequestSectionProps {
+  teamSlugOrId: string;
+}
+
+export function SidebarPullRequestSection({
+  teamSlugOrId,
+}: SidebarPullRequestSectionProps) {
+  const prPrefs = useSidebarPreferences(SIDEBAR_PR_PREFS_KEY);
+
+  return (
+    <div className="mt-4 flex flex-col">
+      <SidebarSectionHeader
+        title="Pull requests"
+        to="/$teamSlugOrId/prs"
+        teamSlugOrId={teamSlugOrId}
+        preferences={prPrefs.preferences}
+        onOrganizeModeChange={prPrefs.setOrganizeMode}
+        onSortByChange={prPrefs.setSortBy}
+        onShowFilterChange={prPrefs.setShowFilter}
+      />
+      <div className="ml-2 pt-px">
+        <SidebarPullRequestList
+          teamSlugOrId={teamSlugOrId}
+          preferences={prPrefs.preferences}
+          isGroupCollapsed={prPrefs.isGroupCollapsed}
+          toggleGroupCollapsed={prPrefs.toggleGroupCollapsed}
+          isGroupExpanded={prPrefs.isGroupExpanded}
+          toggleGroupExpanded={prPrefs.toggleGroupExpanded}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/components/sidebar/SidebarSectionHeader.tsx
+++ b/apps/client/src/components/sidebar/SidebarSectionHeader.tsx
@@ -1,0 +1,68 @@
+import { Link, type LinkProps } from "@tanstack/react-router";
+import clsx from "clsx";
+import type { ReactNode } from "react";
+import { SidebarFilterMenu } from "./SidebarFilterMenu";
+import type { OrganizeMode, SectionPreferences, ShowFilter, SortBy } from "./sidebar-types";
+
+interface SidebarSectionHeaderProps {
+  title: string;
+  to: LinkProps["to"];
+  teamSlugOrId: string;
+  preferences: SectionPreferences;
+  onOrganizeModeChange: (mode: OrganizeMode) => void;
+  onSortByChange: (sort: SortBy) => void;
+  onShowFilterChange: (filter: ShowFilter) => void;
+  /** Optional trailing content (e.g., "+" button for Workspaces) */
+  trailing?: ReactNode;
+  className?: string;
+  /** Data attribute for onboarding targeting */
+  onboardingKey?: string;
+}
+
+export function SidebarSectionHeader({
+  title,
+  to,
+  teamSlugOrId,
+  preferences,
+  onOrganizeModeChange,
+  onSortByChange,
+  onShowFilterChange,
+  trailing,
+  className,
+  onboardingKey,
+}: SidebarSectionHeaderProps) {
+  // Cast params to the expected type for Link
+  const params = { teamSlugOrId } as LinkProps["params"];
+
+  return (
+    <div
+      className={clsx("flex items-center justify-between ml-2 pr-1", className)}
+      {...(onboardingKey && { "data-onboarding": onboardingKey })}
+    >
+      <Link
+        to={to}
+        params={params}
+        activeOptions={{ exact: true }}
+        className={clsx(
+          "pointer-default cursor-default flex items-center rounded-sm pl-2 pr-3 py-0.5 text-[12px] font-medium text-neutral-600 select-none hover:bg-neutral-200/45 dark:text-neutral-300 dark:hover:bg-neutral-800/45 data-[active=true]:hover:bg-neutral-200/75 dark:data-[active=true]:hover:bg-neutral-800/65"
+        )}
+        activeProps={{
+          className:
+            "bg-neutral-200/75 text-neutral-900 dark:bg-neutral-800/65 dark:text-neutral-100",
+          "data-active": "true",
+        }}
+      >
+        {title}
+      </Link>
+      <div className="flex items-center gap-0.5">
+        {trailing}
+        <SidebarFilterMenu
+          preferences={preferences}
+          onOrganizeModeChange={onOrganizeModeChange}
+          onSortByChange={onSortByChange}
+          onShowFilterChange={onShowFilterChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/components/sidebar/SidebarWorkspacesSection.tsx
+++ b/apps/client/src/components/sidebar/SidebarWorkspacesSection.tsx
@@ -1,12 +1,17 @@
 import { env } from "@/client-env";
 import { Dropdown } from "@/components/ui/dropdown";
-import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
 import { Cloud, Monitor, Plus } from "lucide-react";
 import { useCallback } from "react";
+import { SidebarSectionHeader } from "./SidebarSectionHeader";
+import type { OrganizeMode, SectionPreferences, ShowFilter, SortBy } from "./sidebar-types";
 
 interface SidebarWorkspacesSectionProps {
   teamSlugOrId: string;
+  preferences: SectionPreferences;
+  onOrganizeModeChange: (mode: OrganizeMode) => void;
+  onSortByChange: (sort: SortBy) => void;
+  onShowFilterChange: (filter: ShowFilter) => void;
 }
 
 function openCommandBarWithPage(page: string) {
@@ -17,6 +22,10 @@ function openCommandBarWithPage(page: string) {
 
 export function SidebarWorkspacesSection({
   teamSlugOrId,
+  preferences,
+  onOrganizeModeChange,
+  onSortByChange,
+  onShowFilterChange,
 }: SidebarWorkspacesSectionProps) {
   const handleLocalWorkspace = useCallback(() => {
     openCommandBarWithPage("local-workspaces");
@@ -26,58 +35,56 @@ export function SidebarWorkspacesSection({
     openCommandBarWithPage("cloud-workspaces");
   }, []);
 
-  return (
-    <div className="flex items-center justify-between ml-2" data-onboarding="workspaces-link">
-      <Link
-        to="/$teamSlugOrId/workspaces"
-        params={{ teamSlugOrId }}
-        activeOptions={{ exact: true }}
+  const newWorkspaceButton = (
+    <Dropdown.Root>
+      <Dropdown.Trigger
         className={clsx(
-          "pointer-default cursor-default flex items-center rounded-sm pl-2 pr-3 py-0.5 text-[12px] font-medium text-neutral-600 select-none hover:bg-neutral-200/45 dark:text-neutral-300 dark:hover:bg-neutral-800/45 data-[active=true]:hover:bg-neutral-200/75 dark:data-[active=true]:hover:bg-neutral-800/65"
+          "p-1 flex items-center justify-center rounded",
+          "text-neutral-500 dark:text-neutral-400",
+          "hover:text-neutral-700 dark:hover:text-neutral-200",
+          "hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50",
+          "transition-colors"
         )}
-        activeProps={{
-          className:
-            "bg-neutral-200/75 text-neutral-900 dark:bg-neutral-800/65 dark:text-neutral-100",
-          "data-active": "true",
-        }}
+        title="New workspace"
       >
-        Workspaces
-      </Link>
-      <Dropdown.Root>
-        <Dropdown.Trigger
-          className={clsx(
-            "p-1 mr-[3px] flex items-center justify-center",
-            "text-neutral-500 dark:text-neutral-400",
-            "hover:text-neutral-700 dark:hover:text-neutral-200",
-            "transition-colors"
-          )}
-          title="New workspace"
-        >
-          <Plus className="w-3.5 h-3.5" aria-hidden="true" />
-        </Dropdown.Trigger>
-        <Dropdown.Portal>
-          <Dropdown.Positioner sideOffset={4} side="bottom" align="end">
-            <Dropdown.Popup className="min-w-[180px]">
-              {!env.NEXT_PUBLIC_WEB_MODE && (
-                <Dropdown.Item
-                  onClick={handleLocalWorkspace}
-                  className="flex items-center gap-2"
-                >
-                  <Monitor className="w-3.5 h-3.5 text-neutral-500 dark:text-neutral-400" />
-                  <span>Local Workspace</span>
-                </Dropdown.Item>
-              )}
+        <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+      </Dropdown.Trigger>
+      <Dropdown.Portal>
+        <Dropdown.Positioner sideOffset={4} side="bottom" align="end">
+          <Dropdown.Popup className="min-w-[180px]">
+            {!env.NEXT_PUBLIC_WEB_MODE && (
               <Dropdown.Item
-                onClick={handleCloudWorkspace}
+                onClick={handleLocalWorkspace}
                 className="flex items-center gap-2"
               >
-                <Cloud className="w-4 h-4 text-neutral-500 dark:text-neutral-400" />
-                <span>Cloud Workspace</span>
+                <Monitor className="w-3.5 h-3.5 text-neutral-500 dark:text-neutral-400" />
+                <span>Local Workspace</span>
               </Dropdown.Item>
-            </Dropdown.Popup>
-          </Dropdown.Positioner>
-        </Dropdown.Portal>
-      </Dropdown.Root>
-    </div>
+            )}
+            <Dropdown.Item
+              onClick={handleCloudWorkspace}
+              className="flex items-center gap-2"
+            >
+              <Cloud className="w-4 h-4 text-neutral-500 dark:text-neutral-400" />
+              <span>Cloud Workspace</span>
+            </Dropdown.Item>
+          </Dropdown.Popup>
+        </Dropdown.Positioner>
+      </Dropdown.Portal>
+    </Dropdown.Root>
+  );
+
+  return (
+    <SidebarSectionHeader
+      title="Workspaces"
+      to="/$teamSlugOrId/workspaces"
+      teamSlugOrId={teamSlugOrId}
+      preferences={preferences}
+      onOrganizeModeChange={onOrganizeModeChange}
+      onSortByChange={onSortByChange}
+      onShowFilterChange={onShowFilterChange}
+      trailing={newWorkspaceButton}
+      onboardingKey="workspaces-link"
+    />
   );
 }

--- a/apps/client/src/components/sidebar/sidebar-types.ts
+++ b/apps/client/src/components/sidebar/sidebar-types.ts
@@ -1,0 +1,37 @@
+// Sidebar filter/sort/organize types
+
+export type OrganizeMode = "by-project" | "chronological";
+export type SortBy = "created" | "updated";
+export type ShowFilter = "all" | "relevant";
+
+export interface SidebarPreferences {
+  organizeMode: OrganizeMode;
+  sortBy: SortBy;
+  showFilter: ShowFilter;
+}
+
+export interface SectionPreferences extends SidebarPreferences {
+  /** Keys are group identifiers (e.g., "owner/repo"), values indicate collapsed state */
+  collapsedGroups: Record<string, boolean>;
+  /** Keys are group identifiers, values indicate "Show more" expanded state */
+  expandedGroups: Record<string, boolean>;
+}
+
+export const SIDEBAR_PR_PREFS_KEY = "cmux:sidebar-pr-preferences";
+export const SIDEBAR_WS_PREFS_KEY = "cmux:sidebar-ws-preferences";
+
+export const DEFAULT_PREFERENCES: SidebarPreferences = {
+  organizeMode: "by-project",
+  sortBy: "created",
+  showFilter: "relevant",
+};
+
+export const DEFAULT_SECTION_PREFERENCES: SectionPreferences = {
+  ...DEFAULT_PREFERENCES,
+  collapsedGroups: {},
+  expandedGroups: {},
+};
+
+/** Group key used for items without a projectFullName/repoFullName */
+export const OTHER_GROUP_KEY = "__other__";
+export const OTHER_GROUP_DISPLAY_NAME = "Other";

--- a/apps/client/src/components/sidebar/sidebar-utils.ts
+++ b/apps/client/src/components/sidebar/sidebar-utils.ts
@@ -1,0 +1,106 @@
+import { OTHER_GROUP_KEY, OTHER_GROUP_DISPLAY_NAME, type SortBy, type ShowFilter } from "./sidebar-types";
+
+/**
+ * Groups items by a key extracted from each item.
+ * Items without a key are grouped under OTHER_GROUP_KEY.
+ * Returns a Map with group keys as keys, preserving insertion order.
+ */
+export function groupItemsByProject<T>(
+  items: T[],
+  getGroupKey: (item: T) => string | undefined
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  const otherItems: T[] = [];
+
+  for (const item of items) {
+    const key = getGroupKey(item);
+    if (!key) {
+      otherItems.push(item);
+      continue;
+    }
+
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(item);
+    } else {
+      groups.set(key, [item]);
+    }
+  }
+
+  // Add "Other" group at the end if there are ungrouped items
+  if (otherItems.length > 0) {
+    groups.set(OTHER_GROUP_KEY, otherItems);
+  }
+
+  return groups;
+}
+
+/**
+ * Sorts items by the specified field.
+ * Uses the getSortValue function to extract the numeric sort value.
+ * Returns a new sorted array (does not mutate input).
+ */
+export function sortItems<T>(
+  items: T[],
+  sortBy: SortBy,
+  getSortValue: (item: T, sortBy: SortBy) => number
+): T[] {
+  return [...items].sort((a, b) => {
+    // Sort descending (most recent first)
+    return getSortValue(b, sortBy) - getSortValue(a, sortBy);
+  });
+}
+
+/**
+ * Filters items based on the show filter.
+ * Uses the isRelevant function to determine if an item should be shown.
+ * Returns a new filtered array (does not mutate input).
+ */
+export function filterRelevant<T>(
+  items: T[],
+  showFilter: ShowFilter,
+  isRelevant: (item: T) => boolean
+): T[] {
+  if (showFilter === "all") {
+    return items;
+  }
+  return items.filter(isRelevant);
+}
+
+/**
+ * Extracts the display name from a group key.
+ * For "owner/repo" format, returns "repo".
+ * For OTHER_GROUP_KEY, returns "Other".
+ * For other formats, returns the key as-is.
+ */
+export function getGroupDisplayName(groupKey: string): string {
+  if (groupKey === OTHER_GROUP_KEY) {
+    return OTHER_GROUP_DISPLAY_NAME;
+  }
+
+  // Handle "owner/repo" format
+  const parts = groupKey.split("/");
+  if (parts.length >= 2) {
+    return parts[parts.length - 1] ?? groupKey;
+  }
+
+  return groupKey;
+}
+
+/**
+ * Determines if an item is "relevant" based on activity within the last 7 days
+ * or having an unread notification.
+ */
+export function isItemRelevant(
+  lastActivityMs: number,
+  hasUnread: boolean,
+  daysThreshold = 7
+): boolean {
+  if (hasUnread) {
+    return true;
+  }
+
+  const now = Date.now();
+  const thresholdMs = daysThreshold * 24 * 60 * 60 * 1000;
+  return now - lastActivityMs < thresholdMs;
+}

--- a/apps/client/src/components/sidebar/useSidebarPreferences.ts
+++ b/apps/client/src/components/sidebar/useSidebarPreferences.ts
@@ -1,0 +1,136 @@
+import { useCallback, useState } from "react";
+import {
+  DEFAULT_SECTION_PREFERENCES,
+  type OrganizeMode,
+  type SectionPreferences,
+  type ShowFilter,
+  type SortBy,
+} from "./sidebar-types";
+
+function loadPreferences(storageKey: string): SectionPreferences {
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      const parsed = JSON.parse(stored) as Partial<SectionPreferences>;
+      return {
+        ...DEFAULT_SECTION_PREFERENCES,
+        ...parsed,
+        collapsedGroups: parsed.collapsedGroups ?? {},
+        expandedGroups: parsed.expandedGroups ?? {},
+      };
+    }
+  } catch (error) {
+    console.error(`Failed to load sidebar preferences from ${storageKey}:`, error);
+  }
+  return { ...DEFAULT_SECTION_PREFERENCES };
+}
+
+function savePreferences(storageKey: string, prefs: SectionPreferences): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(prefs));
+  } catch (error) {
+    console.error(`Failed to save sidebar preferences to ${storageKey}:`, error);
+  }
+}
+
+export interface UseSidebarPreferencesResult {
+  preferences: SectionPreferences;
+  setOrganizeMode: (mode: OrganizeMode) => void;
+  setSortBy: (sort: SortBy) => void;
+  setShowFilter: (filter: ShowFilter) => void;
+  toggleGroupCollapsed: (groupKey: string) => void;
+  toggleGroupExpanded: (groupKey: string) => void;
+  isGroupCollapsed: (groupKey: string) => boolean;
+  isGroupExpanded: (groupKey: string) => boolean;
+}
+
+export function useSidebarPreferences(
+  storageKey: string
+): UseSidebarPreferencesResult {
+  const [preferences, setPreferences] = useState<SectionPreferences>(() =>
+    loadPreferences(storageKey)
+  );
+
+  const updateAndSave = useCallback(
+    (updater: (prev: SectionPreferences) => SectionPreferences) => {
+      setPreferences((prev) => {
+        const next = updater(prev);
+        savePreferences(storageKey, next);
+        return next;
+      });
+    },
+    [storageKey]
+  );
+
+  const setOrganizeMode = useCallback(
+    (mode: OrganizeMode) => {
+      updateAndSave((prev) => ({ ...prev, organizeMode: mode }));
+    },
+    [updateAndSave]
+  );
+
+  const setSortBy = useCallback(
+    (sort: SortBy) => {
+      updateAndSave((prev) => ({ ...prev, sortBy: sort }));
+    },
+    [updateAndSave]
+  );
+
+  const setShowFilter = useCallback(
+    (filter: ShowFilter) => {
+      updateAndSave((prev) => ({ ...prev, showFilter: filter }));
+    },
+    [updateAndSave]
+  );
+
+  const toggleGroupCollapsed = useCallback(
+    (groupKey: string) => {
+      updateAndSave((prev) => ({
+        ...prev,
+        collapsedGroups: {
+          ...prev.collapsedGroups,
+          [groupKey]: !prev.collapsedGroups[groupKey],
+        },
+      }));
+    },
+    [updateAndSave]
+  );
+
+  const toggleGroupExpanded = useCallback(
+    (groupKey: string) => {
+      updateAndSave((prev) => ({
+        ...prev,
+        expandedGroups: {
+          ...prev.expandedGroups,
+          [groupKey]: !prev.expandedGroups[groupKey],
+        },
+      }));
+    },
+    [updateAndSave]
+  );
+
+  const isGroupCollapsed = useCallback(
+    (groupKey: string): boolean => {
+      return preferences.collapsedGroups[groupKey] ?? false;
+    },
+    [preferences.collapsedGroups]
+  );
+
+  const isGroupExpanded = useCallback(
+    (groupKey: string): boolean => {
+      return preferences.expandedGroups[groupKey] ?? false;
+    },
+    [preferences.expandedGroups]
+  );
+
+  return {
+    preferences,
+    setOrganizeMode,
+    setSortBy,
+    setShowFilter,
+    toggleGroupCollapsed,
+    toggleGroupExpanded,
+    isGroupCollapsed,
+    isGroupExpanded,
+  };
+}

--- a/apps/client/src/components/sidebar/useSidebarVisibility.ts
+++ b/apps/client/src/components/sidebar/useSidebarVisibility.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from "react";
+import { isElectron } from "@/lib/electron";
+
+const STORAGE_KEY = "sidebarHidden";
+
+export interface UseSidebarVisibilityResult {
+  isHidden: boolean;
+  setIsHidden: (hidden: boolean) => void;
+  toggleSidebar: () => void;
+}
+
+/**
+ * Hook to manage sidebar visibility state.
+ * Persists state to localStorage and syncs across tabs via storage events.
+ * Also listens for electron shortcut events if running in electron.
+ */
+export function useSidebarVisibility(): UseSidebarVisibilityResult {
+  const [isHidden, setIsHiddenState] = useState(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === "true";
+  });
+
+  const setIsHidden = useCallback((hidden: boolean) => {
+    setIsHiddenState(hidden);
+    localStorage.setItem(STORAGE_KEY, String(hidden));
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    setIsHiddenState((prev) => {
+      const next = !prev;
+      localStorage.setItem(STORAGE_KEY, String(next));
+      return next;
+    });
+  }, []);
+
+  // Keyboard shortcut to toggle sidebar (Ctrl+Shift+S)
+  useEffect(() => {
+    if (isElectron && window.cmux?.on) {
+      const off = window.cmux.on("shortcut:sidebar-toggle", () => {
+        toggleSidebar();
+      });
+      return () => {
+        if (typeof off === "function") off();
+      };
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.ctrlKey &&
+        e.shiftKey &&
+        !e.altKey &&
+        !e.metaKey &&
+        (e.code === "KeyS" || e.key.toLowerCase() === "s")
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        toggleSidebar();
+      }
+    };
+
+    // Use capture phase to intercept before browser default handlers
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [toggleSidebar]);
+
+  // Listen for storage events from command bar (sidebar visibility sync)
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY && e.newValue !== null) {
+        setIsHiddenState(e.newValue === "true");
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  return {
+    isHidden,
+    setIsHidden,
+    toggleSidebar,
+  };
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.tsx
@@ -1,11 +1,13 @@
 import { CmuxComments } from "@/components/cmux-comments";
 import { CommandBar } from "@/components/CommandBar";
+import { MainContentHeader } from "@/components/MainContentHeader";
 import { Sidebar } from "@/components/Sidebar";
 import {
   SettingsSidebar,
   type SettingsSection,
 } from "@/components/settings/SettingsSidebar";
 import { SIDEBAR_PRS_DEFAULT_LIMIT } from "@/components/sidebar/const";
+import { useSidebarVisibility } from "@/components/sidebar/useSidebarVisibility";
 import { convexQueryClient } from "@/contexts/convex/convex-query-client";
 import { ExpandTasksProvider } from "@/contexts/expand-tasks/ExpandTasksProvider";
 import { cachedGetUser } from "@/lib/cachedGetUser";
@@ -90,6 +92,10 @@ function LayoutComponent() {
   const { teamSlugOrId } = Route.useParams();
   const location = useLocation();
   const navigate = useNavigate();
+
+  // Sidebar visibility state (persisted, synced, keyboard shortcut enabled)
+  const { isHidden: isSidebarHidden, toggleSidebar } = useSidebarVisibility();
+
   // In web mode, exclude local workspaces
   const excludeLocalWorkspaces = env.NEXT_PUBLIC_WEB_MODE || undefined;
   // Use React Query-wrapped Convex queries to avoid real-time subscriptions
@@ -137,10 +143,22 @@ function LayoutComponent() {
             onSectionChange={handleSettingsSectionChange}
           />
         ) : (
-          <Sidebar tasks={displayTasks} teamSlugOrId={teamSlugOrId} />
+          <Sidebar
+            tasks={displayTasks}
+            teamSlugOrId={teamSlugOrId}
+            isHidden={isSidebarHidden}
+            onToggleSidebar={toggleSidebar}
+          />
         )}
 
-        <div className="min-w-full md:min-w-0 grow snap-start snap-always flex flex-col">
+        <div className="relative min-w-full md:min-w-0 grow snap-start snap-always flex flex-col">
+          {/* Show floating header when sidebar is hidden (only on non-settings routes) */}
+          {isSidebarHidden && !isSettingsRoute && (
+            <MainContentHeader
+              onToggleSidebar={toggleSidebar}
+              teamSlugOrId={teamSlugOrId}
+            />
+          )}
           <Suspense fallback={<div>Loading...</div>}>
             <Outlet />
           </Suspense>


### PR DESCRIPTION
## Task

# Plan: Refactor cmux Sidebar with Codex App UI Features

## Overview

Add Codex-style UI features to the cmux sidebar: toggle button, filter/sort/organize menu at section level, collapsible project groups, and "Show more" pagination.

## Features to Implement

1. **Toggle sidebar button** with tooltip showing keyboard shortcut (existing: Ctrl+Shift+S)
2. **Complete sidebar hide** - No leftover bar; toggle icons move to MAIN CONTENT area
3. **Filter/sort/organize icons at section level** - Next to "Pull Requests" and "Workspaces" headers
4. **Collapsible project groups** - Each repo group has expand/collapse arrow
5. **Organization options**: "By project" (default) and "Chronological list"
6. **Sort options**: "Created" and "Updated"
7. **Show filter**: "All threads" and "Relevant"
8. **"Show more (N)" button** within each project group
9. **"Other" group** for items without projectFullName/repoFullName

---

## Design Corrections (from screenshots)

### Header Area

```
[logo] cmux-next     [+]
```

- Header remains simple with logo and new task button
- NO filter/organize icons in main header

### Section Headers (filter/organize icons here)

```
Pull requests                        [filter] [organize]
  > testing-repo-1                   (collapsible group)
      Item 1
      Item 2

Workspaces                      [+] [filter] [organize]
  > testing-repo-1                   (collapsible group)
      Item 1
      Item 2
      Show more (11)
  > Other
      Ungrouped item
```

### When Sidebar Hidden (Images 11, 12, 13)

- **NO collapsed sidebar bar** on the left
- Toggle and New Task icons appear in **MAIN CONTENT area** (top-right corner)
- Layout: Just a vertical stack of two icons (toggle sidebar, new task/plus)
- Sidebar completely disappears like original design

---

## File Structure

### New Files

```
apps/client/src/components/sidebar/
  SidebarSectionHeader.tsx       # Section header with filter/organize icons
  SidebarFilterMenu.tsx          # Dropdown menu for filter/sort/organize
  SidebarProjectGroup.tsx        # Collapsible project group with "Show more"
  useSidebarPreferences.ts       # Hook for localStorage preferences
  sidebar-types.ts               # TypeScript types
  sidebar-utils.ts               # Grouping/sorting utility functions

apps/client/src/components/
  MainContentHeader.tsx          # Floating toggle/new-task icons when sidebar hidden
```

### Modified Files

```
apps/client/src/components/Sidebar.tsx
apps/client/src/components/sidebar/SidebarPullRequestList.tsx
apps/client/src/components/sidebar/SidebarWorkspacesSection.tsx
apps/client/src/routes/_layout.$teamSlugOrId.tsx  # Add MainContentHeader
```

---

## Implementation Steps

### Step 1: Create Types and Preferences Hook

**File:** `apps/client/src/components/sidebar/sidebar-types.ts`

```ts
export type OrganizeMode = 'by-project' | 'chronological';
export type SortBy = 'created' | 'updated';
export type ShowFilter = 'all' | 'relevant';

export interface SidebarPreferences {
  organizeMode: OrganizeMode;       // default: 'by-project'
  sortBy: SortBy;                   // default: 'created'
  showFilter: ShowFilter;           // default: 'relevant'
}

export interface SectionPreferences extends SidebarPreferences {
  collapsedGroups: Record<string, boolean>;  // key: groupKey (repo name)
  expandedGroups: Record<string, boolean>;   // for "Show more" state
}

export const SIDEBAR_PR_PREFS_KEY = 'cmux:sidebar-pr-preferences';
export const SIDEBAR_WS_PREFS_KEY = 'cmux:sidebar-ws-preferences';
```

**File:** `apps/client/src/components/sidebar/useSidebarPreferences.ts`

```ts
export function useSidebarPreferences(storageKey: string) {
  // Initialize from localStorage with defaults
  // Persist on change
  // Return: prefs, setOrganizeMode, setSortBy, setShowFilter,
  //         toggleGroupCollapsed, toggleGroupExpanded
}
```

### Step 2: Create Utility Functions

**File:** `apps/client/src/components/sidebar/sidebar-utils.ts`

```ts
// Group items by projectFullName/repoFullName
export function groupItemsByProject<T>(
  items: T[],
  getGroupKey: (item: T) => string | undefined
): Map<string, T[]>

// Sort items within groups
export function sortItems<T>(
  items: T[],
  sortBy: 'created' | 'updated',
  getSortValue: (item: T) => number
): T[]

// Filter relevant items (7-day activity or has unread)
export function filterRelevant<T>(
  items: T[],
  showFilter: 'all' | 'relevant',
  isRelevant: (item: T) => boolean
): T[]

// Extract display name from "owner/repo" -> "repo"
export function getGroupDisplayName(groupKey: string): string
```

### Step 3: Create Filter Menu Component

**File:** `apps/client/src/components/sidebar/SidebarFilterMenu.tsx`

```tsx
interface SidebarFilterMenuProps {
  preferences: SectionPreferences;
  onOrganizeModeChange: (mode: OrganizeMode) => void;
  onSortByChange: (sort: SortBy) => void;
  onShowFilterChange: (filter: ShowFilter) => void;
}

// Uses existing Dropdown components
// Menu structure (from Image 10):
// ORGANIZE (label)
//   ✓ By project
//     Chronological list
// SORT BY (label)
//   ✓ Created
//     Updated
// SHOW (label)
//     All threads
//   ✓ Relevant
```

### Step 4: Create Section Header Component

**File:** `apps/client/src/components/sidebar/SidebarSectionHeader.tsx`

```tsx
interface SidebarSectionHeaderProps {
  title: string;
  to: string;  // Link destination
  teamSlugOrId: string;
  preferences: SectionPreferences;
  onPreferencesChange: PreferencesHandlers;
  trailing?: ReactNode;  // For Workspaces "+" button
}

// Renders:
// [Title link]  [trailing?] [filter-icon] [organize-icon]
```

### Step 5: Create Collapsible Project Group

**File:** `apps/client/src/components/sidebar/SidebarProjectGroup.tsx`

```tsx
interface SidebarProjectGroupProps<T> {
  groupKey: string;           // "owner/repo" or "__other__"
  displayName: string;        // "repo" or "Other"
  items: T[];
  isCollapsed: boolean;       // Group collapse state
  onToggleCollapse: () => void;
  isExpanded: boolean;        // "Show more" state
  onToggleExpand: () => void;
  renderItem: (item: T) => ReactNode;
  initialDisplayCount?: number;  // default: 5
}

// Renders:
// > repo-name                (collapsible header with chevron)
//     Item 1
//     Item 2
//     Item 3
//     Item 4
//     Item 5
//     [Show more (N)]        (if more items exist)
```

### Step 6: Create Main Content Header (for hidden sidebar state)

**File:** `apps/client/src/components/MainContentHeader.tsx`

```tsx
interface MainContentHeaderProps {
  onToggleSidebar: () => void;
  teamSlugOrId: string;
}

// Renders floating icons in top-left when sidebar is hidden:
// [Toggle sidebar icon]  (with tooltip: "Toggle sidebar Ctrl+Shift+S")
// [New task icon]        (with tooltip: "New task")
//
// Position: absolute/fixed in main content area
// Only visible when sidebar is hidden
```

### Step 7: Update Sidebar Component

**File:** `apps/client/src/components/Sidebar.tsx`

Changes:

1. **Keep existing keyboard shortcut** (`Ctrl+Shift+S`) - no changes needed
2. **Remove collapsed bar logic** - When hidden, return `null` (not a collapsed bar)
3. **Keep header simple** - No filter/organize icons in main header (only logo + new task button)
4. **Pass preferences** to Pull Requests and Workspaces sections
5. **Update tasks rendering** to use grouping when "By project" mode is selected

### Step 8: Update Layout Component

**File:** `apps/client/src/routes/_layout.$teamSlugOrId.tsx`

Changes:

1. **Lift sidebar hidden state** to layout level (or use context/localStorage sync)
2. **Conditionally render MainContentHeader** when sidebar is hidden:

```tsx
   {isSidebarHidden && (
     <MainContentHeader
       onToggleSidebar={() => setIsSidebarHidden(false)}
       teamSlugOrId={teamSlugOrId}
     />
   )}
```

### Step 9: Update Pull Requests Section

**File:** `apps/client/src/components/sidebar/SidebarPullRequestList.tsx`

Changes:

- Accept `preferences` and `onPreferencesChange` props
- Group PRs by `repoFullName` when "By project" mode
- Render `SidebarProjectGroup` for each group
- Apply sort and filter logic

### Step 10: Update Workspaces Section

**File:** `apps/client/src/components/sidebar/SidebarWorkspacesSection.tsx`

Changes:

- Replace simple header with `SidebarSectionHeader`
- Keep the "+" dropdown for new workspace
- Add filter/organize icons
- Pass preferences to grouped task list

---

## Critical Files Reference

| File | Purpose |
|------|---------|
| `Sidebar.tsx:90-401` | Main component - update header, keyboard shortcut |
| `dropdown.parts.tsx:139-191` | Reuse DropdownParts for filter menu |
| `SidebarListItem.tsx:30-122` | Pattern for item styling, toggle button |
| `SidebarWorkspacesSection.tsx:29-83` | Existing section with + dropdown - extend with filter |
| `SidebarSectionLink.tsx:14-43` | Pattern for section header styling |
| `_layout.$teamSlugOrId.tsx:128-148` | Layout - add MainContentHeader |

---

## Key Design Decisions

1. **Keyboard shortcut**: Keep existing `Ctrl+Shift+S`, add tooltip to toggle button showing this shortcut
2. **Filter icons location**: ONLY at section header level (next to "Pull Requests" / "Workspaces"), NOT in main header
3. **When sidebar hidden**: Toggle icons in MAIN CONTENT area (top-right), no leftover bar
4. **Project groups**: Collapsible with chevron arrow
5. **Items per group**: 5 initially, "Show more (N)" button to expand
6. **Separate preferences**: Each section (PRs, Workspaces) has own preferences
7. **"Other" group**: For items without projectFullName/repoFullName, shown at bottom

---

## State Management

### LocalStorage Keys

- `sidebarHidden` - Existing, sidebar visibility
- `sidebarWidth` - Existing, sidebar width
- `cmux:sidebar-pr-preferences` - PR section preferences
- `cmux:sidebar-ws-preferences` - Workspace section preferences

### Preferences Structure (per section)

```ts
{
  organizeMode: 'by-project' | 'chronological',
  sortBy: 'created' | 'updated',
  showFilter: 'all' | 'relevant',
  collapsedGroups: { 'owner/repo': true },  // collapsed project groups
  expandedGroups: { 'owner/repo': true },   // "Show more" expanded state
}
```

---

## Verification

1. **Toggle sidebar**: Press Ctrl+Shift+S (existing shortcut), verify tooltip shows shortcut
2. **Hidden state**: Verify NO leftover bar, icons appear in main content area
3. **Filter menu**: Click organize icon next to section header, verify dropdown
4. **Project groups**: Click chevron to collapse/expand groups
5. **"Show more"**: Click to expand, verify count updates
6. **Preferences persistence**: Refresh, verify settings restored
7. **Dark mode**: Test all components in light and dark
8. **Run&#32;`bun check`**: Fix TypeScript errors


Implement plan, codex app screenshot for ref;

 螢幕截圖 2026-02-16 22.12.26.jpg 

 螢幕截圖 2026-02-16 22.13.49.jpg

## PR Review Summary
- **What Changed**:
  - **Enhanced Navigation**: Refactored the sidebar to support section-level filtering, sorting, and project-based organization (Codex-style).
  - **Project Grouping**: Introduced `SidebarProjectGroup` which provides collapsible repositories/projects with "Show more" pagination for items.
  - **Dynamic UI**: Implemented a complete sidebar hide feature; when hidden, the sidebar returns `null` and floating toggle/new-task icons appear in the main content area via `MainContentHeader`.
  - **Persistent State**: Added `useSidebarPreferences` to manage and persist sort/filter settings and group collapse states to `localStorage`.
  - **Utility Logic**: Centralized sorting, grouping, and relevance filtering (7-day activity check) in `sidebar-utils.ts`.

- **Review Focus**:
  - **Performance**: Monitor the `useMemo` blocks in `Sidebar.tsx` and `SidebarPullRequestList.tsx` for potential lag when processing very large sets of tasks or PRs.
  - **Layout**: Ensure the `absolute top-2 left-2` positioning of `MainContentHeader` does not obscure critical UI elements in different views.
  - **Syncing**: Verify that the `useSidebarVisibility` hook correctly handles both browser storage events and Electron IPC events for shortcut consistency.

- **Test Plan**:
  - **Toggle Action**: Press `Ctrl+Shift+S` to hide the sidebar; verify it disappears entirely and floating buttons appear in the top-left of the main content.
  - **Grouping Logic**: Switch to "By project" mode in both PR and Workspace sections; verify items group correctly and the "Other" group appears for items without a repository name.
  - **Persistence**: Collapse a project group and change the sort order to "Updated," then refresh the page to confirm states are restored.
  - **Filtering**: Toggle the "Relevant" filter and verify that only items with unread notifications or activity within the last 7 days are visible.