### PR TITLE
Show cloud workspace forwarded ports in sidebar

### DIFF
--- a/apps/client/src/hooks/usePublishForwardedPorts.ts
+++ b/apps/client/src/hooks/usePublishForwardedPorts.ts
@@ -1,0 +1,60 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  postApiSandboxesByIdPublishDevcontainer,
+  type PostApiSandboxesByIdPublishDevcontainerResponse,
+} from "@cmux/www-openapi-client";
+import { type Id } from "@cmux/convex/dataModel";
+import { toast } from "sonner";
+
+interface UsePublishForwardedPortsArgs {
+  taskRunId: Id<"taskRuns">;
+  sandboxId?: string | null;
+  teamSlugOrId: string;
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+}
+
+export function usePublishForwardedPorts({
+  taskRunId,
+  sandboxId,
+  teamSlugOrId,
+  onSuccess,
+  onError,
+}: UsePublishForwardedPortsArgs) {
+  return useMutation<
+    PostApiSandboxesByIdPublishDevcontainerResponse,
+    Error,
+    void,
+    { toastId: string | number }
+  >({
+    mutationKey: ["publish-forwarded-ports", "task-run", taskRunId, sandboxId],
+    mutationFn: async () => {
+      if (!sandboxId) {
+        throw new Error("Sandbox ID is required to refresh forwarded ports");
+      }
+
+      const { data } = await postApiSandboxesByIdPublishDevcontainer({
+        path: { id: sandboxId },
+        body: { teamSlugOrId, taskRunId },
+        throwOnError: true,
+      });
+      return data;
+    },
+    onMutate: async () => {
+      const toastId = toast.loading("Refreshing forwarded ports...");
+      return { toastId };
+    },
+    onSuccess: (_data, __, context) => {
+      toast.success("Forwarded ports refreshed", { id: context?.toastId });
+      onSuccess?.();
+    },
+    onError: (error, _variables, context) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to refresh forwarded ports.";
+      toast.error(message, { id: context?.toastId });
+      onError?.(error);
+    },
+  });
+}

--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -451,7 +451,8 @@ async function handleCreateCloudWorkspace(
       // Spawn sandbox via www API
       const { getWwwClient } = await import("./utils/wwwClient");
       const { getWwwOpenApiModule } = await import("./utils/wwwOpenApiModule");
-      const { postApiSandboxesStart } = await getWwwOpenApiModule();
+      const { postApiSandboxesStart, postApiSandboxesByIdPublishDevcontainer } =
+        await getWwwOpenApiModule();
 
       serverLogger.info(
         environmentId
@@ -521,6 +522,22 @@ async function handleCreateCloudWorkspace(
         id: taskRunId,
         status: "running",
       });
+
+      try {
+        await postApiSandboxesByIdPublishDevcontainer({
+          client: getWwwClient(),
+          path: { id: sandboxId },
+          body: { teamSlugOrId, taskRunId },
+        });
+        serverLogger.info(
+          `[create-cloud-workspace] Published forwarded ports for taskRun ${taskRunId}`
+        );
+      } catch (publishError) {
+        serverLogger.warn(
+          `[create-cloud-workspace] Failed to publish forwarded ports for taskRun ${taskRunId} (non-fatal)`,
+          publishError
+        );
+      }
 
       serverLogger.info("[http-api] create-cloud-workspace completed", {
         taskId,

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -2243,7 +2243,10 @@ export function setupSocketHandlers(
           responded = true;
 
           // Spawn Morph instance via www API
-          const { postApiSandboxesStart } = await getWwwOpenApiModule();
+          const {
+            postApiSandboxesStart,
+            postApiSandboxesByIdPublishDevcontainer,
+          } = await getWwwOpenApiModule();
 
           serverLogger.info(
             environmentId
@@ -2319,6 +2322,22 @@ export function setupSocketHandlers(
             id: taskRunId,
             status: "running",
           });
+
+          try {
+            await postApiSandboxesByIdPublishDevcontainer({
+              client: getWwwClient(),
+              path: { id: sandboxId },
+              body: { teamSlugOrId, taskRunId },
+            });
+            serverLogger.info(
+              `[create-cloud-workspace] Published forwarded ports for taskRun ${taskRunId}`
+            );
+          } catch (publishError) {
+            serverLogger.warn(
+              `[create-cloud-workspace] Failed to publish forwarded ports for taskRun ${taskRunId} (non-fatal)`,
+              publishError
+            );
+          }
 
           // Emit vscode-spawned event to the client
           rt.emit("vscode-spawned", {


### PR DESCRIPTION
## Summary
- auto-publish forwarded ports during cloud workspace creation (HTTP and socket flows)
- add a sidebar run action to manually refresh forwarded ports for existing running workspaces
- keep publish failures non-fatal so workspace creation still succeeds

## Why
Cloud workspace sidebar preview/forwarded ports rely on `taskRuns.networking`. In cloud-workspace creation paths this networking was not being published, so preview ports were missing in the task menu.

## Validation
- bun run typecheck (repo root)
- bun run typecheck (apps/client)
- bun run typecheck (apps/server)
