### PR TITLE
feat: add devsh project dispatch command

### DIFF
--- a/packages/devsh/internal/cli/project_dispatch.go
+++ b/packages/devsh/internal/cli/project_dispatch.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/karlorz/devsh/internal/auth"
+	"github.com/karlorz/devsh/internal/vm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	projectDispatchProjectID string
+)
+
+var projectDispatchCmd = &cobra.Command{
+	Use:   "dispatch --project-id <id>",
+	Short: "Dispatch a project plan (create orchestration tasks)",
+	Long: `Dispatch a project plan by creating orchestration tasks for each plan task.
+
+This connects plan tasks to orchestration tasks via orchestrationTaskId, enabling
+automatic status sync as agents complete work.
+
+Examples:
+  devsh project dispatch --project-id s179v13t7hc0zga60pbv419ck982bt8r
+  devsh project dispatch --project-id s179v13t7hc0zga60pbv419ck982bt8r --json`,
+	RunE: runProjectDispatch,
+}
+
+func runProjectDispatch(cmd *cobra.Command, args []string) error {
+	if projectDispatchProjectID == "" {
+		return fmt.Errorf("--project-id flag is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	teamSlug, err := auth.GetTeamSlug()
+	if err != nil {
+		return fmt.Errorf("failed to get team: %w", err)
+	}
+
+	client, err := vm.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	client.SetTeamSlug(teamSlug)
+
+	result, err := client.DispatchProject(ctx, vm.DispatchProjectOptions{
+		ProjectID: projectDispatchProjectID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to dispatch project: %w", err)
+	}
+
+	if flagJSON {
+		data, _ := json.MarshalIndent(result, "", "  ")
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Printf("Dispatched %d task(s) from project plan.\n", result.Dispatched)
+	fmt.Println("Tasks are now linked to orchestration and will auto-sync status on completion.")
+	return nil
+}
+
+func init() {
+	projectDispatchCmd.Flags().StringVar(&projectDispatchProjectID, "project-id", "", "Convex project document ID (required)")
+	projectCmd.AddCommand(projectDispatchCmd)
+}

--- a/packages/devsh/internal/vm/client.go
+++ b/packages/devsh/internal/vm/client.go
@@ -2397,6 +2397,51 @@ type AutopilotInfo struct {
 	} `json:"vscode,omitempty"`
 }
 
+// DispatchProjectOptions configures project dispatch.
+type DispatchProjectOptions struct {
+	ProjectID string // Convex project document ID
+}
+
+// DispatchProjectResult contains the dispatch result.
+type DispatchProjectResult struct {
+	Dispatched int `json:"dispatched"`
+}
+
+// DispatchProject calls POST /api/projects/:projectId/dispatch.
+// This dispatches a project plan, creating orchestration tasks for each plan task.
+func (c *Client) DispatchProject(ctx context.Context, opts DispatchProjectOptions) (*DispatchProjectResult, error) {
+	if c.teamSlug == "" {
+		return nil, fmt.Errorf("team slug not set")
+	}
+	if opts.ProjectID == "" {
+		return nil, fmt.Errorf("project ID is required")
+	}
+
+	path := fmt.Sprintf("/api/projects/%s/dispatch", opts.ProjectID)
+	resp, err := c.doWwwRequest(ctx, "POST", path, map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("project not found")
+	}
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return nil, fmt.Errorf("no plan tasks to dispatch")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("dispatch failed (%d): %s", resp.StatusCode, readErrorBody(resp.Body))
+	}
+
+	var result DispatchProjectResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
 // GetAutopilotInfo gets autopilot session info for a task run using JWT authentication
 // This is for sandbox scripts that don't have user auth, only task run JWT
 func (c *Client) GetAutopilotInfo(ctx context.Context, jwt string) (*AutopilotInfo, error) {


### PR DESCRIPTION
## Summary
Add CLI command to dispatch project plans, fixing the issue where CLI-created tasks bypass the dispatch flow and don't update project status automatically.

## Changes
- `packages/devsh/internal/cli/project_dispatch.go` - NEW: CLI command
- `packages/devsh/internal/vm/client.go` - Added `DispatchProject` method

## Usage
```bash
# Dispatch a project plan (creates linked orchestration tasks)
devsh project dispatch --project-id s179v13t7hc0zga60pbv419ck982bt8r

# JSON output
devsh project dispatch --project-id s179v13t7hc0zga60pbv419ck982bt8r --json
```

## Why This Is Needed
Previously, using `devsh task create` directly bypassed the `dispatchPlan` mutation, which:
1. Creates orchestration tasks
2. Links them via `orchestrationTaskId`
3. Enables `syncPlanStatusFromOrchestration` to fire on completion

Without this linkage, project status never auto-updates, requiring manual Convex updates.

## Test plan
- [ ] `go build ./...` passes
- [ ] `devsh project dispatch --help` shows usage
- [ ] Dispatching a project creates orchestration tasks
- [ ] Task completion auto-updates project status