### PR TITLE
fix: rewrite http:// to https:// in VS Code resourceUrlTemplate for PVE-LXC

### DIFF
--- a/apps/edge-router-pvelxc/src/index.ts
+++ b/apps/edge-router-pvelxc/src/index.ts
@@ -777,6 +777,7 @@ export default {
 
     const contentType = response.headers.get("content-type") || "";
     const skipServiceWorker = port === "39378";
+    const isVSCode = port === "39378";
     const requestOrigin = request.headers.get("Origin");
 
     // Apply HTMLRewriter to HTML responses
@@ -785,6 +786,27 @@ export default {
       if (skipServiceWorker) {
         responseHeaders = addPermissiveCORS(responseHeaders, requestOrigin);
       }
+
+      // For VS Code (port 39378), we need to rewrite http:// URLs to https:// in the
+      // workbench config to fix resourceUrlTemplate using insecure scheme.
+      // VS Code server generates URLs based on the request host but defaults to http://
+      // when behind a reverse proxy that doesn't properly forward X-Forwarded-Proto.
+      if (isVSCode) {
+        // Read the full response body and do text replacement
+        const text = await response.text();
+        // Rewrite http:// URLs that point to the public host pattern
+        const rewritten = text.replace(
+          /http:\/\/port-(\d+)-pvelxc-([^"'\s]+)\.alphasolves\.com/g,
+          "https://port-$1-pvelxc-$2.alphasolves.com",
+        );
+        responseHeaders = sanitizeRewrittenResponseHeaders(responseHeaders);
+        return new Response(rewritten, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: responseHeaders,
+        });
+      }
+
       const rewriter = new HTMLRewriter()
         .on("head", new HeadRewriter(skipServiceWorker))
         .on("script", new ScriptRewriter());
@@ -805,7 +827,14 @@ export default {
     // Rewrite JavaScript files
     if (contentType.includes("javascript") || url.pathname.endsWith(".js")) {
       const text = await response.text();
-      const rewritten = rewriteJavaScript(text, true);
+      let rewritten = rewriteJavaScript(text, true);
+      // For VS Code, also rewrite http:// URLs to https:// for the public domain
+      if (isVSCode) {
+        rewritten = rewritten.replace(
+          /http:\/\/port-(\d+)-pvelxc-([^"'\s]+)\.alphasolves\.com/g,
+          "https://port-$1-pvelxc-$2.alphasolves.com",
+        );
+      }
       let sanitizedHeaders = sanitizeRewrittenResponseHeaders(response.headers);
       sanitizedHeaders = stripCSPHeaders(sanitizedHeaders);
       if (skipServiceWorker) {

--- a/scripts/pve/pve-tunnel-setup.sh
+++ b/scripts/pve/pve-tunnel-setup.sh
@@ -453,6 +453,9 @@ configure_caddy() {
     handle @service {
         reverse_proxy {re.service.2}.${domain_suffix}:{re.service.1} {
             header_up Host {upstream_hostport}
+            # Forward original protocol and host for VS Code resourceUrlTemplate generation
+            header_up X-Forwarded-Proto https
+            header_up X-Forwarded-Host {http.request.host}
             transport http {
                 dial_timeout 10s
             }


### PR DESCRIPTION
## Summary

- Fix VS Code `resourceUrlTemplate` generating `http://` URLs instead of `https://` on PVE-LXC public HTTPS hosts
- Edge router now rewrites `http://port-{port}-pvelxc-{instance}.alphasolves.com` to `https://...` in HTML and JS responses for port 39378 (VS Code)
- Caddy config updated to forward `X-Forwarded-Proto: https` and `X-Forwarded-Host` headers

## Root Cause

VS Code server generates `resourceUrlTemplate` URLs based on the request host but defaults to `http://` when behind a reverse proxy that doesn't properly forward `X-Forwarded-Proto`. This causes mixed-content blocking when the page is served from HTTPS.

## Test plan

- [x] Edge router deployed to Cloudflare Workers
- [ ] Update Caddy on PVE host: `./scripts/pve/pve-tunnel-setup.sh configure-caddy && systemctl reload caddy-cmux`
- [ ] Verify: Open `https://port-39378-pvelxc-{instance}.alphasolves.com/?folder=/root/workspace`
- [ ] Confirm no mixed-content errors in browser devtools
- [ ] Confirm workbench assets/extensions load normally