### PR TITLE
feat(dashboard): add inline activity stats badges to TaskItem

### DIFF
--- a/apps/client/src/components/dashboard/TaskItem.tsx
+++ b/apps/client/src/components/dashboard/TaskItem.tsx
@@ -22,7 +22,9 @@ import {
   Box,
   Check,
   Copy,
+  GitCommitVertical,
   GitMerge,
+  GitPullRequestArrow,
   Loader2,
   Pencil,
   Pin,
@@ -69,6 +71,12 @@ export const TaskItem = memo(function TaskItem({
   // Query for task runs to find VSCode instances
   const taskRunsQuery = useConvexQuery(
     api.taskRuns.getByTask,
+    isFakeConvexId(task._id) ? "skip" : { teamSlugOrId, taskId: task._id }
+  );
+
+  // Query session activity stats for this task
+  const taskStats = useConvexQuery(
+    api.sessionActivity.getTaskStats,
     isFakeConvexId(task._id) ? "skip" : { teamSlugOrId, taskId: task._id }
   );
 
@@ -329,7 +337,7 @@ export const TaskItem = memo(function TaskItem({
                 />
               )}
             </div>
-            <div className="min-w-0 flex items-center">
+            <div className="min-w-0 flex items-center gap-1.5">
               {isRenaming ? (
                 <input
                   ref={renameInputRef}
@@ -359,6 +367,40 @@ export const TaskItem = memo(function TaskItem({
                 <span className="text-[13px] font-medium truncate min-w-0 pr-1">
                   {task.text}
                 </span>
+              )}
+              {/* Inline activity stats badges */}
+              {taskStats && !isRenaming && (
+                <div className="flex items-center gap-1.5 shrink-0">
+                  {taskStats.totalCommits > 0 && (
+                    <span className="inline-flex items-center gap-0.5 text-[10px] tabular-nums text-neutral-400 dark:text-neutral-500">
+                      <GitCommitVertical className="size-3" />
+                      {taskStats.totalCommits}
+                    </span>
+                  )}
+                  {taskStats.totalPRs > 0 && (
+                    <span className="inline-flex items-center gap-0.5 text-[10px] tabular-nums text-purple-400 dark:text-purple-500">
+                      <GitPullRequestArrow className="size-3" />
+                      {taskStats.totalPRs}
+                    </span>
+                  )}
+                  {(taskStats.totalAdditions > 0 || taskStats.totalDeletions > 0) && (
+                    <span className="text-[10px] tabular-nums">
+                      {taskStats.totalAdditions > 0 && (
+                        <span className="text-emerald-500 dark:text-emerald-400">
+                          +{taskStats.totalAdditions}
+                        </span>
+                      )}
+                      {taskStats.totalAdditions > 0 && taskStats.totalDeletions > 0 && (
+                        <span className="text-neutral-300 dark:text-neutral-600">/</span>
+                      )}
+                      {taskStats.totalDeletions > 0 && (
+                        <span className="text-red-400 dark:text-red-500">
+                          -{taskStats.totalDeletions}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </div>
               )}
             </div>
             <div className="text-[11px] text-neutral-400 dark:text-neutral-500 min-w-0 text-right flex items-center justify-end gap-2">

--- a/packages/convex/convex/sessionActivity.ts
+++ b/packages/convex/convex/sessionActivity.ts
@@ -224,3 +224,57 @@ export const getTeamStats = authQuery({
     };
   },
 });
+
+/**
+ * Get aggregated stats for a specific task (across all its runs).
+ * Used by TaskItem to show inline activity badges.
+ */
+export const getTaskStats = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    taskId: v.id("tasks"),
+  },
+  async handler(ctx, args) {
+    // Get all task runs for this task
+    const taskRuns = await ctx.db
+      .query("taskRuns")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .collect();
+
+    if (taskRuns.length === 0) {
+      return null;
+    }
+
+    // Get session activity for all runs in parallel
+    const activityPromises = taskRuns.map((run) =>
+      ctx.db
+        .query("sessionActivity")
+        .withIndex("by_taskRun", (q) => q.eq("taskRunId", run._id))
+        .collect()
+    );
+    const allActivities = (await Promise.all(activityPromises)).flat();
+
+    if (allActivities.length === 0) {
+      return null;
+    }
+
+    // Aggregate
+    return allActivities.reduce(
+      (acc, activity) => {
+        acc.totalCommits += activity.stats.totalCommits;
+        acc.totalPRs += activity.stats.totalPRs;
+        acc.totalAdditions += activity.stats.totalAdditions;
+        acc.totalDeletions += activity.stats.totalDeletions;
+        acc.totalFiles += activity.stats.totalFiles;
+        return acc;
+      },
+      {
+        totalCommits: 0,
+        totalPRs: 0,
+        totalAdditions: 0,
+        totalDeletions: 0,
+        totalFiles: 0,
+      }
+    );
+  },
+});


### PR DESCRIPTION
## Summary
- Add `getTaskStats` Convex authQuery that aggregates session activity (commits, PRs, lines changed) across all runs for a given task
- Display inline activity badges in TaskItem showing commit count, PR count, and +/- lines changed
- Badges appear next to the task name with subtle styling (10px, tabular-nums, color-coded)

## Test plan
- [ ] Verify `bun check` passes (confirmed locally)
- [ ] Verify TaskItem renders correctly with and without activity data
- [ ] Verify badges don't show for tasks with no session activity (returns null)
- [ ] Verify badges display correctly in both light and dark mode