### PR TITLE
ci: add GitHub Actions workflow for devsh-memory-mcp npm publish

### DIFF
--- a/.github/workflows/publish-devsh-memory-mcp.yml
+++ b/.github/workflows/publish-devsh-memory-mcp.yml
@@ -1,0 +1,32 @@
+name: Publish devsh-memory-mcp
+
+on:
+  push:
+    tags:
+      - 'devsh-memory-mcp@*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/devsh-memory-mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Add automated npm publish workflow for devsh-memory-mcp package.

## Trigger
Push tags matching `devsh-memory-mcp@*` (e.g., `devsh-memory-mcp@0.2.0`)

## Usage
```bash
git tag devsh-memory-mcp@0.2.0
git push origin devsh-memory-mcp@0.2.0
```

## Requirements
- Add `NPM_TOKEN` secret to repository settings

## Test plan
- [ ] Merge this PR
- [ ] Add NPM_TOKEN secret
- [ ] Tag and push: `git tag devsh-memory-mcp@0.2.0 && git push origin devsh-memory-mcp@0.2.0`
- [ ] Verify package published at npmjs.com/package/devsh-memory-mcp