### PR TITLE
feat(dashboard): add time range selector to activity cards

### DIFF
--- a/apps/client/src/components/dashboard/FileChangeHeatmap.tsx
+++ b/apps/client/src/components/dashboard/FileChangeHeatmap.tsx
@@ -4,6 +4,9 @@ import { FileCode, FolderOpen } from "lucide-react";
 import { memo, useMemo, useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 
+const TIME_RANGES = [7, 14, 30] as const;
+type TimeRange = (typeof TIME_RANGES)[number];
+
 interface FileChangeHeatmapProps {
   teamSlugOrId: string;
   days?: number;
@@ -282,9 +285,13 @@ function FileChangeHeatmapContent({ teamSlugOrId, days = 7 }: FileChangeHeatmapP
 
 export const FileChangeHeatmap = memo(function FileChangeHeatmap({
   teamSlugOrId,
-  days = 7,
+  days: initialDays = 7,
   className,
 }: FileChangeHeatmapProps) {
+  const [selectedDays, setSelectedDays] = useState<TimeRange>(
+    TIME_RANGES.includes(initialDays as TimeRange) ? (initialDays as TimeRange) : 7
+  );
+
   return (
     <div
       className={cn(
@@ -292,15 +299,33 @@ export const FileChangeHeatmap = memo(function FileChangeHeatmap({
         className
       )}
     >
-      <div className="mb-4">
-        <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
-          File Change Heatmap
-        </h3>
-        <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-          Files changed by intensity over the last {days} days
-        </p>
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+            File Change Heatmap
+          </h3>
+          <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+            Files changed by intensity
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          {TIME_RANGES.map((range) => (
+            <button
+              key={range}
+              onClick={() => setSelectedDays(range)}
+              className={cn(
+                "px-2 py-0.5 text-xs rounded transition-colors",
+                selectedDays === range
+                  ? "bg-neutral-200 text-neutral-900 dark:bg-neutral-700 dark:text-neutral-100"
+                  : "text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+              )}
+            >
+              {range}d
+            </button>
+          ))}
+        </div>
       </div>
-      <FileChangeHeatmapContent teamSlugOrId={teamSlugOrId} days={days} />
+      <FileChangeHeatmapContent teamSlugOrId={teamSlugOrId} days={selectedDays} />
     </div>
   );
 });

--- a/apps/client/src/components/dashboard/SessionActivityCard.tsx
+++ b/apps/client/src/components/dashboard/SessionActivityCard.tsx
@@ -1,8 +1,11 @@
 import { api } from "@cmux/convex/api";
 import { useQuery as useConvexQuery } from "convex/react";
 import { GitCommit, GitPullRequest, FileCode, Plus, Minus, Clock } from "lucide-react";
-import { memo } from "react";
+import { memo, useState } from "react";
 import { cn } from "@/lib/utils";
+
+const TIME_RANGES = [7, 14, 30] as const;
+type TimeRange = (typeof TIME_RANGES)[number];
 
 interface SessionActivityCardProps {
   teamSlugOrId: string;
@@ -103,9 +106,13 @@ function SessionActivityCardContent({ teamSlugOrId, days = 7 }: SessionActivityC
 
 export const SessionActivityCard = memo(function SessionActivityCard({
   teamSlugOrId,
-  days = 7,
+  days: initialDays = 7,
   className,
 }: SessionActivityCardProps) {
+  const [selectedDays, setSelectedDays] = useState<TimeRange>(
+    TIME_RANGES.includes(initialDays as TimeRange) ? (initialDays as TimeRange) : 7
+  );
+
   return (
     <div
       className={cn(
@@ -117,11 +124,24 @@ export const SessionActivityCard = memo(function SessionActivityCard({
         <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
           Session Activity
         </h3>
-        <span className="text-xs text-neutral-500 dark:text-neutral-400">
-          Last {days} days
-        </span>
+        <div className="flex items-center gap-1">
+          {TIME_RANGES.map((range) => (
+            <button
+              key={range}
+              onClick={() => setSelectedDays(range)}
+              className={cn(
+                "px-2 py-0.5 text-xs rounded transition-colors",
+                selectedDays === range
+                  ? "bg-neutral-200 text-neutral-900 dark:bg-neutral-700 dark:text-neutral-100"
+                  : "text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+              )}
+            >
+              {range}d
+            </button>
+          ))}
+        </div>
       </div>
-      <SessionActivityCardContent teamSlugOrId={teamSlugOrId} days={days} />
+      <SessionActivityCardContent teamSlugOrId={teamSlugOrId} days={selectedDays} />
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- Add 7d/14d/30d toggle buttons to SessionActivityCard header
- Add 7d/14d/30d toggle buttons to FileChangeHeatmap header
- Users can filter activity data by different time ranges inline
- Consistent UI pattern across both components

## Test plan
- [ ] Verify `bun check` passes (confirmed locally)
- [ ] Verify time range buttons render correctly
- [ ] Verify clicking a button updates the displayed data
- [ ] Verify both light and dark mode styling