### PR TITLE
chore: remove unused by_team_priority index

### DIFF
--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1575,7 +1575,6 @@ const convexSchema = defineSchema({
     lastRetryAt: v.optional(v.number()), // Timestamp of last retry
     nextRetryAfter: v.optional(v.number()), // When to retry next (ms since epoch)
   })
-    .index("by_team_priority", ["teamId", "priority", "status"])
     .index("by_team_status", ["teamId", "status", "updatedAt"])
     .index("by_team_status_priority", ["teamId", "status", "priority"])
     .index("by_assigned_agent", ["assignedAgentName", "status"])


### PR DESCRIPTION
## Summary
- Remove unused `by_team_priority` index `["teamId", "priority", "status"]` from `orchestrationTasks`
- Never referenced in any query — its purpose is now served by `by_team_status_priority` `["teamId", "status", "priority"]` added in PR #468
- Reduces index overhead

## Test plan
- [x] `bun check` passes
- [x] `bun test apps/server/src/http-api.test.ts` — 34/34 pass
- [x] Grep confirms no references to `by_team_priority` in codebase