### PR TITLE
refactor(openai): use shared task sandbox wrappers

### DIFF
--- a/packages/shared/src/providers/openai/environment.ts
+++ b/packages/shared/src/providers/openai/environment.ts
@@ -11,6 +11,7 @@ import {
 } from "../../agent-memory-protocol";
 import { buildMergedCodexConfigToml } from "../../mcp-preview";
 export { stripFilteredConfigKeys } from "../../mcp-preview";
+import { getTaskSandboxWrapperFiles } from "../common/task-sandbox-wrappers";
 
 /**
  * Apply API keys for OpenAI Codex.
@@ -201,74 +202,7 @@ exit 1
   });
 
   if (hasTaskRunJwt) {
-    const ghWrapperScript = `#!/usr/bin/env sh
-set -eu
-
-# Wrapper to block dangerous gh commands in cmux task sandboxes.
-REAL_GH="/usr/bin/gh"
-
-if [ -n "\${CMUX_TASK_RUN_JWT:-}" ]; then
-  case "\${1:-}:\${2:-}" in
-    pr:create)
-      echo "ERROR: gh pr create is blocked in cmux sandboxes." >&2
-      echo "The cmux crown workflow handles PR creation automatically." >&2
-      exit 1
-      ;;
-    pr:merge)
-      echo "ERROR: gh pr merge is blocked in cmux sandboxes." >&2
-      echo "PR merging requires explicit user approval." >&2
-      exit 1
-      ;;
-    pr:close)
-      echo "ERROR: gh pr close is blocked in cmux sandboxes." >&2
-      echo "PR lifecycle is managed by the cmux platform." >&2
-      exit 1
-      ;;
-    workflow:run)
-      echo "ERROR: gh workflow run is blocked in cmux sandboxes." >&2
-      echo "Infrastructure workflows must be triggered by a human." >&2
-      exit 1
-      ;;
-  esac
-fi
-
-exec "$REAL_GH" "$@"
-`;
-    files.push({
-      destinationPath: "/usr/local/bin/gh",
-      contentBase64: Buffer.from(ghWrapperScript).toString("base64"),
-      mode: "755",
-    });
-
-    // Wrapper to block dangerous git operations in cmux task sandboxes.
-    const gitWrapperScript = `#!/usr/bin/env sh
-set -eu
-
-REAL_GIT="/usr/bin/git"
-
-if [ -n "\${CMUX_TASK_RUN_JWT:-}" ]; then
-  case "\${1:-}" in
-    push)
-      for arg in "$@"; do
-        case "$arg" in
-          --force|--force-with-lease|-f)
-            echo "ERROR: git force push is blocked in cmux sandboxes." >&2
-            echo "Force pushing destroys history and breaks PR workflows." >&2
-            exit 1
-            ;;
-        esac
-      done
-      ;;
-  esac
-fi
-
-exec "$REAL_GIT" "$@"
-`;
-    files.push({
-      destinationPath: "/usr/local/bin/git",
-      contentBase64: Buffer.from(gitWrapperScript).toString("base64"),
-      mode: "755",
-    });
+    files.push(...getTaskSandboxWrapperFiles(Buffer));
   }
 
   // Autopilot wrapper script for unattended OpenAI Codex sessions.


### PR DESCRIPTION
## Summary
- Replaces inline gh/git wrapper scripts in the Codex provider with the shared `getTaskSandboxWrapperFiles()` helper from `common/task-sandbox-wrappers.ts`
- Eliminates ~60 lines of duplicated wrapper code
- Follow-up to #521 which introduced the shared module

## Test plan
- [x] `bun test packages/shared/src/providers/openai/environment.test.ts` — 40/40 pass
- [x] `bun check` — PASS