### PR TITLE
fix: resolve type errors in apps/www

### DIFF
--- a/apps/www/components/preview/preview-dashboard.tsx
+++ b/apps/www/components/preview/preview-dashboard.tsx
@@ -4786,8 +4786,8 @@ function PreviewDashboardInner({
                         </div>
                       </div>
                       <div className="flex items-center gap-1.5">
-                        <Tooltip>
-                          <TooltipTrigger asChild delayDuration={0}>
+                        <Tooltip delay={0}>
+                          <TooltipTrigger asChild>
                             <button
                               type="button"
                               onClick={() => handleOpenConfig(config)}
@@ -4805,8 +4805,8 @@ function PreviewDashboardInner({
                             Edit configuration
                           </TooltipContent>
                         </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild delayDuration={0}>
+                        <Tooltip delay={0}>
+                          <TooltipTrigger asChild>
                             <button
                               type="button"
                               onClick={() => handleRequestDelete(config)}

--- a/apps/www/components/ui/tooltip-base.tsx
+++ b/apps/www/components/ui/tooltip-base.tsx
@@ -5,23 +5,23 @@ import { cn } from "@/lib/utils";
 
 const TooltipProvider = BaseTooltip.Provider;
 
-function Tooltip(props: React.ComponentProps<typeof BaseTooltip.Root>) {
-  return <BaseTooltip.Root {...props} />;
+interface TooltipProps extends React.ComponentProps<typeof BaseTooltip.Root> {
+  /** @deprecated Use delay prop instead */
+  delayDuration?: number;
+}
+
+function Tooltip({ delayDuration, delay, ...props }: TooltipProps) {
+  // Support both delay and legacy delayDuration prop
+  return <BaseTooltip.Root {...props} delay={delay ?? delayDuration} />;
 }
 
 interface TooltipTriggerProps extends React.ComponentProps<typeof BaseTooltip.Trigger> {
   asChild?: boolean;
-  delay?: number;
-  closeDelay?: number;
-  delayDuration?: number;
   children?: React.ReactNode;
 }
 
 function TooltipTrigger({
   asChild,
-  delayDuration,
-  delay = delayDuration ?? 0,
-  closeDelay,
   children,
   ...props
 }: TooltipTriggerProps) {
@@ -30,14 +30,12 @@ function TooltipTrigger({
     return (
       <BaseTooltip.Trigger
         {...props}
-        delay={delay}
-        closeDelay={closeDelay}
         render={children as React.ReactElement<Record<string, unknown>>}
       />
     );
   }
   return (
-    <BaseTooltip.Trigger {...props} delay={delay} closeDelay={closeDelay}>
+    <BaseTooltip.Trigger {...props}>
       {children}
     </BaseTooltip.Trigger>
   );

--- a/apps/www/lib/services/code-review/run-heatmap-review.ts
+++ b/apps/www/lib/services/code-review/run-heatmap-review.ts
@@ -240,10 +240,13 @@ export async function runHeatmapReview(
     });
 
     // Create the base model instance based on provider
-    const baseModelInstance: LanguageModel =
+    // Type assertion needed: ai SDK's LanguageModel type lags behind provider packages
+    // that now return LanguageModelV3. The runtime API is compatible.
+    const baseModelInstance = (
       effectiveModelConfig.provider === "anthropic"
         ? bedrock(effectiveModelConfig.model)
-        : openai(effectiveModelConfig.model);
+        : openai(effectiveModelConfig.model)
+    ) as LanguageModel;
 
     // Wrap model with PostHog tracing if client is available
     // Cast needed due to posthog-node version mismatch between @posthog/ai peer dep and direct dep

--- a/apps/www/lib/services/code-review/run-simple-anthropic-review.ts
+++ b/apps/www/lib/services/code-review/run-simple-anthropic-review.ts
@@ -1,5 +1,6 @@
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModel } from "ai";
 import { streamText } from "ai";
 
 import {
@@ -410,10 +411,13 @@ export async function runSimpleAnthropicReviewStream(
         const prompt = buildFilePrompt(prLabel, file.filePath, file.diffText, tooltipLanguage);
 
         try {
-          const modelInstance =
+          // Type assertion needed: ai SDK's LanguageModel type lags behind provider packages
+          // that now return LanguageModelV3. The runtime API is compatible.
+          const modelInstance = (
             effectiveModelConfig.provider === "openai"
               ? openai(effectiveModelConfig.model)
-              : bedrock(effectiveModelConfig.model);
+              : bedrock(effectiveModelConfig.model)
+          ) as LanguageModel;
 
           const stream = streamText({
             model: modelInstance,

--- a/apps/www/lib/utils/branch-name-generator.test.ts
+++ b/apps/www/lib/utils/branch-name-generator.test.ts
@@ -32,12 +32,6 @@ function createMockResult<RESULT>(
       inputTokens: 1,
       outputTokens: 1,
       totalTokens: 2,
-      inputTokenDetails: {
-        noCacheTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-      },
-      outputTokenDetails: { textTokens: 0, reasoningTokens: 0 },
     },
     warnings: undefined,
     request: { body: undefined },


### PR DESCRIPTION
## Summary
Fix type errors in apps/www caused by dependency version mismatches.

## Changes
- **tooltip-base.tsx**: Move `delay`/`closeDelay` props from `TooltipTrigger` to `Tooltip` (Root)
  - Base UI's Tooltip API has these props on Root, not Trigger
- **preview-dashboard.tsx**: Update tooltip usage to pass `delay` to `Tooltip` component
- **run-heatmap-review.ts**: Add type assertion for LanguageModel (V2/V3 compatibility)
- **run-simple-anthropic-review.ts**: Same type assertion for AI SDK compatibility
- **branch-name-generator.test.ts**: Remove non-existent `inputTokenDetails` and `outputTokenDetails` from mock usage object

## Root Cause
The `ai` SDK core package and provider packages (`@ai-sdk/amazon-bedrock`, `@ai-sdk/openai`) have version mismatches where providers return `LanguageModelV3` but the core expects `LanguageModelV2`. Type assertions are safe as the runtime API is compatible.

## Test Plan
- [x] `bun check` passes locally
- [ ] CI typecheck passes