### PR TITLE
chore: bump devsh-memory-mcp to v0.2.0 with orchestration tools

### DIFF
--- a/packages/devsh-memory-mcp/README.md
+++ b/packages/devsh-memory-mcp/README.md
@@ -1,6 +1,6 @@
 # devsh-memory-mcp
 
-MCP server for devsh/cmux agent memory - enables Claude Desktop, Cursor, and other MCP clients to access sandbox agent memory.
+MCP server for devsh/cmux agent memory - enables Claude Desktop, Cursor, and other MCP clients to access sandbox agent memory and orchestrate multi-agent workflows.
 
 ## Installation
 
@@ -81,13 +81,28 @@ With custom options:
 | `add_task` | Add a new task to TASKS.json |
 | `update_task` | Update the status of a task |
 
-### Orchestration Tools
+### Orchestration Tools (Head Agent)
 
 | Tool | Description |
 |------|-------------|
+| `spawn_agent` | Spawn a sub-agent to work on a task |
+| `get_agent_status` | Get status of a spawned agent |
+| `list_spawned_agents` | List all agents in current orchestration |
+| `wait_for_agent` | Wait for agent to complete (blocking) |
+| `cancel_agent` | Cancel a running/pending agent |
+| `get_orchestration_summary` | Get dashboard-style orchestration summary |
+| `pull_orchestration_updates` | Sync local PLAN.json with server |
 | `read_orchestration` | Read PLAN.json, AGENTS.json, or EVENTS.jsonl |
 | `append_event` | Append an orchestration event to EVENTS.jsonl |
 | `update_plan_task` | Update task status in PLAN.json |
+
+### Environment Variables (Orchestration)
+
+| Variable | Description |
+|----------|-------------|
+| `CMUX_TASK_RUN_JWT` | JWT for authenticating orchestration API calls |
+| `CMUX_ORCHESTRATION_ID` | Current orchestration session ID |
+| `CMUX_API_BASE_URL` | API base URL (default: https://cmux.sh) |
 
 ## Memory Directory Structure
 

--- a/packages/devsh-memory-mcp/package.json
+++ b/packages/devsh-memory-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devsh-memory-mcp",
-  "version": "0.1.1",
-  "description": "MCP server for devsh/cmux agent memory - enables Claude Desktop and external clients to access sandbox memory",
+  "version": "0.2.0",
+  "description": "MCP server for devsh/cmux agent memory - enables Claude Desktop and external clients to access sandbox memory and orchestrate multi-agent workflows",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -33,6 +33,8 @@
     "claude",
     "memory",
     "agent",
+    "orchestration",
+    "multi-agent",
     "model-context-protocol",
     "claude-desktop"
   ],


### PR DESCRIPTION
## Summary
Version bump and documentation update for devsh-memory-mcp npm package.

## Changes
- Version: 0.1.1 -> 0.2.0
- README: Added all orchestration tools documentation
- Keywords: Added orchestration, multi-agent
- Env vars: Documented CMUX_TASK_RUN_JWT, CMUX_ORCHESTRATION_ID, CMUX_API_BASE_URL

## Milestone
devsh prod can now run parallel task progress via MCP tools:
- `spawn_agent` - Spawn sub-agents
- `wait_for_agent` - Block until completion
- `cancel_agent` - Cancel with cascade
- `get_orchestration_summary` - Dashboard view
- `pull_orchestration_updates` - Bi-directional sync

## Test plan
- [ ] npm publish (after merge)
- [ ] Test npx devsh-memory-mcp with orchestration env vars