### PR TITLE
fix: prevent task detail page crash from agent team queries

### DIFF
--- a/apps/client/src/components/dashboard/AgentTeamPanel.tsx
+++ b/apps/client/src/components/dashboard/AgentTeamPanel.tsx
@@ -23,7 +23,7 @@ interface AgentTeamPanelProps {
   parentRunId: Id<"taskRuns">;
 }
 
-type ChildRun = (typeof api.taskRuns.listChildRuns._returnType)[number];
+type ChildRun = NonNullable<typeof api.taskRuns.listChildRuns._returnType>[number];
 type RunStatus = ChildRun["status"];
 
 const STATUS_CONFIG: Record<
@@ -153,6 +153,8 @@ export function AgentTeamPanel({
   });
 
   const isLoading = status === undefined || children === undefined;
+  // null means parent run not found or unauthorized
+  const isNotFound = status === null || children === null;
 
   const sortedChildren = useMemo(
     () =>
@@ -188,6 +190,11 @@ export function AgentTeamPanel({
 
     return Array.from(links.values());
   }, [sortedChildren]);
+
+  // Parent run not found or unauthorized - hide panel entirely
+  if (isNotFound) {
+    return null;
+  }
 
   if (isLoading) {
     return (

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
@@ -479,7 +479,8 @@ function TaskDetailPage() {
   );
   const shouldRenderAgentTeamPanel =
     Boolean(selectedRunId) &&
-    (selectedRunChildren === undefined || selectedRunChildren.length > 0);
+    selectedRunChildren != null &&
+    selectedRunChildren.length > 0;
 
   // Query for existing linked local workspace (to prevent creating duplicates)
   const linkedLocalWorkspace = useQuery(

--- a/packages/convex/convex/cmux_http.ts
+++ b/packages/convex/convex/cmux_http.ts
@@ -2571,6 +2571,10 @@ async function handleListChildRuns(ctx: ActionCtx, req: Request): Promise<Respon
       parentRunId: runId as Id<"taskRuns">,
     });
 
+    if (children === null) {
+      return jsonResponse({ code: 404, message: "Task run not found" }, 404);
+    }
+
     return jsonResponse({
       children: children.map((c) => ({
         id: c._id,
@@ -2587,9 +2591,6 @@ async function handleListChildRuns(ctx: ActionCtx, req: Request): Promise<Respon
   } catch (err) {
     console.error("[cmux.taskRuns.listChildren] Error:", err);
     const message = err instanceof Error ? err.message : "Failed to list child runs";
-    if (message.includes("not found") || message.includes("unauthorized")) {
-      return jsonResponse({ code: 404, message: "Task run not found" }, 404);
-    }
     return jsonResponse({ code: 500, message }, 500);
   }
 }
@@ -2658,13 +2659,14 @@ async function handleGetChildRunsStatus(ctx: ActionCtx, req: Request): Promise<R
       parentRunId: runId as Id<"taskRuns">,
     });
 
+    if (status === null) {
+      return jsonResponse({ code: 404, message: "Task run not found" }, 404);
+    }
+
     return jsonResponse(status);
   } catch (err) {
     console.error("[cmux.taskRuns.getChildStatus] Error:", err);
     const message = err instanceof Error ? err.message : "Failed to get child status";
-    if (message.includes("not found") || message.includes("unauthorized")) {
-      return jsonResponse({ code: 404, message: "Task run not found" }, 404);
-    }
     return jsonResponse({ code: 500, message }, 500);
   }
 }

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -2651,13 +2651,13 @@ export const listChildRuns = authQuery({
     parentRunId: v.id("taskRuns"),
   },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
 
-    // Verify parent run exists and user has access
+    // Verify parent run exists and belongs to the team.
+    // Returns null (not throw) so React useQuery() doesn't crash the error boundary.
     const parentRun = await ctx.db.get(args.parentRunId);
-    if (!parentRun || parentRun.teamId !== teamId || parentRun.userId !== userId) {
-      throw new Error("Parent task run not found or unauthorized");
+    if (!parentRun || parentRun.teamId !== teamId) {
+      return null;
     }
 
     const children = await ctx.db
@@ -2665,10 +2665,8 @@ export const listChildRuns = authQuery({
       .withIndex("by_parent", (q) => q.eq("parentRunId", args.parentRunId))
       .collect();
 
-    // Filter by team/user access
-    return children.filter(
-      (run) => run.teamId === teamId && run.userId === userId
-    );
+    // Filter by team access (same as getByTask pattern)
+    return children.filter((run) => run.teamId === teamId);
   },
 });
 
@@ -2682,11 +2680,12 @@ export const getParentRun = authQuery({
     runId: v.id("taskRuns"),
   },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
 
+    // Throws for invalid/unauthorized run - safe because this query is only called
+    // from the HTTP handler (cmux_http.ts) which has try/catch for 404 mapping.
     const run = await ctx.db.get(args.runId);
-    if (!run || run.teamId !== teamId || run.userId !== userId) {
+    if (!run || run.teamId !== teamId) {
       throw new Error("Task run not found or unauthorized");
     }
 
@@ -2695,8 +2694,8 @@ export const getParentRun = authQuery({
     }
 
     const parentRun = await ctx.db.get(run.parentRunId);
-    if (!parentRun || parentRun.teamId !== teamId || parentRun.userId !== userId) {
-      return null; // Parent exists but user doesn't have access
+    if (!parentRun || parentRun.teamId !== teamId) {
+      return null; // Parent exists but not accessible
     }
 
     return parentRun;
@@ -2713,13 +2712,13 @@ export const getChildRunsStatus = authQuery({
     parentRunId: v.id("taskRuns"),
   },
   handler: async (ctx, args) => {
-    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
 
-    // Verify parent run exists and user has access
+    // Verify parent run exists and belongs to the team.
+    // Returns null (not throw) so React useQuery() doesn't crash the error boundary.
     const parentRun = await ctx.db.get(args.parentRunId);
-    if (!parentRun || parentRun.teamId !== teamId || parentRun.userId !== userId) {
-      throw new Error("Parent task run not found or unauthorized");
+    if (!parentRun || parentRun.teamId !== teamId) {
+      return null;
     }
 
     const children = await ctx.db
@@ -2727,9 +2726,9 @@ export const getChildRunsStatus = authQuery({
       .withIndex("by_parent", (q) => q.eq("parentRunId", args.parentRunId))
       .collect();
 
-    // Filter by team/user access and count by status
+    // Filter by team access (same as getByTask pattern)
     const accessibleChildren = children.filter(
-      (run) => run.teamId === teamId && run.userId === userId
+      (run) => run.teamId === teamId
     );
 
     const statusCounts: Record<string, number> = {


### PR DESCRIPTION
## Summary
- Task detail pages crash with "Something went wrong" after PRs #419/#420 added agent team queries (`listChildRuns`, `getChildRunsStatus`) that `throw` on not-found/unauthorized parent runs — Convex `useQuery()` propagates these throws into React, triggering the root error boundary
- Queries also enforced `userId` checks stricter than `getByTask` (which only checks `teamId`), causing crashes when viewing team-shared tasks
- `shouldRenderAgentTeamPanel` rendered the panel during loading (`undefined`), firing additional queries prematurely

## Changes
- `listChildRuns` / `getChildRunsStatus`: return `null` instead of throwing for not-found (preserves not-found vs empty distinction)
- `cmux_http.ts`: HTTP handlers map `null` → 404, removing string-matching catch blocks
- `getParentRun`: keeps throw (only called from HTTP handler with try/catch)
- All three queries use team-level access consistent with `getByTask`
- Client: `shouldRenderAgentTeamPanel` uses `!= null` check; `AgentTeamPanel` handles `null` gracefully

## Test plan
- [x] `bun check` passes (lint + typecheck)
- [x] Dev server: task detail page loads without crash
- [x] Dev server: no console errors from agent team queries
- [ ] Production deploy: verify task page at `cmux.karldigi.dev` loads correctly
- [ ] Verify tasks with child runs still show AgentTeamPanel correctly