### PR TITLE
[Crown] # Plan: Replace Hardcoded manaflow.com and manaflow:// Refere...

### DIFF
--- a/apps/www/components/preview/preview-test-dashboard.tsx
+++ b/apps/www/components/preview/preview-test-dashboard.tsx
@@ -46,6 +46,7 @@ import {
   getApiPreviewTestCheckAccess,
   getApiPreviewConfigs,
 } from "@cmux/www-openapi-client";
+import { env } from "@/lib/utils/www-env";
 
 type TeamOption = {
   slugOrId: string;
@@ -152,10 +153,10 @@ function PreviewTestDashboardInner({
 
   // Client app base URL for workspace/browser links
   // In development, the client app runs on port 5173
-  // In production, workspace/browser are on www.manaflow.com (not preview.new)
+  // In production, uses NEXT_PUBLIC_BASE_APP_URL or falls back to www.manaflow.com
   const clientBaseUrl = typeof window !== "undefined" && window.location.hostname === "localhost"
     ? "http://localhost:5173"
-    : "https://www.manaflow.com";
+    : (env.NEXT_PUBLIC_BASE_APP_URL ?? "https://www.manaflow.com").replace(/\/$/, "");
 
   // Fetch preview configs for this team
   const { data: configsData, isLoading: isLoadingConfigs } = useQuery({

--- a/apps/www/lib/utils/www-env.ts
+++ b/apps/www/lib/utils/www-env.ts
@@ -78,6 +78,9 @@ export const env = createEnv({
     NEXT_PUBLIC_CONVEX_URL: z.string().min(1),
     NEXT_PUBLIC_GITHUB_APP_SLUG: z.string().min(1).optional(),
     NEXT_PUBLIC_CMUX_PROTOCOL: z.string().min(1).optional(),
+    // Base URL for the app (e.g., https://www.manaflow.com or https://cmux.dev)
+    // Used for constructing URLs in client components
+    NEXT_PUBLIC_BASE_APP_URL: z.string().url().optional(),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,


### PR DESCRIPTION
## Task

# Plan: Replace Hardcoded manaflow.com and manaflow:// References

## Context

PR #320 synced upstream changes and identified remaining hardcoded references to the upstream project's domain and deep link scheme. This plan addresses the follow-up items to make the fork fully configurable:

1. `www.manaflow.com` hardcodes should use `BASE_APP_URL` environment variable
2. `manaflow://` deep link scheme - already uses `NEXT_PUBLIC_CMUX_PROTOCOL` (no action needed)

## Current State

### Environment Variables

- `BASE_APP_URL` - Defined in `packages/convex/_shared/convex-env.ts:17` (Convex server-side only)
- `NEXT_PUBLIC_CMUX_PROTOCOL` - Defined in multiple env files, defaults to `"cmux-next"` (already working)

### Key Finding: www-env has no BASE\_APP\_URL

The www app (`apps/www/lib/utils/www-env.ts`) does not define `BASE_APP_URL`. Since `preview-test-dashboard.tsx` is a `"use client"` component, we need a `NEXT_PUBLIC_*` variable.

### Files Needing Updates

| Priority | File | Issue |
|----------|------|-------|
| P1 | `apps/www/components/preview/preview-test-dashboard.tsx:155-158` | Hardcoded `https://www.manaflow.com` - client component needs env access |
| P2 | `apps/www/lib/routes/iframe-preflight.route.ts:27-37` | Hardcoded in `ALLOWED_EXACT_HOSTS` Set - but this is an allowlist, not a single value |
| P3 | `apps/global-proxy/src/lib.rs:43` | CSP `frame-ancestors` header hardcoded (Rust, deferred) |
| P3 | `apps/devbox/scripts/setup_base_snapshot.sh:775` | CORS `ALLOWED_ORIGINS` hardcoded (shell, deferred) |

### Already Correctly Using Env Variables (No Changes Needed)

- `packages/convex/convex/preview_jobs_http.ts:361` - Uses `BASE_APP_URL || "https://www.manaflow.com"`
- `packages/convex/convex/previewScreenshots.ts:217` - Same pattern
- Deep link files already use `NEXT_PUBLIC_CMUX_PROTOCOL ?? "cmux-next"`

## Implementation Plan

### Task 1: Add NEXT\_PUBLIC\_BASE\_APP\_URL to www-env

**File**: `apps/www/lib/utils/www-env.ts`

Add to client section:

```ts
client: {
  // ... existing fields
  NEXT_PUBLIC_BASE_APP_URL: z.string().url().optional(),
}
```

### Task 2: Fix preview-test-dashboard.tsx (P1)

**File**: `apps/www/components/preview/preview-test-dashboard.tsx`

Replace hardcoded logic at lines 155-158:

```tsx
// BEFORE
const clientBaseUrl = typeof window !== "undefined" && window.location.hostname === "localhost"
  ? "http://localhost:5173"
  : "https://www.manaflow.com";

// AFTER
import { env } from "@/lib/utils/www-env";
// ...
const clientBaseUrl = typeof window !== "undefined" && window.location.hostname === "localhost"
  ? "http://localhost:5173"
  : (env.NEXT_PUBLIC_BASE_APP_URL ?? "https://www.manaflow.com").replace(/\/$/, "");
```

### Task 3: Enhance iframe-preflight.route.ts (P2) - DEFERRED

**File**: `apps/www/lib/routes/iframe-preflight.route.ts`

The current implementation has a static allowlist that includes multiple domains (`cmux.sh`, `cmux.dev`, `manaflow.com`, etc.). This is intentional to support cross-domain scenarios.

**Decision**: Keep as-is. The existing `getDynamicAllowedHostSuffixes()` pattern (used for `PVE_PUBLIC_DOMAIN`) could be extended in the future if needed, but the static allowlist serves the multi-domain production setup.

### Task 4: Document P3 Items as Deferred

The following require more complex changes:

- `apps/global-proxy/src/lib.rs` - Rust code, needs build-time env or runtime config
- `apps/devbox/scripts/setup_base_snapshot.sh` - Shell script, needs different approach

## Verification

1. Run `bun check` to verify TypeScript compiles
2. Verify env schema parses correctly with/without `NEXT_PUBLIC_BASE_APP_URL`
3. Test preview-test-dashboard in localhost mode (should use `http://localhost:5173`)
4. Test preview-test-dashboard in production mode with env set

## Files to Modify

1. `apps/www/lib/utils/www-env.ts` - Add `NEXT_PUBLIC_BASE_APP_URL`
2. `apps/www/components/preview/preview-test-dashboard.tsx` - Use env variable

## PR Review Summary
- **What Changed**:
  - Added `NEXT_PUBLIC_BASE_APP_URL` to the `www` app's environment variable schema in `apps/www/lib/utils/www-env.ts` to enable client-side domain configurability.
  - Modified `apps/www/components/preview/preview-test-dashboard.tsx` to replace the hardcoded `https://www.manaflow.com` domain with the new environment variable.
  - Implemented URL sanitization to strip trailing slashes from the configured base URL.
- **Review Focus**:
  - **Environment Variables**: Verify that the variable is correctly exposed to the client-side runtime environment.
  - **Sanitization Logic**: Ensure the `.replace(/\/$/, "")` regex safely handles various URL string formats without breaking the protocol or host.
  - **Backward Compatibility**: Confirm that the fallback to `https://www.manaflow.com` correctly maintains existing behavior for environments where the variable is unset.
- **Test Plan**:
  - **Development Mode**: Confirm that links still default to `http://localhost:5173` when `window.location.hostname` is `localhost`.
  - **Custom Domain**: Set `NEXT_PUBLIC_BASE_APP_URL` to a test domain (e.g., `https://example.com/`) and verify dashboard links reflect the new domain without a trailing slash.
  - **Validation**: Run `bun check` to ensure the Zod environment schema parses correctly.
- **Follow-ups**:
  - Update Rust-based CSP headers in `apps/global-proxy/src/lib.rs`.
  - Update CORS allowed origins in `apps/devbox/scripts/setup_base_snapshot.sh`.