### PR TITLE
fix: add vitest setup file for test env vars

### DIFF
--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
   test: {
     environment: "node",
     env: testClientEnv,
+    // Setup file runs before any test imports, which is critical for
+    // @t3-oss/env-core validation that happens at import time
+    setupFiles: ["./vitest.setup.ts"],
   },
   define: {
     "import.meta.env": JSON.stringify(testImportMetaEnv),

--- a/apps/client/vitest.setup.ts
+++ b/apps/client/vitest.setup.ts
@@ -1,0 +1,16 @@
+/**
+ * Vitest setup file for apps/client
+ *
+ * This runs BEFORE any test files are loaded, which is critical because
+ * @t3-oss/env-core validates environment variables at import time.
+ *
+ * Without this setup, tests that import client-env.ts will fail with
+ * "Invalid environment variables" errors.
+ */
+
+// Set required environment variables before any module loads
+process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.com/convex";
+process.env.NEXT_PUBLIC_STACK_PROJECT_ID = "test-stack-project";
+process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY = "test-stack-key";
+process.env.NEXT_PUBLIC_WWW_ORIGIN = "https://www.example.com";
+process.env.NEXT_PUBLIC_SERVER_ORIGIN = "https://server.example.com";


### PR DESCRIPTION
## Summary
Fix test failures in apps/client caused by @t3-oss/env-core validating environment variables at import time.

## Problem
Tests that import `client-env.ts` fail with "Invalid environment variables" errors because:
1. `@t3-oss/env-core` validates env vars immediately when `client-env.ts` is imported
2. Vitest's `env` config in vitest.config.ts is applied AFTER modules are loaded
3. By the time tests run, the env validation has already failed

## Solution
Add `vitest.setup.ts` that sets env vars BEFORE any test modules load:
```typescript
process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.com/convex";
// ... other required vars
```

Configure vitest to run this setup file first.

## Test plan
- [x] `npx vitest run` in apps/client - all 64 tests pass
- [x] `bun check` - passes