### PR TITLE
feat(hooks): improve status messages and skip review when idle

### DIFF
--- a/.claude/commands/autopilot_reset.md
+++ b/.claude/commands/autopilot_reset.md
@@ -11,7 +11,7 @@ Mode: $ARGUMENTS (default: reset)
 ## Auto-collected context
 
 ### Current session status
-!`bash -c 'SID=$(cat /tmp/claude-current-session-id 2>/dev/null); if [ -z "$SID" ]; then echo "Session ID: (not set - restart session to enable)"; exit 0; fi; echo "Session ID: ${SID}"; MAX=${CLAUDE_AUTOPILOT_MAX_TURNS:-20}; echo "Max turns: $MAX"; TURNS_FILE="/tmp/claude-autopilot-turns-${SID}"; if [ -f "$TURNS_FILE" ]; then TURNS=$(cat "$TURNS_FILE"); echo "Current turn: $TURNS"; else echo "Current turn: 0 (not started)"; fi; FLAGS=""; [ -f "/tmp/claude-autopilot-stop-$SID" ] && FLAGS="STOP "; [ -f "/tmp/claude-autopilot-blocked-$SID" ] && FLAGS="${FLAGS}BLOCKED"; [ -n "$FLAGS" ] && echo "Status: $FLAGS" || echo "Status: ready"; exit 0'`
+!`bash -c 'SID=$(cat /tmp/claude-current-session-id 2>/dev/null); if [ -z "$SID" ]; then echo "Session ID: (not set - restart session to enable)"; exit 0; fi; echo "Session ID: ${SID}"; MAX=${CLAUDE_AUTOPILOT_MAX_TURNS:-20}; echo "Max turns: $MAX"; TURNS_FILE="/tmp/claude-autopilot-turns-${SID}"; if [ -f "$TURNS_FILE" ]; then TURNS=$(cat "$TURNS_FILE"); echo "Current turn: $TURNS"; HAS_RUN=1; else echo "Current turn: 0"; HAS_RUN=0; fi; if [ -f "/tmp/claude-autopilot-stop-$SID" ]; then echo "Status: STOP (will stop on next turn)"; elif [ -f "/tmp/claude-autopilot-blocked-$SID" ]; then echo "Status: BLOCKED (actively running)"; elif [ "$HAS_RUN" = "0" ]; then echo "Status: idle (not started)"; else echo "Status: ready (available)"; fi; exit 0'`
 
 ## Actions
 

--- a/.claude/hooks/codex-review.sh
+++ b/.claude/hooks/codex-review.sh
@@ -59,6 +59,14 @@ if [ "$AUTOPILOT_ACTIVE" != "1" ] && [ -f "$AUTOPILOT_BLOCKED_FILE" ]; then
   rm -f "$AUTOPILOT_BLOCKED_FILE"
   debug_log "Cleaned up stale autopilot blocked flag"
 fi
+
+# Only run review if autopilot has completed work (turn file exists = work was done)
+# Skip if session never ran autopilot (idle state)
+TURN_FILE="/tmp/claude-autopilot-turns-${SESSION_ID}"
+if [ "$AUTOPILOT_ACTIVE" = "1" ] && [ ! -f "$TURN_FILE" ]; then
+  debug_log "Skipping review: autopilot enabled but no work done yet (idle)"
+  exit 0
+fi
 debug_log "Proceeding with codex review..."
 
 # Dry-run mode: exit after pre-flight checks (for testing hook logic without codex)


### PR DESCRIPTION
## Summary
- Improved `/autopilot_reset status` messages for clarity
- Skip codex-review when autopilot is enabled but no work done yet

## Status Messages
| Status | Meaning |
|--------|---------|
| `idle (not started)` | Turn 0, never ran |
| `ready (available)` | Has run, currently available |
| `STOP (will stop on next turn)` | Stop requested |
| `BLOCKED (actively running)` | Mid-turn, active |

## codex-review Change
Skip review when `AUTOPILOT_ACTIVE=1` but no turn file exists (idle state).

## Test plan
- [x] Tested status output with new messages
- [x] `bun check` passed