### PR TITLE
fix: move OpenCode instructions to global AGENTS path

### DIFF
--- a/packages/shared/src/providers/opencode/environment.test.ts
+++ b/packages/shared/src/providers/opencode/environment.test.ts
@@ -55,6 +55,27 @@ async function decodeOpencodeConfig(args?: {
 }
 
 describe("getOpencodeEnvironment", () => {
+  it("writes memory instructions to the user-level AGENTS path only", async () => {
+    const result = await getOpencodeEnvironment(BASE_CONTEXT);
+    const agentsFile = result.files.find(
+      (file) => file.destinationPath === "$HOME/.config/opencode/AGENTS.md",
+    );
+
+    expect(agentsFile).toBeDefined();
+    expect(
+      result.files.some(
+        (file) => file.destinationPath === "/root/workspace/OPENCODE.md",
+      ),
+    ).toBe(false);
+
+    const instructions = Buffer.from(
+      agentsFile!.contentBase64,
+      "base64",
+    ).toString("utf-8");
+    expect(instructions).toContain("Agent Memory Protocol");
+    expect(instructions).toContain("/root/lifecycle/memory");
+  });
+
   it("includes managed devsh-memory MCP when no custom servers are configured", async () => {
     const config = await decodeOpencodeConfig();
 

--- a/packages/shared/src/providers/opencode/environment.ts
+++ b/packages/shared/src/providers/opencode/environment.ts
@@ -445,14 +445,14 @@ log "Post-start script end"
     );
   }
 
-  // Add OPENCODE.md with memory protocol instructions for the project
-  const opencodeMdContent = `# cmux Project Instructions
+  // Add AGENTS.md with memory protocol instructions at the user-level OpenCode path
+  const opencodeAgentsContent = `# cmux Project Instructions
 
 ${getMemoryProtocolInstructions()}
 `;
   files.push({
-    destinationPath: "/root/workspace/OPENCODE.md",
-    contentBase64: Buffer.from(opencodeMdContent).toString("base64"),
+    destinationPath: "$HOME/.config/opencode/AGENTS.md",
+    contentBase64: Buffer.from(opencodeAgentsContent).toString("base64"),
     mode: "644",
   });
 


### PR DESCRIPTION
## Summary
- write OpenCode memory instructions to `~/.config/opencode/AGENTS.md`
- stop emitting `/root/workspace/OPENCODE.md` in sandboxes
- keep existing `~/.config/opencode/opencode.json` MCP config behavior unchanged

## Testing
- bun test packages/shared/src/providers/opencode/environment.test.ts
- bun check
- verified live PVE-LXC sandbox receives `~/.config/opencode/AGENTS.md` and `~/.config/opencode/opencode.json`
- verified `/root/workspace/OPENCODE.md` is absent and `/root/workspace` git status stays clean