### PR TITLE
feat: unhide notification bell in sidebar

### DIFF
--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -85,7 +85,6 @@ const navItems: SidebarNavItemWithBadge[] = [
     exact: true,
     icon: Bell,
     showBadge: true,
-    hidden: true,
   },
   {
     label: "Environments",


### PR DESCRIPTION
## Summary
- Removes `hidden: true` from the Notifications nav item in Sidebar.tsx
- The entire notifications feature is already built (Convex tables, queries/mutations, HTTP endpoints, frontend page, bell badge component) but the sidebar entry was hidden

## What becomes visible
- Bell icon in sidebar with unread count badge
- Links to `/$teamSlugOrId/notifications` page (already fully implemented)
- Unread indicators on individual tasks in sidebar

## Test plan
- [x] `bun check` passes
- [ ] Manual: verify bell appears in sidebar with unread count
- [ ] Manual: click bell -> notifications page loads with task completion history