### PR TITLE
feat(shared): add typed AgentCommEvent schema for orchestration

### DIFF
--- a/packages/shared/src/agent-comm-events.test.ts
+++ b/packages/shared/src/agent-comm-events.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateEventId,
+  createEventBase,
+  createTaskSpawnRequestedEvent,
+  createTaskCompletedEvent,
+  createWorkerMessageEvent,
+  createOrchestrationCompletedEvent,
+  isTaskLifecycleEvent,
+  isApprovalEvent,
+  isTerminalEvent,
+  type AgentCommEvent,
+  type TaskSpawnRequestedEvent,
+  type ApprovalRequiredEvent,
+  type OrchestrationCompletedEvent,
+} from "./agent-comm-events";
+
+describe("agent-comm-events", () => {
+  describe("generateEventId", () => {
+    it("generates unique IDs with evt_ prefix", () => {
+      const id1 = generateEventId();
+      const id2 = generateEventId();
+
+      expect(id1).toMatch(/^evt_[a-z0-9]+_[a-z0-9]+$/);
+      expect(id2).toMatch(/^evt_[a-z0-9]+_[a-z0-9]+$/);
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe("createEventBase", () => {
+    it("creates base event with required fields", () => {
+      const base = createEventBase("orch_123");
+
+      expect(base.eventId).toMatch(/^evt_/);
+      expect(base.orchestrationId).toBe("orch_123");
+      expect(base.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(base.correlationId).toBeUndefined();
+    });
+
+    it("includes correlation ID when provided", () => {
+      const base = createEventBase("orch_123", "corr_456");
+
+      expect(base.correlationId).toBe("corr_456");
+    });
+  });
+
+  describe("createTaskSpawnRequestedEvent", () => {
+    it("creates spawn event with required fields", () => {
+      const event = createTaskSpawnRequestedEvent(
+        "orch_123",
+        "task_456",
+        "claude/opus-4.5",
+        "Fix the bug in auth.ts"
+      );
+
+      expect(event.type).toBe("task_spawn_requested");
+      expect(event.orchestrationId).toBe("orch_123");
+      expect(event.taskId).toBe("task_456");
+      expect(event.agentName).toBe("claude/opus-4.5");
+      expect(event.prompt).toBe("Fix the bug in auth.ts");
+      expect(event.priority).toBeUndefined();
+      expect(event.dependsOn).toBeUndefined();
+    });
+
+    it("includes optional fields when provided", () => {
+      const event = createTaskSpawnRequestedEvent(
+        "orch_123",
+        "task_456",
+        "codex/gpt-5.1-codex-mini",
+        "Write tests",
+        {
+          priority: 3,
+          dependsOn: ["task_100", "task_200"],
+          metadata: { branch: "feat/auth" },
+          correlationId: "corr_789",
+        }
+      );
+
+      expect(event.priority).toBe(3);
+      expect(event.dependsOn).toEqual(["task_100", "task_200"]);
+      expect(event.metadata).toEqual({ branch: "feat/auth" });
+      expect(event.correlationId).toBe("corr_789");
+    });
+  });
+
+  describe("createTaskCompletedEvent", () => {
+    it("creates completed event with required fields", () => {
+      const event = createTaskCompletedEvent(
+        "orch_123",
+        "task_456",
+        "run_789",
+        "completed"
+      );
+
+      expect(event.type).toBe("task_completed");
+      expect(event.taskId).toBe("task_456");
+      expect(event.taskRunId).toBe("run_789");
+      expect(event.status).toBe("completed");
+    });
+
+    it("includes optional fields for success", () => {
+      const event = createTaskCompletedEvent(
+        "orch_123",
+        "task_456",
+        "run_789",
+        "completed",
+        {
+          exitCode: 0,
+          summary: "Fixed auth bug and added tests",
+          artifacts: [
+            { type: "pr_url", value: "https://github.com/org/repo/pull/123" },
+            { type: "commit", value: "abc123def" },
+          ],
+        }
+      );
+
+      expect(event.exitCode).toBe(0);
+      expect(event.summary).toBe("Fixed auth bug and added tests");
+      expect(event.artifacts).toHaveLength(2);
+      expect(event.artifacts?.[0].type).toBe("pr_url");
+    });
+
+    it("includes error for failed status", () => {
+      const event = createTaskCompletedEvent(
+        "orch_123",
+        "task_456",
+        "run_789",
+        "failed",
+        {
+          exitCode: 1,
+          error: "Test suite failed with 3 errors",
+        }
+      );
+
+      expect(event.status).toBe("failed");
+      expect(event.exitCode).toBe(1);
+      expect(event.error).toBe("Test suite failed with 3 errors");
+    });
+  });
+
+  describe("createWorkerMessageEvent", () => {
+    it("creates message event with required fields", () => {
+      const event = createWorkerMessageEvent(
+        "orch_123",
+        "worker_1",
+        "head_agent",
+        "status",
+        "Completed phase 1 of implementation"
+      );
+
+      expect(event.type).toBe("worker_message");
+      expect(event.from).toBe("worker_1");
+      expect(event.to).toBe("head_agent");
+      expect(event.messageType).toBe("status");
+      expect(event.body).toBe("Completed phase 1 of implementation");
+    });
+
+    it("includes task context when provided", () => {
+      const event = createWorkerMessageEvent(
+        "orch_123",
+        "worker_1",
+        "head_agent",
+        "result",
+        "PR created: https://github.com/org/repo/pull/456",
+        {
+          taskId: "task_456",
+          taskRunId: "run_789",
+          replyTo: "evt_abc123",
+        }
+      );
+
+      expect(event.taskId).toBe("task_456");
+      expect(event.taskRunId).toBe("run_789");
+      expect(event.replyTo).toBe("evt_abc123");
+    });
+  });
+
+  describe("createOrchestrationCompletedEvent", () => {
+    it("creates completed event with summary stats", () => {
+      const event = createOrchestrationCompletedEvent("orch_123", "completed", {
+        summary: "All tasks completed successfully",
+        totalTasks: 5,
+        completedTasks: 5,
+        failedTasks: 0,
+      });
+
+      expect(event.type).toBe("orchestration_completed");
+      expect(event.status).toBe("completed");
+      expect(event.totalTasks).toBe(5);
+      expect(event.completedTasks).toBe(5);
+      expect(event.failedTasks).toBe(0);
+    });
+
+    it("handles failed orchestration", () => {
+      const event = createOrchestrationCompletedEvent("orch_123", "failed", {
+        summary: "Critical task failed",
+        totalTasks: 5,
+        completedTasks: 2,
+        failedTasks: 1,
+      });
+
+      expect(event.status).toBe("failed");
+      expect(event.failedTasks).toBe(1);
+    });
+  });
+
+  describe("type guards", () => {
+    describe("isTaskLifecycleEvent", () => {
+      it("returns true for task lifecycle events", () => {
+        const spawnEvent: TaskSpawnRequestedEvent = {
+          eventId: "evt_1",
+          orchestrationId: "orch_1",
+          timestamp: new Date().toISOString(),
+          type: "task_spawn_requested",
+          taskId: "task_1",
+          agentName: "claude/opus-4.5",
+          prompt: "Do something",
+        };
+
+        expect(isTaskLifecycleEvent(spawnEvent)).toBe(true);
+      });
+
+      it("returns false for non-lifecycle events", () => {
+        const approvalEvent: ApprovalRequiredEvent = {
+          eventId: "evt_1",
+          orchestrationId: "orch_1",
+          timestamp: new Date().toISOString(),
+          type: "approval_required",
+          taskId: "task_1",
+          source: "worker_1",
+          action: "deploy",
+          payload: {},
+        };
+
+        expect(isTaskLifecycleEvent(approvalEvent)).toBe(false);
+      });
+    });
+
+    describe("isApprovalEvent", () => {
+      it("returns true for approval events", () => {
+        const event: ApprovalRequiredEvent = {
+          eventId: "evt_1",
+          orchestrationId: "orch_1",
+          timestamp: new Date().toISOString(),
+          type: "approval_required",
+          taskId: "task_1",
+          source: "worker_1",
+          action: "merge_pr",
+          payload: { prUrl: "https://github.com/org/repo/pull/123" },
+        };
+
+        expect(isApprovalEvent(event)).toBe(true);
+      });
+
+      it("returns false for non-approval events", () => {
+        const event = createTaskCompletedEvent(
+          "orch_1",
+          "task_1",
+          "run_1",
+          "completed"
+        );
+
+        expect(isApprovalEvent(event)).toBe(false);
+      });
+    });
+
+    describe("isTerminalEvent", () => {
+      it("returns true for orchestration completed event", () => {
+        const event: OrchestrationCompletedEvent = {
+          eventId: "evt_1",
+          orchestrationId: "orch_1",
+          timestamp: new Date().toISOString(),
+          type: "orchestration_completed",
+          status: "completed",
+        };
+
+        expect(isTerminalEvent(event)).toBe(true);
+      });
+
+      it("returns false for non-terminal events", () => {
+        const event = createTaskSpawnRequestedEvent(
+          "orch_1",
+          "task_1",
+          "claude/opus-4.5",
+          "Do something"
+        );
+
+        expect(isTerminalEvent(event)).toBe(false);
+      });
+    });
+  });
+
+  describe("event serialization", () => {
+    it("events are JSON serializable", () => {
+      const event = createTaskSpawnRequestedEvent(
+        "orch_123",
+        "task_456",
+        "claude/opus-4.5",
+        "Fix bug",
+        {
+          priority: 5,
+          dependsOn: ["task_1"],
+          metadata: { branch: "main" },
+        }
+      );
+
+      const serialized = JSON.stringify(event);
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized.type).toBe("task_spawn_requested");
+      expect(deserialized.taskId).toBe("task_456");
+      expect(deserialized.metadata.branch).toBe("main");
+    });
+  });
+});

--- a/packages/shared/src/agent-comm-events.ts
+++ b/packages/shared/src/agent-comm-events.ts
@@ -1,0 +1,418 @@
+/**
+ * Agent Communication Events - Typed event schema for orchestration.
+ *
+ * This module defines the canonical event types for agent-to-agent and
+ * agent-to-system communication. These events serve as the live transport
+ * layer, while PLAN.json, AGENTS.json, EVENTS.jsonl, and MAILBOX.json
+ * serve as durable projections.
+ *
+ * Design principles:
+ * - Events are immutable records of what happened
+ * - All events have a consistent base shape (type, orchestrationId, timestamp)
+ * - Events can be routed, persisted, and replayed
+ * - Events are the source of truth; file projections derive from them
+ *
+ * @see cmux-bridge-inspired-agent-communication.md for architecture context
+ */
+
+// =============================================================================
+// Base Event Types
+// =============================================================================
+
+/**
+ * Common fields for all agent communication events.
+ */
+export interface AgentCommEventBase {
+  /** Unique event ID for deduplication and tracking */
+  eventId: string;
+  /** Orchestration this event belongs to */
+  orchestrationId: string;
+  /** ISO 8601 timestamp when event was created */
+  timestamp: string;
+  /** Optional correlation ID for request-response tracking */
+  correlationId?: string;
+}
+
+// =============================================================================
+// Task Lifecycle Events
+// =============================================================================
+
+/**
+ * A task spawn was requested (before actual sandbox creation).
+ */
+export interface TaskSpawnRequestedEvent extends AgentCommEventBase {
+  type: "task_spawn_requested";
+  taskId: string;
+  agentName: string;
+  prompt: string;
+  priority?: number;
+  dependsOn?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * A task has started execution in a sandbox.
+ */
+export interface TaskStartedEvent extends AgentCommEventBase {
+  type: "task_started";
+  taskId: string;
+  taskRunId: string;
+  provider: string;
+  sandboxId?: string;
+  providerSessionId?: string;
+}
+
+/**
+ * A task's status has changed.
+ */
+export interface TaskStatusChangedEvent extends AgentCommEventBase {
+  type: "task_status_changed";
+  taskId: string;
+  taskRunId?: string;
+  previousStatus: string;
+  newStatus: string;
+  reason?: string;
+}
+
+/**
+ * A task has completed (successfully or with failure).
+ */
+export interface TaskCompletedEvent extends AgentCommEventBase {
+  type: "task_completed";
+  taskId: string;
+  taskRunId: string;
+  status: "completed" | "failed" | "cancelled";
+  exitCode?: number;
+  summary?: string;
+  artifacts?: TaskArtifact[];
+  error?: string;
+}
+
+/**
+ * Artifact produced by a task.
+ */
+export interface TaskArtifact {
+  type: "pr_url" | "commit" | "file" | "log" | "other";
+  value: string;
+  label?: string;
+}
+
+// =============================================================================
+// Worker Communication Events
+// =============================================================================
+
+/**
+ * A message sent between agents (worker-to-head, head-to-worker, peer-to-peer).
+ */
+export interface WorkerMessageEvent extends AgentCommEventBase {
+  type: "worker_message";
+  taskId?: string;
+  taskRunId?: string;
+  from: string;
+  to: string;
+  messageType: "handoff" | "request" | "status" | "result" | "error";
+  body: string;
+  replyTo?: string;
+}
+
+/**
+ * A worker status update (progress, heartbeat, etc.).
+ */
+export interface WorkerStatusEvent extends AgentCommEventBase {
+  type: "worker_status";
+  taskId: string;
+  taskRunId: string;
+  status: "idle" | "working" | "waiting" | "blocked" | "reviewing";
+  progress?: number;
+  currentStep?: string;
+  metadata?: Record<string, unknown>;
+}
+
+// =============================================================================
+// Approval and Review Events
+// =============================================================================
+
+/**
+ * An approval is required before proceeding.
+ */
+export interface ApprovalRequiredEvent extends AgentCommEventBase {
+  type: "approval_required";
+  taskId: string;
+  taskRunId?: string;
+  source: string;
+  action: string;
+  payload: unknown;
+  policy?: ApprovalPolicy;
+  expiresAt?: string;
+}
+
+/**
+ * An approval request has been resolved.
+ */
+export interface ApprovalResolvedEvent extends AgentCommEventBase {
+  type: "approval_resolved";
+  taskId: string;
+  taskRunId?: string;
+  approvalId: string;
+  resolution: "allow" | "deny" | "timeout";
+  resolvedBy?: string;
+  reason?: string;
+}
+
+/**
+ * Approval policy for gating actions.
+ */
+export interface ApprovalPolicy {
+  requiredApprovers?: string[];
+  autoApproveAfterMs?: number;
+  escalationTarget?: string;
+}
+
+// =============================================================================
+// Plan and Orchestration Events
+// =============================================================================
+
+/**
+ * The orchestration plan was updated.
+ */
+export interface PlanUpdatedEvent extends AgentCommEventBase {
+  type: "plan_updated";
+  planStatus: "pending" | "running" | "paused" | "completed" | "failed";
+  tasksAdded?: string[];
+  tasksRemoved?: string[];
+  dependenciesChanged?: boolean;
+}
+
+/**
+ * The entire orchestration has completed.
+ */
+export interface OrchestrationCompletedEvent extends AgentCommEventBase {
+  type: "orchestration_completed";
+  status: "completed" | "failed" | "cancelled";
+  summary?: string;
+  totalTasks?: number;
+  completedTasks?: number;
+  failedTasks?: number;
+}
+
+// =============================================================================
+// Provider Session Events
+// =============================================================================
+
+/**
+ * A provider session was bound to a task.
+ */
+export interface ProviderSessionBoundEvent extends AgentCommEventBase {
+  type: "provider_session_bound";
+  taskId: string;
+  taskRunId: string;
+  provider: string;
+  providerSessionId?: string;
+  providerThreadId?: string;
+  mode: "head" | "worker" | "reviewer";
+}
+
+// =============================================================================
+// Union Type
+// =============================================================================
+
+/**
+ * All possible agent communication events.
+ */
+export type AgentCommEvent =
+  | TaskSpawnRequestedEvent
+  | TaskStartedEvent
+  | TaskStatusChangedEvent
+  | TaskCompletedEvent
+  | WorkerMessageEvent
+  | WorkerStatusEvent
+  | ApprovalRequiredEvent
+  | ApprovalResolvedEvent
+  | PlanUpdatedEvent
+  | OrchestrationCompletedEvent
+  | ProviderSessionBoundEvent;
+
+/**
+ * Extract event type string from event union.
+ */
+export type AgentCommEventType = AgentCommEvent["type"];
+
+// =============================================================================
+// Event Utilities
+// =============================================================================
+
+/**
+ * Generate a unique event ID.
+ */
+export function generateEventId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 10);
+  return `evt_${timestamp}_${random}`;
+}
+
+/**
+ * Create a base event with common fields populated.
+ */
+export function createEventBase(
+  orchestrationId: string,
+  correlationId?: string
+): AgentCommEventBase {
+  return {
+    eventId: generateEventId(),
+    orchestrationId,
+    timestamp: new Date().toISOString(),
+    correlationId,
+  };
+}
+
+/**
+ * Create a task spawn requested event.
+ */
+export function createTaskSpawnRequestedEvent(
+  orchestrationId: string,
+  taskId: string,
+  agentName: string,
+  prompt: string,
+  options?: {
+    priority?: number;
+    dependsOn?: string[];
+    metadata?: Record<string, unknown>;
+    correlationId?: string;
+  }
+): TaskSpawnRequestedEvent {
+  return {
+    ...createEventBase(orchestrationId, options?.correlationId),
+    type: "task_spawn_requested",
+    taskId,
+    agentName,
+    prompt,
+    priority: options?.priority,
+    dependsOn: options?.dependsOn,
+    metadata: options?.metadata,
+  };
+}
+
+/**
+ * Create a task completed event.
+ */
+export function createTaskCompletedEvent(
+  orchestrationId: string,
+  taskId: string,
+  taskRunId: string,
+  status: "completed" | "failed" | "cancelled",
+  options?: {
+    exitCode?: number;
+    summary?: string;
+    artifacts?: TaskArtifact[];
+    error?: string;
+    correlationId?: string;
+  }
+): TaskCompletedEvent {
+  return {
+    ...createEventBase(orchestrationId, options?.correlationId),
+    type: "task_completed",
+    taskId,
+    taskRunId,
+    status,
+    exitCode: options?.exitCode,
+    summary: options?.summary,
+    artifacts: options?.artifacts,
+    error: options?.error,
+  };
+}
+
+/**
+ * Create a worker message event.
+ */
+export function createWorkerMessageEvent(
+  orchestrationId: string,
+  from: string,
+  to: string,
+  messageType: WorkerMessageEvent["messageType"],
+  body: string,
+  options?: {
+    taskId?: string;
+    taskRunId?: string;
+    replyTo?: string;
+    correlationId?: string;
+  }
+): WorkerMessageEvent {
+  return {
+    ...createEventBase(orchestrationId, options?.correlationId),
+    type: "worker_message",
+    taskId: options?.taskId,
+    taskRunId: options?.taskRunId,
+    from,
+    to,
+    messageType,
+    body,
+    replyTo: options?.replyTo,
+  };
+}
+
+/**
+ * Create an orchestration completed event.
+ */
+export function createOrchestrationCompletedEvent(
+  orchestrationId: string,
+  status: "completed" | "failed" | "cancelled",
+  options?: {
+    summary?: string;
+    totalTasks?: number;
+    completedTasks?: number;
+    failedTasks?: number;
+    correlationId?: string;
+  }
+): OrchestrationCompletedEvent {
+  return {
+    ...createEventBase(orchestrationId, options?.correlationId),
+    type: "orchestration_completed",
+    status,
+    summary: options?.summary,
+    totalTasks: options?.totalTasks,
+    completedTasks: options?.completedTasks,
+    failedTasks: options?.failedTasks,
+  };
+}
+
+// =============================================================================
+// Type Guards
+// =============================================================================
+
+/**
+ * Check if an event is a task lifecycle event.
+ */
+export function isTaskLifecycleEvent(
+  event: AgentCommEvent
+): event is
+  | TaskSpawnRequestedEvent
+  | TaskStartedEvent
+  | TaskStatusChangedEvent
+  | TaskCompletedEvent {
+  return (
+    event.type === "task_spawn_requested" ||
+    event.type === "task_started" ||
+    event.type === "task_status_changed" ||
+    event.type === "task_completed"
+  );
+}
+
+/**
+ * Check if an event is an approval-related event.
+ */
+export function isApprovalEvent(
+  event: AgentCommEvent
+): event is ApprovalRequiredEvent | ApprovalResolvedEvent {
+  return (
+    event.type === "approval_required" || event.type === "approval_resolved"
+  );
+}
+
+/**
+ * Check if an event signals orchestration completion.
+ */
+export function isTerminalEvent(
+  event: AgentCommEvent
+): event is OrchestrationCompletedEvent {
+  return event.type === "orchestration_completed";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,7 @@ export * from "./mcp-presets";
 export * from "./mcp-injection";
 export * from "./mcp-form";
 export * from "./mcp-preview";
+export * from "./agent-comm-events";
 // Note: useNetwork hook is NOT exported here to avoid SSR issues.
 // Import directly from "@cmux/shared/hooks/use-network" in client components.
 // Note: Environment component utilities are NOT exported here.


### PR DESCRIPTION
## Summary
Add foundational typed event schema for agent-to-agent and agent-to-system communication. This is P0 of the bridge-inspired agent communication architecture.

### Event Types
- **Task lifecycle**: `task_spawn_requested`, `task_started`, `task_status_changed`, `task_completed`
- **Worker communication**: `worker_message`, `worker_status`
- **Approval flow**: `approval_required`, `approval_resolved`
- **Orchestration**: `plan_updated`, `orchestration_completed`
- **Provider binding**: `provider_session_bound`

### Utilities
- `generateEventId()` - unique event ID generation
- `createEventBase()` - common field population
- Factory functions for all event types
- Type guards: `isTaskLifecycleEvent`, `isApprovalEvent`, `isTerminalEvent`

### Architecture
Events serve as the live transport layer. PLAN.json, AGENTS.json, EVENTS.jsonl, and MAILBOX.json serve as durable projections derived from events.

## Test plan
- [x] 19 tests, 54 assertions pass
- [x] `bun check` passes
- [ ] Verify exports work from `@cmux/shared`

## Related
- cmux-bridge-inspired-agent-communication.md (architecture doc)
- Follow-up: P1 event-driven head-agent control loop