### PR TITLE
fix: extend JWT TTL to 7 days for cloud workspaces

### DIFF
--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -17,6 +17,13 @@ import {
   type StoredPullRequestInfo,
 } from "@cmux/shared/pull-request-state";
 
+const CLOUD_WORKSPACE_JWT_TTL = "7d";
+const DEFAULT_JWT_TTL = "12h";
+
+function getJwtTtl(isCloudWorkspace?: boolean): string {
+  return isCloudWorkspace ? CLOUD_WORKSPACE_JWT_TTL : DEFAULT_JWT_TTL;
+}
+
 function rewriteMorphUrl(url: string): string {
   // do not rewrite ports 39375 39377 39378 39379 39380 39381 39383
   if (
@@ -588,7 +595,7 @@ export const createInternal = internalMutation({
     })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt()
-      .setExpirationTime("12h")
+      .setExpirationTime(getJwtTtl(task.isCloudWorkspace))
       .sign(new TextEncoder().encode(env.CMUX_TASK_RUN_JWT_SECRET));
 
     return { taskRunId, jwt };
@@ -680,7 +687,7 @@ export const create = authMutation({
     })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt()
-      .setExpirationTime("12h")
+      .setExpirationTime(getJwtTtl(task.isCloudWorkspace))
       .sign(new TextEncoder().encode(env.CMUX_TASK_RUN_JWT_SECRET));
 
     return { taskRunId, jwt };
@@ -1221,7 +1228,7 @@ export const getJwt = authMutation({
     })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt()
-      .setExpirationTime("12h")
+      .setExpirationTime(getJwtTtl(doc.isCloudWorkspace))
       .sign(new TextEncoder().encode(env.CMUX_TASK_RUN_JWT_SECRET));
 
     return { jwt };
@@ -1247,7 +1254,7 @@ export const getJwtInternal = internalMutation({
     })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt()
-      .setExpirationTime("12h")
+      .setExpirationTime(getJwtTtl(doc.isCloudWorkspace))
       .sign(new TextEncoder().encode(env.CMUX_TASK_RUN_JWT_SECRET));
 
     return { jwt, teamId: doc.teamId, userId: doc.userId };
@@ -2601,7 +2608,7 @@ export const createForPreview = internalMutation({
     })
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt()
-      .setExpirationTime("12h")
+      .setExpirationTime(getJwtTtl(task.isCloudWorkspace))
       .sign(new TextEncoder().encode(env.CMUX_TASK_RUN_JWT_SECRET));
 
     return { taskRunId, jwt };


### PR DESCRIPTION
## Summary
- Cloud workspaces persist across multiple sessions on the same sandbox, but the 12h JWT TTL causes memory sync to Convex to fail with 401 after expiry
- Extends JWT TTL from 12h to 7d for cloud workspace task runs (`isCloudWorkspace: true`)
- Regular (non-cloud-workspace) task runs keep the existing 12h TTL
- Extracts `getJwtTtl()` helper to centralize the TTL logic across all 5 JWT creation sites

## Test plan
- [ ] `bun check` passes
- [ ] Deploy to production Convex: `bun run convex:deploy:prod`
- [ ] Verify next cloud workspace task run gets 7d JWT (decode JWT payload to check `exp`)
- [ ] Verify memory sync works in cloud workspace sidebar after new task starts