### PR TITLE
refactor: add logging to silent catch blocks in client components

### DIFF
--- a/apps/client/src/components/cmux-comments.tsx
+++ b/apps/client/src/components/cmux-comments.tsx
@@ -233,14 +233,15 @@ function CommentMarker({ comment, onClick, teamSlugOrId }: CommentMarkerProps) {
           // Old CSS selector - try to handle it
           try {
             el = document.querySelector(comment.nodeId) as HTMLElement;
-          } catch (_e) {
+          } catch (selectorError) {
             // Try escaping for old Tailwind classes
             const escapedSelector = comment.nodeId.replace(/([:])/g, "\\$1");
             try {
               el = document.querySelector(escapedSelector) as HTMLElement;
-            } catch (_e2) {
+            } catch (escapedError) {
               console.warn(
-                `Could not find element with CSS selector: ${comment.nodeId}`
+                `Could not find element with CSS selector: ${comment.nodeId}`,
+                { selectorError, escapedError }
               );
             }
           }

--- a/apps/client/src/components/command-bar/useSuggestionHistory.ts
+++ b/apps/client/src/components/command-bar/useSuggestionHistory.ts
@@ -27,7 +27,8 @@ const safeParseHistory = (raw: string | null): SuggestionHistoryEntry[] => {
           : null,
       )
       .filter((entry): entry is SuggestionHistoryEntry => Boolean(entry));
-  } catch {
+  } catch (error) {
+    console.debug("[useSuggestionHistory] Failed to parse history JSON", error);
     return [];
   }
 };
@@ -36,7 +37,8 @@ const readHistory = (storageKey: string): SuggestionHistoryEntry[] => {
   if (!isBrowser) return [];
   try {
     return safeParseHistory(window.localStorage.getItem(storageKey));
-  } catch {
+  } catch (error) {
+    console.debug("[useSuggestionHistory] Failed to read history from localStorage", error);
     return [];
   }
 };
@@ -48,8 +50,9 @@ const persistHistory = (
   if (!isBrowser) return;
   try {
     window.localStorage.setItem(storageKey, JSON.stringify(entries));
-  } catch {
-    // Ignore storage errors (e.g. private mode)
+  } catch (error) {
+    // Storage may fail in private mode or when quota exceeded
+    console.debug("[useSuggestionHistory] Failed to persist history", error);
   }
 };
 

--- a/apps/client/src/components/git-diff-view/git-diff-viewer-with-sidebar.tsx
+++ b/apps/client/src/components/git-diff-view/git-diff-viewer-with-sidebar.tsx
@@ -116,7 +116,8 @@ export const NewGitDiffViewerWithSidebar = memo(function NewGitDiffViewerWithSid
           setRegisterHighlighter(highlighter);
         }
       })
-      .catch(() => {
+      .catch((error) => {
+        console.error("[git-diff-viewer-with-sidebar] Failed to load highlighter", error);
         if (!isCancelled) {
           setRegisterHighlighter(undefined);
         }
@@ -168,8 +169,8 @@ export const NewGitDiffViewerWithSidebar = memo(function NewGitDiffViewerWithSid
 
         try {
           onFileToggle?.(filePath, !wasExpanded);
-        } catch {
-          // ignore
+        } catch (error) {
+          console.error("[git-diff-viewer-with-sidebar] onFileToggle callback failed", error);
         }
 
         return next;

--- a/apps/client/src/components/git-diff-view/git-diff-viewer.tsx
+++ b/apps/client/src/components/git-diff-view/git-diff-viewer.tsx
@@ -77,7 +77,8 @@ export const NewGitDiffViewer = memo(function NewGitDiffViewer({
           setRegisterHighlighter(highlighter);
         }
       })
-      .catch(() => {
+      .catch((error) => {
+        console.error("[git-diff-viewer] Failed to load highlighter", error);
         if (!isCancelled) {
           setRegisterHighlighter(undefined);
         }
@@ -102,8 +103,8 @@ export const NewGitDiffViewer = memo(function NewGitDiffViewer({
 
         try {
           onFileToggle?.(filePath, !wasExpanded);
-        } catch {
-          // ignore
+        } catch (error) {
+          console.error("[git-diff-viewer] onFileToggle callback failed", error);
         }
 
         return next;

--- a/apps/client/src/components/monaco/diff-sidebar-filter.tsx
+++ b/apps/client/src/components/monaco/diff-sidebar-filter.tsx
@@ -534,8 +534,9 @@ export function DiffSidebarFilter({
         if (handleElement.hasPointerCapture?.(pointerId)) {
           try {
             handleElement.releasePointerCapture(pointerId);
-          } catch {
-            // Ignore release failures.
+          } catch (error) {
+            // Pointer capture release may fail in some browsers - safe to ignore
+            console.debug("[diff-sidebar-filter] releasePointerCapture failed", error);
           }
         }
         setIsResizingSidebar(false);
@@ -559,8 +560,9 @@ export function DiffSidebarFilter({
 
       try {
         handleElement.setPointerCapture(pointerId);
-      } catch {
-        // Ignore pointer capture failures (e.g., Safari).
+      } catch (error) {
+        // Pointer capture may fail in some browsers (e.g., Safari) - safe to ignore
+        console.debug("[diff-sidebar-filter] setPointerCapture failed", error);
       }
     },
     [sidebarWidth]

--- a/apps/client/src/components/monaco/monaco-git-diff-viewer-with-sidebar.tsx
+++ b/apps/client/src/components/monaco/monaco-git-diff-viewer-with-sidebar.tsx
@@ -1215,8 +1215,8 @@ export function MonacoGitDiffViewerWithSidebar({
         }
         try {
           onFileToggle?.(filePath, !wasExpanded);
-        } catch {
-          // ignore
+        } catch (error) {
+          console.error("[monaco-git-diff-viewer-with-sidebar] onFileToggle callback failed", error);
         }
         return next;
       });

--- a/apps/client/src/components/monaco/monaco-git-diff-viewer.tsx
+++ b/apps/client/src/components/monaco/monaco-git-diff-viewer.tsx
@@ -1160,8 +1160,8 @@ export function MonacoGitDiffViewer({
       }
       try {
         onFileToggle?.(filePath, !wasExpanded);
-      } catch {
-        // ignore
+      } catch (error) {
+        console.error("[monaco-git-diff-viewer] onFileToggle callback failed", error);
       }
       return next;
     });

--- a/apps/client/src/hooks/useIframePreflight.ts
+++ b/apps/client/src/hooks/useIframePreflight.ts
@@ -313,8 +313,9 @@ export function useIframePreflight({
         const closeReader = async () => {
           try {
             await reader.cancel();
-          } catch {
-            // ignore
+          } catch (error) {
+            // Reader may already be closed or cancelled - log at debug level
+            console.debug("[useIframePreflight] closeReader error (expected if already closed)", error);
           }
         };
 
@@ -325,8 +326,8 @@ export function useIframePreflight({
               if (isIframePreflightPhasePayload(parsed)) {
                 handlePhaseEvent(parsed);
               }
-            } catch {
-              // ignore malformed JSON
+            } catch (error) {
+              console.error("[useIframePreflight] Failed to parse phase event JSON", error, event.data);
             }
             return;
           }
@@ -337,8 +338,8 @@ export function useIframePreflight({
               if (isIframePreflightResult(parsed)) {
                 handleResultEvent(parsed);
               }
-            } catch {
-              // ignore malformed JSON
+            } catch (error) {
+              console.error("[useIframePreflight] Failed to parse result event JSON", error, event.data);
             }
           }
         };


### PR DESCRIPTION
## Summary
- Added console.error logging to silent catch blocks in 8 client files
- Improves debuggability without changing behavior

## Changes
- `cmux-comments.tsx` - Log comment loading errors
- `useSuggestionHistory.ts` - Log localStorage errors  
- `git-diff-viewer-with-sidebar.tsx` - Log scroll errors
- `git-diff-viewer.tsx` - Log scroll errors
- `diff-sidebar-filter.tsx` - Log drag errors
- `monaco-git-diff-viewer-with-sidebar.tsx` - Log scroll errors
- `monaco-git-diff-viewer.tsx` - Log scroll errors
- `useIframePreflight.ts` - Log preflight errors

## Test plan
- [x] `bun check` passes