### PR TITLE
[Crown] ### Summary

  Build a repeatable investigation and validatio...

### DIFF
--- a/.github/workflows/pve-lxc-snapshot.yml
+++ b/.github/workflows/pve-lxc-snapshot.yml
@@ -79,6 +79,7 @@ jobs:
             echo "Attempt $attempt of $max_attempts"
             if uv run ./scripts/snapshot-pvelxc.py \
               --template-vmid "$TEMPLATE_VMID" \
+              --results-json "logs/pve-lxc-snapshot/results.json" \
               --standard-vcpus "$STANDARD_VCPUS" \
               --standard-memory "$STANDARD_MEMORY" \
               --standard-disk-size "$STANDARD_DISK_SIZE" \
@@ -98,6 +99,30 @@ jobs:
           done
           echo "All $max_attempts attempts failed"
           exit 1
+
+      - name: Build devsh (for runtime validation)
+        run: |
+          make install-devsh-dev
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Runtime smoke test (new snapshots)
+        env:
+          PVE_API_URL: ${{ secrets.PVE_API_URL }}
+          PVE_API_TOKEN: ${{ secrets.PVE_API_TOKEN }}
+          PVE_PUBLIC_DOMAIN: ${{ secrets.PVE_PUBLIC_DOMAIN }}
+          PVE_NODE: ${{ secrets.PVE_NODE }}
+        run: |
+          ./scripts/pve/pve-lxc-snapshot-runtime-smoke.sh logs/pve-lxc-snapshot/results.json
+
+      - name: Upload diagnostics (networkd)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pve-lxc-networkd-diag
+          path: |
+            logs/pve-lxc-snapshot/results.json
+            logs/pve-lxc-networkd/*.txt
+          if-no-files-found: warn
 
       - name: Check for changes
         id: changes

--- a/scripts/pve/README.md
+++ b/scripts/pve/README.md
@@ -243,6 +243,43 @@ systemctl status caddy-cmux
 curl -v https://port-39378-pvelxc-abc123.example.com
 ```
 
+### Snapshot Runtime Validation (systemd-networkd DHCP)
+
+The snapshot build pipeline enforces DHCP hostname + DNS behavior via a systemd-networkd drop-in:
+
+- `SendHostname=yes`
+- `UseDNS=no`
+
+Quick triage on a running sandbox:
+
+```bash
+./scripts/pve/pve-lxc-networkd-verify.sh pvelxc-abc123
+./scripts/pve/pve-lxc-networkd-diag.sh pvelxc-abc123
+```
+
+Build + validate a new snapshot locally (requires PVE credentials):
+
+```bash
+uv run --env-file .env ./scripts/snapshot-pvelxc.py --template-vmid 9000 --results-json logs/pve-lxc-snapshot/results.json
+make install-devsh-dev
+export PATH="$HOME/.local/bin:$PATH"
+./scripts/pve/pve-lxc-snapshot-runtime-smoke.sh logs/pve-lxc-snapshot/results.json
+```
+
+Artifacts are saved under `logs/pve-lxc-networkd/` with timestamped filenames for diffing:
+
+- `diag.build-pre-template.*` (captured before template conversion)
+- `diag.runtime.*` (captured from a sandbox started from the new snapshot ID)
+
+Rollback/disable strategy (inside a container):
+
+1. Identify the active network file:
+   - `networkctl status eth0`
+2. Remove the cmux drop-in:
+   - `rm -f /etc/systemd/network/<basename>.network.d/99-cmux-dhcp.conf`
+3. Restart networkd:
+   - `systemctl restart systemd-networkd`
+
 ### Common Errors
 
 - **401 Unauthorized**: Check API token format and permissions

--- a/scripts/pve/pve-lxc-networkd-diag-inner.sh
+++ b/scripts/pve/pve-lxc-networkd-diag-inner.sh
@@ -1,0 +1,74 @@
+set -euo pipefail
+
+iface="${CMUX_NET_IFACE:-eth0}"
+
+echo "=== CMUX PVE-LXC systemd-networkd diagnostics ==="
+echo "timestamp: $(date -Is 2>/dev/null || date)"
+echo "iface: ${iface}"
+echo ""
+
+echo "=== /etc/systemd/network/eth0.network ==="
+if [ -f /etc/systemd/network/eth0.network ]; then
+  sed -n '1,200p' /etc/systemd/network/eth0.network
+else
+  echo "(missing)"
+fi
+echo ""
+
+echo "=== /etc/systemd/network (tree) ==="
+ls -la /etc/systemd/network 2>/dev/null || true
+find /etc/systemd/network -maxdepth 2 -type f -print 2>/dev/null | sort || true
+echo ""
+
+echo "=== networkctl status ${iface} ==="
+networkctl status "${iface}" --no-pager 2>/dev/null || true
+echo ""
+
+net_file="$(
+  networkctl status "${iface}" --no-pager 2>/dev/null \
+    | awk -F': ' '/Network File/ {print $2; exit}' \
+    | tr -d '\r'
+)"
+if [ -n "${net_file}" ]; then
+  echo "network_file: ${net_file}"
+else
+  echo "network_file: (not detected)"
+fi
+echo ""
+
+if [ -n "${net_file}" ]; then
+  base="$(basename "${net_file}")"
+  drop_file="/etc/systemd/network/${base}.d/99-cmux-dhcp.conf"
+  echo "=== expected drop-in (${drop_file}) ==="
+  if [ -f "${drop_file}" ]; then
+    sed -n '1,200p' "${drop_file}"
+  else
+    echo "(missing)"
+  fi
+  echo ""
+fi
+
+echo "=== systemd-analyze cat-config systemd/network ==="
+if command -v systemd-analyze >/dev/null 2>&1; then
+  SYSTEMD_PAGER=cat systemd-analyze cat-config systemd/network 2>/dev/null || true
+else
+  echo "(systemd-analyze not found)"
+fi
+echo ""
+
+if [ -n "${net_file}" ] && command -v systemd-analyze >/dev/null 2>&1; then
+  echo "=== systemd-analyze cat-config ${net_file} ==="
+  SYSTEMD_PAGER=cat systemd-analyze cat-config "${net_file}" 2>/dev/null || true
+  echo ""
+fi
+
+echo "=== /etc/resolv.conf ==="
+if [ -f /etc/resolv.conf ]; then
+  sed -n '1,200p' /etc/resolv.conf
+else
+  echo "(missing)"
+fi
+echo ""
+
+echo "=== journalctl -u systemd-networkd -n 200 ==="
+journalctl -u systemd-networkd --no-pager -n 200 2>/dev/null || true

--- a/scripts/pve/pve-lxc-networkd-diag.sh
+++ b/scripts/pve/pve-lxc-networkd-diag.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+id="${1:-}"
+out="${2:-}"
+
+if [[ -z "${id}" ]]; then
+  echo "Usage: $0 <instance-id> [output-file]" >&2
+  exit 2
+fi
+
+if ! command -v devsh >/dev/null 2>&1; then
+  echo "ERROR: devsh not found on PATH" >&2
+  exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+inner_path="${script_dir}/pve-lxc-networkd-diag-inner.sh"
+
+if [[ ! -f "${inner_path}" ]]; then
+  echo "ERROR: missing inner script: ${inner_path}" >&2
+  exit 2
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+if [[ -z "${out}" ]]; then
+  out="logs/pve-lxc-networkd/diag.runtime.${id}.${timestamp}.txt"
+fi
+
+mkdir -p "$(dirname -- "${out}")"
+
+inner="$(cat "${inner_path}")"
+remote_cmd="$(cat <<EOF
+set -euo pipefail
+tmp="/tmp/cmux-networkd-diag.sh"
+cat >"\${tmp}" <<'CMUX_NETWORKD_DIAG_EOF'
+${inner}
+CMUX_NETWORKD_DIAG_EOF
+set +e
+/bin/bash "\${tmp}"
+rc=\$?
+set -e
+rm -f "\${tmp}" || true
+exit "\${rc}"
+EOF
+)"
+
+set +e
+output="$(devsh exec "${id}" "${remote_cmd}" 2>&1)"
+rc=$?
+set -e
+
+printf '%s\n' "${output}" > "${out}"
+
+if [[ $rc -ne 0 ]]; then
+  echo "ERROR: diagnostics failed for ${id} (exit ${rc})" >&2
+  echo "Saved: ${out}" >&2
+  exit "${rc}"
+fi
+
+echo "Saved: ${out}"

--- a/scripts/pve/pve-lxc-networkd-verify-inner.sh
+++ b/scripts/pve/pve-lxc-networkd-verify-inner.sh
@@ -1,0 +1,61 @@
+set -euo pipefail
+
+iface="${CMUX_NET_IFACE:-eth0}"
+
+net_file="$(
+  networkctl status "${iface}" --no-pager 2>/dev/null \
+    | awk -F': ' '/Network File/ {print $2; exit}' \
+    | tr -d '\r'
+)"
+if [ -z "${net_file}" ]; then
+  echo "FAIL: could not determine Network File for ${iface}" >&2
+  networkctl status "${iface}" --no-pager 2>/dev/null || true
+  exit 1
+fi
+
+base="$(basename "${net_file}")"
+drop_file="/etc/systemd/network/${base}.d/99-cmux-dhcp.conf"
+if [ ! -f "${drop_file}" ]; then
+  echo "FAIL: expected networkd drop-in missing: ${drop_file}" >&2
+  echo "Base network file: ${net_file}" >&2
+  ls -la "/etc/systemd/network/${base}.d" 2>/dev/null || true
+  exit 1
+fi
+
+if ! grep -Eiq '^SendHostname[[:space:]]*=[[:space:]]*yes[[:space:]]*$' "${drop_file}"; then
+  echo "FAIL: drop-in does not contain SendHostname=yes: ${drop_file}" >&2
+  sed -n '1,200p' "${drop_file}" >&2 || true
+  exit 1
+fi
+if ! grep -Eiq '^UseDNS[[:space:]]*=[[:space:]]*no[[:space:]]*$' "${drop_file}"; then
+  echo "FAIL: drop-in does not contain UseDNS=no: ${drop_file}" >&2
+  sed -n '1,200p' "${drop_file}" >&2 || true
+  exit 1
+fi
+
+if ! command -v systemd-analyze >/dev/null 2>&1; then
+  echo "FAIL: systemd-analyze not found" >&2
+  exit 1
+fi
+
+cfg="$(SYSTEMD_PAGER=cat systemd-analyze cat-config "${net_file}" 2>/dev/null || true)"
+if [ -z "${cfg}" ]; then
+  echo "FAIL: systemd-analyze cat-config produced no output for ${net_file}" >&2
+  exit 1
+fi
+
+if ! echo "${cfg}" | grep -Eiq 'SendHostname[[:space:]]*=[[:space:]]*yes'; then
+  echo "FAIL: SendHostname=yes missing from effective config (${net_file})" >&2
+  echo "--- cat-config (${net_file}) ---" >&2
+  echo "${cfg}" >&2
+  exit 1
+fi
+
+if ! echo "${cfg}" | grep -Eiq 'UseDNS[[:space:]]*=[[:space:]]*no'; then
+  echo "FAIL: UseDNS=no missing from effective config (${net_file})" >&2
+  echo "--- cat-config (${net_file}) ---" >&2
+  echo "${cfg}" >&2
+  exit 1
+fi
+
+echo "PASS: networkd DHCP config ok (${iface} via ${net_file})"

--- a/scripts/pve/pve-lxc-networkd-verify.sh
+++ b/scripts/pve/pve-lxc-networkd-verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+id="${1:-}"
+
+if [[ -z "${id}" ]]; then
+  echo "Usage: $0 <instance-id>" >&2
+  exit 2
+fi
+
+if ! command -v devsh >/dev/null 2>&1; then
+  echo "ERROR: devsh not found on PATH" >&2
+  exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+inner_path="${script_dir}/pve-lxc-networkd-verify-inner.sh"
+
+if [[ ! -f "${inner_path}" ]]; then
+  echo "ERROR: missing inner script: ${inner_path}" >&2
+  exit 2
+fi
+
+inner="$(cat "${inner_path}")"
+remote_cmd="$(cat <<EOF
+set -euo pipefail
+tmp="/tmp/cmux-networkd-verify.sh"
+cat >"\${tmp}" <<'CMUX_NETWORKD_VERIFY_EOF'
+${inner}
+CMUX_NETWORKD_VERIFY_EOF
+set +e
+/bin/bash "\${tmp}"
+rc=\$?
+set -e
+rm -f "\${tmp}" || true
+exit "\${rc}"
+EOF
+)"
+
+devsh exec "${id}" "${remote_cmd}"

--- a/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+results_json="${1:-}"
+
+if [[ -z "${results_json}" ]]; then
+  echo "Usage: $0 <results-json>" >&2
+  echo "Example: $0 logs/pve-lxc-snapshot/results.json" >&2
+  exit 2
+fi
+
+if [[ ! -f "${results_json}" ]]; then
+  echo "ERROR: results json not found: ${results_json}" >&2
+  exit 2
+fi
+
+if ! command -v devsh >/dev/null 2>&1; then
+  echo "ERROR: devsh not found on PATH" >&2
+  exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+verify="${script_dir}/pve-lxc-networkd-verify.sh"
+diag="${script_dir}/pve-lxc-networkd-diag.sh"
+
+if [[ ! -x "${verify}" ]]; then
+  echo "ERROR: missing verify script: ${verify}" >&2
+  exit 2
+fi
+if [[ ! -x "${diag}" ]]; then
+  echo "ERROR: missing diag script: ${diag}" >&2
+  exit 2
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+log_dir="logs/pve-lxc-networkd"
+mkdir -p "${log_dir}"
+
+readarray -t snapshot_lines < <(
+  python3 - <<'PY'
+import json
+import sys
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+results = data.get("results") or []
+for r in results:
+    preset = (r.get("presetId") or r.get("preset_id") or "unknown").strip()
+    snap = (r.get("snapshotId") or r.get("snapshot_id") or "").strip()
+    if not snap:
+        continue
+    print(f"{preset}\t{snap}")
+PY
+  "${results_json}"
+)
+
+if [[ ${#snapshot_lines[@]} -eq 0 ]]; then
+  echo "ERROR: no snapshot IDs found in ${results_json}" >&2
+  exit 2
+fi
+
+active_id=""
+cleanup() {
+  if [[ -n "${active_id}" ]]; then
+    devsh delete "${active_id}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+for line in "${snapshot_lines[@]}"; do
+  preset="$(printf '%s' "${line}" | cut -f1)"
+  snapshot_id="$(printf '%s' "${line}" | cut -f2)"
+
+  echo ""
+  echo "=== Runtime smoke: ${preset} (${snapshot_id}) ==="
+
+  set +e
+  start_out="$(timeout 12m devsh start -p pve-lxc --no-auth --snapshot "${snapshot_id}" 2>&1)"
+  start_rc=$?
+  set -e
+  echo "${start_out}"
+  if [[ $start_rc -ne 0 ]]; then
+    echo "ERROR: devsh start failed for snapshot ${snapshot_id}" >&2
+    exit $start_rc
+  fi
+
+  active_id="$(printf '%s' "${start_out}" | grep -oE 'pvelxc-[a-z0-9]+' | head -n 1 || true)"
+  if [[ -z "${active_id}" ]]; then
+    active_id="$(printf '%s' "${start_out}" | grep -oE 'cmux-[0-9]+' | head -n 1 || true)"
+  fi
+  if [[ -z "${active_id}" ]]; then
+    echo "ERROR: could not parse instance ID from devsh output" >&2
+    exit 1
+  fi
+
+  echo "Instance: ${active_id}"
+
+  echo "Waiting for exec..."
+  exec_ready="false"
+  for _ in $(seq 1 40); do
+    if devsh exec "${active_id}" "echo exec_ready" >/dev/null 2>&1; then
+      exec_ready="true"
+      break
+    fi
+    sleep 3
+  done
+  if [[ "${exec_ready}" != "true" ]]; then
+    echo "ERROR: exec not ready for ${active_id}" >&2
+    "${diag}" "${active_id}" "${log_dir}/diag.runtime.${preset}.${snapshot_id}.${active_id}.${timestamp}.txt" || true
+    exit 1
+  fi
+
+  diag_out="${log_dir}/diag.runtime.${preset}.${snapshot_id}.${active_id}.${timestamp}.txt"
+  "${diag}" "${active_id}" "${diag_out}" || true
+
+  if ! "${verify}" "${active_id}"; then
+    echo "ERROR: runtime verification failed for ${active_id} (${snapshot_id})" >&2
+    echo "Diagnostics: ${diag_out}" >&2
+    exit 1
+  fi
+
+  echo "Re-checking after 30s (post-boot overwrite detection)..."
+  sleep 30
+  if ! "${verify}" "${active_id}"; then
+    late_diag_out="${log_dir}/diag.runtime.late.${preset}.${snapshot_id}.${active_id}.${timestamp}.txt"
+    "${diag}" "${active_id}" "${late_diag_out}" || true
+    echo "ERROR: runtime verification regressed after boot for ${active_id} (${snapshot_id})" >&2
+    echo "Diagnostics (early): ${diag_out}" >&2
+    echo "Diagnostics (late): ${late_diag_out}" >&2
+    exit 1
+  fi
+
+  echo "PASS: ${preset} (${snapshot_id})"
+
+  devsh delete "${active_id}" >/dev/null 2>&1 || true
+  active_id=""
+done
+
+echo ""
+echo "All runtime smoke checks passed"

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -1193,6 +1193,48 @@ class TemplateRunResult:
     node: str
 
 
+def _resolve_repo_relative_path(repo_root: Path, path: str) -> Path:
+    out = Path(path).expanduser()
+    if not out.is_absolute():
+        out = (repo_root / out)
+    return out.resolve()
+
+
+def _serialize_template_result(result: TemplateRunResult) -> dict[str, t.Any]:
+    return {
+        "presetId": result.preset.preset_id,
+        "label": result.preset.label,
+        "snapshotId": result.snapshot_id,
+        "templateVmid": result.template_vmid,
+        "capturedAt": result.captured_at,
+        "node": result.node,
+        "vcpus": result.preset.vcpus,
+        "memoryMib": result.preset.memory_mib,
+        "diskSizeMib": result.preset.disk_size_mib,
+    }
+
+
+def _write_results_json(
+    *,
+    out_path: Path,
+    mode: str,
+    base_template_vmid: int,
+    ide_provider: str,
+    results_payload: list[dict[str, t.Any]],
+) -> None:
+    payload = {
+        "schemaVersion": 1,
+        "mode": mode,
+        "baseTemplateVmid": base_template_vmid,
+        "ideProvider": ide_provider,
+        "manifestPath": str(PVE_SNAPSHOT_MANIFEST_PATH),
+        "generatedAt": _iso_timestamp(),
+        "results": results_payload,
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def _iso_timestamp() -> str:
     return (
         datetime.now(tz=timezone.utc)
@@ -2052,23 +2094,58 @@ async def task_install_base_packages(ctx: PveTaskContext) -> None:
         rm -f chrome.deb
 
         rm -rf /var/lib/apt/lists/*
-
-        # Configure systemd-networkd to send hostname in DHCP requests
-        # This enables router DNS to resolve container hostnames
-        # UseDNS=no prevents overwriting our custom DNS config (PVE host)
-        if [ -f /etc/systemd/network/eth0.network ]; then
-            if ! grep -q 'SendHostname' /etc/systemd/network/eth0.network; then
-                cat >> /etc/systemd/network/eth0.network << 'NETEOF'
-
-[DHCPv4]
-SendHostname = yes
-UseDNS = no
-NETEOF
-            fi
-        fi
         """
     )
     await ctx.run("install-base-packages", cmd)
+
+
+@registry.task(
+    name="configure-networkd-dhcp",
+    deps=("install-base-packages",),
+    description="Ensure systemd-networkd DHCP settings (SendHostname=yes, UseDNS=no)",
+)
+@update_registry.task(
+    name="configure-networkd-dhcp",
+    deps=(),  # Safe to run anytime in update mode
+    description="Ensure systemd-networkd DHCP settings (SendHostname=yes, UseDNS=no)",
+)
+async def task_configure_networkd_dhcp(ctx: PveTaskContext) -> None:
+    cmd = textwrap.dedent(
+        """
+        set -euo pipefail
+
+        iface="eth0"
+        net_file="$(
+          networkctl status "${iface}" --no-pager 2>/dev/null \
+            | awk -F': ' '/Network File/ {print $2; exit}' \
+            | tr -d '\\r'
+        )"
+        if [ -z "${net_file}" ] && [ -f /etc/systemd/network/eth0.network ]; then
+          net_file="/etc/systemd/network/eth0.network"
+        fi
+        if [ -z "${net_file}" ]; then
+          echo "[networkd] ERROR: could not determine Network File for ${iface}" >&2
+          networkctl status "${iface}" --no-pager 2>/dev/null || true
+          ls -la /etc/systemd/network 2>/dev/null || true
+          exit 1
+        fi
+
+        base="$(basename "${net_file}")"
+        drop_dir="/etc/systemd/network/${base}.d"
+        drop_file="${drop_dir}/99-cmux-dhcp.conf"
+        install -d -m 0755 "${drop_dir}"
+        cat > "${drop_file}" <<'EOF'
+# Managed by cmux snapshot-pvelxc.py
+# Ensures router DNS can resolve container hostnames and preserves custom DNS.
+[DHCPv4]
+SendHostname=yes
+UseDNS=no
+EOF
+
+        echo "[networkd] Installed ${drop_file} (base: ${net_file})"
+        """
+    )
+    await ctx.run("configure-networkd-dhcp", cmd)
 
 
 @registry.task(
@@ -3961,7 +4038,7 @@ async def update_existing_template(
     console: Console,
     client: PveLxcClient,
     repo_root: Path,
-) -> int:
+) -> dict[str, t.Any]:
     """Update an existing template container by cloning, updating, and converting to new template.
 
     This skips heavy dependency installation (apt, rust, go, node, etc.) and only
@@ -3974,7 +4051,7 @@ async def update_existing_template(
     4. Stop and convert to new template
     5. Return new template VMID
 
-    Returns the new template VMID (or original VMID if it was a regular container).
+    Returns a result payload suitable for --results-json output.
     """
     source_vmid = args.update_vmid
     console.always(f"\n=== Update mode: source container {source_vmid} ===")
@@ -4083,9 +4160,29 @@ async def update_existing_template(
         for line in summary:
             console.always(line)
 
+    # Capture diagnostics before template conversion for diffing with runtime sandboxes.
+    diag_path = await _capture_networkd_diagnostics(
+        vmid=work_vmid,
+        client=client,
+        console=console,
+        repo_root=repo_root,
+        stage="update-pre-template",
+        preset_id="update",
+    )
+
     # Verify critical artifacts exist before converting to template
     console.info("Verifying critical build artifacts...")
     await _verify_template_artifacts(work_vmid, client, console)
+
+    # Hard fail if required systemd-networkd DHCP behavior regresses.
+    console.info("Verifying systemd-networkd DHCP configuration...")
+    await _verify_networkd_dhcp_config(
+        vmid=work_vmid,
+        client=client,
+        console=console,
+        repo_root=repo_root,
+        diag_path=diag_path,
+    )
 
     # Gracefully shutdown container before converting to template
     console.info(f"Shutting down container {work_vmid} for template conversion...")
@@ -4142,7 +4239,15 @@ async def update_existing_template(
     else:
         console.always(f"\nContainer {work_vmid} converted to template")
 
-    return work_vmid
+    return {
+        "presetId": preset_id or "unknown",
+        "label": preset_entry.get("label") if preset_entry else "unknown",
+        "snapshotId": snapshot_id,
+        "templateVmid": work_vmid,
+        "capturedAt": captured_at,
+        "node": node,
+        "sourceVmid": source_vmid,
+    }
 
 
 async def _verify_template_artifacts(
@@ -4229,6 +4334,100 @@ async def _verify_template_artifacts(
         raise RuntimeError(error_msg)
 
     console.info("[verify] All critical artifacts verified successfully")
+
+
+def _wrap_bash(command: str) -> str:
+    """Wrap a multi-line command to run via /bin/bash -c with safe quoting."""
+    escaped = command.replace("'", "'\"'\"'")
+    return f"/bin/bash -c '{escaped}'"
+
+
+def _read_repo_script(repo_root: Path, relative_path: str) -> str:
+    path = (repo_root / relative_path).resolve()
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Missing script: {relative_path} (resolved: {path})") from exc
+
+
+def _networkd_artifact_dir(repo_root: Path) -> Path:
+    return (repo_root / "logs" / "pve-lxc-networkd").resolve()
+
+
+async def _capture_networkd_diagnostics(
+    *,
+    vmid: int,
+    client: PveLxcClient,
+    console: Console,
+    repo_root: Path,
+    stage: str,
+    preset_id: str | None = None,
+) -> Path:
+    """Capture networkd diagnostics from inside a container and save under logs/."""
+    artifact_dir = _networkd_artifact_dir(repo_root)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    preset_label = preset_id or "unknown"
+    out_path = artifact_dir / f"diag.{stage}.{preset_label}.vmid-{vmid}.{timestamp}.txt"
+
+    diag_script = _read_repo_script(repo_root, "scripts/pve/pve-lxc-networkd-diag-inner.sh")
+    content_parts: list[str] = []
+    try:
+        result = await client.aexec_in_container(
+            vmid,
+            _wrap_bash(diag_script),
+            timeout=60,
+            check=False,
+        )
+        if result.stdout:
+            content_parts.append(result.stdout.rstrip("\n"))
+        if result.stderr:
+            content_parts.append("=== STDERR ===")
+            content_parts.append(result.stderr.rstrip("\n"))
+    except Exception as exc:
+        content_parts.append("=== ERROR ===")
+        content_parts.append(str(exc))
+
+    out_path.write_text("\n".join(content_parts) + "\n", encoding="utf-8")
+    console.info(f"[diag] Saved networkd diagnostics: {out_path}")
+    return out_path
+
+
+async def _verify_networkd_dhcp_config(
+    *,
+    vmid: int,
+    client: PveLxcClient,
+    console: Console,
+    repo_root: Path,
+    diag_path: Path | None = None,
+) -> None:
+    """Fail the build unless effective networkd config includes required DHCP keys."""
+    verify_script = _read_repo_script(repo_root, "scripts/pve/pve-lxc-networkd-verify-inner.sh")
+    result = await client.aexec_in_container(
+        vmid,
+        _wrap_bash(verify_script),
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        hint = f"\nDiagnostics: {diag_path}" if diag_path else ""
+        error_msg = (
+            "Networkd DHCP verification failed.\n"
+            "Expected effective config to contain:\n"
+            "  - SendHostname=yes\n"
+            "  - UseDNS=no\n\n"
+            f"Exit code: {result.returncode}\n"
+        )
+        if result.stdout.strip():
+            error_msg += f"\nstdout:\n{result.stdout.rstrip()}\n"
+        if result.stderr.strip():
+            error_msg += f"\nstderr:\n{result.stderr.rstrip()}\n"
+        error_msg += hint
+        raise RuntimeError(error_msg)
+
+    if result.stdout.strip():
+        console.info(f"[verify-networkd] {result.stdout.strip()}")
 
 
 async def provision_and_create_template(
@@ -4361,9 +4560,29 @@ async def provision_and_create_template(
             for line in summary:
                 console.always(line)
 
+        # Capture diagnostics before template conversion for diffing with runtime sandboxes.
+        diag_path = await _capture_networkd_diagnostics(
+            vmid=new_vmid,
+            client=client,
+            console=console,
+            repo_root=repo_root,
+            stage="build-pre-template",
+            preset_id=preset.preset_id,
+        )
+
         # Verify critical artifacts exist before converting to template
         console.info("Verifying critical build artifacts...")
         await _verify_template_artifacts(new_vmid, client, console)
+
+        # Hard fail if required systemd-networkd DHCP behavior regresses.
+        console.info("Verifying systemd-networkd DHCP configuration...")
+        await _verify_networkd_dhcp_config(
+            vmid=new_vmid,
+            client=client,
+            console=console,
+            repo_root=repo_root,
+            diag_path=diag_path,
+        )
 
         # Gracefully shutdown container before converting to template
         console.info(f"Shutting down container {new_vmid} for template conversion...")
@@ -4605,6 +4824,18 @@ async def provision_and_snapshot(args: argparse.Namespace) -> None:
     console.always("  2. Start clone: pct start <new-vmid>")
     console.always("  3. Enter clone: pct enter <new-vmid>")
 
+    results_json = getattr(args, "results_json", None)
+    if results_json:
+        out_path = _resolve_repo_relative_path(repo_root, results_json)
+        _write_results_json(
+            out_path=out_path,
+            mode="snapshot",
+            base_template_vmid=args.template_vmid,
+            ide_provider=args.ide_provider,
+            results_payload=[_serialize_template_result(r) for r in results],
+        )
+        console.always(f"Results JSON written: {out_path}")
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -4620,6 +4851,12 @@ def parse_args() -> argparse.Namespace:
         "--repo-root",
         default=".",
         help="Repository root (default: current directory)",
+    )
+    parser.add_argument(
+        "--results-json",
+        dest="results_json",
+        default="",
+        help="Write snapshot results to a JSON file (path is relative to --repo-root unless absolute)",
     )
     parser.add_argument(
         "--standard-vcpus",
@@ -4834,12 +5071,23 @@ async def run_update_mode(args: argparse.Namespace) -> None:
         client.start_ssh_control_master()
 
     try:
-        await update_existing_template(
+        result = await update_existing_template(
             args,
             console=console,
             client=client,
             repo_root=repo_root,
         )
+        results_json = getattr(args, "results_json", None)
+        if results_json:
+            out_path = _resolve_repo_relative_path(repo_root, results_json)
+            _write_results_json(
+                out_path=out_path,
+                mode="update",
+                base_template_vmid=args.update_vmid,
+                ide_provider=args.ide_provider,
+                results_payload=[result],
+            )
+            console.always(f"Results JSON written: {out_path}")
     finally:
         if client._ssh_host_explicit:
             client.stop_ssh_control_master()


### PR DESCRIPTION
## Task

### Summary

  Build a repeatable investigation and validation pipeline that proves whether snapshot build logic in scripts/snapshot-pvelxc.py is preserved in runtime sandboxes created via
  devsh start -p pve-lxc --snapshot ....
  Primary target is the DHCP hostname behavior (SendHostname, UseDNS) and any other snapshot-time config that may be lost after clone/start.

  ### Goal and Success Criteria

- Identify exact failure point in lifecycle: build-time apply, template conversion, clone, boot, or post-boot service overwrite.
- Produce deterministic pass/fail tests runnable locally and in CI.
- Gate snapshot PR creation on runtime correctness checks.
- Success means:

1. A fresh sandbox from latest snapshot has expected networkd behavior.
2. Tests fail when behavior regresses.
3. Snapshot workflow no longer publishes manifest updates when runtime checks fail.

  ### Scope

- In scope:

1. Snapshot build script logic and task graph in scripts/snapshot-pvelxc.py
2. Snapshot CI workflow in .github/workflows/pve-lxc-snapshot.yml
3. Runtime verification via devsh start/exec/delete against newly created snapshot IDs

- Out of scope:

1. General PVE provider redesign
2. Non-PVE sandbox providers

  ### Implementation Plan

1. Establish a baseline evidence harness.

- Create a read-only diagnostic command set (shell script or make target) that captures:
    - /etc/systemd/network/eth0.network
    - networkctl status eth0
    - systemd-analyze cat-config systemd/network output
    - /etc/resolv.conf
    - journalctl -u systemd-networkd --no-pager -n 200
- Run it at two points:
    - Immediately after template build (before convert-to-template)
    - In a sandbox started from resulting snapshot ID
- Save artifacts under logs/ with timestamped filenames for diffing.

2. Replace fragile network file mutation strategy.

- Stop appending directly to /etc/systemd/network/eth0.network.
- Write a deterministic persistent config strategy:
    - Preferred: dedicated drop-in in /etc/systemd/network/ with ordered filename and only [DHCPv4] controls.
    - Ensure idempotency and explicit ownership comments in file body.
- Update the corresponding task in scripts/snapshot-pvelxc.py to enforce expected final config content.

3. Add in-script hard verification before template conversion.

- Add a verification task near existing artifact verification that fails build unless:
    - effective networkd config contains SendHostname=yes
    - effective networkd config contains UseDNS=no
- Keep failure message explicit and actionable with printed diagnostic snippets.

4. Add snapshot runtime smoke test step in workflow.

- In .github/workflows/pve-lxc-snapshot.yml, after snapshot build and before commit/PR:
    - Start a sandbox using newly generated snapshot ID.
    - Execute validation commands for network config and hostname resolution behavior.
    - Delete sandbox regardless of test outcome.
- If smoke test fails, workflow fails and does not create snapshot branch/PR.

5. Build a regression matrix for deep study.

- Validate both new preset snapshots each run:
    - standard (4vcpu\_8gb\_32gb)
    - performance (6vcpu\_8gb\_40gb)
- Validate both modes over time:
    - full build mode
    - --update mode (if used operationally)
- Record whether behavior differs by mode.

6. Document operating runbook.

- Add a short troubleshooting section in scripts/pve/README.md:
    - expected outputs
    - quick triage commands
    - rollback/disable strategy if network regression appears in production snapshots

  ### Test Cases and Scenarios

1. Unit-like script behavior tests.

- Idempotency: running config task twice does not duplicate or alter semantics unexpectedly.
- Config parser check: output includes required keys exactly once in effective config.

2. Integration tests on built template.

- After build, verify expected network config exists before conversion.
- Verify build fails when the config is intentionally absent.

3. End-to-end snapshot sandbox tests.

- Confirm hostname and DNS behavior is consistent with intended design.
  ### Important API/Interface/Type Changes
- No public HTTP API contract changes required.
- Internal interface changes:

1. New internal verification task(s) in snapshot task graph.
2. New CI workflow step contract: “snapshot build must pass runtime smoke-check before manifest commit.”
3. Optional new helper script interface for standardized diagnostics (CLI args: vmid/snapshot-id/output path).

  ### Risks and Mitigations

- Risk: distro/networkd differences may interpret config ordering unexpectedly.
- Mitigation: verify effective config via systemd-analyze cat-config instead of file-presence only.
- Risk: smoke tests increase workflow time/cost.
- Mitigation: single short-lived sandbox per preset; strict timeout; always cleanup.
- Risk: intermittent DNS dependencies.
- Mitigation: assert deterministic local config first; treat DNS reachability separately with soft diagnostics.

  ### Assumptions and Defaults

- Assume latest snapshot workflow remains branch/PR-driven (no direct main commits).
- Assume devsh and PVE credentials are available in CI env as currently configured.
- Default strategy: implement full hardening (persistent config + in-script verify + CI smoke-check), not investigate-only.
- Default acceptance threshold: both preset snapshots must pass runtime validation in the same workflow run.

This pull request introduces a robust validation pipeline for PVE-LXC snapshots, specifically targeting the persistence of `systemd-networkd` configurations (`SendHostname` and `UseDNS`). It replaces fragile file mutation with a deterministic drop-in configuration strategy and adds mandatory runtime smoke tests in CI that gate snapshot publication.