### PR TITLE
feat(dashboard): wire SessionTimeline and FileChangeHeatmap into main dashboard

### DIFF
--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -3,7 +3,9 @@ import type { EditorApi } from "@/components/dashboard/DashboardInput";
 import { DashboardInputControls } from "@/components/dashboard/DashboardInputControls";
 import { DashboardInputFooter } from "@/components/dashboard/DashboardInputFooter";
 import { DashboardStartTaskButton } from "@/components/dashboard/DashboardStartTaskButton";
+import { FileChangeHeatmap } from "@/components/dashboard/FileChangeHeatmap";
 import { SessionActivityCard } from "@/components/dashboard/SessionActivityCard";
+import { SessionTimeline } from "@/components/dashboard/SessionTimeline";
 import { TaskList } from "@/components/dashboard/TaskList";
 import { WorkspaceCreationButtons } from "@/components/dashboard/WorkspaceCreationButtons";
 import { FloatingPane } from "@/components/floating-pane";
@@ -1480,6 +1482,12 @@ function DashboardComponent() {
 
           {/* Session Activity */}
           <SessionActivityCard teamSlugOrId={teamSlugOrId} className="mb-4" />
+
+          {/* Visual Charts */}
+          <div className="mb-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <SessionTimeline teamSlugOrId={teamSlugOrId} limit={5} />
+            <FileChangeHeatmap teamSlugOrId={teamSlugOrId} days={7} />
+          </div>
 
           {/* Task List */}
           <div className="w-full">


### PR DESCRIPTION
## Summary
- Wire the new visual dashboard components (from PR #534) into the main dashboard route
- SessionTimeline shows collapsible session history with commit/PR events
- FileChangeHeatmap shows file change intensity grouped by directory
- Side-by-side layout on large screens, stacked on mobile

## Test Plan
- [x] `bun check` passes
- [ ] Visual verification in browser