### PR TITLE
docs: add JSDoc comments to public APIs in packages/shared

### DIFF
--- a/packages/shared/src/convex-ready.ts
+++ b/packages/shared/src/convex-ready.ts
@@ -1,11 +1,34 @@
+/**
+ * Module for coordinating startup timing between Convex initialization
+ * and dependent services.
+ */
+
 const onConvexReadyListeners: (() => void)[] = [];
 
-export async function onConvexReady() {
+/**
+ * Returns a promise that resolves when Convex is ready.
+ * Use this to wait for Convex initialization before starting
+ * dependent services.
+ *
+ * @returns Promise that resolves to true when emitConvexReady() is called
+ *
+ * @example
+ * ```ts
+ * await onConvexReady();
+ * // Convex is now initialized, safe to proceed
+ * ```
+ */
+export async function onConvexReady(): Promise<boolean> {
   return new Promise((resolve) => {
     onConvexReadyListeners.push(() => resolve(true));
   });
 }
 
-export function emitConvexReady() {
+/**
+ * Signals that Convex has finished initializing.
+ * Call this after Convex setup completes to unblock
+ * any services waiting via onConvexReady().
+ */
+export function emitConvexReady(): void {
   onConvexReadyListeners.forEach((listener) => listener());
 }

--- a/packages/shared/src/diff-types.ts
+++ b/packages/shared/src/diff-types.ts
@@ -1,18 +1,40 @@
+/**
+ * Types for representing file diffs between git revisions.
+ */
+
+/** The type of change applied to a file in a diff */
 export type DiffStatus = "added" | "modified" | "deleted" | "renamed";
 
+/**
+ * Represents a single file entry in a git diff.
+ * Contains metadata about the change and optionally the content.
+ */
 export interface ReplaceDiffEntry {
+  /** Current path of the file */
   filePath: string;
+  /** Original path (only set for renamed files) */
   oldPath?: string;
+  /** Type of change: added, modified, deleted, or renamed */
   status: DiffStatus;
+  /** Number of lines added */
   additions: number;
+  /** Number of lines removed */
   deletions: number;
+  /** Unified diff patch content */
   patch?: string;
+  /** Full content of the file before changes */
   oldContent?: string;
+  /** Full content of the file after changes */
   newContent?: string;
+  /** Whether the file is binary (patch/content unavailable) */
   isBinary: boolean;
+  /** Whether content was omitted due to size limits */
   contentOmitted?: boolean;
+  /** Size of file before changes in bytes */
   oldSize?: number;
+  /** Size of file after changes in bytes */
   newSize?: number;
+  /** Size of the patch in bytes */
   patchSize?: number;
 }
 

--- a/packages/shared/src/getShortId.ts
+++ b/packages/shared/src/getShortId.ts
@@ -1,3 +1,16 @@
-export function getShortId(id: string) {
+/**
+ * Truncates an identifier to its first 12 characters.
+ * Useful for displaying shortened IDs in the UI.
+ *
+ * @param id - The full identifier string to truncate
+ * @returns The first 12 characters of the id, or the full id if shorter
+ *
+ * @example
+ * ```ts
+ * getShortId("abc123def456xyz789") // returns "abc123def456"
+ * getShortId("short") // returns "short"
+ * ```
+ */
+export function getShortId(id: string): string {
   return id.substring(0, 12);
 }

--- a/packages/shared/src/git-constants.ts
+++ b/packages/shared/src/git-constants.ts
@@ -1,5 +1,16 @@
 /**
+ * Git-related constants used across the application.
+ */
+
+/**
  * Default branch prefix used when creating new branches.
  * Users can customize this in Settings > Git, including setting to empty string for no prefix.
+ *
+ * @example
+ * ```ts
+ * // With default prefix: "dev/fix-login-bug"
+ * // With empty prefix: "fix-login-bug"
+ * const branchName = `${DEFAULT_BRANCH_PREFIX}${taskSlug}`;
+ * ```
  */
 export const DEFAULT_BRANCH_PREFIX = "dev/";

--- a/packages/shared/src/iframe-preflight.ts
+++ b/packages/shared/src/iframe-preflight.ts
@@ -1,3 +1,14 @@
+/**
+ * Types and utilities for iframe preflight checks.
+ *
+ * Preflight checks verify that sandbox endpoints are reachable
+ * before attempting to render them in iframes.
+ */
+
+/**
+ * Server-side phases during preflight processing.
+ * Used to communicate progress to the client via SSE.
+ */
 const IFRAME_PREFLIGHT_SERVER_PHASES = [
   "resuming",
   "resume_retry",
@@ -13,30 +24,45 @@ const IFRAME_PREFLIGHT_SERVER_PHASES = [
 
 type KnownRecord = Record<string, unknown>;
 
+/** A phase in the iframe preflight process */
 export type IframePreflightServerPhase =
   (typeof IFRAME_PREFLIGHT_SERVER_PHASES)[number];
 
+/** Payload sent from server during preflight, includes phase and optional extra data */
 export type IframePreflightPhasePayload = {
   phase: IframePreflightServerPhase;
 } & KnownRecord;
 
+/** HTTP method used for the preflight check */
 export type IframePreflightMethod = "HEAD" | "GET";
 
+/** Result of an iframe preflight check */
 export interface IframePreflightResult {
+  /** Whether the preflight check succeeded */
   ok: boolean;
+  /** HTTP status code from the check, or null if request failed */
   status: number | null;
+  /** HTTP method used for the check */
   method: IframePreflightMethod | null;
+  /** Error message if the check failed */
   error?: string;
 }
 
+/** Function type for sending preflight phase updates to clients */
 export type SendPhaseFn = (
   phase: IframePreflightServerPhase,
   extra?: KnownRecord,
 ) => Promise<void>;
 
+/**
+ * Type guard to check if a value is a plain object.
+ */
 const isRecord = (value: unknown): value is KnownRecord =>
   typeof value === "object" && value !== null;
 
+/**
+ * Type guard to check if a value is a valid IframePreflightServerPhase.
+ */
 export const isIframePreflightServerPhase = (
   value: unknown,
 ): value is IframePreflightServerPhase => {
@@ -60,6 +86,9 @@ export const isIframePreflightServerPhase = (
   }
 };
 
+/**
+ * Type guard to check if a value is a valid IframePreflightPhasePayload.
+ */
 export const isIframePreflightPhasePayload = (
   value: unknown,
 ): value is IframePreflightPhasePayload => {
@@ -74,6 +103,9 @@ export const isIframePreflightPhasePayload = (
   return true;
 };
 
+/**
+ * Type guard to check if a value is a valid IframePreflightResult.
+ */
 export const isIframePreflightResult = (
   value: unknown,
 ): value is IframePreflightResult => {

--- a/packages/shared/src/provider-types.ts
+++ b/packages/shared/src/provider-types.ts
@@ -1,4 +1,19 @@
-// Canonical tuples - single source of truth for sandbox-related providers.
+/**
+ * Canonical provider type definitions for sandbox environments.
+ *
+ * This module is the single source of truth for all sandbox-related
+ * provider types used throughout the application.
+ */
+
+/**
+ * Providers that can run workspaces at runtime.
+ * - docker: Local Docker containers
+ * - morph: Morph Cloud VMs
+ * - e2b: E2B sandboxes
+ * - daytona: Daytona workspaces
+ * - pve-lxc: Proxmox VE LXC containers
+ * - other: Generic/unknown provider
+ */
 export const RUNTIME_PROVIDERS = [
   "docker",
   "morph",
@@ -8,8 +23,10 @@ export const RUNTIME_PROVIDERS = [
   "other",
 ] as const;
 
+/** Providers that support snapshot/restore operations */
 export const SNAPSHOT_PROVIDERS = [...RUNTIME_PROVIDERS, "pve-vm"] as const;
 
+/** Providers that support devbox (development environment) operations */
 export const DEVBOX_PROVIDERS = [
   "morph",
   "e2b",
@@ -18,17 +35,30 @@ export const DEVBOX_PROVIDERS = [
   "pve-lxc",
 ] as const;
 
+/** Providers that support configuration via the sandbox config API */
 export const CONFIG_PROVIDERS = ["morph", "pve-lxc", "pve-vm"] as const;
 
+/** A provider that can execute workspace containers at runtime */
 export type RuntimeProvider = (typeof RUNTIME_PROVIDERS)[number];
+
+/** A provider that supports snapshot/restore operations */
 export type SnapshotProvider = (typeof SNAPSHOT_PROVIDERS)[number];
+
+/** A provider that supports devbox operations */
 export type DevboxProvider = (typeof DEVBOX_PROVIDERS)[number];
+
+/** A provider that supports configuration via the sandbox config API */
 export type ConfigProvider = (typeof CONFIG_PROVIDERS)[number];
 
-// Default sandbox provider used when SANDBOX_PROVIDER env is unset and
-// auto-detection finds no credentials.  Change this single constant to
-// switch the project-wide fallback.
+/**
+ * Default sandbox provider used when SANDBOX_PROVIDER env is unset and
+ * auto-detection finds no credentials. Change this single constant to
+ * switch the project-wide fallback.
+ */
 export const DEFAULT_SANDBOX_PROVIDER = "pve-lxc" as const;
 
-// Backward-compatible alias for existing call sites.
+/**
+ * Backward-compatible alias for existing call sites.
+ * @deprecated Use RuntimeProvider instead
+ */
 export type VSCodeProvider = RuntimeProvider;

--- a/packages/shared/src/utils/anthropic.ts
+++ b/packages/shared/src/utils/anthropic.ts
@@ -1,16 +1,41 @@
+/**
+ * Utilities for working with Anthropic API configuration.
+ */
+
+/** Cloudflare AI Gateway URL for proxying Anthropic requests */
 export const CLOUDFLARE_ANTHROPIC_BASE_URL =
   "https://gateway.ai.cloudflare.com/v1/0c1675e0def6de1ab3a50a4e17dc5656/cmux-ai-proxy/anthropic";
 
+/** Placeholder API key used when routing through cmux proxy */
 export const CMUX_ANTHROPIC_PROXY_PLACEHOLDER_API_KEY =
   "sk_placeholder_cmux_anthropic_api_key";
 
+/**
+ * Normalized Anthropic base URLs for different SDK contexts.
+ */
 export type NormalizedAnthropicBaseUrl = {
-  // For AI SDK providers (createAnthropic), which expect baseURL to include /v1.
+  /** For AI SDK providers (createAnthropic), which expect baseURL to include /v1 */
   forAiSdk: string;
-  // For raw fetch + Claude Code ANTHROPIC_BASE_URL, where callers append /v1/*.
+  /** For raw fetch + Claude Code ANTHROPIC_BASE_URL, where callers append /v1/* */
   forRawFetch: string;
 };
 
+/**
+ * Normalizes an Anthropic API base URL to consistent formats.
+ * Handles both URLs with and without /v1 suffix.
+ *
+ * @param url - The base URL to normalize
+ * @returns Object with normalized URLs for different SDK contexts
+ *
+ * @example
+ * ```ts
+ * normalizeAnthropicBaseUrl("https://api.anthropic.com")
+ * // { forAiSdk: "https://api.anthropic.com/v1", forRawFetch: "https://api.anthropic.com" }
+ *
+ * normalizeAnthropicBaseUrl("https://api.anthropic.com/v1")
+ * // { forAiSdk: "https://api.anthropic.com/v1", forRawFetch: "https://api.anthropic.com" }
+ * ```
+ */
 export function normalizeAnthropicBaseUrl(
   url: string,
 ): NormalizedAnthropicBaseUrl {

--- a/packages/shared/src/utils/derive-repo-base-name.ts
+++ b/packages/shared/src/utils/derive-repo-base-name.ts
@@ -1,3 +1,16 @@
+/**
+ * Extracts the repository base name from either a project full name or repository URL.
+ *
+ * @param options.projectFullName - Full name in "owner/repo" format (e.g., "anthropics/claude-code")
+ * @param options.repoUrl - Git repository URL (e.g., "https://github.com/owner/repo.git")
+ * @returns The repository name without owner prefix or .git suffix, or undefined if neither input is valid
+ *
+ * @example
+ * ```ts
+ * deriveRepoBaseName({ projectFullName: "anthropics/claude-code" }) // "claude-code"
+ * deriveRepoBaseName({ repoUrl: "https://github.com/owner/my-repo.git" }) // "my-repo"
+ * ```
+ */
 export function deriveRepoBaseName({
   projectFullName,
   repoUrl,

--- a/packages/shared/src/utils/format-env-vars-content.ts
+++ b/packages/shared/src/utils/format-env-vars-content.ts
@@ -1,16 +1,47 @@
+/**
+ * Utilities for formatting environment variables into .env file format.
+ */
+
+/** A single environment variable entry */
 export type EnvVarEntry = {
+  /** The environment variable name (e.g., "API_KEY") */
   name: string;
+  /** The environment variable value */
   value: string;
 };
 
+/**
+ * Escapes double quotes in a string for .env file format.
+ */
 function escapeDoubleQuotes(value: string): string {
   return value.replaceAll("\"", "\\\"");
 }
 
+/**
+ * Normalizes line endings to Unix format (LF).
+ */
 function normalizeLineEndings(value: string): string {
   return value.replace(/\r\n?/g, "\n");
 }
 
+/**
+ * Formats an array of environment variable entries into .env file content.
+ * Values are quoted and escaped to handle special characters safely.
+ *
+ * @param entries - Array of environment variable name/value pairs
+ * @returns Formatted string suitable for writing to a .env file
+ *
+ * @example
+ * ```ts
+ * formatEnvVarsContent([
+ *   { name: "API_KEY", value: "secret123" },
+ *   { name: "MESSAGE", value: "Hello \"World\"" }
+ * ])
+ * // Returns:
+ * // API_KEY="secret123"
+ * // MESSAGE="Hello \"World\""
+ * ```
+ */
 export function formatEnvVarsContent(entries: EnvVarEntry[]): string {
   const lines: string[] = [];
 


### PR DESCRIPTION
## Summary
Added JSDoc documentation to public APIs in packages/shared for better developer experience and IDE support.

## Files Changed (10 files, +267 lines)
- `packages/shared/src/convex-ready.ts` - Document convex ready utilities
- `packages/shared/src/diff-types.ts` - Document diff type definitions
- `packages/shared/src/getShortId.ts` - Document ID generation
- `packages/shared/src/git-constants.ts` - Document git constants
- `packages/shared/src/iframe-preflight.ts` - Document iframe utilities
- `packages/shared/src/provider-types.ts` - Document provider types
- `packages/shared/src/pull-request-state.ts` - Document PR state types
- `packages/shared/src/utils/anthropic.ts` - Document Anthropic utilities
- `packages/shared/src/utils/derive-repo-base-name.ts` - Document repo name derivation
- `packages/shared/src/utils/format-env-vars-content.ts` - Document env var formatting

## Test plan
- [x] `bun check` passes locally