### PR TITLE
[Crown] # Plan: Fix Desktop App Sign-in to Show Account Picker

## Co...

### DIFF
--- a/apps/client/src/components/sign-in-component.tsx
+++ b/apps/client/src/components/sign-in-component.tsx
@@ -80,7 +80,8 @@ export function SignInComponent() {
               <button
                 onClick={() => {
                   if (!browserSignInSupported) return;
-                  const url = `${WWW_ORIGIN}/handler/sign-in`;
+                  const signInPath = "/handler/sign-in";
+                  const url = `${WWW_ORIGIN}/api/auth/reset-session?returnTo=${encodeURIComponent(signInPath)}`;
                   window.open(url, "_blank", "noopener,noreferrer");
                 }}
                 disabled={!browserSignInSupported}


### PR DESCRIPTION
## Task

# Plan: Fix Desktop App Sign-in to Show Account Picker

## Context

The desktop app sign-in flow redirects to `https://cmux-www.karldigi.dev/handler/sign-in`, which auto-logs in users if they have existing browser session cookies, skipping the account selection UI. The web app already handles this correctly using `/sign-in?force=true` which signs out first. This causes issues when:

- Users want to sign in with a different account
- Users previously signed out but browser still has stale cookies

Related PR: https://github.com/karlorz/cmux/pull/323 (added `force` parameter support for web sign-out flows)

## Root Cause

The `/handler/sign-in` route uses Stack Auth's `StackHandler` component which automatically redirects authenticated users back without showing the sign-in UI. There's no way to pass a "force" parameter to `StackHandler`.

## Solution

Use the existing `/api/auth/reset-session` route to clear Stack Auth cookies before redirecting to `/handler/sign-in`. This pattern is already used by preview pages (`/preview/test`, `/preview/configure`) to break auth redirect loops.

## Implementation

### File: `apps/client/src/components/sign-in-component.tsx`

Change the "Sign in with browser" button onClick handler (lines 81-84):

**Current:**

```tsx
const url = `${WWW_ORIGIN}/handler/sign-in`;
window.open(url, "_blank", "noopener,noreferrer");
```

**New:**

```tsx
const signInPath = "/handler/sign-in";
const url = `${WWW_ORIGIN}/api/auth/reset-session?returnTo=${encodeURIComponent(signInPath)}`;
window.open(url, "_blank", "noopener,noreferrer");
```

### Flow After Change

1. Desktop "Sign in with browser" clicked
2. Browser opens `/api/auth/reset-session?returnTo=/handler/sign-in`
3. `reset-session` clears all `stack-*` cookies
4. Redirects to `/handler/sign-in`
5. Stack Auth shows sign-in UI (no valid session)
6. User authenticates and selects account
7. Redirected to `/handler/after-sign-in` -> Electron deep link

## Files Involved

| File | Action |
|------|--------|
| `apps/client/src/components/sign-in-component.tsx:83` | Modify URL to use reset-session |
| `apps/www/app/api/auth/reset-session/route.ts` | No changes (existing route) |
| `apps/www/app/(home)/handler/[...stack]/page.tsx` | No changes |

## Security

- `reset-session` already validates `returnTo` starts with `/` (prevents open redirects)
- Same-origin cookie clearing only
- No authentication bypass - user must still authenticate

## Verification

1. **Existing web session test:**

- Log into cmux-www.karldigi.dev in browser
- Open desktop app, click "Sign in with browser"
- Should show sign-in UI (not auto-redirect)

2. **Fresh session test:**

- Clear browser cookies
- Open desktop app, click "Sign in with browser"
- Should show sign-in UI

3. **Complete flow test:**

- Sign in through browser
- Verify Electron receives auth callback with valid tokens

4. Run `bun check` to verify no type errors

## PR Review Summary
- **What Changed**:
  - Modified the browser sign-in logic in `apps/client/src/components/sign-in-component.tsx` to route through `/api/auth/reset-session`.
  - Added a `returnTo` parameter pointing to `/handler/sign-in` to ensure the session is cleared before re-authenticating.
  - This prevents the desktop app from automatically logging into an existing browser session and forces the account selection UI to appear.

- **Review Focus**:
  - **Redirect Safety**: Ensure the `reset-session` endpoint (existing) continues to strictly validate that `returnTo` is a relative path to prevent open redirect vulnerabilities.
  - **Dependency**: Confirm that the `/api/auth/reset-session` route is deployed and functional on the `WWW_ORIGIN` target.

- **Test Plan**:
  - **Existing Session Test**: Log into the web application, then trigger 'Sign in with browser' from the desktop app. Verify the account picker is displayed instead of an automatic redirect.
  - **Full Loop Test**: Complete the authentication process and verify the browser successfully redirects back to the Electron app via the deep link handler.
  - **No Session Test**: Clear browser cookies and verify the sign-in flow still functions correctly from a clean state.