### PR TITLE
feat: orchestration observability follow-up for PR #495

### DIFF
--- a/.agents/skills/devsh-orchestrator/SKILL.md
+++ b/.agents/skills/devsh-orchestrator/SKILL.md
@@ -24,11 +24,17 @@ devsh orchestrate spawn --agent claude/haiku-4.5 --repo owner/repo "Fix the auth
 # Check status of the spawned task with polling watch mode
 devsh orchestrate status <orch-task-id> --watch
 
+# Stream live orchestration events for the task
+devsh orchestrate debug <orch-task-id> --events
+
+# Send steering guidance to the running worker
+devsh orchestrate message <task-run-id> "Focus on the failing API test first" --type request
+
+# Retry a failed PR/check workflow on the original task branch
+devsh task retry <task-id>
+
 # Wait for completion
 devsh orchestrate wait <orch-task-id>
-
-# Cancel an orchestration task
-devsh orchestrate cancel <orch-task-id>
 
 # Get aggregated results from an orchestration session
 # Requires an orchestration session ID from a flow that creates one
@@ -42,8 +48,11 @@ For small, reliable workflows, prefer this portable pattern:
 1. Plan locally in your current workspace
 2. Keep any `.claude/plans/*.md` file as a **local convenience**
 3. Embed the relevant plan content into the `devsh orchestrate spawn` prompt
-4. Track execution with `status`, `wait`, and `cancel` using `<orch-task-id>`
-5. Use `results <orchestration-id>` only when your workflow actually has an orchestration session ID
+4. Track execution with `status --watch` using `<orch-task-id>`
+5. Use `debug --events <orch-task-id>` for live orchestration insight
+6. Use `message <task-run-id>` to steer a running worker
+7. Use `task retry <task-id>` for failed PR/check workflows
+8. Use `results <orchestration-id>` only when your workflow actually has an orchestration session ID
 
 This avoids assuming the spawned sandbox can read a local plan path from your machine.
 
@@ -124,6 +133,23 @@ devsh orchestrate status <orch-task-id> --watch
 # Custom polling interval
 devsh orchestrate status <orch-task-id> --watch --interval 5
 ```
+
+### Stream Live Orchestration Events
+
+Inspect live orchestration updates for a spawned task.
+
+```bash
+devsh orchestrate debug <orch-task-id> --events
+```
+
+`debug --events` accepts the **orchestration task ID** printed by `spawn`. It resolves the best available stream key automatically:
+- grouped workflows: uses the orchestration session ID from task metadata
+- single local CLI workflows: falls back to the task's own orchestration task ID
+
+Use it when `status --watch` is not enough and you need live triage detail. On failures it points to the next likely operator actions:
+- `devsh orchestrate message <task-run-id> ...` for mid-run steering
+- `devsh task retry <task-id>` for failed PR/check workflows
+- `devsh orchestrate results <orchestration-id>` only when a real orchestration session ID exists
 
 ### Get Orchestration Results
 
@@ -306,10 +332,11 @@ orchestration/
 
 1. **Prefer the portable default first**: local planning plus inline prompt delegation is the safest default workflow
 2. **Use specialized agents**: haiku for quick fixes, opus for complex reasoning, codex for implementation-heavy tasks
-3. **Monitor with watch mode**: `status --watch` is polling watch mode
-4. **Use the right ID**: `<orch-task-id>` for status/wait/cancel, `<orchestration-id>` for results
-5. **Use advanced head-agent paths intentionally**: `--cloud-workspace`, `--use-env-jwt`, `pull_orchestration_updates`, and `orchestrate migrate` are advanced workflow options
-6. **Keep prompts focused**: each sub-agent should have a clear, specific task
+3. **Monitor with polling first**: `status --watch` is polling watch mode
+4. **Escalate to live triage when needed**: `debug --events` is the operator-facing event stream for live orchestration insight
+5. **Use the right ID**: `<orch-task-id>` for status/debug/wait/cancel, `<task-run-id>` for message, `<task-id>` for `task retry`, `<orchestration-id>` for results
+6. **Use advanced head-agent paths intentionally**: `--cloud-workspace`, `--use-env-jwt`, `pull_orchestration_updates`, and `orchestrate migrate` are advanced workflow options
+7. **Keep prompts focused**: each sub-agent should have a clear, specific task
 
 ## Integration with MCP
 

--- a/.agents/skills/execute-plan/SKILL.md
+++ b/.agents/skills/execute-plan/SKILL.md
@@ -82,12 +82,27 @@ If you use `--json`, the payload includes fields such as `orchestrationTaskId`, 
    devsh orchestrate status <orch-task-id> --watch
    ```
 
-2. **Wait for Completion**:
+2. **Open Live Triage When Needed**:
+   ```bash
+   devsh orchestrate debug <orch-task-id> --events
+   ```
+
+3. **Steer a Running Worker**:
+   ```bash
+   devsh orchestrate message <task-run-id> "Focus on the failing typecheck first" --type request
+   ```
+
+4. **Retry a Failed PR/Check Workflow**:
+   ```bash
+   devsh task retry <task-id>
+   ```
+
+5. **Wait for Completion**:
    ```bash
    devsh orchestrate wait <orch-task-id>
    ```
 
-3. **Get Aggregated Results**:
+6. **Get Aggregated Results**:
    ```bash
    devsh orchestrate results <orchestration-id>
    ```
@@ -130,6 +145,7 @@ Brief summary
 
 - The worker should not be told to read a local `.claude/plans/*.md` path directly.
 - The portable default is: verify local file, read local file, embed plan content in the spawned prompt.
+- Preserve the task-vs-session contract: `<orch-task-id>` for `status`, `debug`, and `wait`; `<task-run-id>` for `message`; `<task-id>` for `task retry`; `<orchestration-id>` for `results` only when one exists.
 
 ## Related Skills
 

--- a/.agents/skills/head-agent-init/SKILL.md
+++ b/.agents/skills/head-agent-init/SKILL.md
@@ -67,6 +67,15 @@ For large plans, inline only the relevant excerpt or a tight summary instead of 
 # Use the Orchestration Task ID printed by spawn
 devsh orchestrate status <orch-task-id> --watch
 
+# Escalate to live event streaming when you need deeper triage
+devsh orchestrate debug <orch-task-id> --events
+
+# Steer the worker mid-run when course correction is needed
+devsh orchestrate message <task-run-id> "Prioritize fixing the failing checks" --type request
+
+# Retry a failed PR/check workflow on the original task branch
+devsh task retry <task-id>
+
 # Or wait for completion
 devsh orchestrate wait <orch-task-id>
 
@@ -120,6 +129,7 @@ flowchart TD
 
 - This skill provides **workflow scaffolding** for planning, delegation, and reporting.
 - The default portable workflow is: local planning + inline prompt delegation + task-level tracking.
+- The intended operator sequence is `spawn` → `status --watch` → `debug --events` when needed → `message` for mid-run steering → `task retry` for failed PR/check flows → `results` only when a real orchestration session ID exists.
 - Stronger orchestration-session flows such as `--cloud-workspace` and `devsh orchestrate migrate` are advanced options, not the default path for a small workflow-skills change.
 
 ## Related Skills

--- a/.agents/skills/track-agent/SKILL.md
+++ b/.agents/skills/track-agent/SKILL.md
@@ -43,6 +43,18 @@ devsh orchestrate status <orch-task-id> --watch
 
 # Custom polling interval
 devsh orchestrate status <orch-task-id> --watch --interval 5
+
+# Live event stream for deeper triage
+devsh orchestrate debug <orch-task-id> --events
+```
+
+### Steer or Recover
+```bash
+# Send a steering message to the running worker
+devsh orchestrate message <task-run-id> "Investigate the failed lint step" --type request
+
+# Retry a failed PR/check workflow on the original task
+devsh task retry <task-id>
 ```
 
 ### Get Aggregated Results
@@ -97,9 +109,12 @@ Sandbox: morphvm_xyz789
 ## Notes
 
 - `status --watch` is **polling watch mode**, not an SSE stream.
-- `status`, `wait`, and `cancel` take `<orch-task-id>`.
-- `results` takes `<orchestration-id>`.
-- Use this skill for monitoring and cancellation, not for planning or delegation.
+- `debug --events` is the live orchestration event stream and also takes `<orch-task-id>`.
+- `status`, `debug`, `wait`, and `cancel` take `<orch-task-id>`.
+- `message` takes `<task-run-id>`.
+- `task retry` takes `<task-id>`.
+- `results` takes `<orchestration-id>` and only applies when the workflow exposes one.
+- Use this skill for monitoring and recovery, not for planning or delegation.
 
 ## Related Skills
 

--- a/apps/server/src/http-api.test.ts
+++ b/apps/server/src/http-api.test.ts
@@ -15,8 +15,12 @@
  * is not available.
  */
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { AGENT_CATALOG } from "@cmux/shared/agent-catalog";
+import { handleHttpRequest, matchesOrchestrationTaskGroup } from "./http-api";
 
 const SERVER_URL = process.env.CMUX_SERVER_URL ?? "http://localhost:9776";
 
@@ -98,6 +102,68 @@ async function safeFetch(
 }
 
 describe("HTTP API - apps/server", () => {
+  describe("Orchestration filtering helpers", () => {
+    it("matches a single-task local flow by task id", () => {
+      const orchestrationId = "orch_task_local_123";
+      const task = {
+        _id: orchestrationId,
+        status: "running",
+        metadata: null,
+      };
+
+      expect(matchesOrchestrationTaskGroup(task, orchestrationId)).toBe(true);
+      expect(matchesOrchestrationTaskGroup(task, "different_orchestration")).toBe(
+        false,
+      );
+    });
+
+    it("matches a grouped orchestration flow by metadata.orchestrationId", () => {
+      const orchestrationId = "orch_group_456";
+      const groupedTask = {
+        _id: "orch_task_child_1",
+        status: "completed",
+        metadata: {
+          orchestrationId,
+        },
+      };
+      const unrelatedTask = {
+        _id: "orch_task_child_2",
+        status: "completed",
+        metadata: {
+          orchestrationId: "other_group",
+        },
+      };
+
+      expect(matchesOrchestrationTaskGroup(groupedTask, orchestrationId)).toBe(true);
+      expect(matchesOrchestrationTaskGroup(unrelatedTask, orchestrationId)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("Orchestration events auth", () => {
+    it("rejects missing auth for the events endpoint", async () => {
+      const server = createServer((req, res) => {
+        if (!handleHttpRequest(req, res)) {
+          res.statusCode = 404;
+          res.end();
+        }
+      });
+
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+
+      const address = server.address() as AddressInfo;
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/api/orchestrate/events/orch_task_local_123`,
+      );
+
+      expect(response.status).toBe(401);
+      await server.closeAllConnections();
+      server.close();
+    });
+  });
+
   beforeAll(async () => {
     // Ensure preflight check is complete before tests run
     await serverCheckPromise;

--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -666,6 +666,44 @@ interface OrchestrationSpawnResponse {
   status: string;
 }
 
+interface OrchestrationTaskLike {
+  _id: string;
+  status: string;
+  prompt?: string;
+  result?: string | null;
+  errorMessage?: string | null;
+  taskRunId?: string | null;
+  assignedAgentName?: string | null;
+  completedAt?: number | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export function matchesOrchestrationTaskGroup(
+  task: OrchestrationTaskLike,
+  orchestrationId: string,
+): boolean {
+  if (task._id === orchestrationId) {
+    return true;
+  }
+  return task.metadata?.orchestrationId === orchestrationId;
+}
+
+function summarizeOrchestrationTasks(tasks: OrchestrationTaskLike[]) {
+  const completedCount = tasks.filter((task) => task.status === "completed").length;
+  const pendingCount = tasks.filter((task) => task.status === "pending").length;
+  const failedCount = tasks.filter((task) => task.status === "failed").length;
+  const runningCount = tasks.filter(
+    (task) => task.status === "running" || task.status === "assigned",
+  ).length;
+
+  return {
+    completedCount,
+    pendingCount,
+    failedCount,
+    runningCount,
+  };
+}
+
 /**
  * Handle POST /api/orchestrate/spawn
  *
@@ -1160,19 +1198,9 @@ async function handleOrchestrationResults(
         limit: 100,
       });
 
-      // Filter by orchestrationId
-      // Check both:
-      // 1. Task's own _id (for CLI-spawned tasks where _id is the orchestrationId)
-      // 2. metadata.orchestrationId (for MCP-spawned tasks grouped by parent orchestrationId)
-      const filteredTasks = tasks.filter((task) => {
-        // Match if orchestrationId is the task's own ID
-        if (task._id === orchestrationId) {
-          return true;
-        }
-        // Match if orchestrationId is stored in metadata (for grouped tasks)
-        const metadata = task.metadata as Record<string, unknown> | undefined;
-        return metadata?.orchestrationId === orchestrationId;
-      });
+      const filteredTasks = tasks.filter((task) =>
+        matchesOrchestrationTaskGroup(task, orchestrationId),
+      );
 
       const totalTasks = filteredTasks.length;
       const completedTasks = filteredTasks.filter((t) => t.status === "completed").length;
@@ -1324,16 +1352,12 @@ async function handleOrchestrationEvents(
             teamSlugOrId,
             limit: 100,
           });
-          const filtered = tasks.filter((t) => {
-            const metadata = t.metadata as Record<string, unknown> | undefined;
-            return metadata?.orchestrationId === orchestrationId;
-          });
+          const filtered = tasks.filter((task) =>
+            matchesOrchestrationTaskGroup(task, orchestrationId),
+          );
           return {
             tasks: filtered,
-            completedCount: filtered.filter((t) => t.status === "completed").length,
-            pendingCount: filtered.filter((t) => t.status === "pending").length,
-            failedCount: filtered.filter((t) => t.status === "failed").length,
-            runningCount: filtered.filter((t) => t.status === "running" || t.status === "assigned").length,
+            ...summarizeOrchestrationTasks(filtered),
           };
         });
       }
@@ -2075,7 +2099,7 @@ export function handleHttpRequest(
   // CORS headers for CLI access
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Task-Run-JWT, Last-Event-ID");
 
   // Handle preflight
   if (method === "OPTIONS") {

--- a/packages/devsh/internal/cli/orchestrate_debug.go
+++ b/packages/devsh/internal/cli/orchestrate_debug.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -42,8 +41,10 @@ Examples:
   devsh orchestrate debug <task-id> --events # Stream events from sandbox`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+		ctx := cmd.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
 
 		teamSlug, err := auth.GetTeamSlug()
 		if err != nil {
@@ -195,28 +196,219 @@ func showDependencyGraph(ctx context.Context, client *vm.Client, orchTaskID stri
 }
 
 func streamEvents(ctx context.Context, client *vm.Client, orchTaskID string) error {
-	// Get task to find sandbox/instance info
-	result, err := client.OrchestrationStatus(ctx, orchTaskID)
+	statusCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	result, err := client.OrchestrationStatus(statusCtx, orchTaskID)
+	cancel()
 	if err != nil {
 		return fmt.Errorf("failed to get task: %w", err)
 	}
 
-	if result.TaskRun == nil {
-		return fmt.Errorf("task has no linked task run - cannot stream events")
+	streamID, hasSessionID := resolveEventStreamID(result)
+	if strings.TrimSpace(streamID) == "" {
+		return fmt.Errorf("task %s does not expose an event stream identifier", orchTaskID)
 	}
 
-	fmt.Fprintf(os.Stderr, "Streaming events from task run: %s\n", result.TaskRun.ID)
-	fmt.Fprintf(os.Stderr, "Note: Event streaming requires sandbox access\n")
-	fmt.Fprintf(os.Stderr, "Events path: /root/lifecycle/memory/orchestration/EVENTS.jsonl\n")
-	fmt.Fprintf(os.Stderr, "\n--- Events would appear here if sandbox is accessible ---\n")
-
-	// TODO: Implement actual event streaming via sandbox exec or workerUrl websocket
-	// For now, show instructions for manual access
-	if result.TaskRun.VSCodeURL != "" {
-		fmt.Fprintf(os.Stderr, "\nOpen VSCode to view events:\n  %s\n", result.TaskRun.VSCodeURL)
+	fmt.Printf("Streaming orchestration events for %s\n", streamID)
+	fmt.Printf("Source task: %s\n", orchTaskID)
+	if result.TaskRun != nil {
+		fmt.Printf("Linked task run: %s\n", result.TaskRun.ID)
 	}
+	if hasSessionID {
+		fmt.Println("Mode: orchestration session stream")
+	} else {
+		fmt.Println("Mode: single-task fallback stream")
+		fmt.Println("Results tip: this flow may not have a standalone orchestration session ID; rely on status/debug output unless one is shown elsewhere.")
+	}
+	fmt.Println("Press Ctrl+C to stop streaming.")
+	fmt.Println()
 
-	return nil
+	return client.SubscribeOrchestrationEvents(ctx, streamID, "", func(event vm.OrchestrationEvent) {
+		if event.Event == "" {
+			return
+		}
+
+		line, nextAction, terminalStatus := formatOrchestrationEvent(event, result, hasSessionID)
+		if line != "" {
+			fmt.Println(line)
+		}
+		if nextAction != "" {
+			fmt.Println(nextAction)
+		}
+		_ = terminalStatus
+	})
+}
+
+func resolveEventStreamID(result *vm.OrchestrationStatusResult) (string, bool) {
+	if result == nil {
+		return "", false
+	}
+	metadata := result.Task.Metadata
+	if metadata != nil {
+		if orchestrationID, ok := metadata["orchestrationId"].(string); ok && strings.TrimSpace(orchestrationID) != "" {
+			return strings.TrimSpace(orchestrationID), true
+		}
+	}
+	if strings.TrimSpace(result.Task.ID) != "" {
+		return strings.TrimSpace(result.Task.ID), false
+	}
+	return "", false
+}
+
+func formatOrchestrationEvent(event vm.OrchestrationEvent, result *vm.OrchestrationStatusResult, hasSessionID bool) (string, string, string) {
+	timestamp := time.Now().Format("15:04:05")
+	data := event.Data
+	taskID := strings.TrimSpace(getEventString(data, "taskId"))
+	status := strings.TrimSpace(getEventString(data, "status"))
+	assignedAgent := strings.TrimSpace(getEventString(data, "assignedAgentName"))
+	completedCount := getEventInt(data, "completedCount")
+	pendingCount := getEventInt(data, "pendingCount")
+	failedCount := getEventInt(data, "failedCount")
+	runningCount := getEventInt(data, "runningCount")
+
+	switch event.Event {
+	case "connected":
+		return fmt.Sprintf("[%s] connected stream=%s", timestamp, getEventString(data, "orchestrationId")), "", ""
+	case "heartbeat":
+		return fmt.Sprintf("[%s] heartbeat running=%d pending=%d completed=%d failed=%d", timestamp, runningCount, pendingCount, completedCount, failedCount), "", ""
+	case "task_completed":
+		resultSummary := summarizeText(getEventString(data, "result"), 120)
+		line := fmt.Sprintf("[%s] task_completed %s status=completed", timestamp, fallbackTaskID(taskID, result))
+		if resultSummary != "" {
+			line += fmt.Sprintf(" result=%q", resultSummary)
+		}
+		return line, "", "completed"
+	case "task_status":
+		line := fmt.Sprintf("[%s] task_status %s status=%s", timestamp, fallbackTaskID(taskID, result), fallbackStatus(status))
+		if assignedAgent != "" {
+			line += fmt.Sprintf(" agent=%s", assignedAgent)
+		}
+		errorSummary := summarizeText(getEventString(data, "errorMessage"), 160)
+		if errorSummary != "" {
+			line += fmt.Sprintf(" error=%q", errorSummary)
+			return line, renderFailureGuidance(result, hasSessionID), status
+		}
+		if isTerminalStatus(status) && status != "completed" {
+			return line, renderFailureGuidance(result, hasSessionID), status
+		}
+		return line, "", status
+	default:
+		return fmt.Sprintf("[%s] %s %s", timestamp, event.Event, summarizeText(mustMarshalEventData(data), 160)), "", ""
+	}
+}
+
+func renderFailureGuidance(result *vm.OrchestrationStatusResult, hasSessionID bool) string {
+	actions := make([]string, 0, 3)
+	if result != nil && result.TaskRun != nil && strings.TrimSpace(result.TaskRun.ID) != "" {
+		actions = append(actions, fmt.Sprintf("next: devsh orchestrate message %s \"<guidance>\" --type request", result.TaskRun.ID))
+	}
+	if result != nil && result.Task.TaskID != nil && strings.TrimSpace(*result.Task.TaskID) != "" {
+		actions = append(actions, fmt.Sprintf("retry: devsh task retry %s", strings.TrimSpace(*result.Task.TaskID)))
+	}
+	if hasSessionID {
+		if orchestrationID, ok := resolveFailureResultsID(result); ok {
+			actions = append(actions, fmt.Sprintf("results: devsh orchestrate results %s", orchestrationID))
+		}
+	}
+	return strings.Join(actions, " | ")
+}
+
+func resolveFailureResultsID(result *vm.OrchestrationStatusResult) (string, bool) {
+	if result == nil {
+		return "", false
+	}
+	metadata := result.Task.Metadata
+	if metadata == nil {
+		return "", false
+	}
+	orchestrationID, ok := metadata["orchestrationId"].(string)
+	if !ok || strings.TrimSpace(orchestrationID) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(orchestrationID), true
+}
+
+func fallbackTaskID(taskID string, result *vm.OrchestrationStatusResult) string {
+	if strings.TrimSpace(taskID) != "" {
+		return strings.TrimSpace(taskID)
+	}
+	if result != nil {
+		return strings.TrimSpace(result.Task.ID)
+	}
+	return "unknown-task"
+}
+
+func fallbackStatus(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return "unknown"
+	}
+	return strings.TrimSpace(status)
+}
+
+func getEventString(data map[string]any, key string) string {
+	if data == nil {
+		return ""
+	}
+	value, ok := data[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}
+
+func getEventInt(data map[string]any, key string) int {
+	if data == nil {
+		return 0
+	}
+	value, ok := data[key]
+	if !ok || value == nil {
+		return 0
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int32:
+		return int(typed)
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err == nil {
+			return int(parsed)
+		}
+	}
+	return 0
+}
+
+func summarizeText(value string, limit int) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	trimmed = strings.Join(strings.Fields(trimmed), " ")
+	if len(trimmed) <= limit {
+		return trimmed
+	}
+	if limit <= 3 {
+		return trimmed[:limit]
+	}
+	return trimmed[:limit-3] + "..."
+}
+
+func mustMarshalEventData(data map[string]any) string {
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
 }
 
 func showTaskDetails(ctx context.Context, client *vm.Client, orchTaskID string) error {

--- a/packages/devsh/internal/vm/client.go
+++ b/packages/devsh/internal/vm/client.go
@@ -2012,24 +2012,25 @@ type OrchestrationSpawnResult struct {
 
 // OrchestrationTask represents an orchestration task from the API
 type OrchestrationTask struct {
-	ID                string   `json:"_id"`
-	TeamID            string   `json:"teamId"`
-	UserID            string   `json:"userId"`
-	Prompt            string   `json:"prompt"`
-	Status            string   `json:"status"`
-	Priority          int      `json:"priority"`
-	Dependencies      []string `json:"dependencies,omitempty"`
-	AssignedAgentName *string  `json:"assignedAgentName,omitempty"`
-	AssignedSandboxID *string  `json:"assignedSandboxId,omitempty"`
-	TaskID            *string  `json:"taskId,omitempty"`
-	TaskRunID         *string  `json:"taskRunId,omitempty"`
-	Result            *string  `json:"result,omitempty"`
-	ErrorMessage      *string  `json:"errorMessage,omitempty"`
-	CreatedAt         int64    `json:"createdAt"`
-	UpdatedAt         int64    `json:"updatedAt"`
-	AssignedAt        *int64   `json:"assignedAt,omitempty"`
-	StartedAt         *int64   `json:"startedAt,omitempty"`
-	CompletedAt       *int64   `json:"completedAt,omitempty"`
+	ID                string                 `json:"_id"`
+	TeamID            string                 `json:"teamId"`
+	UserID            string                 `json:"userId"`
+	Prompt            string                 `json:"prompt"`
+	Status            string                 `json:"status"`
+	Priority          int                    `json:"priority"`
+	Dependencies      []string               `json:"dependencies,omitempty"`
+	AssignedAgentName *string                `json:"assignedAgentName,omitempty"`
+	AssignedSandboxID *string                `json:"assignedSandboxId,omitempty"`
+	TaskID            *string                `json:"taskId,omitempty"`
+	TaskRunID         *string                `json:"taskRunId,omitempty"`
+	Metadata          map[string]interface{} `json:"metadata,omitempty"`
+	Result            *string                `json:"result,omitempty"`
+	ErrorMessage      *string                `json:"errorMessage,omitempty"`
+	CreatedAt         int64                  `json:"createdAt"`
+	UpdatedAt         int64                  `json:"updatedAt"`
+	AssignedAt        *int64                 `json:"assignedAt,omitempty"`
+	StartedAt         *int64                 `json:"startedAt,omitempty"`
+	CompletedAt       *int64                 `json:"completedAt,omitempty"`
 }
 
 // OrchestrationListResult represents the result of listing orchestration tasks
@@ -2347,9 +2348,9 @@ type OrchestrationProviderInfo struct {
 
 // OrchestrationEvent represents an SSE event from orchestration updates
 type OrchestrationEvent struct {
-	Event string                 `json:"event"`
-	Data  map[string]interface{} `json:"data"`
-	ID    string                 `json:"id,omitempty"`
+	Event string         `json:"event"`
+	Data  map[string]any `json:"data"`
+	ID    string         `json:"id,omitempty"`
 }
 
 // OrchestrationSSECallback is called for each SSE event received
@@ -2362,7 +2363,7 @@ func (c *Client) SubscribeOrchestrationEvents(ctx context.Context, orchestration
 
 	path := fmt.Sprintf("/api/orchestrate/events/%s", orchestrationID)
 	if c.teamSlug != "" && taskRunJwt == "" {
-		path += "?teamSlugOrId=" + c.teamSlug
+		path += "?teamSlugOrId=" + url.QueryEscape(c.teamSlug)
 	}
 
 	url := cfg.ServerURL + path
@@ -2372,7 +2373,6 @@ func (c *Client) SubscribeOrchestrationEvents(ctx context.Context, orchestration
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set auth header
 	if taskRunJwt != "" {
 		req.Header.Set("X-Task-Run-JWT", taskRunJwt)
 	} else {
@@ -2384,68 +2384,104 @@ func (c *Client) SubscribeOrchestrationEvents(ctx context.Context, orchestration
 	}
 
 	req.Header.Set("Accept", "text/event-stream")
-	req.Header.Set("Cache-Control", "no-cache")
+	if taskRunJwt != "" {
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req.Header.Set("Content-Type", "text/event-stream")
+	}
+	if c.teamSlug != "" {
+		req.Header.Set("X-Team-Slug", c.teamSlug)
+	}
+	if lastEventID := os.Getenv("DEVSH_LAST_EVENT_ID"); strings.TrimSpace(lastEventID) != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+	if taskRunID := os.Getenv("CMUX_PARENT_TASK_RUN_ID"); strings.TrimSpace(taskRunID) != "" {
+		query := req.URL.Query()
+		if query.Get("taskRunId") == "" {
+			query.Set("taskRunId", taskRunID)
+			req.URL.RawQuery = query.Encode()
+		}
+	}
+	if taskRunJwt != "" {
+		query := req.URL.Query()
+		if query.Get("taskRunId") == "" {
+			if taskRunID := os.Getenv("CMUX_TASK_RUN_ID"); strings.TrimSpace(taskRunID) != "" {
+				query.Set("taskRunId", taskRunID)
+				req.URL.RawQuery = query.Encode()
+			}
+		}
+	}
+	if taskRunJwt == "" && c.teamSlug != "" {
+		req.Header.Set("Cache-Control", "no-cache")
+	}
 
-	// Use a client without timeout for SSE
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return fmt.Errorf("SSE connection failed: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
-		return fmt.Errorf("SSE endpoint returned %d", resp.StatusCode)
+		defer resp.Body.Close()
+		return fmt.Errorf("SSE endpoint returned %d: %s", resp.StatusCode, readErrorBody(resp.Body))
 	}
 
-	// Read SSE events in a goroutine
-	go func() {
-		defer resp.Body.Close()
+	defer resp.Body.Close()
 
-		scanner := bufio.NewScanner(resp.Body)
-		// Set larger buffer to handle large SSE payloads (256KB max line)
-		const maxScanTokenSize = 256 * 1024
-		scanner.Buffer(make([]byte, maxScanTokenSize), maxScanTokenSize)
+	scanner := bufio.NewScanner(resp.Body)
+	const maxScanTokenSize = 256 * 1024
+	scanner.Buffer(make([]byte, maxScanTokenSize), maxScanTokenSize)
 
-		var eventType string
-		var data string
-		var id string
+	var eventType string
+	var dataParts []string
+	var id string
 
-		for scanner.Scan() {
-			line := scanner.Text()
-
-			if line == "" {
-				// Empty line = end of event
-				if eventType != "" && data != "" {
-					var eventData map[string]interface{}
-					if err := json.Unmarshal([]byte(data), &eventData); err == nil {
-						callback(OrchestrationEvent{
-							Event: eventType,
-							Data:  eventData,
-							ID:    id,
-						})
-					}
-				}
-				eventType = ""
-				data = ""
-				id = ""
-				continue
-			}
-
-			if strings.HasPrefix(line, "event:") {
-				eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
-			} else if strings.HasPrefix(line, "data:") {
-				data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-			} else if strings.HasPrefix(line, "id:") {
-				id = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
-			}
+	dispatch := func() {
+		if eventType == "" || len(dataParts) == 0 {
+			return
 		}
-
-		// Log scanner errors if any
-		if err := scanner.Err(); err != nil {
-			fmt.Fprintf(os.Stderr, "[SSE] Scanner error: %v\n", err)
+		var eventData map[string]any
+		payload := strings.Join(dataParts, "\n")
+		if err := json.Unmarshal([]byte(payload), &eventData); err == nil {
+			callback(OrchestrationEvent{
+				Event: eventType,
+				Data:  eventData,
+				ID:    id,
+			})
 		}
-	}()
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			dispatch()
+			eventType = ""
+			dataParts = nil
+			id = ""
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "event:") {
+			eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataParts = append(dataParts, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			continue
+		}
+		if strings.HasPrefix(line, "id:") {
+			id = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+		}
+	}
+
+	dispatch()
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		return fmt.Errorf("SSE scanner error: %w", err)
+	}
+	if err := ctx.Err(); err != nil && err != context.Canceled {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Wire `devsh orchestrate debug <orch-task-id> --events` to live SSE infrastructure
- Align server-side event filtering with results filtering semantics
- Update workflow skill docs with explicit operator sequence for failure handling

## Changes

**CLI (packages/devsh)**
- `orchestrate_debug.go`: Replace placeholder with live `SubscribeOrchestrationEvents` call, add failure guidance output
- `client.go`: Add `Metadata` field to `OrchestrationTask`, improve SSE parsing for multi-line data

**Server (apps/server)**
- `http-api.ts`: Extract `matchesOrchestrationTaskGroup` helper for consistent filtering across events/results
- `http-api.test.ts`: Add filtering helper tests and auth rejection test

**Skill docs (.agents/skills)**
- Document operator sequence: spawn → status --watch → debug --events → message → task retry → results
- Clarify ID usage: orch-task-id vs task-run-id vs task-id vs orchestration-id

## Test plan

- [x] `bun check` passes
- [x] `bun test src/http-api.test.ts` passes (37 tests)
- [x] `go build ./...` passes for devsh CLI
- [ ] Manual: `devsh orchestrate spawn` + `debug --events` streams live updates
- [ ] Manual: Failure events show next-action guidance