### PR TITLE
fix: use priority-based ordering in getReadyTasks and listPendingTasks

### DIFF
--- a/packages/convex/convex/orchestrationQueries.ts
+++ b/packages/convex/convex/orchestrationQueries.ts
@@ -95,7 +95,7 @@ export const listPendingTasks = authQuery({
 
     return ctx.db
       .query("orchestrationTasks")
-      .withIndex("by_team_status", (q) =>
+      .withIndex("by_team_status_priority", (q) =>
         q.eq("teamId", teamId).eq("status", "pending")
       )
       .order("asc")
@@ -265,7 +265,7 @@ export const getReadyTasks = authQuery({
 
     const pendingTasks = await ctx.db
       .query("orchestrationTasks")
-      .withIndex("by_team_status", (q) =>
+      .withIndex("by_team_status_priority", (q) =>
         q.eq("teamId", teamId).eq("status", "pending")
       )
       .order("asc")
@@ -1140,7 +1140,7 @@ export const getReadyTasksInternal = internalQuery({
   handler: async (ctx, { teamId, limit = 10 }) => {
     const pendingTasks = await ctx.db
       .query("orchestrationTasks")
-      .withIndex("by_team_status", (q) =>
+      .withIndex("by_team_status_priority", (q) =>
         q.eq("teamId", teamId).eq("status", "pending")
       )
       .order("asc")

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1577,6 +1577,7 @@ const convexSchema = defineSchema({
   })
     .index("by_team_priority", ["teamId", "priority", "status"])
     .index("by_team_status", ["teamId", "status", "updatedAt"])
+    .index("by_team_status_priority", ["teamId", "status", "priority"])
     .index("by_assigned_agent", ["assignedAgentName", "status"])
     .index("by_parent", ["parentTaskId", "createdAt"])
     .index("by_task_run", ["taskRunId"]),


### PR DESCRIPTION
## Summary
- `getReadyTasks`, `getReadyTasksInternal`, and `listPendingTasks` sorted by `updatedAt` (via `by_team_status` index) instead of `priority`, causing priority starvation where old low-priority tasks blocked new high-priority ones
- Added `by_team_status_priority` index `["teamId", "status", "priority"]` to `orchestrationTasks` schema
- Switched the three priority-sensitive functions to use the new index so tasks are served in priority order (0 = highest first)
- `listTasksByTeam` left unchanged — it intentionally uses `updatedAt` ordering for the UI

## Test plan
- [x] `bun check` passes
- [x] `bun test apps/server/src/http-api.test.ts` — 34/34 tests pass
- [ ] Convex validates new index at deploy time
- [ ] `devsh orchestrate list` renders correctly