### PR TITLE
feat(sandboxes): improve GitHub auth refresh error messages

### DIFF
--- a/apps/client/src/hooks/useMorphWorkspace.ts
+++ b/apps/client/src/hooks/useMorphWorkspace.ts
@@ -183,14 +183,26 @@ export function useRefreshGitHubAuth({
               ? "Container is stopped. Resume it first."
               : "VM is paused. Resume it first.";
         } else if (
+          error.message.includes("503") ||
+          error.message.includes("exec service") ||
+          error.message.includes("not reachable")
+        ) {
+          message =
+            provider === "pve-lxc"
+              ? "Container exec service not responding. Try restarting the container."
+              : "Instance exec service not responding. Try restarting the VM.";
+        } else if (
           error.message.includes("401") ||
-          error.message.includes("GitHub")
+          error.message.includes("GitHub account not connected")
         ) {
           message = "GitHub account not connected. Check your settings.";
         } else if (error.message.includes("Unsupported provider")) {
           message = "This workspace type does not support GitHub refresh.";
+        } else if (error.message.includes("404") || error.message.includes("not found")) {
+          message = "Sandbox not found or has been deleted.";
         } else {
-          message = error.message;
+          // Show server error message if available
+          message = error.message || "Failed to refresh GitHub auth.";
         }
       }
       toast.error(message, { id: context?.toastId });

--- a/apps/www/lib/routes/morph.route.ts
+++ b/apps/www/lib/routes/morph.route.ts
@@ -470,11 +470,19 @@ morphRouter.openapi(
 
       return c.json({ refreshed: true });
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       console.error(
-        "[morph.refresh-github-auth] Failed to refresh GitHub auth:",
-        error
+        `[morph.refresh-github-auth] Failed to refresh GitHub auth for ${instanceId}:`,
+        errorMessage
       );
-      return c.text("Failed to refresh GitHub authentication", 500);
+      // Return more specific error message for debugging
+      if (errorMessage.includes("exec failed") || errorMessage.includes("HTTP exec")) {
+        return c.text("Instance exec service not reachable - instance may need restart", 503);
+      }
+      if (errorMessage.includes("not found") || errorMessage.includes("does not exist")) {
+        return c.text("Instance not found or deleted", 404);
+      }
+      return c.text(`Failed to refresh GitHub authentication: ${errorMessage.slice(0, 200)}`, 500);
     }
   }
 );

--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -2321,7 +2321,13 @@ sandboxesRouter.openapi(
         return c.text("Unsupported sandbox provider", 400);
       }
 
+      console.log(
+        `[sandboxes.refresh-github-auth] Fetching instance ${id} (provider=${provider})`
+      );
       const instance = await getInstanceById(id, getMorphClientOrNull());
+      console.log(
+        `[sandboxes.refresh-github-auth] Instance ${id} status=${instance.status}`
+      );
 
       const metadataTeamId = getInstanceTeamId(instance);
       if (metadataTeamId && metadataTeamId !== team.uuid) {
@@ -2332,9 +2338,15 @@ sandboxesRouter.openapi(
       if (provider === "morph" && instance.status === "paused") {
         return c.text("Instance is paused - resume it first", 409);
       } else if (provider === "pve-lxc" && instance.status !== "running") {
-        return c.text("Container is stopped - resume it first", 409);
+        console.log(
+          `[sandboxes.refresh-github-auth] Container ${id} is ${instance.status}, not running`
+        );
+        return c.text(`Container is ${instance.status} - resume it first`, 409);
       }
 
+      console.log(
+        `[sandboxes.refresh-github-auth] Running gh auth login for ${id}`
+      );
       await configureGithubAccess(instance, gitAuthToken);
 
       console.log(
@@ -2343,11 +2355,19 @@ sandboxesRouter.openapi(
 
       return c.json({ refreshed: true });
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       console.error(
         `[sandboxes.refresh-github-auth] Failed to refresh GitHub auth for sandbox ${id}:`,
-        error
+        errorMessage
       );
-      return c.text("Failed to refresh GitHub authentication", 500);
+      // Return more specific error message for debugging
+      if (errorMessage.includes("exec failed") || errorMessage.includes("cmux-execd")) {
+        return c.text("Container exec service not reachable - container may need restart", 503);
+      }
+      if (errorMessage.includes("not found") || errorMessage.includes("Unable to resolve")) {
+        return c.text("Sandbox not found or deleted", 404);
+      }
+      return c.text(`Failed to refresh GitHub authentication: ${errorMessage.slice(0, 200)}`, 500);
     }
   }
 );


### PR DESCRIPTION
## Summary
- Add detailed server-side logging for GitHub auth refresh debugging
- Return specific HTTP status codes: 503 for exec service unreachable, 404 for instance not found
- Show actual error message in response instead of generic "Failed to refresh"
- Update frontend to display actionable messages for each error type

## Context
Investigating "Failed to refresh GitHub auth" errors. This PR adds logging and specific error responses to help diagnose whether the issue is:
- Container not running (409)
- Exec service (cmux-execd) not responding (503)
- Instance deleted/not found (404)
- PVE API connectivity issues

## Test plan
- [ ] Deploy to production
- [ ] Trigger GitHub auth refresh on a running sandbox
- [ ] Check server logs for detailed error output
- [ ] Verify frontend shows specific error messages