### PR TITLE
feat(memory): add S15 behavior provenance tracking

### DIFF
--- a/apps/client/src/components/TaskRunMemoryPanel.tsx
+++ b/apps/client/src/components/TaskRunMemoryPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@cmux/convex/api";
 import type { Id } from "@cmux/convex/dataModel";
-import { Brain, FileText, Calendar, CheckSquare, Mail, AlertCircle, Clock, ArrowRight, Megaphone, MessageSquare, CheckCheck, Zap, ListChecks, FolderTree, Sparkles } from "lucide-react";
+import { Brain, FileText, Calendar, CheckSquare, Mail, AlertCircle, Clock, ArrowRight, Megaphone, MessageSquare, CheckCheck, Zap, ListChecks, FolderTree, Sparkles, Eye } from "lucide-react";
 import clsx from "clsx";
 
 export interface TaskRunMemoryPanelProps {
@@ -14,7 +14,7 @@ export interface TaskRunMemoryPanelProps {
 type FactualMemoryType = "knowledge" | "daily" | "tasks" | "mailbox";
 
 // Behavior memory types (self-improving preferences)
-type BehaviorMemoryType = "behavior_hot" | "behavior_corrections" | "behavior_domain" | "behavior_project" | "behavior_index";
+type BehaviorMemoryType = "behavior_hot" | "behavior_corrections" | "behavior_domain" | "behavior_project" | "behavior_index" | "behavior_provenance";
 
 type MemoryType = FactualMemoryType | BehaviorMemoryType;
 
@@ -33,6 +33,7 @@ const MEMORY_TYPE_LABELS: Record<MemoryType, string> = {
   behavior_domain: "Domain Rules",
   behavior_project: "Project Rules",
   behavior_index: "Index",
+  behavior_provenance: "Applied",
 };
 
 const MEMORY_TYPE_ICONS: Record<MemoryType, React.ElementType> = {
@@ -47,10 +48,11 @@ const MEMORY_TYPE_ICONS: Record<MemoryType, React.ElementType> = {
   behavior_domain: FolderTree,
   behavior_project: FileText,
   behavior_index: Sparkles,
+  behavior_provenance: Eye,
 };
 
 const FACTUAL_MEMORY_TYPES: FactualMemoryType[] = ["knowledge", "daily", "tasks", "mailbox"];
-const BEHAVIOR_MEMORY_TYPES: BehaviorMemoryType[] = ["behavior_hot", "behavior_corrections", "behavior_domain", "behavior_project", "behavior_index"];
+const BEHAVIOR_MEMORY_TYPES: BehaviorMemoryType[] = ["behavior_provenance", "behavior_hot", "behavior_corrections", "behavior_domain", "behavior_project", "behavior_index"];
 
 export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPanelProps) {
   const [selectedCategory, setSelectedCategory] = useState<MemoryCategory>("factual");
@@ -62,11 +64,17 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
     taskRunId ? { teamSlugOrId, taskRunId } : "skip"
   );
 
+  // Query provenance data (rules applied during this task run)
+  const provenance = useQuery(
+    api.agentMemoryQueries.getBehaviorRulesForTaskRun,
+    taskRunId ? { teamSlugOrId, taskRunId } : "skip"
+  );
+
   // Group snapshots by type
   const snapshotsByType = useMemo(() => {
     if (!snapshots) return null;
 
-    const grouped: Record<MemoryType, typeof snapshots> = {
+    const grouped: Record<Exclude<MemoryType, "behavior_provenance">, typeof snapshots> = {
       // Factual
       knowledge: [],
       daily: [],
@@ -81,8 +89,8 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
     };
 
     for (const snapshot of snapshots) {
-      const type = snapshot.memoryType as MemoryType;
-      if (grouped[type]) {
+      const type = snapshot.memoryType as Exclude<MemoryType, "behavior_provenance">;
+      if (type in grouped) {
         grouped[type].push(snapshot);
       }
     }
@@ -97,11 +105,19 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
     return grouped;
   }, [snapshots]);
 
-  // Check if any behavior memory exists
+  // Check if any behavior memory exists (including provenance)
   const hasBehaviorMemory = useMemo(() => {
+    // Check provenance data
+    const hasProvenance = provenance && (provenance.rules.length > 0 || provenance.events.length > 0);
+    if (hasProvenance) return true;
+    // Check snapshot-based behavior memory
     if (!snapshotsByType) return false;
-    return BEHAVIOR_MEMORY_TYPES.some((type) => snapshotsByType[type].length > 0);
-  }, [snapshotsByType]);
+    const snapshotTypes = ["behavior_hot", "behavior_corrections", "behavior_domain", "behavior_project", "behavior_index"] as const;
+    return snapshotTypes.some((type) => snapshotsByType[type]?.length > 0);
+  }, [snapshotsByType, provenance]);
+
+  // Get provenance count for tab display
+  const provenanceCount = provenance?.rules.length ?? 0;
 
   // Get available dates for daily logs
   const dailyDates = useMemo(() => {
@@ -111,6 +127,9 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
 
   // Get the selected snapshot content
   const selectedContent = useMemo(() => {
+    // Provenance is handled separately
+    if (selectedType === "behavior_provenance") return null;
+
     if (!snapshotsByType) return null;
 
     if (selectedType === "daily") {
@@ -122,7 +141,8 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
     }
 
     // For other types, get the first (and only) snapshot
-    return snapshotsByType[selectedType][0] ?? null;
+    const typeSnapshots = snapshotsByType[selectedType as keyof typeof snapshotsByType];
+    return typeSnapshots?.[0] ?? null;
   }, [snapshotsByType, selectedType, selectedDate, dailyDates]);
 
   // Empty state - no task run selected (check before loading to avoid spinner when skipped)
@@ -176,11 +196,16 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
           if (category === "factual") {
             setSelectedType("knowledge");
           } else {
-            // Find first behavior type with content
-            const firstWithContent = BEHAVIOR_MEMORY_TYPES.find(
-              (type) => (snapshotsByType?.[type]?.length ?? 0) > 0
-            );
-            setSelectedType(firstWithContent ?? "behavior_hot");
+            // Find first behavior type with content (check provenance first)
+            if (provenanceCount > 0) {
+              setSelectedType("behavior_provenance");
+            } else {
+              const snapshotBehaviorTypes = ["behavior_hot", "behavior_corrections", "behavior_domain", "behavior_project", "behavior_index"] as const;
+              const firstWithContent = snapshotBehaviorTypes.find(
+                (type) => (snapshotsByType?.[type]?.length ?? 0) > 0
+              );
+              setSelectedType(firstWithContent ?? "behavior_provenance");
+            }
           }
         }}
         className={clsx(
@@ -200,7 +225,10 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
 
   const renderTabButton = (type: MemoryType) => {
     const Icon = MEMORY_TYPE_ICONS[type];
-    const count = snapshotsByType?.[type]?.length ?? 0;
+    // Provenance uses rules count, others use snapshot count
+    const count = type === "behavior_provenance"
+      ? provenanceCount
+      : (snapshotsByType?.[type as Exclude<MemoryType, "behavior_provenance">]?.length ?? 0);
     const isActive = selectedType === type;
 
     return (
@@ -224,7 +252,7 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
       >
         <Icon className="size-3.5" />
         {MEMORY_TYPE_LABELS[type]}
-        {count > 1 && (
+        {count > 0 && (
           <span className="text-[10px] text-neutral-400 dark:text-neutral-500">
             ({count})
           </span>
@@ -234,6 +262,11 @@ export function TaskRunMemoryPanel({ teamSlugOrId, taskRunId }: TaskRunMemoryPan
   };
 
   const renderContent = () => {
+    // Handle provenance specially - it comes from a different query
+    if (selectedType === "behavior_provenance") {
+      return <BehaviorProvenanceView provenance={provenance} />;
+    }
+
     if (!selectedContent) {
       return (
         <div className="flex h-full flex-col items-center justify-center gap-2 text-neutral-500 dark:text-neutral-400">
@@ -607,6 +640,153 @@ function BehaviorCorrectionsView({ content }: { content: string }) {
           )}
         </div>
       ))}
+    </div>
+  );
+}
+
+// Behavior provenance view - shows which rules were applied during the task run
+// Uses loose typing since Convex returns complex union types
+interface ProvenanceRule {
+  _id: string;
+  text?: string;
+  scope?: string;
+  namespace?: string;
+  status?: string;
+  confidence?: number;
+  timesSeen?: number;
+  timesUsed?: number;
+  sourceType?: string;
+  createdAt?: number;
+  lastUsedAt?: number;
+}
+
+interface ProvenanceEvent {
+  _id: string;
+  eventType?: string;
+  appliedInContext?: string;
+  createdAt?: number;
+}
+
+interface ProvenanceData {
+  rules: ProvenanceRule[];
+  events: ProvenanceEvent[];
+}
+
+function BehaviorProvenanceView({ provenance }: { provenance: { rules: unknown[]; events: unknown[] } | undefined | null }) {
+  // Cast to typed interface after null check
+  const typedProvenance = provenance as ProvenanceData | undefined | null;
+  if (!typedProvenance) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-neutral-500 dark:text-neutral-400">
+        <div className="size-5 animate-spin rounded-full border-2 border-neutral-300 border-t-neutral-600 dark:border-neutral-600 dark:border-t-neutral-300" />
+        <span className="text-sm">Loading provenance...</span>
+      </div>
+    );
+  }
+
+  // Filter out null rules
+  const rules = typedProvenance.rules.filter((r): r is ProvenanceRule => r !== null && r.text !== undefined);
+  const events = typedProvenance.events.filter((e): e is ProvenanceEvent => e !== null);
+
+  if (rules.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 py-8 text-neutral-500 dark:text-neutral-400">
+        <Eye className="size-8 text-neutral-300 dark:text-neutral-600" />
+        <p className="text-sm">No behavior rules were applied in this run</p>
+        <p className="text-xs text-neutral-400 dark:text-neutral-500">
+          Rules are tracked when agents reference behavior memory
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-neutral-200 bg-neutral-50 px-3 py-2 dark:border-neutral-800 dark:bg-neutral-900">
+        <span className="text-xs font-medium text-neutral-600 dark:text-neutral-300">
+          {rules.length} rule{rules.length !== 1 ? "s" : ""} applied
+        </span>
+        <span className="text-xs text-neutral-400 dark:text-neutral-500">
+          {events.length} application{events.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Rules list */}
+      <div className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3">
+        {rules.map((rule) => {
+          // Find events for this rule
+          const ruleEvents = events.filter(
+            (e) => e.eventType === "rule_used"
+          );
+
+          return (
+            <div
+              key={rule._id}
+              className="rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900"
+            >
+              {/* Rule header */}
+              <div className="flex items-center gap-2 text-xs">
+                <span
+                  className={clsx(
+                    "inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium",
+                    rule.scope === "hot" && "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+                    rule.scope === "domain" && "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+                    rule.scope === "project" && "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400"
+                  )}
+                >
+                  <Zap className="size-3" />
+                  {rule.scope}
+                </span>
+                <span className="text-neutral-400 dark:text-neutral-500">
+                  {rule.namespace}
+                </span>
+                <span className="ml-auto flex items-center gap-1 text-neutral-400 dark:text-neutral-500">
+                  <CheckCheck className="size-3" />
+                  used {rule.timesUsed ?? 0}x
+                </span>
+              </div>
+
+              {/* Rule text */}
+              <div className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">
+                {rule.text}
+              </div>
+
+              {/* Usage contexts */}
+              {ruleEvents.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  {ruleEvents.slice(0, 3).map((event) => (
+                    <div
+                      key={event._id}
+                      className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400"
+                    >
+                      <Clock className="size-3" />
+                      <span>{event.createdAt ? new Date(event.createdAt).toLocaleTimeString() : "unknown"}</span>
+                      {event.appliedInContext && (
+                        <span className="truncate text-neutral-400 dark:text-neutral-500">
+                          in {event.appliedInContext}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                  {ruleEvents.length > 3 && (
+                    <div className="text-xs text-neutral-400 dark:text-neutral-500">
+                      +{ruleEvents.length - 3} more applications
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Source info */}
+              <div className="mt-2 flex items-center gap-2 text-xs text-neutral-400 dark:text-neutral-500">
+                <span>Source: {(rule.sourceType ?? "unknown").replace(/_/g, " ")}</span>
+                <span>|</span>
+                <span>Confidence: {Math.round((rule.confidence ?? 0) * 100)}%</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as admin from "../admin.js";
+import type * as agentBehaviorMutations from "../agentBehaviorMutations.js";
 import type * as agentMemoryQueries from "../agentMemoryQueries.js";
 import type * as agentMemory_http from "../agentMemory_http.js";
 import type * as analytics from "../analytics.js";
@@ -124,6 +125,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   admin: typeof admin;
+  agentBehaviorMutations: typeof agentBehaviorMutations;
   agentMemoryQueries: typeof agentMemoryQueries;
   agentMemory_http: typeof agentMemory_http;
   analytics: typeof analytics;

--- a/packages/convex/convex/agentBehaviorMutations.ts
+++ b/packages/convex/convex/agentBehaviorMutations.ts
@@ -1,0 +1,270 @@
+import { v } from "convex/values";
+import { getTeamId } from "../_shared/team";
+import { authMutation } from "./users/utils";
+
+/**
+ * Log a behavior correction event.
+ * Used when a user explicitly corrects agent behavior.
+ */
+export const logCorrection = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    taskRunId: v.optional(v.id("taskRuns")),
+    wrongAction: v.string(),
+    correctAction: v.string(),
+    learnedRule: v.optional(v.string()),
+    context: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+
+    // Create the event
+    const eventId = await ctx.db.insert("agentBehaviorEvents", {
+      teamId,
+      userId,
+      taskRunId: args.taskRunId,
+      eventType: "correction_logged",
+      wrongAction: args.wrongAction,
+      correctAction: args.correctAction,
+      learnedRule: args.learnedRule,
+      context: args.context,
+      createdAt: Date.now(),
+    });
+
+    // If a learned rule was derived, create a candidate rule
+    let ruleId = undefined;
+    if (args.learnedRule) {
+      ruleId = await ctx.db.insert("agentBehaviorRules", {
+        teamId,
+        userId,
+        namespace: "general",
+        scope: "hot",
+        status: "candidate",
+        text: args.learnedRule,
+        sourceType: "user_correction",
+        sourceTaskRunId: args.taskRunId,
+        confidence: 0.5,
+        timesSeen: 1,
+        timesUsed: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      // Link the rule to the event
+      await ctx.db.patch(eventId, { ruleId });
+    }
+
+    return { eventId, ruleId };
+  },
+});
+
+/**
+ * Log a rule_used event (provenance tracking).
+ * Called when an agent applies a behavior rule during execution.
+ */
+export const logRuleUsed = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    taskRunId: v.id("taskRuns"),
+    ruleId: v.id("agentBehaviorRules"),
+    appliedInContext: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+
+    // Verify the rule exists
+    const rule = await ctx.db.get(args.ruleId);
+    if (!rule || rule.teamId !== teamId) {
+      throw new Error("Rule not found or unauthorized");
+    }
+
+    // Create the event
+    const eventId = await ctx.db.insert("agentBehaviorEvents", {
+      teamId,
+      userId,
+      taskRunId: args.taskRunId,
+      ruleId: args.ruleId,
+      eventType: "rule_used",
+      appliedInContext: args.appliedInContext,
+      createdAt: Date.now(),
+    });
+
+    // Update rule usage stats
+    await ctx.db.patch(args.ruleId, {
+      timesUsed: (rule.timesUsed ?? 0) + 1,
+      lastUsedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    return eventId;
+  },
+});
+
+/**
+ * Promote a candidate rule to active status.
+ * Called when a user confirms a rule should be applied.
+ */
+export const promoteRule = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    ruleId: v.id("agentBehaviorRules"),
+    scope: v.optional(
+      v.union(v.literal("hot"), v.literal("domain"), v.literal("project"))
+    ),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+
+    const rule = await ctx.db.get(args.ruleId);
+    if (!rule || rule.teamId !== teamId) {
+      throw new Error("Rule not found or unauthorized");
+    }
+
+    const previousStatus = rule.status;
+
+    // Update rule status
+    await ctx.db.patch(args.ruleId, {
+      status: "active",
+      scope: args.scope ?? rule.scope,
+      confidence: 1.0,
+      lastConfirmedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    // Log the promotion event
+    const eventId = await ctx.db.insert("agentBehaviorEvents", {
+      teamId,
+      userId,
+      ruleId: args.ruleId,
+      eventType: "rule_promoted",
+      previousStatus,
+      newStatus: "active",
+      createdAt: Date.now(),
+    });
+
+    return eventId;
+  },
+});
+
+/**
+ * Suppress a rule (user doesn't want it applied).
+ */
+export const suppressRule = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    ruleId: v.id("agentBehaviorRules"),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+
+    const rule = await ctx.db.get(args.ruleId);
+    if (!rule || rule.teamId !== teamId) {
+      throw new Error("Rule not found or unauthorized");
+    }
+
+    const previousStatus = rule.status;
+
+    await ctx.db.patch(args.ruleId, {
+      status: "suppressed",
+      updatedAt: Date.now(),
+    });
+
+    const eventId = await ctx.db.insert("agentBehaviorEvents", {
+      teamId,
+      userId,
+      ruleId: args.ruleId,
+      eventType: "rule_suppressed",
+      previousStatus,
+      newStatus: "suppressed",
+      createdAt: Date.now(),
+    });
+
+    return eventId;
+  },
+});
+
+/**
+ * Forget a rule (permanently remove from active retrieval).
+ */
+export const forgetRule = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    ruleId: v.id("agentBehaviorRules"),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+
+    const rule = await ctx.db.get(args.ruleId);
+    if (!rule || rule.teamId !== teamId) {
+      throw new Error("Rule not found or unauthorized");
+    }
+
+    const previousStatus = rule.status;
+
+    await ctx.db.patch(args.ruleId, {
+      status: "archived",
+      updatedAt: Date.now(),
+    });
+
+    const eventId = await ctx.db.insert("agentBehaviorEvents", {
+      teamId,
+      userId,
+      ruleId: args.ruleId,
+      eventType: "rule_forgotten",
+      previousStatus,
+      newStatus: "archived",
+      createdAt: Date.now(),
+    });
+
+    return eventId;
+  },
+});
+
+/**
+ * Create a behavior rule directly (manual import).
+ */
+export const createRule = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    text: v.string(),
+    scope: v.union(v.literal("hot"), v.literal("domain"), v.literal("project")),
+    namespace: v.optional(v.string()),
+    projectFullName: v.optional(v.string()),
+    status: v.optional(
+      v.union(
+        v.literal("candidate"),
+        v.literal("active"),
+        v.literal("suppressed"),
+        v.literal("archived")
+      )
+    ),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+
+    const ruleId = await ctx.db.insert("agentBehaviorRules", {
+      teamId,
+      userId,
+      projectFullName: args.projectFullName,
+      namespace: args.namespace ?? "general",
+      scope: args.scope,
+      status: args.status ?? "active",
+      text: args.text,
+      sourceType: "manual_import",
+      confidence: 1.0,
+      timesSeen: 1,
+      timesUsed: 0,
+      lastConfirmedAt: Date.now(),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    return ruleId;
+  },
+});

--- a/packages/convex/convex/agentMemoryQueries.ts
+++ b/packages/convex/convex/agentMemoryQueries.ts
@@ -381,3 +381,149 @@ export const getTeamBehaviorMemory = authQuery({
     return results;
   },
 });
+
+// =============================================================================
+// Behavior Rules Queries (S15 provenance tracking)
+// =============================================================================
+
+/**
+ * Get active behavior rules for a team.
+ * Used to show which rules are currently loaded and their usage stats.
+ */
+export const getActiveBehaviorRules = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    scope: v.optional(
+      v.union(v.literal("hot"), v.literal("domain"), v.literal("project"))
+    ),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const limit = args.limit ?? 50;
+
+    let query = ctx.db
+      .query("agentBehaviorRules")
+      .withIndex("by_team_status", (q) =>
+        q.eq("teamId", teamId).eq("status", "active")
+      );
+
+    const rules = await query.order("desc").take(limit);
+
+    // Filter by scope if specified
+    if (args.scope) {
+      return rules.filter((r) => r.scope === args.scope);
+    }
+
+    return rules;
+  },
+});
+
+/**
+ * Get behavior rules applied in a specific task run (provenance).
+ * Shows which rules were actually used during agent execution.
+ */
+export const getBehaviorRulesForTaskRun = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    taskRunId: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    // Verify task run belongs to team
+    const taskRun = await ctx.db.get(args.taskRunId);
+    if (!taskRun || taskRun.teamId !== teamId) {
+      return { rules: [], events: [] };
+    }
+
+    // Get rule_used events for this task run
+    const events = await ctx.db
+      .query("agentBehaviorEvents")
+      .withIndex("by_task_run", (q) => q.eq("taskRunId", args.taskRunId))
+      .collect();
+
+    // Get unique rule IDs from rule_used events
+    const ruleIds = new Set<string>();
+    for (const event of events) {
+      if (event.eventType === "rule_used" && event.ruleId) {
+        ruleIds.add(event.ruleId);
+      }
+    }
+
+    // Fetch the actual rules
+    const rules = await Promise.all(
+      Array.from(ruleIds).map((id) => ctx.db.get(id as any))
+    );
+
+    return {
+      rules: rules.filter(Boolean),
+      events: events.filter((e) => e.eventType === "rule_used"),
+    };
+  },
+});
+
+/**
+ * Get behavior events for a team (corrections, promotions, demotions).
+ * Used by the behavior dashboard to show history.
+ */
+export const getBehaviorEvents = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    eventType: v.optional(
+      v.union(
+        v.literal("correction_logged"),
+        v.literal("reflection_logged"),
+        v.literal("rule_promoted"),
+        v.literal("rule_demoted"),
+        v.literal("rule_forgotten"),
+        v.literal("rule_suppressed"),
+        v.literal("rule_used")
+      )
+    ),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const limit = args.limit ?? 50;
+
+    if (args.eventType) {
+      return ctx.db
+        .query("agentBehaviorEvents")
+        .withIndex("by_team_type", (q) =>
+          q.eq("teamId", teamId).eq("eventType", args.eventType!)
+        )
+        .order("desc")
+        .take(limit);
+    }
+
+    return ctx.db
+      .query("agentBehaviorEvents")
+      .withIndex("by_team_created", (q) => q.eq("teamId", teamId))
+      .order("desc")
+      .take(limit);
+  },
+});
+
+/**
+ * Get candidate rules pending confirmation.
+ * Used by the review dashboard to show rules that need user approval.
+ */
+export const getCandidateBehaviorRules = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const limit = args.limit ?? 20;
+
+    return ctx.db
+      .query("agentBehaviorRules")
+      .withIndex("by_team_status", (q) =>
+        q.eq("teamId", teamId).eq("status", "candidate")
+      )
+      .order("desc")
+      .take(limit);
+  },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1531,6 +1531,79 @@ const convexSchema = defineSchema({
     .index("by_team_type", ["teamId", "memoryType", "createdAt"])
     .index("by_team_created", ["teamId", "createdAt"]),
 
+  // Normalized behavior rules for self-improving memory (S15 provenance)
+  // Enables fast querying, cross-run seeding, and provenance tracking
+  agentBehaviorRules: defineTable({
+    teamId: v.string(),
+    userId: v.optional(v.string()),
+    projectFullName: v.optional(v.string()), // e.g., "karlorz/cmux"
+    namespace: v.string(), // e.g., "coding", "research", "communication"
+    scope: v.union(
+      v.literal("hot"), // Always-loaded rules
+      v.literal("domain"), // Domain-specific rules
+      v.literal("project") // Project-specific rules
+    ),
+    status: v.union(
+      v.literal("candidate"), // Seen but not confirmed
+      v.literal("active"), // Confirmed and in use
+      v.literal("suppressed"), // User-suppressed
+      v.literal("archived") // Decayed/archived
+    ),
+    text: v.string(), // The rule content
+    sourceType: v.union(
+      v.literal("user_correction"), // From explicit user feedback
+      v.literal("stop_hook_reflection"), // From agent self-reflection
+      v.literal("manual_promotion"), // Manually promoted by user
+      v.literal("manual_import") // Imported from external source
+    ),
+    sourceTaskRunId: v.optional(v.id("taskRuns")),
+    sourceSnapshotId: v.optional(v.id("agentMemorySnapshots")),
+    confidence: v.number(), // 0.0 to 1.0
+    timesSeen: v.number(), // How many times this rule was seen
+    timesUsed: v.number(), // How many times this rule was applied
+    lastUsedAt: v.optional(v.number()), // Timestamp of last application
+    lastConfirmedAt: v.optional(v.number()), // Timestamp of last user confirmation
+    staleScore: v.optional(v.number()), // Decay score for archival
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_team_status", ["teamId", "status", "updatedAt"])
+    .index("by_team_scope_status", ["teamId", "scope", "status"])
+    .index("by_team_namespace_status", ["teamId", "namespace", "status"])
+    .index("by_team_project_status", ["teamId", "projectFullName", "status"])
+    .index("by_team_updated", ["teamId", "updatedAt"]),
+
+  // Behavior events log for provenance tracking (S15)
+  // Append-only log of rule applications, corrections, promotions, and demotions
+  agentBehaviorEvents: defineTable({
+    teamId: v.string(),
+    userId: v.optional(v.string()),
+    taskRunId: v.optional(v.id("taskRuns")),
+    ruleId: v.optional(v.id("agentBehaviorRules")),
+    eventType: v.union(
+      v.literal("correction_logged"), // User provided correction
+      v.literal("reflection_logged"), // Agent self-reflection
+      v.literal("rule_promoted"), // Rule promoted to active
+      v.literal("rule_demoted"), // Rule demoted from active
+      v.literal("rule_forgotten"), // Rule permanently removed
+      v.literal("rule_suppressed"), // Rule suppressed by user
+      v.literal("rule_used") // Rule was applied in a run (provenance)
+    ),
+    // Event payload - varies by eventType
+    wrongAction: v.optional(v.string()), // For corrections
+    correctAction: v.optional(v.string()), // For corrections
+    learnedRule: v.optional(v.string()), // Derived rule text
+    context: v.optional(v.string()), // Additional context
+    previousStatus: v.optional(v.string()), // For status changes
+    newStatus: v.optional(v.string()), // For status changes
+    appliedInContext: v.optional(v.string()), // For rule_used: where it was applied
+    createdAt: v.number(),
+  })
+    .index("by_team_type", ["teamId", "eventType", "createdAt"])
+    .index("by_task_run", ["taskRunId", "createdAt"])
+    .index("by_rule", ["ruleId", "createdAt"])
+    .index("by_team_created", ["teamId", "createdAt"]),
+
   // Provider health tracking for circuit breaker and resilience patterns
   // Tracks latency, success rate, and circuit state per provider
   providerHealth: defineTable({


### PR DESCRIPTION
## Summary
- Add `agentBehaviorRules` table for normalized behavior rules with scope (hot/domain/project), status (candidate/active/suppressed/archived), and usage tracking
- Add `agentBehaviorEvents` table for provenance event log (corrections, promotions, demotions, rule usage)
- Add 4 queries: `getActiveBehaviorRules`, `getBehaviorRulesForTaskRun`, `getBehaviorEvents`, `getCandidateBehaviorRules`
- Add 6 mutations: `logCorrection`, `logRuleUsed`, `promoteRule`, `suppressRule`, `forgetRule`, `createRule`
- Add "Applied" tab in TaskRunMemoryPanel showing which behavior rules were used during task execution

## Test plan
- [x] `bun check` passes
- [ ] Verify Convex schema deploys without errors
- [ ] Verify queries return expected data structure
- [ ] Verify Applied tab renders in Memory panel