### PR TITLE
Silence expected framework detection errors and simplify retries

### DIFF
--- a/apps/www/lib/github/framework-detection.ts
+++ b/apps/www/lib/github/framework-detection.ts
@@ -677,8 +677,8 @@ async function repoFileExists(
       path,
     });
     return true;
-  } catch (error) {
-    console.error("[framework-detection] Failed to detect framework at path:", error);
+  } catch {
+    // Expected: most probed paths won't exist during framework detection
     return false;
   }
 }

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -92,14 +92,12 @@ function concatConfigBlocks(
  */
 async function waitForVSCodeReady(
   vscodeUrl: string,
-  options: { timeoutMs?: number; intervalMs?: number; maxRetries?: number } = {}
+  options: { timeoutMs?: number; intervalMs?: number } = {}
 ): Promise<boolean> {
-  const { timeoutMs = 15_000, intervalMs = 500, maxRetries = 30 } = options;
+  const { timeoutMs = 15_000, intervalMs = 500 } = options;
   const start = Date.now();
-  let retries = 0;
 
-  while (Date.now() - start < timeoutMs && retries < maxRetries) {
-    retries++;
+  while (Date.now() - start < timeoutMs) {
     try {
       // Use a simple HEAD request to check if the server is responding
       const response = await fetch(vscodeUrl, {
@@ -126,14 +124,12 @@ async function waitForVSCodeReady(
  */
 async function waitForWorkerReady(
   workerUrl: string,
-  options: { timeoutMs?: number; intervalMs?: number; maxRetries?: number } = {}
+  options: { timeoutMs?: number; intervalMs?: number } = {}
 ): Promise<boolean> {
-  const { timeoutMs = 15_000, intervalMs = 500, maxRetries = 30 } = options;
+  const { timeoutMs = 15_000, intervalMs = 500 } = options;
   const start = Date.now();
-  let retries = 0;
 
-  while (Date.now() - start < timeoutMs && retries < maxRetries) {
-    retries++;
+  while (Date.now() - start < timeoutMs) {
     try {
       // Worker service uses socket.io - check if the HTTP endpoint responds
       // Socket.io exposes a polling transport at /socket.io/?EIO=4&transport=polling


### PR DESCRIPTION
Summary
- stop logging expected errors when probing for nonexistent framework files in `framework-detection.ts`
- simplify the `waitForVSCodeReady` and `waitForWorkerReady` helpers by removing the unused retry counter/maxRetries option and relying solely on the timeout loop

Testing
- Not run (not requested)