### PR TITLE
feat: add wait_for_agent MCP tool and update skill docs

### DIFF
--- a/.agents/skills/devsh-orchestrator/SKILL.md
+++ b/.agents/skills/devsh-orchestrator/SKILL.md
@@ -437,27 +437,132 @@ Append-only log of orchestration events.
 
 ## Integration with MCP
 
-When running as a head agent with MCP, you can use these tools programmatically:
+When running as a head agent with MCP, you can use these tools programmatically via the `devsh-memory-mcp` server:
+
+### Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `spawn_agent` | Spawn a sub-agent to work on a task |
+| `get_agent_status` | Get status of a spawned agent by task ID |
+| `list_spawned_agents` | List all agents in current orchestration |
+| `wait_for_agent` | Wait for an agent to reach terminal state |
+| `pull_orchestration_updates` | Sync local PLAN.json with server |
+| `send_message` | Send message to another agent |
+| `get_my_messages` | Get messages addressed to this agent |
+
+### spawn_agent
+
+Spawn a sub-agent to work on a specific task.
 
 ```typescript
-// Example MCP tool calls
-await spawn_agent({
+const result = await spawn_agent({
+  prompt: "Implement user authentication",
   agentName: "claude/haiku-4.5",
-  repo: "owner/repo",
-  prompt: "Fix the bug"
+  repo: "owner/repo",           // optional
+  branch: "main",               // optional
+  dependsOn: ["task_id_1"],     // optional - wait for these tasks first
+  priority: 5                   // optional - 0=highest, 10=lowest
 });
+// Returns: { orchestrationTaskId, taskId, taskRunId, agentName, status }
+```
 
-const status = await get_agent_status({ orchestrationTaskId: "ns7abc123" });
+### get_agent_status
 
-await send_message({
-  to: "ns7abc123",
-  message: "Please also check the edge cases",
-  type: "request"
+Get the current status of a spawned agent.
+
+```typescript
+const status = await get_agent_status({
+  orchestrationTaskId: "ns7abc123"
 });
+// Returns: { status, prompt, result, errorMessage, ... }
+```
 
-// Head agent: pull updates from server
+### list_spawned_agents
+
+List all agents spawned in the current orchestration.
+
+```typescript
+const agents = await list_spawned_agents({
+  status: "running"  // optional filter: pending, running, completed, failed
+});
+// Returns: [{ id, prompt, status, agentName, ... }]
+```
+
+### wait_for_agent
+
+Wait for an agent to complete (blocks until terminal state).
+
+```typescript
+const result = await wait_for_agent({
+  orchestrationTaskId: "ns7abc123",
+  timeout: 300000  // optional - max wait in ms (default: 5 minutes)
+});
+// Returns: { status, result, errorMessage }
+```
+
+### pull_orchestration_updates
+
+Sync local PLAN.json with server state. Call periodically to get latest status.
+
+```typescript
 const updates = await pull_orchestration_updates({
-  orchestrationId: "orch_abc123"
+  orchestrationId: "orch_abc123"  // optional - uses CMUX_ORCHESTRATION_ID env var
+});
+// Returns: { synced, tasks, messages, aggregatedStatus }
+```
+
+### Example: Parallel Task Execution
+
+```typescript
+// Spawn multiple agents in parallel
+const task1 = await spawn_agent({
+  prompt: "Implement auth endpoints",
+  agentName: "claude/sonnet-4.5"
+});
+
+const task2 = await spawn_agent({
+  prompt: "Write database migrations",
+  agentName: "claude/haiku-4.5"
+});
+
+// Wait for both to complete
+const [result1, result2] = await Promise.all([
+  wait_for_agent({ orchestrationTaskId: task1.orchestrationTaskId }),
+  wait_for_agent({ orchestrationTaskId: task2.orchestrationTaskId })
+]);
+
+// Spawn dependent task
+const task3 = await spawn_agent({
+  prompt: "Write integration tests",
+  agentName: "codex/gpt-5.1-codex-mini",
+  dependsOn: [task1.orchestrationTaskId, task2.orchestrationTaskId]
+});
+```
+
+### Example: Sequential Pipeline
+
+```typescript
+// Step 1: Implement feature
+const impl = await spawn_agent({
+  prompt: "Implement user roles feature",
+  agentName: "claude/sonnet-4.5"
+});
+await wait_for_agent({ orchestrationTaskId: impl.orchestrationTaskId });
+
+// Step 2: Write tests (after implementation)
+const tests = await spawn_agent({
+  prompt: "Write tests for user roles",
+  agentName: "codex/gpt-5.1-codex-mini",
+  dependsOn: [impl.orchestrationTaskId]
+});
+await wait_for_agent({ orchestrationTaskId: tests.orchestrationTaskId });
+
+// Step 3: Review
+const review = await spawn_agent({
+  prompt: "Review the implementation and tests",
+  agentName: "claude/opus-4.5",
+  dependsOn: [tests.orchestrationTaskId]
 });
 ```
 

--- a/packages/devsh-memory-mcp/src/index.ts
+++ b/packages/devsh-memory-mcp/src/index.ts
@@ -603,6 +603,24 @@ export function createMemoryMcpServer(config?: Partial<MemoryMcpConfig>) {
         },
       },
       {
+        name: "wait_for_agent",
+        description: "Wait for a spawned sub-agent to reach a terminal state (completed, failed, or cancelled). Polls every 5 seconds until the agent finishes or timeout.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            orchestrationTaskId: {
+              type: "string",
+              description: "The orchestration task ID to wait for",
+            },
+            timeout: {
+              type: "number",
+              description: "Maximum wait time in milliseconds (default: 300000 = 5 minutes)",
+            },
+          },
+          required: ["orchestrationTaskId"],
+        },
+      },
+      {
         name: "list_spawned_agents",
         description: "List all sub-agents spawned by this orchestration. Returns status summary of all tasks.",
         inputSchema: {
@@ -1199,6 +1217,110 @@ export function createMemoryMcpServer(config?: Partial<MemoryMcpConfig>) {
             content: [{
               type: "text",
               text: `Error getting agent status: ${errorMsg}`,
+            }],
+          };
+        }
+      }
+
+      case "wait_for_agent": {
+        const { orchestrationTaskId, timeout = 300000 } = args as {
+          orchestrationTaskId: string;
+          timeout?: number;
+        };
+
+        const jwt = process.env.CMUX_TASK_RUN_JWT;
+        const apiBaseUrl = process.env.CMUX_API_BASE_URL ?? "https://cmux.sh";
+
+        if (!jwt) {
+          return {
+            content: [{
+              type: "text",
+              text: "CMUX_TASK_RUN_JWT environment variable not set. This tool requires JWT authentication.",
+            }],
+          };
+        }
+
+        const startTime = Date.now();
+        const pollInterval = 5000; // 5 seconds
+
+        try {
+          while (Date.now() - startTime < timeout) {
+            const url = `${apiBaseUrl}/api/orchestrate/status/${orchestrationTaskId}`;
+            const response = await fetch(url, {
+              method: "GET",
+              headers: {
+                "X-Task-Run-JWT": jwt,
+                "Content-Type": "application/json",
+              },
+            });
+
+            if (!response.ok) {
+              const errorText = await response.text();
+              return {
+                content: [{
+                  type: "text",
+                  text: `Failed to get agent status: ${response.status} ${errorText}`,
+                }],
+              };
+            }
+
+            const result = await response.json() as {
+              task: {
+                status: string;
+                result?: string;
+                errorMessage?: string;
+                prompt?: string;
+              };
+            };
+
+            const status = result.task.status;
+
+            // Check for terminal states
+            if (status === "completed" || status === "failed" || status === "cancelled") {
+              appendEvent({
+                timestamp: new Date().toISOString(),
+                event: "agent_wait_completed",
+                message: `Agent ${orchestrationTaskId} reached terminal state: ${status}`,
+                taskRunId: orchestrationTaskId,
+                status,
+              });
+
+              return {
+                content: [{
+                  type: "text",
+                  text: JSON.stringify({
+                    orchestrationTaskId,
+                    status,
+                    result: result.task.result ?? null,
+                    errorMessage: result.task.errorMessage ?? null,
+                    waitDuration: Date.now() - startTime,
+                  }, null, 2),
+                }],
+              };
+            }
+
+            // Wait before next poll
+            await new Promise((resolve) => setTimeout(resolve, pollInterval));
+          }
+
+          // Timeout reached
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                orchestrationTaskId,
+                status: "timeout",
+                message: `Timed out waiting for agent after ${timeout}ms`,
+                waitDuration: Date.now() - startTime,
+              }, null, 2),
+            }],
+          };
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{
+              type: "text",
+              text: `Error waiting for agent: ${errorMsg}`,
             }],
           };
         }


### PR DESCRIPTION
## Summary
- Add `wait_for_agent` MCP tool for blocking wait on sub-agent completion
- Update devsh-orchestrator skill documentation with comprehensive MCP examples

## wait_for_agent Tool
- Polls agent status every 5 seconds until terminal state
- Configurable timeout (default 5 minutes)
- Returns: status, result, errorMessage, waitDuration

## Skill Documentation Updates
- Added MCP tools table
- Added detailed examples for each tool
- Added parallel execution pattern example
- Added sequential pipeline pattern example

## Test plan
- [ ] Call wait_for_agent on running task, verify it blocks
- [ ] Verify returns when task completes
- [ ] Verify timeout behavior when task never completes