### PR TITLE
feat: add --status and --no-linked-task flags to devsh project items

### DIFF
--- a/packages/convex/convex/cmux_http.ts
+++ b/packages/convex/convex/cmux_http.ts
@@ -1900,6 +1900,7 @@ export const listTasks = httpAction(async (ctx, req) => {
           exitCode: selectedRun?.exitCode,
           pullRequestUrl: selectedRun?.pullRequestUrl,
           mergeStatus: task.mergeStatus,
+          githubProjectItemId: task.githubProjectItemId,
         };
       })
     );

--- a/packages/devsh/internal/cli/project_items.go
+++ b/packages/devsh/internal/cli/project_items.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/karlorz/devsh/internal/auth"
@@ -16,6 +17,8 @@ var (
 	projectItemsInstallationID int
 	projectItemsFirst          int
 	projectItemsAfter          string
+	projectItemsStatus         string
+	projectItemsNoLinkedTask   bool
 )
 
 var projectItemsCmd = &cobra.Command{
@@ -26,6 +29,8 @@ var projectItemsCmd = &cobra.Command{
 Examples:
   devsh project items --project-id PVT_xxx --installation-id 12345
   devsh project items --project-id PVT_xxx --installation-id 12345 --first 20
+  devsh project items --project-id PVT_xxx --installation-id 12345 --status "Backlog"
+  devsh project items --project-id PVT_xxx --installation-id 12345 --no-linked-task
   devsh project items --project-id PVT_xxx --installation-id 12345 --json`,
 	RunE: runProjectItems,
 }
@@ -62,13 +67,65 @@ func runProjectItems(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get project items: %w", err)
 	}
 
+	// Build set of linked project item IDs if --no-linked-task is set
+	var linkedItemIds map[string]bool
+	if projectItemsNoLinkedTask {
+		linkedItemIds = make(map[string]bool)
+		// Fetch tasks to get their githubProjectItemId values
+		tasksResult, err := client.ListTasks(ctx, false)
+		if err != nil {
+			return fmt.Errorf("failed to list tasks for linked-task filter: %w", err)
+		}
+		for _, task := range tasksResult.Tasks {
+			if task.GithubProjectItemId != "" {
+				linkedItemIds[task.GithubProjectItemId] = true
+			}
+		}
+	}
+
+	// Apply filters
+	var filteredItems []vm.ProjectItem
+	for _, item := range result.Items {
+		// --status filter: case-insensitive match on Status field
+		if projectItemsStatus != "" {
+			itemStatus := ""
+			if sv, ok := item.FieldValues["Status"]; ok {
+				if s, ok := sv.(string); ok {
+					itemStatus = s
+				}
+			}
+			if !strings.EqualFold(itemStatus, projectItemsStatus) {
+				continue
+			}
+		}
+
+		// --no-linked-task filter: exclude items that have a linked cmux task
+		if projectItemsNoLinkedTask && linkedItemIds[item.ID] {
+			continue
+		}
+
+		filteredItems = append(filteredItems, item)
+	}
+
+	// For JSON output, return filtered items
 	if flagJSON {
-		data, _ := json.MarshalIndent(result, "", "  ")
+		output := struct {
+			Items    []vm.ProjectItem `json:"items"`
+			PageInfo struct {
+				HasNextPage bool    `json:"hasNextPage"`
+				EndCursor   *string `json:"endCursor"`
+			} `json:"pageInfo"`
+		}{
+			Items: filteredItems,
+		}
+		output.PageInfo.HasNextPage = result.PageInfo.HasNextPage
+		output.PageInfo.EndCursor = result.PageInfo.EndCursor
+		data, _ := json.MarshalIndent(output, "", "  ")
 		fmt.Println(string(data))
 		return nil
 	}
 
-	if len(result.Items) == 0 {
+	if len(filteredItems) == 0 {
 		fmt.Println("No items found.")
 		return nil
 	}
@@ -76,7 +133,7 @@ func runProjectItems(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%-28s %-10s %-60s %-14s %s\n", "ID", "TYPE", "TITLE", "STATUS", "URL")
 	fmt.Println("----------------------------", "----------", "------------------------------------------------------------", "--------------", "------------------------------------------------------------")
 
-	for _, item := range result.Items {
+	for _, item := range filteredItems {
 		itemType := "Draft"
 		title := "(untitled)"
 		url := "-"
@@ -149,5 +206,7 @@ func init() {
 	projectItemsCmd.Flags().IntVar(&projectItemsInstallationID, "installation-id", 0, "GitHub App installation ID (required)")
 	projectItemsCmd.Flags().IntVar(&projectItemsFirst, "first", 50, "Number of items to fetch (default 50)")
 	projectItemsCmd.Flags().StringVar(&projectItemsAfter, "after", "", "Pagination cursor")
+	projectItemsCmd.Flags().StringVar(&projectItemsStatus, "status", "", "Filter by status field (e.g., Backlog, In Progress, Done)")
+	projectItemsCmd.Flags().BoolVar(&projectItemsNoLinkedTask, "no-linked-task", false, "Exclude items that already have a linked cmux task")
 	projectCmd.AddCommand(projectItemsCmd)
 }

--- a/packages/devsh/internal/vm/client.go
+++ b/packages/devsh/internal/vm/client.go
@@ -729,21 +729,22 @@ func (c *Client) SwitchTeam(ctx context.Context, teamSlugOrId string) (*SwitchTe
 
 // Task represents a task from the web app
 type Task struct {
-	ID             string `json:"id"`
-	Prompt         string `json:"prompt"`
-	Repository     string `json:"repository"`
-	BaseBranch     string `json:"baseBranch"`
-	Status         string `json:"status"`
-	Agent          string `json:"agent"`
-	VSCodeURL      string `json:"vscodeUrl"`
-	IsCompleted    bool   `json:"isCompleted"`
-	IsArchived     bool   `json:"isArchived"`
-	CreatedAt      int64  `json:"createdAt"`
-	UpdatedAt      int64  `json:"updatedAt"`
-	TaskRunID      string `json:"taskRunId"`
-	ExitCode       *int   `json:"exitCode,omitempty"`
-	PullRequestURL string `json:"pullRequestUrl,omitempty"`
-	MergeStatus    string `json:"mergeStatus,omitempty"`
+	ID                  string `json:"id"`
+	Prompt              string `json:"prompt"`
+	Repository          string `json:"repository"`
+	BaseBranch          string `json:"baseBranch"`
+	Status              string `json:"status"`
+	Agent               string `json:"agent"`
+	VSCodeURL           string `json:"vscodeUrl"`
+	IsCompleted         bool   `json:"isCompleted"`
+	IsArchived          bool   `json:"isArchived"`
+	CreatedAt           int64  `json:"createdAt"`
+	UpdatedAt           int64  `json:"updatedAt"`
+	TaskRunID           string `json:"taskRunId"`
+	ExitCode            *int   `json:"exitCode,omitempty"`
+	PullRequestURL      string `json:"pullRequestUrl,omitempty"`
+	MergeStatus         string `json:"mergeStatus,omitempty"`
+	GithubProjectItemId string `json:"githubProjectItemId,omitempty"`
 }
 
 // TaskRun represents a run within a task


### PR DESCRIPTION
## Summary
Add filtering flags to `devsh project items` command for head agent discovery:
- `--status` - Filter by project item status (Backlog, In Progress, Done)
- `--no-linked-task` - Exclude items that already have a linked cmux task

These enable the head agent to discover unassigned work items from GitHub Projects.

## Test plan
- [ ] `devsh project items --status Backlog` filters correctly
- [ ] `devsh project items --no-linked-task` excludes linked items