### PR TITLE
[Crown] Implement the following plan

# Plan: Fix Desktop App Sign-in...

### DIFF
--- a/apps/client/src/components/sign-in-component.tsx
+++ b/apps/client/src/components/sign-in-component.tsx
@@ -80,8 +80,7 @@ export function SignInComponent() {
               <button
                 onClick={() => {
                   if (!browserSignInSupported) return;
-                  const signInPath = "/handler/sign-in";
-                  const url = `${WWW_ORIGIN}/api/auth/reset-session?returnTo=${encodeURIComponent(signInPath)}`;
+                  const url = `${WWW_ORIGIN}/handler/sign-in?force=true`;
                   window.open(url, "_blank", "noopener,noreferrer");
                 }}
                 disabled={!browserSignInSupported}

--- a/apps/www/app/(home)/handler/[...stack]/page.tsx
+++ b/apps/www/app/(home)/handler/[...stack]/page.tsx
@@ -1,6 +1,20 @@
 import { stackServerApp } from "@/lib/utils/stack";
 import { StackHandler } from "@stackframe/stack";
 
-export default function Handler(props: unknown) {
+export default async function Handler(props: {
+  params: Promise<{ stack: string[] }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const searchParams = await props.searchParams;
+
+  // If force=true and user is signed in, sign them out first
+  // This is used by the desktop app to show the account picker
+  if (searchParams.force === "true") {
+    const user = await stackServerApp.getUser();
+    if (user) {
+      await user.signOut();
+    }
+  }
+
   return <StackHandler fullPage app={stackServerApp} routeProps={props} />;
 }


### PR DESCRIPTION
## Task

Implement the following plan

# Plan: Fix Desktop App Sign-in to Show Account Picker

## Context

The desktop app's "Sign in with browser" button opens `https://cmux-www.karldigi.dev/api/auth/reset-session?returnTo=/handler/sign-in`. This doesn't work because:

1. `/api/auth/reset-session` only clears cookies but doesn't actually sign out from Stack Auth
2. `/handler/sign-in` (Stack Auth's handler) auto-redirects authenticated users without showing the sign-in UI

PR #323 already solved this for the web app's command bar sign-out flow by adding `force=true` parameter support to `apps/client/src/routes/sign-in.tsx`. When `force=true`:

1. It signs out any existing user via `user.signOut()`
2. Shows the sign-in UI instead of auto-redirecting

## Root Cause

The desktop app opens a browser to the **www app** (`WWW_ORIGIN/...`) for authentication, but the `force` parameter was only added to the **client app** (`apps/client`). The www app needs similar `force` support.

## Solution

Add a `force` parameter to the www app's `/handler/sign-in` route that signs out any existing session before rendering the Stack Auth sign-in UI.

## Implementation

### File 1: `apps/www/app/(home)/handler/[...stack]/page.tsx`

Add server-side logic to check for `force=true` and sign out before rendering:

```tsx
import { stackServerApp } from "@/lib/utils/stack";
import { StackHandler } from "@stackframe/stack";

export default async function Handler(props: {
  params: Promise<{ stack: string[] }>;
  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
}) {
  const searchParams = await props.searchParams;

  // If force=true and user is signed in, sign them out first
  if (searchParams.force === "true") {
    const user = await stackServerApp.getUser();
    if (user) {
      await user.signOut();
    }
  }

  return <StackHandler fullPage app={stackServerApp} routeProps={props} />;
}
```

### File 2: `apps/client/src/components/sign-in-component.tsx`

Update the onClick handler to use `/handler/sign-in?force=true` directly (no need for reset-session):

**Current (line 83-84):**

```tsx
const signInPath = "/handler/sign-in";
const url = `${WWW_ORIGIN}/api/auth/reset-session?returnTo=${encodeURIComponent(signInPath)}`;
```

**New:**

```tsx
const url = `${WWW_ORIGIN}/handler/sign-in?force=true`;
```

## Files to Modify

| File | Change |
|------|--------|
| `apps/www/app/(home)/handler/[...stack]/page.tsx` | Add `force` parameter handling with server-side sign-out |
| `apps/client/src/components/sign-in-component.tsx:83-84` | Simplify to use `?force=true` directly |

## Flow After Change

1. Desktop app: "Sign in with browser" clicked
2. Browser opens `https://cmux-www.karldigi.dev/handler/sign-in?force=true`
3. Server checks `force=true`, signs out any existing user
4. Stack Auth renders sign-in UI (fresh session)
5. User authenticates with GitHub (account picker shown since no active session)
6. After sign-in, redirected to `/handler/after-sign-in` -> Electron deep link

## Verification

1. **Existing web session test:**

- Log into cmux-www.karldigi.dev in browser with account A
- Open desktop app, click "Sign in with browser"
- Should show sign-in UI and GitHub account picker (not auto-redirect to account A)

2. **Fresh session test:**

- Clear browser cookies
- Open desktop app, click "Sign in with browser"
- Should show sign-in UI normally

3. **Complete flow test:**

- Sign in through browser with selected account
- Verify Electron receives auth callback with valid tokens

4. Run `bun check` to verify no type errors

## PR Review Summary

- **What Changed**:
  - **Server-side Sign-out Logic**: Updated the `www` app's Stack handler in `apps/www/app/(home)/handler/[...stack]/page.tsx` to support a `force=true` parameter. This asynchronously signs out any existing user before rendering the Stack Auth UI.
  - **Desktop Flow Optimization**: Simplified the sign-in URL in `apps/client/src/components/sign-in-component.tsx` to point directly to the auth handler with `?force=true`, removing the need for the intermediate `/api/auth/reset-session` redirect.

- **Review Focus**:
  - **Async Component**: The `Handler` component in `apps/www` is now an `async` function. Verify this aligns with the expected Next.js 13/14/15 server component patterns for this route.
  - **Session Clearing**: Confirm that `user.signOut()` on the server side is sufficient to prevent Stack Auth from auto-redirecting previously authenticated users.

- **Test Plan**:
  - **Authenticated State**: Log into the web app (WWW_ORIGIN). Open the desktop app and click 'Sign in with browser'. Ensure the browser displays the sign-in screen/account picker rather than auto-signing in.
  - **Unauthenticated State**: Clear cookies and trigger the flow to ensure it still functions for new users.
  - **Callback Verification**: Complete the sign-in flow and verify the deep link successfully returns tokens to the desktop application.