### PR TITLE
fix(edge-router-pvelxc): add x-stack-auth to CORS allowed headers

### DIFF
--- a/apps/edge-router-pvelxc/src/index.ts
+++ b/apps/edge-router-pvelxc/src/index.ts
@@ -187,7 +187,7 @@ function addPermissiveCORS(headers: Headers, origin?: string | null): Headers {
   );
   headers.set(
     "access-control-allow-headers",
-    "Authorization, Content-Type, X-Client-Version, X-Client-Type, X-Request-Id, Accept, Origin, Cache-Control",
+    "Authorization, Content-Type, X-Client-Version, X-Client-Type, X-Request-Id, Accept, Origin, Cache-Control, x-stack-auth",
   );
   headers.set("access-control-expose-headers", "*");
   headers.set("access-control-allow-credentials", "true");


### PR DESCRIPTION
## Summary
- Added `x-stack-auth` to the `Access-Control-Allow-Headers` list in the PVE-LXC edge router
- Fixes "Failed to fetch" errors when loading branch lists and workspace configs on the dashboard

## Root Cause
The browser preflight (OPTIONS) request was rejected because the Cloudflare Worker wasn't allowing the `x-stack-auth` header. This header is used by Stack Auth for authentication.

## Test plan
- [ ] Deploy edge router: `cd apps/edge-router-pvelxc && bun run deploy`
- [ ] Visit dashboard, select a repo, verify branch list loads without CORS errors