### PR TITLE
feat: add EVENTS.jsonl sync to memory protocol

### DIFF
--- a/packages/convex/convex/agentMemory_http.ts
+++ b/packages/convex/convex/agentMemory_http.ts
@@ -18,7 +18,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
 const MemoryFileSchema = z.object({
-  memoryType: z.enum(["knowledge", "daily", "tasks", "mailbox"]),
+  memoryType: z.enum(["knowledge", "daily", "tasks", "mailbox", "events"]),
   content: z.string(),
   fileName: z.string().optional(),
   date: z
@@ -39,7 +39,8 @@ const memoryTypeValidator = v.union(
   v.literal("knowledge"),
   v.literal("daily"),
   v.literal("tasks"),
-  v.literal("mailbox")
+  v.literal("mailbox"),
+  v.literal("events")
 );
 
 /**

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1460,7 +1460,8 @@ const convexSchema = defineSchema({
       v.literal("knowledge"),
       v.literal("daily"),
       v.literal("tasks"),
-      v.literal("mailbox")
+      v.literal("mailbox"),
+      v.literal("events")
     ),
     content: v.string(),
     fileName: v.optional(v.string()),

--- a/packages/shared/src/agent-memory-protocol.ts
+++ b/packages/shared/src/agent-memory-protocol.ts
@@ -471,6 +471,13 @@ sync_memory() {
     log "Added MAILBOX.json"
   fi
 
+  # Sync orchestration/EVENTS.jsonl (orchestration event stream)
+  if [ -f "$MEMORY_DIR/orchestration/EVENTS.jsonl" ]; then
+    content=$(head -c $MAX_SIZE "$MEMORY_DIR/orchestration/EVENTS.jsonl" | jq -Rs .)
+    files_json=$(echo "$files_json" | jq --argjson c "$content" '. + [{"memoryType": "events", "content": ($c), "fileName": "orchestration/EVENTS.jsonl"}]')
+    log "Added orchestration/EVENTS.jsonl"
+  fi
+
   # Check if we have any files to sync
   file_count=$(echo "$files_json" | jq 'length')
   if [ "$file_count" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Add `events` memoryType for orchestration event stream (EVENTS.jsonl)
- Wire EVENTS.jsonl to sync.sh so events sync to Convex on agent completion
- Enables observability of orchestration events in dashboard

## Changes
- `packages/convex/convex/schema.ts`: Add 'events' to memoryType union
- `packages/convex/convex/agentMemory_http.ts`: Add 'events' to validators
- `packages/shared/src/agent-memory-protocol.ts`: Add EVENTS.jsonl to sync script

## Test plan
- [ ] Deploy Convex schema
- [ ] Spawn agent with orchestration enabled
- [ ] Verify EVENTS.jsonl syncs to `agentMemorySnapshots` table
- [ ] Check events appear in memory viewer