### PR TITLE
fix(hooks): improve autopilot + codex-review stop hook cooperation

### DIFF
--- a/.claude/hooks/codex-review.sh
+++ b/.claude/hooks/codex-review.sh
@@ -3,15 +3,22 @@
 
 set -euo pipefail
 
-# Debug log file
-DEBUG_LOG="/tmp/codex-review-debug.log"
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] === codex-review.sh START ===" >> "$DEBUG_LOG"
-echo "CODEX_REVIEW_DISABLED=${CODEX_REVIEW_DISABLED:-}" >> "$DEBUG_LOG"
-echo "CLAUDE_AUTOPILOT=${CLAUDE_AUTOPILOT:-}" >> "$DEBUG_LOG"
+# Debug logging is opt-in via CODEX_REVIEW_DEBUG=1 to avoid writing
+# raw hook input (which may contain repo content) to world-readable /tmp.
+DEBUG_ENABLED="${CODEX_REVIEW_DEBUG:-0}"
+debug_log() {
+  if [ "$DEBUG_ENABLED" = "1" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "/tmp/codex-review-debug.log"
+  fi
+}
+
+debug_log "=== codex-review.sh START ==="
+debug_log "CODEX_REVIEW_DISABLED=${CODEX_REVIEW_DISABLED:-}"
+debug_log "CLAUDE_AUTOPILOT=${CLAUDE_AUTOPILOT:-}"
 
 # Skip if disabled via env var
 if [ "${CODEX_REVIEW_DISABLED:-}" = "1" ]; then
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Exiting: CODEX_REVIEW_DISABLED=1" >> "$DEBUG_LOG"
+  debug_log "Exiting: CODEX_REVIEW_DISABLED=1"
   exit 0
 fi
 
@@ -19,22 +26,46 @@ cd "$CLAUDE_PROJECT_DIR"
 
 # Read session_id from hook stdin JSON
 INPUT=$(cat)
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] INPUT JSON: $INPUT" >> "$DEBUG_LOG"
+debug_log "INPUT JSON: $INPUT"
 
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null || echo "default")
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] SESSION_ID: $SESSION_ID" >> "$DEBUG_LOG"
+debug_log "SESSION_ID: $SESSION_ID"
 
-# Skip if autopilot blocked this stop (another hook already issued a block decision).
-# This avoids running a slow review on every autopilot turn, but still allows
-# the review to run on the final stop when autopilot permits it through.
-STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] STOP_HOOK_ACTIVE: $STOP_HOOK_ACTIVE" >> "$DEBUG_LOG"
+# Skip if autopilot specifically blocked this stop. We check the autopilot-specific
+# flag file instead of the generic stop_hook_active, because stop_hook_active can
+# be set by any previous hook (e.g. bun-check), which would incorrectly prevent
+# the review from running on the final stop.
+#
+# Guard: only honor the flag file when autopilot is actually active. This prevents
+# stale flag files from suppressing review after autopilot is toggled off or if
+# cleanup was missed (e.g. process crash).
+AUTOPILOT_BLOCKED_FILE="/tmp/claude-autopilot-blocked-${SESSION_ID}"
+# Autopilot is only truly active when enabled AND not disabled via override.
+# AUTOPILOT_KEEP_RUNNING_DISABLED=1 causes the autopilot hook to exit before
+# cleanup, so the blocked flag can persist even though autopilot is effectively off.
+AUTOPILOT_ACTIVE="0"
+if [ "${CLAUDE_AUTOPILOT:-0}" = "1" ] && [ "${AUTOPILOT_KEEP_RUNNING_DISABLED:-0}" != "1" ]; then
+  AUTOPILOT_ACTIVE="1"
+fi
+debug_log "AUTOPILOT_ACTIVE: $AUTOPILOT_ACTIVE, AUTOPILOT_BLOCKED_FILE exists: $([ -f "$AUTOPILOT_BLOCKED_FILE" ] && echo 'true' || echo 'false')"
 
-if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Exiting: stop_hook_active=true (autopilot blocked)" >> "$DEBUG_LOG"
+if [ "$AUTOPILOT_ACTIVE" = "1" ] && [ -f "$AUTOPILOT_BLOCKED_FILE" ]; then
+  debug_log "Exiting: autopilot blocked this stop (flag file exists)"
   exit 0
 fi
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] Proceeding with codex review..." >> "$DEBUG_LOG"
+
+# Clean up stale flag file if autopilot is not active
+if [ "$AUTOPILOT_ACTIVE" != "1" ] && [ -f "$AUTOPILOT_BLOCKED_FILE" ]; then
+  rm -f "$AUTOPILOT_BLOCKED_FILE"
+  debug_log "Cleaned up stale autopilot blocked flag"
+fi
+debug_log "Proceeding with codex review..."
+
+# Dry-run mode: exit after pre-flight checks (for testing hook logic without codex)
+if [ "${CODEX_REVIEW_DRY_RUN:-}" = "1" ]; then
+  debug_log "Dry-run mode, exiting after pre-flight"
+  exit 0
+fi
 
 # Hard stop after 5 failures to prevent excessive loops (per session)
 FAIL_COUNT_FILE="/tmp/codex-review-fails-${SESSION_ID}"
@@ -53,15 +84,14 @@ trap 'rm -f "$TMPFILE"' EXIT
 # REVIEW.md guidelines are loaded via AGENTS.md (codex reads it automatically).
 # --base and [PROMPT] are mutually exclusive, so we cannot pass a custom prompt here.
 # --enable use_linux_sandbox_bwrap avoids Landlock restrictions in containerized environments.
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] Running codex review..." >> "$DEBUG_LOG"
+debug_log "Running codex review..."
 unbuffer codex \
   --dangerously-bypass-approvals-and-sandbox \
   --enable use_linux_sandbox_bwrap \
   --model gpt-5.3-codex \
   -c model_reasoning_effort="low" \
   review --base main > "$TMPFILE" 2>&1 || true
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] Codex review finished, TMPFILE contents:" >> "$DEBUG_LOG"
-head -100 "$TMPFILE" >> "$DEBUG_LOG" 2>/dev/null || echo "(empty)" >> "$DEBUG_LOG"
+debug_log "Codex review finished"
 
 # Strip ANSI codes first, then extract final codex response
 CLEAN=$(sed 's/\x1b\[[0-9;]*m//g' "$TMPFILE")
@@ -74,10 +104,10 @@ FINDINGS=$(echo "$CLEAN" | awk '
 ' | sed '/^$/d' | grep -v '^tokens used' | head -50)
 
 if [ -z "$FINDINGS" ]; then
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] No FINDINGS extracted, exiting" >> "$DEBUG_LOG"
+  debug_log "No FINDINGS extracted, exiting"
   exit 0  # No output from codex
 fi
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] FINDINGS: $FINDINGS" >> "$DEBUG_LOG"
+debug_log "FINDINGS extracted ($(echo "$FINDINGS" | wc -l) lines)"
 
 # Use opencode to check if review passed (lgtm) or has issues
 VERDICT=$(opencode run "Output: $FINDINGS
@@ -86,13 +116,13 @@ If the output indicates code review passed with no issues, return exactly 'lgtm'
 
 if echo "$VERDICT" | grep -qi "lgtm"; then
   rm -f "$FAIL_COUNT_FILE"  # Reset counter on success
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Review PASSED (lgtm)" >> "$DEBUG_LOG"
+  debug_log "Review PASSED (lgtm)"
   exit 0  # Review passed, don't bother Claude
 fi
 
 # Has issues - increment counter and show to Claude
 echo $((FAIL_COUNT + 1)) > "$FAIL_COUNT_FILE"
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] Review has ISSUES, showing to Claude" >> "$DEBUG_LOG"
+debug_log "Review has ISSUES, showing to Claude"
 echo "## Codex Code Review Findings (attempt $((FAIL_COUNT + 1))/5)" >&2
 echo "" >&2
 echo "$FINDINGS" >&2

--- a/scripts/test-stop-hooks.sh
+++ b/scripts/test-stop-hooks.sh
@@ -1,0 +1,433 @@
+#!/bin/bash
+# Test script for stop hook cooperation between autopilot-keep-running.sh and codex-review.sh
+# Tests the flag-file mechanism that replaced the generic stop_hook_active check.
+#
+# Usage: ./scripts/test-stop-hooks.sh
+#
+# Each test simulates the hook execution flow by calling the actual hook scripts
+# with crafted input JSON and environment variables, then verifying side effects
+# (flag files, debug log entries, exit codes).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$PROJECT_DIR/.claude/hooks"
+
+AUTOPILOT_HOOK="$HOOKS_DIR/autopilot-keep-running.sh"
+CODEX_REVIEW_HOOK="$HOOKS_DIR/codex-review.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc (got: $actual)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected: $expected, got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1" path="$2"
+  TOTAL=$((TOTAL + 1))
+  if [ -f "$path" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc (file exists: $path)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (file missing: $path)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_not_exists() {
+  local desc="$1" path="$2"
+  TOTAL=$((TOTAL + 1))
+  if [ ! -f "$path" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc (file absent: $path)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (file should not exist: $path)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_log_contains() {
+  local desc="$1" log_file="$2" pattern="$3"
+  TOTAL=$((TOTAL + 1))
+  if grep -q "$pattern" "$log_file" 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC}: $desc (log contains: $pattern)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (log missing: $pattern)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+cleanup_session() {
+  local sid="$1"
+  rm -f "/tmp/claude-autopilot-blocked-${sid}"
+  rm -f "/tmp/claude-autopilot-turns-${sid}"
+  rm -f "/tmp/claude-autopilot-stop-${sid}"
+  rm -f "/tmp/codex-review-fails-${sid}"
+  rm -f "/tmp/codex-review-debug.log"
+}
+
+# Common env vars for codex-review invocations
+# CODEX_REVIEW_DEBUG=1 enables the opt-in debug log so assertions can check it
+# CODEX_REVIEW_DRY_RUN=1 exits before the actual codex binary call
+REVIEW_COMMON_ENV="CODEX_REVIEW_DISABLED=0 CODEX_REVIEW_DEBUG=1 CODEX_REVIEW_DRY_RUN=1"
+
+# ============================================================================
+# Test 1: Autopilot blocks -> flag file created -> codex-review skips
+# ============================================================================
+echo ""
+echo -e "${YELLOW}Test 1: Autopilot blocks -> codex-review skips${NC}"
+
+SID="test-stop-hook-1"
+cleanup_session "$SID"
+
+INPUT_JSON='{"session_id":"'"$SID"'","stop_hook_active":false}'
+
+# Run autopilot hook (should block)
+AUTOPILOT_OUTPUT=$(echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_MAX_TURNS=20 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" 2>/dev/null) || true
+
+# Check autopilot created flag file
+assert_file_exists "autopilot created blocked flag file" "/tmp/claude-autopilot-blocked-${SID}"
+
+# Check autopilot output contains block decision
+DECISION=$(echo "$AUTOPILOT_OUTPUT" | jq -r '.decision' 2>/dev/null || echo "")
+assert_eq "autopilot output block decision" "block" "$DECISION"
+
+# Run codex-review hook (should skip due to flag file)
+REVIEW_EXIT=0
+echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CODEX_REVIEW_DISABLED=0 \
+  CODEX_REVIEW_DEBUG=1 \
+  CODEX_REVIEW_DRY_RUN=1 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$CODEX_REVIEW_HOOK" 2>/dev/null || REVIEW_EXIT=$?
+
+assert_eq "codex-review exits 0 (skipped)" "0" "$REVIEW_EXIT"
+assert_log_contains "debug log shows autopilot blocked" "/tmp/codex-review-debug.log" "autopilot blocked this stop"
+
+cleanup_session "$SID"
+
+# ============================================================================
+# Test 2: Autopilot allows (max turns reached) -> flag cleaned -> codex-review runs
+# ============================================================================
+echo ""
+echo -e "${YELLOW}Test 2: Autopilot allows (max turns) -> codex-review proceeds${NC}"
+
+SID="test-stop-hook-2"
+cleanup_session "$SID"
+
+# Pre-seed turn counter to 0, set max to 1 so next turn hits limit
+echo "0" > "/tmp/claude-autopilot-turns-${SID}"
+# Pre-create a flag file as if autopilot blocked on a previous stop
+echo "1" > "/tmp/claude-autopilot-blocked-${SID}"
+
+INPUT_JSON='{"session_id":"'"$SID"'","stop_hook_active":false}'
+
+# Run autopilot hook (should allow - max turns reached)
+AUTOPILOT_OUTPUT=$(echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_MAX_TURNS=1 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" 2>/dev/null) || true
+
+# Flag file should be cleaned up
+assert_file_not_exists "autopilot cleaned flag file on max turns" "/tmp/claude-autopilot-blocked-${SID}"
+
+# Autopilot should NOT output a block decision (it exits 0 silently)
+assert_eq "autopilot output empty (allowed stop)" "" "$AUTOPILOT_OUTPUT"
+
+# Run codex-review hook (should proceed past autopilot check)
+REVIEW_EXIT=0
+echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CODEX_REVIEW_DISABLED=0 \
+  CODEX_REVIEW_DEBUG=1 \
+  CODEX_REVIEW_DRY_RUN=1 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$CODEX_REVIEW_HOOK" 2>/dev/null || REVIEW_EXIT=$?
+
+assert_log_contains "debug log shows proceeding with review" "/tmp/codex-review-debug.log" "Proceeding with codex review"
+
+cleanup_session "$SID"
+
+# ============================================================================
+# Test 3: Autopilot off + stale flag file -> cleaned up, codex-review runs
+# ============================================================================
+echo ""
+echo -e "${YELLOW}Test 3: Autopilot off + stale flag -> cleaned, codex-review proceeds${NC}"
+
+SID="test-stop-hook-3"
+cleanup_session "$SID"
+
+# Create stale flag file (left over from previous autopilot session)
+echo "stale" > "/tmp/claude-autopilot-blocked-${SID}"
+
+INPUT_JSON='{"session_id":"'"$SID"'","stop_hook_active":false}'
+
+# Run codex-review with autopilot explicitly OFF
+REVIEW_EXIT=0
+echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=0 \
+  CODEX_REVIEW_DISABLED=0 \
+  CODEX_REVIEW_DEBUG=1 \
+  CODEX_REVIEW_DRY_RUN=1 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$CODEX_REVIEW_HOOK" 2>/dev/null || REVIEW_EXIT=$?
+
+# Stale flag file should be cleaned up
+assert_file_not_exists "stale flag file cleaned up" "/tmp/claude-autopilot-blocked-${SID}"
+assert_log_contains "debug log shows stale cleanup" "/tmp/codex-review-debug.log" "Cleaned up stale autopilot blocked flag"
+assert_log_contains "debug log shows proceeding" "/tmp/codex-review-debug.log" "Proceeding with codex review"
+
+cleanup_session "$SID"
+
+# ============================================================================
+# Test 4: bun-check blocks (stop_hook_active=true) but codex-review still runs
+# ============================================================================
+echo ""
+echo -e "${YELLOW}Test 4: bun-check blocks (stop_hook_active=true) -> codex-review still runs${NC}"
+
+SID="test-stop-hook-4"
+cleanup_session "$SID"
+
+# stop_hook_active=true simulates bun-check having blocked
+INPUT_JSON='{"session_id":"'"$SID"'","stop_hook_active":true}'
+
+# No flag file exists (autopilot didn't block, or is off)
+# Run codex-review with autopilot explicitly OFF
+REVIEW_EXIT=0
+echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=0 \
+  CODEX_REVIEW_DISABLED=0 \
+  CODEX_REVIEW_DEBUG=1 \
+  CODEX_REVIEW_DRY_RUN=1 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$CODEX_REVIEW_HOOK" 2>/dev/null || REVIEW_EXIT=$?
+
+# codex-review should NOT skip (no flag file, autopilot not active)
+assert_log_contains "debug log shows proceeding despite stop_hook_active" "/tmp/codex-review-debug.log" "Proceeding with codex review"
+
+cleanup_session "$SID"
+
+# ============================================================================
+# Test 5: stop_hook_active=true -> autopilot still blocks (ignores flag)
+# ============================================================================
+echo ""
+echo -e "${YELLOW}Test 5: stop_hook_active=true -> autopilot still blocks (MAX_TURNS is the guard)${NC}"
+
+SID="test-stop-hook-5"
+cleanup_session "$SID"
+
+# Pre-create flag file as if autopilot blocked on a previous cycle
+echo "5" > "/tmp/claude-autopilot-blocked-${SID}"
+
+INPUT_JSON='{"session_id":"'"$SID"'","stop_hook_active":true}'
+
+# Run autopilot hook -- should block regardless of stop_hook_active
+# (autopilot is first in chain, MAX_TURNS is the only loop guard)
+AUTOPILOT_OUTPUT=$(echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_MAX_TURNS=20 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" 2>/dev/null) || true
+
+# Autopilot should still block (turn 1, well under max)
+DECISION=$(echo "$AUTOPILOT_OUTPUT" | jq -r '.decision' 2>/dev/null || echo "")
+assert_eq "autopilot blocks despite stop_hook_active=true" "block" "$DECISION"
+
+# Flag file should be updated with new turn count
+assert_file_exists "flag file updated after block" "/tmp/claude-autopilot-blocked-${SID}"
+
+# Turn counter should be at 1
+TURN_COUNT=$(cat "/tmp/claude-autopilot-turns-${SID}" 2>/dev/null || echo "0")
+assert_eq "turn counter incremented to 1" "1" "$TURN_COUNT"
+
+# Verify codex-review still skips because flag file exists
+REVIEW_EXIT=0
+echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CODEX_REVIEW_DISABLED=0 \
+  CODEX_REVIEW_DEBUG=1 \
+  CODEX_REVIEW_DRY_RUN=1 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$CODEX_REVIEW_HOOK" 2>/dev/null || REVIEW_EXIT=$?
+
+assert_eq "codex-review exits 0 (skipped, flag exists)" "0" "$REVIEW_EXIT"
+assert_log_contains "debug log shows autopilot blocked" "/tmp/codex-review-debug.log" "autopilot blocked this stop"
+
+cleanup_session "$SID"
+
+# ============================================================================
+# Test 6: Session stop file -> autopilot allows and cleans flag
+# ============================================================================
+echo ""
+echo -e "${YELLOW}Test 6: Session stop file -> autopilot allows, flag cleaned${NC}"
+
+SID="test-stop-hook-6"
+cleanup_session "$SID"
+
+# Pre-create flag file and session stop file
+echo "3" > "/tmp/claude-autopilot-blocked-${SID}"
+touch "/tmp/claude-autopilot-stop-${SID}"
+
+INPUT_JSON='{"session_id":"'"$SID"'","stop_hook_active":false}'
+
+# Run autopilot hook (should detect stop file, clean flag, and allow)
+AUTOPILOT_OUTPUT=$(echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" 2>/dev/null) || true
+
+assert_file_not_exists "flag file cleaned on stop file" "/tmp/claude-autopilot-blocked-${SID}"
+assert_eq "autopilot output empty (allowed stop)" "" "$AUTOPILOT_OUTPUT"
+
+cleanup_session "$SID"
+
+# ============================================================================
+# Test 7: AUTOPILOT_KEEP_RUNNING_DISABLED=1 + stale flag -> codex-review runs
+# ============================================================================
+echo ""
+echo -e "${YELLOW}Test 7: Autopilot disabled via override + stale flag -> codex-review proceeds${NC}"
+
+SID="test-stop-hook-7"
+cleanup_session "$SID"
+
+# Stale flag file from before the override was set
+echo "2" > "/tmp/claude-autopilot-blocked-${SID}"
+
+INPUT_JSON='{"session_id":"'"$SID"'","stop_hook_active":false}'
+
+# CLAUDE_AUTOPILOT=1 but AUTOPILOT_KEEP_RUNNING_DISABLED=1 overrides it
+REVIEW_EXIT=0
+echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  AUTOPILOT_KEEP_RUNNING_DISABLED=1 \
+  CODEX_REVIEW_DISABLED=0 \
+  CODEX_REVIEW_DEBUG=1 \
+  CODEX_REVIEW_DRY_RUN=1 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$CODEX_REVIEW_HOOK" 2>/dev/null || REVIEW_EXIT=$?
+
+# codex-review should treat autopilot as inactive and clean stale flag
+assert_file_not_exists "stale flag cleaned when override active" "/tmp/claude-autopilot-blocked-${SID}"
+assert_log_contains "debug log shows stale cleanup" "/tmp/codex-review-debug.log" "Cleaned up stale autopilot blocked flag"
+assert_log_contains "debug log shows proceeding" "/tmp/codex-review-debug.log" "Proceeding with codex review"
+
+cleanup_session "$SID"
+
+# ============================================================================
+# Test 8: Smart delay escalation - work phase vs monitoring phase
+# ============================================================================
+echo ""
+echo -e "${YELLOW}Test 8: Delay escalation - work vs monitoring phase${NC}"
+
+SID="test-stop-hook-8"
+cleanup_session "$SID"
+
+INPUT_JSON='{"session_id":"'"$SID"'","stop_hook_active":false}'
+
+# Turn 1: should be "work" phase (no sleep instruction in output)
+AUTOPILOT_OUTPUT=$(echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_MAX_TURNS=30 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_AUTOPILOT_MONITORING_THRESHOLD=3 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" 2>/dev/null) || true
+
+REASON=$(echo "$AUTOPILOT_OUTPUT" | jq -r '.reason' 2>/dev/null || echo "")
+HAS_SLEEP=$(echo "$REASON" | grep -c "sleep" || true)
+assert_eq "turn 1 (work phase) has no sleep instruction" "0" "$HAS_SLEEP"
+
+# Turn 4 (threshold=3, so turn 4 is monitoring phase 1): should include "sleep 30"
+echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_MAX_TURNS=30 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_AUTOPILOT_MONITORING_THRESHOLD=3 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" >/dev/null 2>&1 || true
+echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_MAX_TURNS=30 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_AUTOPILOT_MONITORING_THRESHOLD=3 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" >/dev/null 2>&1 || true
+
+AUTOPILOT_OUTPUT=$(echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_MAX_TURNS=30 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_AUTOPILOT_MONITORING_THRESHOLD=3 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" 2>/dev/null) || true
+
+REASON=$(echo "$AUTOPILOT_OUTPUT" | jq -r '.reason' 2>/dev/null || echo "")
+HAS_SLEEP_30=$(echo "$REASON" | grep -c "sleep 30" || true)
+assert_eq "turn 4 (monitoring phase 1) includes sleep 30" "1" "$HAS_SLEEP_30"
+
+# Turn 9 (threshold=3, so turn 9 = 3+5+1 is monitoring phase 2): should include "sleep 60"
+for i in $(seq 5 8); do
+  echo "$INPUT_JSON" | \
+    CLAUDE_AUTOPILOT=1 \
+    CLAUDE_AUTOPILOT_MAX_TURNS=30 \
+    CLAUDE_AUTOPILOT_DELAY=0 \
+    CLAUDE_AUTOPILOT_MONITORING_THRESHOLD=3 \
+    CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+    bash "$AUTOPILOT_HOOK" >/dev/null 2>&1 || true
+done
+
+AUTOPILOT_OUTPUT=$(echo "$INPUT_JSON" | \
+  CLAUDE_AUTOPILOT=1 \
+  CLAUDE_AUTOPILOT_MAX_TURNS=30 \
+  CLAUDE_AUTOPILOT_DELAY=0 \
+  CLAUDE_AUTOPILOT_MONITORING_THRESHOLD=3 \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash "$AUTOPILOT_HOOK" 2>/dev/null) || true
+
+REASON=$(echo "$AUTOPILOT_OUTPUT" | jq -r '.reason' 2>/dev/null || echo "")
+HAS_SLEEP_60=$(echo "$REASON" | grep -c "sleep 60" || true)
+assert_eq "turn 9 (monitoring phase 2) includes sleep 60" "1" "$HAS_SLEEP_60"
+
+cleanup_session "$SID"
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "============================================"
+if [ "$FAIL" -eq 0 ]; then
+  echo -e "${GREEN}All $TOTAL assertions passed ($PASS/$TOTAL)${NC}"
+else
+  echo -e "${RED}$FAIL/$TOTAL assertions failed${NC} (${PASS} passed)"
+fi
+echo "============================================"
+
+exit "$FAIL"


### PR DESCRIPTION
## Summary
- Replace generic `stop_hook_active` check with autopilot-specific flag file mechanism
- Remove `stop_hook_active` infinite loop guard (was limiting to ~1 block per cycle)
- Add smart delay escalation for long-running monitoring tasks
- Make codex-review debug logging opt-in (`CODEX_REVIEW_DEBUG=1`)
- Add `AUTOPILOT_KEEP_RUNNING_DISABLED` override handling

## Test plan
- [x] 24/24 shell test assertions pass (`scripts/test-stop-hooks.sh`)
- [x] Live session test: 5+ min monitoring with proper delay escalation
- [x] Verified agent follows "sleep 30/60" instructions in monitoring phase