### PR TITLE
[Crown] update @[.github/workflows/checks.yml ](https://github.com/ka...

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,23 +36,37 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # Stack Auth env vars
           STACK_SECRET_SERVER_KEY: ${{ secrets.STACK_SECRET_SERVER_KEY }}
           STACK_SUPER_SECRET_ADMIN_KEY: ${{ secrets.STACK_SUPER_SECRET_ADMIN_KEY }}
           STACK_DATA_VAULT_SECRET: ${{ secrets.STACK_DATA_VAULT_SECRET }}
+          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
+          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
+          # GitHub App
           CMUX_GITHUB_APP_ID: ${{ secrets.CMUX_GITHUB_APP_ID }}
           CMUX_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CMUX_GITHUB_APP_PRIVATE_KEY }}
           CMUX_TASK_RUN_JWT_SECRET: ${{ secrets.CMUX_TASK_RUN_JWT_SECRET }}
+          # API Keys
           MORPH_API_KEY: ${{ secrets.MORPH_API_KEY }}
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          NEXT_PUBLIC_STACK_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_STACK_PROJECT_ID }}
-          NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY }}
+          # Convex - Cloud (use CONVEX_DEPLOY_KEY) or Self-hosted (use CONVEX_SELF_HOSTED_*)
+          # When CONVEX_SELF_HOSTED_ADMIN_KEY is set, CONVEX_DEPLOY_KEY is unset in the run script
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          CONVEX_SELF_HOSTED_URL: ${{ secrets.CONVEX_SELF_HOSTED_URL }}
+          CONVEX_SELF_HOSTED_ADMIN_KEY: ${{ secrets.CONVEX_SELF_HOSTED_ADMIN_KEY }}
+          CONVEX_SITE_URL: ${{ secrets.CONVEX_SITE_URL }}
           NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+          NEXT_PUBLIC_WWW_ORIGIN: ${{ secrets.NEXT_PUBLIC_WWW_ORIGIN }}
+          NEXT_PUBLIC_GITHUB_APP_SLUG: ${{ secrets.NEXT_PUBLIC_GITHUB_APP_SLUG }}
           # Test user and team
           STACK_TEST_USER_ID: ${{ secrets.STACK_TEST_USER_ID }}
           CMUX_TEST_TEAM_SLUG: ${{ secrets.CMUX_TEST_TEAM_SLUG }}
         run: |
           set -euo pipefail
+          # Unset CONVEX_DEPLOY_KEY when using self-hosted Convex
+          if [ -n "$CONVEX_SELF_HOSTED_ADMIN_KEY" ]; then
+            unset CONVEX_DEPLOY_KEY
+          fi
           bun run check & pid1=$!
           (cd packages/cmux && bun run test) & pid2=$!
           wait $pid1; s1=$?


### PR DESCRIPTION
## Task

update @[.github/workflows/checks.yml ](https://github.com/karlorz/cmux/blob/f04b3a539de2bde0f2631f69a6166310feef0cff/.github/workflows/checks.yml) new self host convex like @[.github/](https://github.com/karlorz/cmux/blob/f04b3a539de2bde0f2631f69a6166310feef0cff/.github/workflows/checks.yml)workflow/tests.yml

## PR Review Summary

- **What Changed**:
  - Updated `.github/workflows/checks.yml` to support self-hosted Convex configurations, aligning it with the logic used in `tests.yml`.
  - Added several new environment variables: `CONVEX_SELF_HOSTED_URL`, `CONVEX_SELF_HOSTED_ADMIN_KEY`, `CONVEX_SITE_URL`, `NEXT_PUBLIC_WWW_ORIGIN`, and `NEXT_PUBLIC_GITHUB_APP_SLUG`.
  - Modified the execution script to `unset CONVEX_DEPLOY_KEY` if a self-hosted admin key is detected, preventing conflicts between cloud and self-hosted deployment modes.
  - Categorized environment variables into sections (Stack Auth, GitHub App, API Keys, Convex) for better readability.

- **Review Focus**:
  - **Conditional Logic**: Ensure the bash snippet `if [ -n "$CONVEX_SELF_HOSTED_ADMIN_KEY" ]; then unset CONVEX_DEPLOY_KEY; fi` correctly triggers based on your CI secrets configuration.
  - **Secret Names**: Verify that all new secret names in the YAML (e.g., `NEXT_PUBLIC_WWW_ORIGIN`) exactly match the keys defined in the GitHub repository settings.

- **Test Plan**:
  - Trigger the GitHub Action by pushing a commit or manually running the workflow.
  - Inspect workflow logs to ensure `bun run check` and `bun run test` initialize correctly with the self-hosted Convex parameters.
  - Validate that the lack of `CONVEX_DEPLOY_KEY` (when self-hosted is active) does not cause the Convex CLI to throw errors during the test run.