### PR TITLE
fix(client): extract iframe preflight utils to fix vitest resolution

### DIFF
--- a/apps/client/src/hooks/iframePreflight.utils.ts
+++ b/apps/client/src/hooks/iframePreflight.utils.ts
@@ -1,0 +1,30 @@
+import { extractMorphInstanceInfo, isLoopbackHostname } from "@cmux/shared";
+
+export function shouldUseIframePreflightProxy(
+  target: string | URL | null | undefined
+): boolean {
+  if (!target) {
+    return false;
+  }
+
+  try {
+    return extractMorphInstanceInfo(target) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function shouldUseServerIframePreflight(
+  target: string | URL | null | undefined
+): boolean {
+  if (!target) {
+    return false;
+  }
+
+  try {
+    const url = typeof target === "string" ? new URL(target) : target;
+    return isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
+}

--- a/apps/client/src/hooks/useIframePreflight.test.ts
+++ b/apps/client/src/hooks/useIframePreflight.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   shouldUseIframePreflightProxy,
   shouldUseServerIframePreflight,
-} from "./useIframePreflight";
+} from "./iframePreflight.utils";
 
 describe("shouldUseIframePreflightProxy", () => {
   it("returns true for direct Morph cloud hosts", () => {

--- a/apps/client/src/hooks/useIframePreflight.ts
+++ b/apps/client/src/hooks/useIframePreflight.ts
@@ -1,13 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  extractMorphInstanceInfo,
   isIframePreflightPhasePayload,
   isIframePreflightResult,
-  isLoopbackHostname,
   type IframePreflightPhasePayload,
   type IframePreflightResult,
   type IframePreflightServerPhase,
 } from "@cmux/shared";
+export {
+  shouldUseIframePreflightProxy,
+  shouldUseServerIframePreflight,
+} from "./iframePreflight.utils";
+import {
+  shouldUseIframePreflightProxy,
+  shouldUseServerIframePreflight,
+} from "./iframePreflight.utils";
 import { WWW_ORIGIN } from "@/lib/wwwOrigin";
 import { useSocket } from "@/contexts/socket/use-socket";
 import { useUser } from "@stackframe/react";
@@ -41,35 +47,6 @@ type ParsedEvent = {
   event: string;
   data: string;
 };
-
-export function shouldUseIframePreflightProxy(
-  target: string | URL | null | undefined
-): boolean {
-  if (!target) {
-    return false;
-  }
-
-  try {
-    return extractMorphInstanceInfo(target) !== null;
-  } catch {
-    return false;
-  }
-}
-
-export function shouldUseServerIframePreflight(
-  target: string | URL | null | undefined
-): boolean {
-  if (!target) {
-    return false;
-  }
-
-  try {
-    const url = typeof target === "string" ? new URL(target) : target;
-    return isLoopbackHostname(url.hostname);
-  } catch {
-    return false;
-  }
-}
 
 const EVENT_SEPARATOR = "\n\n";
 


### PR DESCRIPTION
## Summary
- Extract `shouldUseIframePreflightProxy` and `shouldUseServerIframePreflight` from `useIframePreflight.ts` into `iframePreflight.utils.ts`
- These are pure URL-matching functions with no React/browser dependencies
- Fixes `useIframePreflight.test.ts` failing under vitest workspace mode because transitive `@/` imports (React hooks, socket context) couldn't be resolved by Node's ESM loader

## Test plan
- [x] `bunx vitest run apps/client/src/hooks/useIframePreflight.test.ts` - 11/11 pass (was 0/11 failing)
- [x] `bun check` passes
- [x] Re-exports preserved so existing consumers (`TaskPanelFactory.tsx`, `vscode.tsx`) continue working