### PR TITLE
chore(snapshot): refresh PVE-LXC templates and IDE deps

### DIFF
--- a/configs/ide-deps.json
+++ b/configs/ide-deps.json
@@ -13,7 +13,7 @@
     {
       "publisher": "ms-vscode",
       "name": "vscode-typescript-next",
-      "version": "6.0.20260227"
+      "version": "6.0.20260302"
     },
     {
       "publisher": "ms-python",
@@ -27,13 +27,13 @@
     }
   ],
   "packages": {
-    "@openai/codex": "0.106.0",
+    "@openai/codex": "0.107.0",
     "@anthropic-ai/claude-code": "2.1.63",
     "@google/gemini-cli": "0.31.0",
     "opencode-ai": "1.2.15",
-    "codebuff": "1.0.622",
+    "codebuff": "1.0.623",
     "@devcontainers/cli": "0.83.3",
-    "@sourcegraph/amp": "0.0.1772294494-g9b3cb4",
+    "@sourcegraph/amp": "0.0.1772516766-g0ea5eb",
     "devsh": "0.1.2"
   }
 }

--- a/packages/shared/src/pve-lxc-snapshots.json
+++ b/packages/shared/src/pve-lxc-snapshots.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-02-28T18:52:26Z",
+  "updatedAt": "2026-03-03T07:48:36Z",
   "presets": [
     {
       "presetId": "4vcpu_8gb_32gb",
@@ -159,6 +159,12 @@
           "snapshotId": "snapshot_ed84f89b",
           "templateVmid": 9096,
           "capturedAt": "2026-02-28T18:52:26Z"
+        },
+        {
+          "version": 68,
+          "snapshotId": "snapshot_d038629a",
+          "templateVmid": 9105,
+          "capturedAt": "2026-03-03T07:40:24Z"
         }
       ]
     },
@@ -295,6 +301,12 @@
           "snapshotId": "snapshot_d661826e",
           "templateVmid": 9093,
           "capturedAt": "2026-02-28T17:49:21Z"
+        },
+        {
+          "version": 52,
+          "snapshotId": "snapshot_f5f9d91a",
+          "templateVmid": 9106,
+          "capturedAt": "2026-03-03T07:48:36Z"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- refresh `configs/ide-deps.json` to latest pinned IDE/tool versions captured during snapshot update
- append new PVE-LXC snapshot manifest entries in `packages/shared/src/pve-lxc-snapshots.json`
  - standard preset: template `9105`, snapshot `snapshot_d038629a`
  - boosted preset: template `9106`, snapshot `snapshot_f5f9d91a`
- update manifest `updatedAt` timestamp

## Why
- carry forward the snapshot rebuild outputs after PR #416 merged
- keep runtime snapshot catalog and dependency pins aligned with newly captured templates

## Validation
- snapshot update workflow completed for both presets
- verified `~/.claude/skills/devsh/SKILL.md` exists on fresh containers from both new templates