### PR TITLE
fix: prevent iframe focus loss in remote VSCode panels

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
@@ -116,8 +116,17 @@ function BrowserComponent() {
       if (runId !== taskRunId) return;
       const viewer = vncRef.current;
       if (!viewer) return;
+      const previousFocus = document.activeElement;
       viewer.disconnect();
       viewer.connect();
+      requestAnimationFrame(() => {
+        if (
+          previousFocus instanceof HTMLElement &&
+          document.activeElement !== previousFocus
+        ) {
+          previousFocus.focus({ preventScroll: true });
+        }
+      });
     });
   }, [taskRunId]);
 

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
@@ -233,9 +233,19 @@ function VSCodeComponent() {
     void webviewActions.focus();
   }, [iframeStatus, webviewActions, workspaceUrl]);
 
+  // Only auto-focus on initial load, not every iframeStatus change (RC-8)
+  const hasInitiallyFocusedRef = useRef(false);
   useEffect(() => {
-    focusWebviewIfReady();
-  }, [focusWebviewIfReady]);
+    if (iframeStatus === "loaded" && !hasInitiallyFocusedRef.current) {
+      hasInitiallyFocusedRef.current = true;
+      focusWebviewIfReady();
+    }
+  }, [focusWebviewIfReady, iframeStatus]);
+
+  // Reset initial focus tracking when workspace URL genuinely changes
+  useEffect(() => {
+    hasInitiallyFocusedRef.current = false;
+  }, [workspaceUrl]);
 
   const handleElectronWindowFocus = useCallback(() => {
     void (async () => {

--- a/packages/shared/src/components/vnc-viewer.tsx
+++ b/packages/shared/src/components/vnc-viewer.tsx
@@ -220,6 +220,7 @@ export const VncViewer = forwardRef<VncViewerHandle, VncViewerProps>(
     const reconnectAttemptsRef = useRef(0);
     const currentReconnectDelayRef = useRef(reconnectDelay);
     const isUnmountedRef = useRef(false);
+    const focusWasOutsideVncRef = useRef(false);
     const urlRef = useRef(url);
     const shouldReconnectRef = useRef(autoReconnect);
     const connectInternalRef = useRef<(() => Promise<void>) | null>(null);
@@ -323,6 +324,7 @@ export const VncViewer = forwardRef<VncViewerHandle, VncViewerProps>(
           previouslyFocused &&
           previouslyFocused !== containerEl &&
           !containerEl.contains(previouslyFocused);
+        focusWasOutsideVncRef.current = !!focusWasOutsideVnc;
 
         const rfb = new RFB(containerEl, wsUrl, {
           credentials: undefined,
@@ -349,6 +351,9 @@ export const VncViewer = forwardRef<VncViewerHandle, VncViewerProps>(
           if (isUnmountedRef.current) return;
           reconnectAttemptsRef.current = 0;
           currentReconnectDelayRef.current = reconnectDelay;
+          if (focusWasOutsideVncRef.current) {
+            rfb.blur();
+          }
           updateStatus("connected");
           onConnect?.(rfb);
         });
@@ -448,7 +453,16 @@ export const VncViewer = forwardRef<VncViewerHandle, VncViewerProps>(
     useEffect(() => {
       if (network.online && !prevOnlineRef.current) {
         if (status === "error" || status === "disconnected") {
+          const previousFocus = document.activeElement;
           connect();
+          requestAnimationFrame(() => {
+            if (
+              previousFocus instanceof HTMLElement &&
+              document.activeElement !== previousFocus
+            ) {
+              previousFocus.focus({ preventScroll: true });
+            }
+          });
         }
       }
       prevOnlineRef.current = network.online;


### PR DESCRIPTION
## Summary

- **RC-1 gap**: Blur VNC canvas after async `connect` event fires, preventing the noVNC canvas from holding focus when the user was typing in VSCode
- **RC-6**: Save/restore `document.activeElement` around network recovery reconnect so going online doesn't steal focus
- **RC-7**: Save/restore focus around browser reload disconnect/connect cycle
- **RC-8**: Only auto-focus VSCode iframe on initial load (not every `iframeStatus` change), reset tracking when workspace URL genuinely changes

## Test plan
- [ ] Open a task with VSCode + Browser panels visible. Click inside VSCode, type. Wait for VNC to connect. Typing should continue in VSCode without interruption.
- [ ] Simulate network recovery (disconnect/reconnect WiFi). Focus should stay in VSCode.
- [ ] Trigger browser reload. Focus should not jump to VNC panel.
- [ ] Expand/collapse panels. Focus should not jump unexpectedly.