### PR TITLE
fix: add expect package to snapshot builds for unbuffer support

### DIFF
--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -2071,7 +2071,7 @@ async def task_install_base_packages(ctx: PveTaskContext) -> None:
             gh \
             zsh \
             zsh-autosuggestions \
-            ripgrep ffmpeg xdotool
+            ripgrep ffmpeg xdotool expect
 
         # Download and install Chrome
         arch="$(dpkg --print-architecture)"

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -978,7 +978,7 @@ async def task_install_base_packages(ctx: TaskContext) -> None:
             gh \
             zsh \
             zsh-autosuggestions \
-            ripgrep ffmpeg xdotool
+            ripgrep ffmpeg xdotool expect
 
 
         # Download and install Chrome


### PR DESCRIPTION
## Summary
- Adds `expect` package to base package installs in both `snapshot.py` (Morph) and `snapshot-pvelxc.py` (PVE LXC)
- The `expect` package provides `unbuffer`, which is used by the codex review stop hook to capture review output

## Test plan
- [ ] Trigger PVE LXC snapshot rebuild and verify `expect` is installed
- [ ] Trigger Morph snapshot rebuild and verify `expect` is installed
- [ ] Verify `unbuffer` command is available in new sandboxes