### PR TITLE
fix(client): proactive iframe focus ownership tracking on window blur/focus

### DIFF
--- a/apps/client/src/lib/iframeFocusGuard.dom.test.ts
+++ b/apps/client/src/lib/iframeFocusGuard.dom.test.ts
@@ -3,7 +3,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  clearFocusedIframeBeforeBlur,
   ensureIframeFocusGuard,
+  getWindowHasFocus,
   resetIframeFocusGuardForTests,
   setIframeFocusAllowedChecker,
 } from "./iframeFocusGuard";
@@ -114,5 +116,151 @@ describe("iframeFocusGuard", () => {
     expect(elementFocusSpy).toHaveBeenCalled();
     expect(fallbackElement).not.toBeNull();
     expect(document.activeElement).toBe(fallbackElement);
+  });
+
+  it("captures iframe focus ownership on window blur and restores on refocus", async () => {
+    const iframe = document.createElement("iframe");
+    Object.defineProperty(iframe, "getClientRects", {
+      configurable: true,
+      value: () => [{ width: 200, height: 100 }],
+    });
+    iframe.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 100,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(iframe);
+
+    // Make iframe focus-eligible
+    setIframeFocusAllowedChecker(() => true);
+    ensureIframeFocusGuard();
+
+    // Simulate iframe having focus
+    let simulatedActiveElement: Element | null = iframe;
+    Object.defineProperty(document, "activeElement", {
+      configurable: true,
+      get: () => simulatedActiveElement,
+    });
+
+    const iframeFocusSpy = vi.spyOn(iframe, "focus").mockImplementation(() => {
+      simulatedActiveElement = iframe;
+    });
+
+    // Window blur should capture iframe focus ownership
+    expect(getWindowHasFocus()).toBe(true);
+    window.dispatchEvent(new Event("blur"));
+    expect(getWindowHasFocus()).toBe(false);
+
+    // Simulate focus moving to body during blur (browser behavior)
+    simulatedActiveElement = document.body;
+
+    // Window focus should restore iframe focus
+    window.dispatchEvent(new Event("focus"));
+    expect(getWindowHasFocus()).toBe(true);
+
+    // Wait for requestAnimationFrame
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(iframeFocusSpy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it("does not restore iframe focus if user clicked elsewhere during refocus", async () => {
+    const iframe = document.createElement("iframe");
+    Object.defineProperty(iframe, "getClientRects", {
+      configurable: true,
+      value: () => [{ width: 200, height: 100 }],
+    });
+    iframe.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 100,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(iframe);
+
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    setIframeFocusAllowedChecker(() => true);
+    ensureIframeFocusGuard();
+
+    // Simulate iframe having focus
+    let simulatedActiveElement: Element | null = iframe;
+    Object.defineProperty(document, "activeElement", {
+      configurable: true,
+      get: () => simulatedActiveElement,
+    });
+
+    const iframeFocusSpy = vi.spyOn(iframe, "focus");
+
+    // Window blur captures iframe
+    window.dispatchEvent(new Event("blur"));
+
+    // User clicks button during refocus
+    simulatedActiveElement = button;
+
+    // Window focus
+    window.dispatchEvent(new Event("focus"));
+
+    // Wait for requestAnimationFrame
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    // Should NOT restore iframe focus because button is interactive
+    expect(iframeFocusSpy).not.toHaveBeenCalled();
+  });
+
+  it("clears focus ownership when clearFocusedIframeBeforeBlur is called", async () => {
+    const iframe = document.createElement("iframe");
+    Object.defineProperty(iframe, "getClientRects", {
+      configurable: true,
+      value: () => [{ width: 200, height: 100 }],
+    });
+    iframe.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 100,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(iframe);
+
+    setIframeFocusAllowedChecker(() => true);
+    ensureIframeFocusGuard();
+
+    Object.defineProperty(document, "activeElement", {
+      configurable: true,
+      get: () => iframe,
+    });
+
+    const iframeFocusSpy = vi.spyOn(iframe, "focus");
+
+    // Window blur captures iframe
+    window.dispatchEvent(new Event("blur"));
+
+    // Explicitly clear the stored focus
+    clearFocusedIframeBeforeBlur();
+
+    // Window focus
+    window.dispatchEvent(new Event("focus"));
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    // Should NOT restore because we cleared ownership
+    expect(iframeFocusSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/src/lib/iframeFocusGuard.ts
+++ b/apps/client/src/lib/iframeFocusGuard.ts
@@ -2,7 +2,16 @@ let focusGuardInitialized = false;
 let lastActiveElement: Element | null = null;
 let iframeFocusAllowedChecker: (iframe: HTMLIFrameElement) => boolean = () => true;
 let focusInHandler: ((event: FocusEvent) => void) | null = null;
+let windowBlurHandler: (() => void) | null = null;
+let windowFocusHandler: (() => void) | null = null;
 let focusGuardFallbackElement: HTMLDivElement | null = null;
+/**
+ * Tracks which iframe had focus before window blur.
+ * This is captured proactively on blur (before activeElement changes)
+ * so we can restore focus correctly on window refocus.
+ */
+let focusedIframeBeforeBlur: HTMLIFrameElement | null = null;
+let windowHasFocus = typeof document !== "undefined" ? document.hasFocus() : true;
 const FOCUS_GUARD_FALLBACK_ID = "cmux-iframe-focus-guard-fallback";
 const PERSISTENT_IFRAME_CONTAINER_ID = "persistent-iframe-container";
 const INTERACTIVE_FOCUS_RETENTION_ROLES = new Set([
@@ -266,6 +275,7 @@ export const ensureIframeFocusGuard = (): void => {
 
   focusGuardInitialized = true;
   lastActiveElement = document.activeElement;
+  windowHasFocus = document.hasFocus();
 
   const handleFocusIn = (event: FocusEvent) => {
     const target = event.target;
@@ -291,13 +301,94 @@ export const ensureIframeFocusGuard = (): void => {
     lastActiveElement = target;
   };
 
+  /**
+   * Capture iframe focus ownership BEFORE the window loses focus.
+   * This is critical because once the window blurs, document.activeElement
+   * may have already changed (especially for cross-origin iframes).
+   */
+  const handleWindowBlur = () => {
+    windowHasFocus = false;
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLIFrameElement) {
+      // Only remember if the iframe is focus-eligible
+      if (iframeFocusAllowedChecker(activeElement) && isIframeVisibleOnScreen(activeElement)) {
+        focusedIframeBeforeBlur = activeElement;
+      } else {
+        focusedIframeBeforeBlur = null;
+      }
+    } else {
+      focusedIframeBeforeBlur = null;
+    }
+  };
+
+  /**
+   * On window refocus, restore focus to the iframe that had it before blur,
+   * but only if it's still eligible for focus.
+   */
+  const handleWindowFocus = () => {
+    windowHasFocus = true;
+    const iframeToRestore = focusedIframeBeforeBlur;
+    focusedIframeBeforeBlur = null;
+
+    if (!iframeToRestore || !iframeToRestore.isConnected) {
+      return;
+    }
+
+    // Check if the iframe is still eligible for focus
+    if (!iframeFocusAllowedChecker(iframeToRestore) || !isIframeVisibleOnScreen(iframeToRestore)) {
+      return;
+    }
+
+    // Check if user has clicked on something else during refocus
+    const currentActive = document.activeElement;
+    if (isInteractiveFocusRetentionElement(currentActive)) {
+      return;
+    }
+
+    // Use a short delay to let the browser settle focus state
+    requestAnimationFrame(() => {
+      // Re-check conditions after the frame
+      if (!iframeToRestore.isConnected) {
+        return;
+      }
+      if (!iframeFocusAllowedChecker(iframeToRestore) || !isIframeVisibleOnScreen(iframeToRestore)) {
+        return;
+      }
+      const stillCurrentActive = document.activeElement;
+      if (isInteractiveFocusRetentionElement(stillCurrentActive)) {
+        return;
+      }
+
+      try {
+        iframeToRestore.focus({ preventScroll: true });
+        lastActiveElement = iframeToRestore;
+      } catch (error) {
+        console.error("Failed to restore iframe focus on window refocus", error);
+      }
+    });
+  };
+
   focusInHandler = handleFocusIn;
+  windowBlurHandler = handleWindowBlur;
+  windowFocusHandler = handleWindowFocus;
+
   document.addEventListener("focusin", handleFocusIn, true);
+  window.addEventListener("blur", handleWindowBlur);
+  window.addEventListener("focus", handleWindowFocus);
 };
 
 export const resetIframeFocusGuardForTests = (): void => {
   if (typeof document !== "undefined" && focusInHandler) {
     document.removeEventListener("focusin", focusInHandler, true);
+  }
+
+  if (typeof window !== "undefined") {
+    if (windowBlurHandler) {
+      window.removeEventListener("blur", windowBlurHandler);
+    }
+    if (windowFocusHandler) {
+      window.removeEventListener("focus", windowFocusHandler);
+    }
   }
 
   if (typeof document !== "undefined") {
@@ -307,6 +398,24 @@ export const resetIframeFocusGuardForTests = (): void => {
   focusGuardFallbackElement = null;
   focusGuardInitialized = false;
   focusInHandler = null;
+  windowBlurHandler = null;
+  windowFocusHandler = null;
   lastActiveElement = null;
+  focusedIframeBeforeBlur = null;
+  windowHasFocus = typeof document !== "undefined" ? document.hasFocus() : true;
   iframeFocusAllowedChecker = () => true;
+};
+
+/**
+ * Returns whether the window currently has focus.
+ * Useful for components that need to know focus state without querying document.hasFocus().
+ */
+export const getWindowHasFocus = (): boolean => windowHasFocus;
+
+/**
+ * Manually clear the stored iframe focus ownership.
+ * Call this when programmatically moving focus away from iframes.
+ */
+export const clearFocusedIframeBeforeBlur = (): void => {
+  focusedIframeBeforeBlur = null;
 };


### PR DESCRIPTION
## Summary
- Fixes remote VSCode iframe focus loss that became consistent and unusable
- Root cause: `iframeFocusGuard.ts` queried `document.activeElement` AFTER blur events, but browser had already moved focus away from cross-origin iframes
- Solution: Track iframe focus ownership proactively BEFORE window blur fires

## Changes
- Add `focusedIframeBeforeBlur` to capture which iframe had focus before blur
- Add `windowHasFocus` flag for reliable focus state tracking  
- Add `handleWindowBlur()` to capture iframe ownership proactively
- Add `handleWindowFocus()` to restore iframe focus after rAF delay
- Safety checks: iframe must be connected, focus-eligible, and user must not have clicked an interactive element
- Export `getWindowHasFocus()` and `clearFocusedIframeBeforeBlur()` utilities
- Add 3 new tests for window blur/focus behavior (5 total)

## Test plan
- [x] `bun check` passes
- [x] `vitest run iframeFocusGuard.dom.test.ts` - 5/5 pass
- [x] `vitest run persistentIframeManager.dom.test.ts` - 5/5 pass
- [ ] Manual verification: Open task detail with VS Code iframe, switch away from window, switch back - focus should restore