### PR TITLE
refactor: improve code quality in editorSettings.ts

### DIFF
--- a/apps/server/src/utils/editorSettings.ts
+++ b/apps/server/src/utils/editorSettings.ts
@@ -157,9 +157,11 @@ export function deduplicateExtensions(entries: string[]): string[] {
     // Otherwise: keep existing (first versioned wins, or first unversioned if no version)
   }
 
-  return Array.from(seen.values())
-    .map(formatExtensionSpec)
-    .sort((a, b) => parseExtensionSpec(a).id.toLowerCase().localeCompare(parseExtensionSpec(b).id.toLowerCase()));
+  // Sort by extension ID (case-insensitive) - use pre-computed keys for performance
+  const sortedSpecs = Array.from(seen.values()).sort((a, b) =>
+    a.id.toLowerCase().localeCompare(b.id.toLowerCase())
+  );
+  return sortedSpecs.map(formatExtensionSpec);
 }
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -248,7 +250,12 @@ async function pathExists(target: string): Promise<boolean> {
   try {
     await fs.access(target);
     return true;
-  } catch {
+  } catch (error) {
+    // Expected for non-existent paths - only log unexpected errors
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== "ENOENT" && err.code !== "EACCES") {
+      serverLogger.debug(`[EditorSettings] Unexpected error checking path ${target}:`, error);
+    }
     return false;
   }
 }
@@ -259,7 +266,8 @@ async function listJsonFiles(dir: string): Promise<string[]> {
     return entries
       .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".json"))
       .map((entry) => path.join(dir, entry.name));
-  } catch {
+  } catch (error) {
+    serverLogger.debug(`[EditorSettings] Failed to list JSON files in ${dir}:`, error);
     return [];
   }
 }
@@ -290,8 +298,8 @@ async function runCliListExtensions(
       if (lines.length > 0) {
         return deduplicateExtensions(lines);
       }
-    } catch {
-      // Ignore CLI errors and try the next candidate
+    } catch (error) {
+      serverLogger.debug(`[EditorSettings] CLI ${cli} failed to list extensions:`, error);
     }
   }
   return undefined;
@@ -306,7 +314,8 @@ async function listExtensionsFromDirs(
     let entries;
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      serverLogger.debug(`[EditorSettings] Failed to read extensions dir ${dir}:`, error);
       continue;
     }
     for (const entry of entries) {
@@ -319,8 +328,8 @@ async function listExtensionsFromDirs(
         if (pkg.publisher && pkg.name) {
           identifiers.add(`${pkg.publisher}.${pkg.name}`);
         }
-      } catch {
-        // Ignore malformed package.json entries
+      } catch (error) {
+        serverLogger.debug(`[EditorSettings] Failed to parse ${packageJsonPath}:`, error);
       }
     }
   }
@@ -380,8 +389,8 @@ async function exportEditor(def: EditorDef): Promise<EditorExport | null> {
           path: snippetFile,
           content: await fs.readFile(snippetFile, "utf8"),
         });
-      } catch {
-        // Ignore unreadable snippet files
+      } catch (error) {
+        serverLogger.debug(`[EditorSettings] Failed to read snippet ${snippetFile}:`, error);
       }
     }
   }
@@ -551,115 +560,78 @@ function buildExtensionInstallCommand(listPath: string): string {
   ].join("\n");
 }
 
-/**
- * Build EditorSettingsUpload from user-uploaded settings (web UI)
- * This converts user-provided JSON strings into authFiles for the sandbox
- */
-function buildUploadFromUserSettings(
-  userSettings: UserUploadedEditorSettings
-): EditorSettingsUpload | null {
-  const authFiles: AuthFile[] = [];
-  const startupCommands: string[] = [];
+// Helper: Get all settings.json target paths across IDE providers
+function getSettingsTargetPaths(): string[] {
+  return [
+    // cmux-code paths
+    posix.join(IDE_PATHS["cmux-code"].userDir, "settings.json"),
+    posix.join(
+      IDE_PATHS["cmux-code"].profileDir ?? IDE_PATHS["cmux-code"].userDir,
+      "settings.json"
+    ),
+    posix.join(IDE_PATHS["cmux-code"].machineDir, "settings.json"),
+    // OpenVSCode paths
+    posix.join(IDE_PATHS.openvscode.userDir, "settings.json"),
+    posix.join(
+      IDE_PATHS.openvscode.profileDir ?? IDE_PATHS.openvscode.userDir,
+      "settings.json"
+    ),
+    posix.join(IDE_PATHS.openvscode.machineDir, "settings.json"),
+    // Coder paths
+    posix.join(IDE_PATHS.coder.userDir, "settings.json"),
+    posix.join(IDE_PATHS.coder.machineDir, "settings.json"),
+  ];
+}
 
-  if (userSettings.settingsJson) {
-    const encodedSettings = encode(userSettings.settingsJson);
-    // Write settings to all IDE provider locations for compatibility
-    const targets = [
-      // cmux-code paths
-      posix.join(IDE_PATHS["cmux-code"].userDir, "settings.json"),
-      posix.join(
-        IDE_PATHS["cmux-code"].profileDir ?? IDE_PATHS["cmux-code"].userDir,
-        "settings.json"
-      ),
-      posix.join(IDE_PATHS["cmux-code"].machineDir, "settings.json"),
-      // OpenVSCode paths
-      posix.join(IDE_PATHS.openvscode.userDir, "settings.json"),
-      posix.join(
-        IDE_PATHS.openvscode.profileDir ?? IDE_PATHS.openvscode.userDir,
-        "settings.json"
-      ),
-      posix.join(IDE_PATHS.openvscode.machineDir, "settings.json"),
-      // Coder paths
-      posix.join(IDE_PATHS.coder.userDir, "settings.json"),
-      posix.join(IDE_PATHS.coder.machineDir, "settings.json"),
-    ];
-    for (const destinationPath of targets) {
-      authFiles.push({
-        destinationPath,
-        contentBase64: encodedSettings,
-        mode: "644",
-      });
-    }
+// Helper: Add settings.json auth files for all IDE providers
+function addSettingsAuthFiles(authFiles: AuthFile[], settingsContent: string): void {
+  const encodedSettings = encode(settingsContent);
+  for (const destinationPath of getSettingsTargetPaths()) {
+    authFiles.push({
+      destinationPath,
+      contentBase64: encodedSettings,
+      mode: "644",
+    });
   }
+}
 
-  if (userSettings.keybindingsJson) {
-    const encodedKeybindings = encode(userSettings.keybindingsJson);
-    // Write keybindings to all IDE provider locations
+// Helper: Add keybindings.json auth files for all IDE providers
+function addKeybindingsAuthFiles(authFiles: AuthFile[], keybindingsContent: string): void {
+  const encodedKeybindings = encode(keybindingsContent);
+  const userDirs = [
+    IDE_PATHS["cmux-code"].userDir,
+    IDE_PATHS.openvscode.userDir,
+    IDE_PATHS.coder.userDir,
+  ];
+  for (const userDir of userDirs) {
     authFiles.push({
-      destinationPath: posix.join(IDE_PATHS["cmux-code"].userDir, "keybindings.json"),
-      contentBase64: encodedKeybindings,
-      mode: "644",
-    });
-    authFiles.push({
-      destinationPath: posix.join(IDE_PATHS.openvscode.userDir, "keybindings.json"),
-      contentBase64: encodedKeybindings,
-      mode: "644",
-    });
-    authFiles.push({
-      destinationPath: posix.join(IDE_PATHS.coder.userDir, "keybindings.json"),
+      destinationPath: posix.join(userDir, "keybindings.json"),
       contentBase64: encodedKeybindings,
       mode: "644",
     });
   }
+}
 
-  if (userSettings.snippets && userSettings.snippets.length > 0) {
-    for (const snippet of userSettings.snippets) {
-      if (!snippet.name || !snippet.content) continue;
-      // Sanitize filename to prevent path traversal attacks
-      const sanitizedName = posix.basename(snippet.name);
-      if (!sanitizedName) continue;
-      const encodedSnippet = encode(snippet.content);
-      // Write snippets to all IDE provider locations
-      authFiles.push({
-        destinationPath: posix.join(IDE_PATHS["cmux-code"].snippetsDir, sanitizedName),
-        contentBase64: encodedSnippet,
-        mode: "644",
-      });
-      authFiles.push({
-        destinationPath: posix.join(IDE_PATHS.openvscode.snippetsDir, sanitizedName),
-        contentBase64: encodedSnippet,
-        mode: "644",
-      });
-      authFiles.push({
-        destinationPath: posix.join(IDE_PATHS.coder.snippetsDir, sanitizedName),
-        contentBase64: encodedSnippet,
-        mode: "644",
-      });
-    }
+// Helper: Add a snippet auth file for all IDE providers
+function addSnippetAuthFiles(authFiles: AuthFile[], name: string, content: string): void {
+  const encodedSnippet = encode(content);
+  const snippetsDirs = [
+    IDE_PATHS["cmux-code"].snippetsDir,
+    IDE_PATHS.openvscode.snippetsDir,
+    IDE_PATHS.coder.snippetsDir,
+  ];
+  for (const snippetsDir of snippetsDirs) {
+    authFiles.push({
+      destinationPath: posix.join(snippetsDir, name),
+      contentBase64: encodedSnippet,
+      mode: "644",
+    });
   }
+}
 
-  if (userSettings.extensions) {
-    const extensionList = userSettings.extensions
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean);
-
-    if (extensionList.length > 0) {
-      // Use version-aware deduplication: versioned entries take precedence
-      const uniqueExtensions = deduplicateExtensions(extensionList);
-      const extensionContent = `${uniqueExtensions.join("\n")}\n`;
-      authFiles.push({
-        destinationPath: EXTENSION_LIST_PATH,
-        contentBase64: encode(extensionContent),
-        mode: "644",
-      });
-
-      // Create background installation script that auto-executes on shell startup
-      const installScriptPath = "/root/.cmux/install-extensions-background.sh";
-      const installScript = buildExtensionInstallCommand(EXTENSION_LIST_PATH);
-
-      // Create self-contained background installer with lock mechanism
-      const backgroundWrapper = `#!/bin/bash
+// Helper: Build the background extension installer wrapper script
+function buildBackgroundInstallerWrapper(installScript: string): string {
+  return `#!/bin/bash
 # Background extension installer - runs once per container
 
 LOCK_FILE="/root/.cmux/extensions-install.lock"
@@ -681,29 +653,88 @@ touch "$LOCK_FILE"
   rm -f "$LOCK_FILE"
 ) > /root/.cmux/install-extensions-background.log 2>&1 &
 `;
+}
 
-      authFiles.push({
-        destinationPath: installScriptPath,
-        contentBase64: encode(backgroundWrapper),
-        mode: "755",
-      });
-
-      // Use /etc/profile.d/ for automatic execution on all shell sessions
-      const profileHook = `# cmux: Auto-trigger extension installation in background (non-blocking)
+// Helper: Build the profile.d hook for auto-triggering extension installation
+function buildProfileHook(installScriptPath: string): string {
+  return `# cmux: Auto-trigger extension installation in background (non-blocking)
 (
   if [ -f "${installScriptPath}" ]; then
     nohup "${installScriptPath}" >/dev/null 2>&1 &
   fi
 ) >/dev/null 2>&1 &
 `;
+}
 
-      authFiles.push({
-        destinationPath: "/etc/profile.d/cmux-extensions.sh",
-        contentBase64: encode(profileHook),
-        mode: "644",
-      });
+// Helper: Add extension installation auth files and startup commands
+function addExtensionInstallationFiles(
+  authFiles: AuthFile[],
+  startupCommands: string[],
+  extensionList: string[]
+): void {
+  const uniqueExtensions = deduplicateExtensions(extensionList);
+  const extensionContent = `${uniqueExtensions.join("\n")}\n`;
+  authFiles.push({
+    destinationPath: EXTENSION_LIST_PATH,
+    contentBase64: encode(extensionContent),
+    mode: "644",
+  });
 
-      startupCommands.push(`bash "${installScriptPath}" || true`);
+  const installScriptPath = "/root/.cmux/install-extensions-background.sh";
+  const installScript = buildExtensionInstallCommand(EXTENSION_LIST_PATH);
+  const backgroundWrapper = buildBackgroundInstallerWrapper(installScript);
+
+  authFiles.push({
+    destinationPath: installScriptPath,
+    contentBase64: encode(backgroundWrapper),
+    mode: "755",
+  });
+
+  authFiles.push({
+    destinationPath: "/etc/profile.d/cmux-extensions.sh",
+    contentBase64: encode(buildProfileHook(installScriptPath)),
+    mode: "644",
+  });
+
+  startupCommands.push(`bash "${installScriptPath}" || true`);
+}
+
+/**
+ * Build EditorSettingsUpload from user-uploaded settings (web UI)
+ * This converts user-provided JSON strings into authFiles for the sandbox
+ */
+function buildUploadFromUserSettings(
+  userSettings: UserUploadedEditorSettings
+): EditorSettingsUpload | null {
+  const authFiles: AuthFile[] = [];
+  const startupCommands: string[] = [];
+
+  if (userSettings.settingsJson) {
+    addSettingsAuthFiles(authFiles, userSettings.settingsJson);
+  }
+
+  if (userSettings.keybindingsJson) {
+    addKeybindingsAuthFiles(authFiles, userSettings.keybindingsJson);
+  }
+
+  if (userSettings.snippets && userSettings.snippets.length > 0) {
+    for (const snippet of userSettings.snippets) {
+      if (!snippet.name || !snippet.content) continue;
+      // Sanitize filename to prevent path traversal attacks
+      const sanitizedName = posix.basename(snippet.name);
+      if (!sanitizedName) continue;
+      addSnippetAuthFiles(authFiles, sanitizedName, snippet.content);
+    }
+  }
+
+  if (userSettings.extensions) {
+    const extensionList = userSettings.extensions
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    if (extensionList.length > 0) {
+      addExtensionInstallationFiles(authFiles, startupCommands, extensionList);
     }
   }
 
@@ -724,141 +755,23 @@ function buildUpload(editor: EditorExport): EditorSettingsUpload | null {
   const startupCommands: string[] = [];
 
   if (editor.settings) {
-    const encodedSettings = encode(editor.settings.content);
-    // Write settings to both IDE provider locations for compatibility
-    // The correct one will be used based on which IDE is installed
-    const targets = [
-      // cmux-code paths
-      posix.join(IDE_PATHS["cmux-code"].userDir, "settings.json"),
-      posix.join(
-        IDE_PATHS["cmux-code"].profileDir ?? IDE_PATHS["cmux-code"].userDir,
-        "settings.json"
-      ),
-      posix.join(IDE_PATHS["cmux-code"].machineDir, "settings.json"),
-      // OpenVSCode paths
-      posix.join(IDE_PATHS.openvscode.userDir, "settings.json"),
-      posix.join(
-        IDE_PATHS.openvscode.profileDir ?? IDE_PATHS.openvscode.userDir,
-        "settings.json"
-      ),
-      posix.join(IDE_PATHS.openvscode.machineDir, "settings.json"),
-      // Coder paths
-      posix.join(IDE_PATHS.coder.userDir, "settings.json"),
-      posix.join(IDE_PATHS.coder.machineDir, "settings.json"),
-    ];
-    for (const destinationPath of targets) {
-      authFiles.push({
-        destinationPath,
-        contentBase64: encodedSettings,
-        mode: "644",
-      });
-    }
+    addSettingsAuthFiles(authFiles, editor.settings.content);
   }
 
   if (editor.keybindings) {
-    // Write keybindings to all IDE provider locations
-    authFiles.push({
-      destinationPath: posix.join(IDE_PATHS["cmux-code"].userDir, "keybindings.json"),
-      contentBase64: encode(editor.keybindings.content),
-      mode: "644",
-    });
-    authFiles.push({
-      destinationPath: posix.join(IDE_PATHS.openvscode.userDir, "keybindings.json"),
-      contentBase64: encode(editor.keybindings.content),
-      mode: "644",
-    });
-    authFiles.push({
-      destinationPath: posix.join(IDE_PATHS.coder.userDir, "keybindings.json"),
-      contentBase64: encode(editor.keybindings.content),
-      mode: "644",
-    });
+    addKeybindingsAuthFiles(authFiles, editor.keybindings.content);
   }
 
   if (editor.snippets.length > 0) {
     for (const snippet of editor.snippets) {
       const name = path.basename(snippet.path);
       if (!name) continue;
-      // Write snippets to all IDE provider locations
-      authFiles.push({
-        destinationPath: posix.join(IDE_PATHS["cmux-code"].snippetsDir, name),
-        contentBase64: encode(snippet.content),
-        mode: "644",
-      });
-      authFiles.push({
-        destinationPath: posix.join(IDE_PATHS.openvscode.snippetsDir, name),
-        contentBase64: encode(snippet.content),
-        mode: "644",
-      });
-      authFiles.push({
-        destinationPath: posix.join(IDE_PATHS.coder.snippetsDir, name),
-        contentBase64: encode(snippet.content),
-        mode: "644",
-      });
+      addSnippetAuthFiles(authFiles, name, snippet.content);
     }
   }
 
   if (editor.extensions && editor.extensions.length > 0) {
-    // Use version-aware deduplication: versioned entries take precedence
-    const uniqueExtensions = deduplicateExtensions(editor.extensions);
-    const extensionContent = `${uniqueExtensions.join("\n")}\n`;
-    authFiles.push({
-      destinationPath: EXTENSION_LIST_PATH,
-      contentBase64: encode(extensionContent),
-      mode: "644",
-    });
-
-    // Create background installation script that auto-executes on shell startup
-    const installScriptPath = "/root/.cmux/install-extensions-background.sh";
-    const installScript = buildExtensionInstallCommand(EXTENSION_LIST_PATH);
-
-    // Create self-contained background installer with lock mechanism
-    const backgroundWrapper = `#!/bin/bash
-# Background extension installer - runs once per container
-
-LOCK_FILE="/root/.cmux/extensions-install.lock"
-DONE_FILE="/root/.cmux/extensions-installed"
-
-# Skip if already done
-[ -f "$DONE_FILE" ] && exit 0
-
-# Skip if already running
-[ -f "$LOCK_FILE" ] && exit 0
-
-# Create lock file
-touch "$LOCK_FILE"
-
-# Run installation in detached background
-(
-  ${installScript}
-  touch "$DONE_FILE"
-  rm -f "$LOCK_FILE"
-) > /root/.cmux/install-extensions-background.log 2>&1 &
-`;
-
-    authFiles.push({
-      destinationPath: installScriptPath,
-      contentBase64: encode(backgroundWrapper),
-      mode: "755",
-    });
-
-    // Use /etc/profile.d/ for automatic execution on all shell sessions
-    // This is the standard Linux mechanism for global shell initialization
-    // Use subshell with disown to ensure it never blocks shell initialization
-    const profileHook = `# cmux: Auto-trigger extension installation in background (non-blocking)
-(
-  if [ -f "${installScriptPath}" ]; then
-    nohup "${installScriptPath}" >/dev/null 2>&1 &
-  fi
-) >/dev/null 2>&1 &
-`;
-
-    authFiles.push({
-      destinationPath: "/etc/profile.d/cmux-extensions.sh",
-      contentBase64: encode(profileHook),
-      mode: "644",
-    });
-
-    startupCommands.push(`bash "${installScriptPath}" || true`);
+    addExtensionInstallationFiles(authFiles, startupCommands, editor.extensions);
   }
 
   if (authFiles.length === 0 && startupCommands.length === 0) {


### PR DESCRIPTION
## Summary
- Added debug logging to silent catch blocks
- Extracted helper functions to reduce code duplication
- Improved performance in deduplicateExtensions (pre-compute sort keys)
- Net reduction: -87 lines

## Changes
All changes are in `apps/server/src/utils/editorSettings.ts`:

**New helper functions extracted:**
- `getSettingsTargetPaths()` - Returns all settings.json paths across IDE providers
- `addSettingsAuthFiles()` - Adds settings.json to auth files for all providers
- `addKeybindingsAuthFiles()` - Adds keybindings.json to auth files for all providers
- `addSnippetAuthFiles()` - Adds snippet files to auth files for all providers

**Logging added to:**
- `pathExists()` - Log unexpected errors (not ENOENT/EACCES)
- `listJsonFiles()` - Log directory read failures
- `runCliListExtensions()` - Log CLI execution failures
- `listExtensionsFromDirs()` - Log directory/package.json parse failures
- `exportEditor()` - Log snippet read failures

**Performance:**
- `deduplicateExtensions()` - Sort using pre-computed lowercase IDs instead of re-parsing

## Test plan
- [x] `bun check` passes
- [x] All helper functions maintain same behavior as original code