### PR TITLE
[Crown] Implemen following tasks

# Fix: GitHub App token not enablin...

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1036,6 +1036,20 @@ managementIO.on("connection", (socket) => {
         await fs.writeFile(credentialStorePath, credentialsContent);
         await fs.chmod(credentialStorePath, 0o600);
         console.log("GitHub credentials stored in .git-credentials");
+
+        // Authenticate GitHub CLI with the same token so `gh pr create` works in sandboxes
+        try {
+          await execAsync(
+            `printf "%s" "$GH_TOKEN" | gh auth login --hostname github.com --git-protocol https --with-token 2>&1`,
+            {
+              env: { ...process.env, GH_TOKEN: validated.githubToken },
+            }
+          );
+          await execAsync("gh auth setup-git 2>&1");
+          console.log("GitHub CLI authenticated with token");
+        } catch (ghAuthError) {
+          console.error("Failed to authenticate gh CLI:", ghAuthError);
+        }
       } else {
         const credentialSection = configSections.get("credential");
         if (credentialSection?.get("helper")) {


### PR DESCRIPTION
## Task

Implemen following tasks

# Fix: GitHub App token not enabling `gh pr create` in sandbox workers

## Context

PR creation via `gh pr create` fails inside sandbox workers (Morph/PVE) because the `gh` CLI is never authenticated with the GitHub App installation token. The GitHub App (`cmux-client`) already has `pull_requests: read/write` permission set on github.com — the problem is in how tokens flow into the sandbox.

**Two gaps identified:**

1. **`worker:configure-git`&#32;handler** (`apps/worker/src/index.ts:1026-1038`) stores the token in `.git-credentials` for `git push`, but never runs `gh auth login --with-token` — so `gh` CLI has no auth.
2. **Crown PR creation** (`apps/worker/src/crown/pullRequest.ts:128`) calls `gh pr create` with `...process.env` but no `GH_TOKEN` is set, and `gh` isn't logged in.

## Plan

### Step 1: Add `gh auth login` to `worker:configure-git` handler

**File:** `apps/worker/src/index.ts` (around line 1038)

After writing `.git-credentials`, also authenticate the `gh` CLI:

```typescript
// After: await fs.chmod(credentialStorePath, 0o600);
// Add: authenticate gh CLI with the same token
try {
  await execAsync(
    `printf '%s' '${validated.githubToken.replace(/'/g, "'\\''")}' | gh auth login --with-token 2>&1`
  );
  await execAsync("gh auth setup-git 2>&1");
  console.log("GitHub CLI authenticated with token");
} catch (ghAuthError) {
  console.error("Failed to authenticate gh CLI:", ghAuthError);
}
```

This ensures that when the worker is initialized with a GitHub token (whether user OAuth or App installation token), the `gh` CLI is also authenticated.

### Step 2: Pass `GH_TOKEN` env var in crown `createPullRequest`

**File:** `apps/worker/src/crown/pullRequest.ts` (line 135-140)

As a belt-and-suspenders fix, also set `GH_TOKEN` in the environment if a token is available. This requires threading the token through from the workflow.

However, the simpler fix is Step 1 alone — once `gh auth login` is done during worker setup, `gh pr create` will work automatically.

### Step 3 (optional): Also fix `performAutoCommitAndPush` server path

**File:** `apps/server/src/performAutoCommitAndPush.ts` (line 218)

The Docker-based path at `DockerVSCodeInstance.ts:1035` already runs `gh auth login --with-token` during `bootstrapGitHubAuth()`. The Morph/PVE path uses `worker:configure-git` which is fixed by Step 1.

No additional change needed here if Step 1 is applied.

## Files to modify

1. `apps/worker/src/index.ts` — Add `gh auth login` + `gh auth setup-git` after `.git-credentials` setup (\~5 lines)

## Verification

1. Start a task with auto-PR enabled
2. After agent completes, check crown worker logs for "GitHub CLI authenticated with token"
3. Verify `gh pr create` succeeds (no auth errors)
4. Run `bun check` to ensure no type errors

## PR Review Summary - What Changed: Modified apps/worker/src/index.ts to authenticate the GitHub CLI (gh) during the worker:configure-git lifecycle. After writing git credentials, it now securely pipes the githubToken into gh auth login and runs gh auth setup-git. - Review Focus: Confirm that the gh CLI is pre-installed in all sandbox worker images (Morph/PVE). Verify that error handling in the try-catch block prevents worker crashes if gh authentication fails. - Test Plan: 1. Start a task with auto-PR enabled in a sandbox worker. 2. Monitor worker logs for 'GitHub CLI authenticated with token'. 3. Confirm the agent successfully creates a PR via the CLI. 4. Run bun check to verify type safety.