### PR TITLE
feat: add cross-tool symlinks for shared AGENTS.md instructions

### DIFF
--- a/packages/shared/src/agent-memory-protocol.ts
+++ b/packages/shared/src/agent-memory-protocol.ts
@@ -526,6 +526,25 @@ export function getMemoryStartupCommand(): string {
 }
 
 /**
+ * Get startup commands to create cross-tool instruction symlinks.
+ *
+ * Master file: ~/.claude/CLAUDE.md (created by Claude environment)
+ * Symlinks:
+ *   - ~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md (for Codex CLI)
+ *   - ~/.gemini/GEMINI.md -> ~/.claude/CLAUDE.md (for Gemini CLI)
+ *
+ * This enables all tools to share the same instructions without polluting
+ * the git repository. Each tool reads from its native user-level path.
+ */
+export function getCrossToolSymlinkCommands(): string[] {
+  return [
+    "mkdir -p ~/.codex ~/.gemini",
+    "[ -f ~/.claude/CLAUDE.md ] && ln -sf ~/.claude/CLAUDE.md ~/.codex/AGENTS.md || true",
+    "[ -f ~/.claude/CLAUDE.md ] && ln -sf ~/.claude/CLAUDE.md ~/.gemini/GEMINI.md || true",
+  ];
+}
+
+/**
  * Generate the memory sync bash script that reads memory files and POSTs them to Convex.
  * This script is called by provider stop hooks before crown/complete.
  *

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -11,6 +11,7 @@ import {
   getMemorySeedFiles,
   getMemoryProtocolInstructions,
   getProjectContextFile,
+  getCrossToolSymlinkCommands,
 } from "../../agent-memory-protocol";
 
 export const CLAUDE_KEY_ENV_VARS_TO_UNSET = [
@@ -365,6 +366,11 @@ ${getMemoryProtocolInstructions()}
     contentBase64: Buffer.from(claudeMdContent).toString("base64"),
     mode: "644",
   });
+
+  // Create cross-tool symlinks for shared instructions
+  // This allows Codex and Gemini to read the same CLAUDE.md via symlinks
+  // at their native user-level paths (~/.codex/AGENTS.md, ~/.gemini/GEMINI.md)
+  startupCommands.push(...getCrossToolSymlinkCommands());
 
   return {
     files,

--- a/packages/shared/src/providers/gemini/environment.ts
+++ b/packages/shared/src/providers/gemini/environment.ts
@@ -8,6 +8,7 @@ import {
   getMemorySeedFiles,
   getMemoryProtocolInstructions,
   getProjectContextFile,
+  getCrossToolSymlinkCommands,
 } from "../../agent-memory-protocol";
 
 type GeminiModelSettings = {
@@ -206,6 +207,11 @@ export async function getGeminiEnvironment(
   startupCommands.push(getMemoryStartupCommand());
   files.push(...getMemorySeedFiles(ctx.taskRunId, ctx.previousKnowledge, ctx.previousMailbox, ctx.orchestrationOptions));
 
+  // Create cross-tool symlinks for shared instructions
+  // If Claude's CLAUDE.md exists, link it to ~/.gemini/GEMINI.md
+  // This allows all tools to share the same instructions at user-level paths
+  startupCommands.push(...getCrossToolSymlinkCommands());
+
   // Inject GitHub Projects context if task is linked to a project item (Phase 5)
   if (ctx.githubProjectContext) {
     files.push(
@@ -217,13 +223,16 @@ export async function getGeminiEnvironment(
     );
   }
 
-  // Add GEMINI.md with memory protocol instructions for the project
+  // Add GEMINI.md with memory protocol instructions as fallback
+  // This is created at user-level ~/.gemini/GEMINI.md (not in workspace)
+  // If Claude's CLAUDE.md exists, the symlink from getCrossToolSymlinkCommands()
+  // will override this file, ensuring all tools share the same instructions
   const geminiMdContent = `# cmux Project Instructions
 
 ${getMemoryProtocolInstructions()}
 `;
   files.push({
-    destinationPath: "/root/workspace/GEMINI.md",
+    destinationPath: "$HOME/.gemini/GEMINI.md",
     contentBase64: Buffer.from(geminiMdContent).toString("base64"),
     mode: "644",
   });

--- a/packages/shared/src/providers/openai/environment.ts
+++ b/packages/shared/src/providers/openai/environment.ts
@@ -7,6 +7,7 @@ import {
   getMemorySeedFiles,
   getMemoryProtocolInstructions,
   getProjectContextFile,
+  getCrossToolSymlinkCommands,
 } from "../../agent-memory-protocol";
 
 /**
@@ -287,6 +288,11 @@ touch /root/lifecycle/codex-done.txt /root/lifecycle/done.txt
   // Add agent memory protocol support
   startupCommands.push(getMemoryStartupCommand());
   files.push(...getMemorySeedFiles(ctx.taskRunId, ctx.previousKnowledge, ctx.previousMailbox, ctx.orchestrationOptions));
+
+  // Create cross-tool symlinks for shared instructions
+  // If Claude's CLAUDE.md exists, link it to ~/.codex/AGENTS.md
+  // This allows all tools to share the same instructions
+  startupCommands.push(...getCrossToolSymlinkCommands());
 
   // Inject GitHub Projects context if task is linked to a project item (Phase 5)
   if (ctx.githubProjectContext) {


### PR DESCRIPTION
## Summary
- Add `getCrossToolSymlinkCommands()` helper to create symlinks at user-level paths
- Enable Claude, Codex, and Gemini to share instructions via `~/.claude/CLAUDE.md`
- Move Gemini's GEMINI.md from workspace to user-level `~/.gemini/GEMINI.md`

## Symlinks Created
```
~/.codex/AGENTS.md -> ~/.claude/CLAUDE.md
~/.gemini/GEMINI.md -> ~/.claude/CLAUDE.md
```

## Test plan
- [ ] Spawn Claude agent, verify `~/.claude/CLAUDE.md` exists
- [ ] Verify `ls -la ~/.codex/` shows AGENTS.md symlink
- [ ] Verify `ls -la ~/.gemini/` shows GEMINI.md symlink
- [ ] Spawn Codex agent, verify it reads `~/.codex/AGENTS.md`
- [ ] Spawn Gemini agent, verify it reads `~/.gemini/GEMINI.md`