### PR TITLE
docs: add git policy to prevent direct main commits/merges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,23 @@ This project is called cmux. cmux is a web app that spawns Claude Code, Codex CL
 - Primary upstream for this workspace is `manaflow-ai/manaflow`, with fork target `karlorz/cmux`.
 - Terminal project is separate: upstream `manaflow-ai/cmux`, fork `karl-digi/cmux`, and should be handled in a separate workspace (for example `/Users/karlchow/Desktop/code/cmux-terminal`).
 
+# Git Policy (IMPORTANT)
+
+**All agents (Claude, Codex, Gemini, etc.) MUST follow these rules:**
+
+1. **NO direct commits to main/master** - Always create a feature branch first
+2. **NO direct push to main/master** - Push to feature branches only
+3. **NO merging PRs without explicit user approval** - Create PR, wait for user to review and approve
+4. **NO force push to main/master** - This destroys history
+
+**Workflow:**
+1. Create feature branch: `git checkout -b <type>/<description>`
+2. Make changes and commit to feature branch
+3. Push feature branch: `git push -u origin <branch>`
+4. Create PR: `gh pr create --base main`
+5. **STOP and wait for user approval before merging**
+6. Only merge after user explicitly says "merge" or "approve"
+
 # Code Review
 
 When reviewing code, apply the guidelines in REVIEW.md at the project root.

--- a/packages/devsh/npm/devsh/AGENTS.md
+++ b/packages/devsh/npm/devsh/AGENTS.md
@@ -77,6 +77,15 @@ devsh pause cmux_abc123    # Pause to save costs (can resume later)
 devsh delete cmux_abc123   # Delete permanently
 ```
 
+## Git Policy (IMPORTANT)
+
+**When working in VMs or this repo, ALWAYS follow these rules:**
+
+1. **NO direct commits to main/master** - Create feature branch first
+2. **NO direct push to main/master** - Push to feature branches only
+3. **NO merging PRs without explicit user approval** - Wait for user to say "merge" or "approve"
+4. **NO force push to main/master**
+
 ## Tips
 
 - Run `devsh login` first if not authenticated

--- a/packages/sandbox/AGENTS.md
+++ b/packages/sandbox/AGENTS.md
@@ -8,3 +8,12 @@ Make sure to run `cargo clippy` and fix all lint warnings.
 Before finishing, make sure to run tests and `cargo fmt`.
 After tests pass (and only for sandbox/dmux changes), run `cd packages/sandbox && ./scripts/reload.sh` to rebuild/reinstall the dmux CLI (debug) and restart the sandbox server.
 After finishing, use the macOS `say` command to notify the user with a short description of what to check/the next action the user should take (like a shell command/url/program they should interact with to verify).
+
+## Git Policy (IMPORTANT)
+
+**ALWAYS follow these rules:**
+
+1. **NO direct commits to main/master** - Create feature branch first
+2. **NO direct push to main/master** - Push to feature branches only
+3. **NO merging PRs without explicit user approval** - Wait for user to say "merge" or "approve"
+4. **NO force push to main/master**


### PR DESCRIPTION
## Summary
Add Git Policy section to CLAUDE.md and AGENTS.md files to prevent agents from:
1. Direct commits to main/master
2. Direct push to main/master
3. Merging PRs without explicit user approval
4. Force push to main/master

## Files Changed
- `CLAUDE.md` - Main policy documentation
- `packages/sandbox/AGENTS.md` - Policy for sandbox/dmux agents

## Test plan
- [x] Policy text is clear and unambiguous
- [x] `bun check` passed