### PR TITLE
fix: add reset keys to ErrorBoundary components

### DIFF
--- a/apps/client/src/components/TaskRunSummaryPanel.tsx
+++ b/apps/client/src/components/TaskRunSummaryPanel.tsx
@@ -132,8 +132,10 @@ function TaskRunSummaryPanelContent({
 }
 
 export function TaskRunSummaryPanel(props: TaskRunSummaryPanelProps) {
+  // Key the ErrorBoundary by task/run ID so it resets when context changes
+  const resetKey = `${props.task?._id ?? "no-task"}-${props.selectedRun?._id ?? "no-run"}`;
   return (
-    <ErrorBoundary fallback={<TaskRunSummaryPanelErrorFallback />}>
+    <ErrorBoundary key={resetKey} fallback={<TaskRunSummaryPanelErrorFallback />}>
       <TaskRunSummaryPanelContent {...props} />
     </ErrorBoundary>
   );

--- a/apps/client/src/components/task-detail-header.tsx
+++ b/apps/client/src/components/task-detail-header.tsx
@@ -805,8 +805,10 @@ function TaskDetailHeaderErrorFallback() {
 }
 
 export function TaskDetailHeader(props: TaskDetailHeaderProps) {
+  // Key the ErrorBoundary by task/run ID so it resets when context changes
+  const resetKey = `${props.task?._id ?? "no-task"}-${props.selectedRun?._id ?? "no-run"}`;
   return (
-    <ErrorBoundary fallback={<TaskDetailHeaderErrorFallback />}>
+    <ErrorBoundary key={resetKey} fallback={<TaskDetailHeaderErrorFallback />}>
       <TaskDetailHeaderContent {...props} />
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary
Fix ErrorBoundary components that stay in fallback state permanently.

## Issue (from Codex review)
ErrorBoundary without reset keys stays in fallback after a single render error,
even when selecting different task/run contexts.

## Fix
Key ErrorBoundary by `task._id + selectedRun._id` so it resets on context change:
- `TaskRunSummaryPanel.tsx` - line 137
- `task-detail-header.tsx` - line 809

## Test plan
- [ ] Trigger error in summary panel, navigate to different run, verify recovery
- [ ] Trigger error in header, navigate to different task, verify recovery