### PR TITLE
feat(orchestration): add provider session bindings for task resume

### DIFF
--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -85,6 +85,7 @@ import type * as preview_jobs_worker from "../preview_jobs_worker.js";
 import type * as preview_screenshots_http from "../preview_screenshots_http.js";
 import type * as projectQueries from "../projectQueries.js";
 import type * as providerOverrides from "../providerOverrides.js";
+import type * as providerSessions from "../providerSessions.js";
 import type * as pveLxcInstances from "../pveLxcInstances.js";
 import type * as pve_lxc_actions from "../pve_lxc_actions.js";
 import type * as resultAggregation from "../resultAggregation.js";
@@ -202,6 +203,7 @@ declare const fullApi: ApiFromModules<{
   preview_screenshots_http: typeof preview_screenshots_http;
   projectQueries: typeof projectQueries;
   providerOverrides: typeof providerOverrides;
+  providerSessions: typeof providerSessions;
   pveLxcInstances: typeof pveLxcInstances;
   pve_lxc_actions: typeof pve_lxc_actions;
   resultAggregation: typeof resultAggregation;

--- a/packages/convex/convex/providerSessions.ts
+++ b/packages/convex/convex/providerSessions.ts
@@ -1,0 +1,386 @@
+/**
+ * Provider Session Bindings - Mutations and queries for session persistence.
+ *
+ * Provides durable storage for provider-specific session identifiers,
+ * enabling task-bound resume and continuity across retries.
+ *
+ * Use cases:
+ * - Resume a Claude session after task retry
+ * - Continue a Codex thread for iterative work
+ * - Track which provider session is bound to which task
+ */
+
+import { v } from "convex/values";
+import { getTeamId } from "../_shared/team";
+import { internalMutation, internalQuery } from "./_generated/server";
+import { authMutation, authQuery } from "./users/utils";
+
+// =============================================================================
+// Validators
+// =============================================================================
+
+const providerValidator = v.union(
+  v.literal("claude"),
+  v.literal("codex"),
+  v.literal("gemini"),
+  v.literal("opencode"),
+  v.literal("amp"),
+  v.literal("grok"),
+  v.literal("cursor"),
+  v.literal("qwen")
+);
+
+const modeValidator = v.union(
+  v.literal("head"),
+  v.literal("worker"),
+  v.literal("reviewer")
+);
+
+const statusValidator = v.union(
+  v.literal("active"),
+  v.literal("suspended"),
+  v.literal("expired"),
+  v.literal("terminated")
+);
+
+const replyChannelValidator = v.union(
+  v.literal("mailbox"),
+  v.literal("sse"),
+  v.literal("pty"),
+  v.literal("ui")
+);
+
+// =============================================================================
+// Public Mutations
+// =============================================================================
+
+/**
+ * Create or update a provider session binding.
+ */
+export const bindSession = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    orchestrationId: v.string(),
+    taskId: v.string(),
+    taskRunId: v.optional(v.id("taskRuns")),
+    agentName: v.string(),
+    provider: providerValidator,
+    mode: modeValidator,
+    providerSessionId: v.optional(v.string()),
+    providerThreadId: v.optional(v.string()),
+    providerConversationId: v.optional(v.string()),
+    replyChannel: v.optional(replyChannelValidator),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const now = Date.now();
+
+    // Check for existing binding
+    const existing = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .first();
+
+    if (existing) {
+      // Update existing binding
+      await ctx.db.patch(existing._id, {
+        providerSessionId: args.providerSessionId ?? existing.providerSessionId,
+        providerThreadId: args.providerThreadId ?? existing.providerThreadId,
+        providerConversationId:
+          args.providerConversationId ?? existing.providerConversationId,
+        replyChannel: args.replyChannel ?? existing.replyChannel,
+        taskRunId: args.taskRunId ?? existing.taskRunId,
+        status: "active",
+        lastActiveAt: now,
+        updatedAt: now,
+      });
+      return { bindingId: existing._id, updated: true };
+    }
+
+    // Create new binding
+    const bindingId = await ctx.db.insert("providerSessionBindings", {
+      orchestrationId: args.orchestrationId,
+      taskId: args.taskId,
+      taskRunId: args.taskRunId,
+      teamId,
+      agentName: args.agentName,
+      provider: args.provider,
+      mode: args.mode,
+      providerSessionId: args.providerSessionId,
+      providerThreadId: args.providerThreadId,
+      providerConversationId: args.providerConversationId,
+      replyChannel: args.replyChannel,
+      status: "active",
+      lastActiveAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { bindingId, updated: false };
+  },
+});
+
+/**
+ * Update session status (suspend, expire, terminate).
+ */
+export const updateSessionStatus = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    taskId: v.string(),
+    status: statusValidator,
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    const binding = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .first();
+
+    if (!binding || binding.teamId !== teamId) {
+      throw new Error("Session binding not found or unauthorized");
+    }
+
+    await ctx.db.patch(binding._id, {
+      status: args.status,
+      updatedAt: Date.now(),
+    });
+
+    return { success: true };
+  },
+});
+
+/**
+ * Record session activity (heartbeat).
+ */
+export const recordActivity = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    taskId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    const binding = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .first();
+
+    if (!binding || binding.teamId !== teamId) {
+      return { success: false };
+    }
+
+    await ctx.db.patch(binding._id, {
+      lastActiveAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    return { success: true };
+  },
+});
+
+// =============================================================================
+// Public Queries
+// =============================================================================
+
+/**
+ * Get session binding for a task.
+ */
+export const getByTask = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    taskId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    const binding = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .first();
+
+    if (!binding || binding.teamId !== teamId) {
+      return null;
+    }
+
+    return binding;
+  },
+});
+
+/**
+ * Get session binding for a task run.
+ */
+export const getByTaskRun = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    taskRunId: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    const binding = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task_run", (q) => q.eq("taskRunId", args.taskRunId))
+      .first();
+
+    if (!binding || binding.teamId !== teamId) {
+      return null;
+    }
+
+    return binding;
+  },
+});
+
+/**
+ * Get all session bindings for an orchestration.
+ */
+export const getByOrchestration = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    orchestrationId: v.string(),
+    status: v.optional(statusValidator),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    let bindings = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_orchestration", (q) =>
+        q.eq("orchestrationId", args.orchestrationId)
+      )
+      .collect();
+
+    // Filter by team (security)
+    bindings = bindings.filter((b) => b.teamId === teamId);
+
+    // Filter by status if specified
+    if (args.status) {
+      bindings = bindings.filter((b) => b.status === args.status);
+    }
+
+    return bindings;
+  },
+});
+
+/**
+ * Get active sessions by provider.
+ */
+export const getActiveByProvider = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    provider: providerValidator,
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    const limit = args.limit ?? 50;
+
+    const bindings = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_team_provider", (q) =>
+        q.eq("teamId", teamId).eq("provider", args.provider).eq("status", "active")
+      )
+      .take(limit);
+
+    return bindings;
+  },
+});
+
+// =============================================================================
+// Internal Mutations (for background worker)
+// =============================================================================
+
+/**
+ * Bind session internally (no auth).
+ */
+export const bindSessionInternal = internalMutation({
+  args: {
+    teamId: v.string(),
+    orchestrationId: v.string(),
+    taskId: v.string(),
+    taskRunId: v.optional(v.id("taskRuns")),
+    agentName: v.string(),
+    provider: providerValidator,
+    mode: modeValidator,
+    providerSessionId: v.optional(v.string()),
+    providerThreadId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+
+    // Check for existing binding
+    const existing = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        providerSessionId: args.providerSessionId ?? existing.providerSessionId,
+        providerThreadId: args.providerThreadId ?? existing.providerThreadId,
+        taskRunId: args.taskRunId ?? existing.taskRunId,
+        status: "active",
+        lastActiveAt: now,
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+
+    return ctx.db.insert("providerSessionBindings", {
+      orchestrationId: args.orchestrationId,
+      taskId: args.taskId,
+      taskRunId: args.taskRunId,
+      teamId: args.teamId,
+      agentName: args.agentName,
+      provider: args.provider,
+      mode: args.mode,
+      providerSessionId: args.providerSessionId,
+      providerThreadId: args.providerThreadId,
+      status: "active",
+      lastActiveAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+/**
+ * Terminate session when task completes.
+ */
+export const terminateSessionInternal = internalMutation({
+  args: {
+    taskId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const binding = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .first();
+
+    if (binding) {
+      await ctx.db.patch(binding._id, {
+        status: "terminated",
+        updatedAt: Date.now(),
+      });
+    }
+  },
+});
+
+// =============================================================================
+// Internal Queries
+// =============================================================================
+
+/**
+ * Get session binding for resume (internal).
+ */
+export const getForResume = internalQuery({
+  args: {
+    taskId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .first();
+  },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -1731,6 +1731,51 @@ const convexSchema = defineSchema({
     .index("by_task_run", ["taskRunId", "createdAt"])
     .index("by_event_id", ["eventId"]),
 
+  // Provider session bindings for task-bound resume and continuity
+  // Persists provider-specific session IDs (Claude session, Codex thread) per task
+  providerSessionBindings: defineTable({
+    orchestrationId: v.string(), // Parent orchestration
+    taskId: v.string(), // Orchestration task ID
+    taskRunId: v.optional(v.id("taskRuns")), // Link to task run
+    teamId: v.string(),
+    agentName: v.string(), // e.g., "claude/opus-4.5", "codex/gpt-5.1-codex"
+    provider: v.union(
+      v.literal("claude"),
+      v.literal("codex"),
+      v.literal("gemini"),
+      v.literal("opencode"),
+      v.literal("amp"),
+      v.literal("grok"),
+      v.literal("cursor"),
+      v.literal("qwen")
+    ),
+    mode: v.union(v.literal("head"), v.literal("worker"), v.literal("reviewer")),
+    // Provider-specific session identifiers
+    providerSessionId: v.optional(v.string()), // Claude session ID
+    providerThreadId: v.optional(v.string()), // Codex thread ID
+    providerConversationId: v.optional(v.string()), // Generic conversation ID
+    // Communication channel preference
+    replyChannel: v.optional(
+      v.union(v.literal("mailbox"), v.literal("sse"), v.literal("pty"), v.literal("ui"))
+    ),
+    // Lifecycle tracking
+    status: v.union(
+      v.literal("active"),
+      v.literal("suspended"),
+      v.literal("expired"),
+      v.literal("terminated")
+    ),
+    lastActiveAt: v.optional(v.number()),
+    expiresAt: v.optional(v.number()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_orchestration", ["orchestrationId", "createdAt"])
+    .index("by_task", ["taskId"])
+    .index("by_task_run", ["taskRunId"])
+    .index("by_team_provider", ["teamId", "provider", "status"])
+    .index("by_team_agent", ["teamId", "agentName", "status"]),
+
   // Projects for grouping related tasks and tracking aggregate progress
   // Supports plan storage, Obsidian integration, and progress metrics
   projects: defineTable({


### PR DESCRIPTION
## Summary
Add `providerSessionBindings` table to persist provider-specific session identifiers per orchestration task, enabling task-bound resume and continuity across retries.

### Schema
- `providerSessionBindings` table with fields:
  - `orchestrationId`, `taskId`, `taskRunId` - task identifiers
  - `agentName`, `provider`, `mode` - agent configuration
  - `providerSessionId` - Claude session ID
  - `providerThreadId` - Codex thread ID
  - `providerConversationId` - generic conversation ID
  - `replyChannel` - communication preference (mailbox/sse/pty/ui)
  - `status` - active/suspended/expired/terminated

### Mutations
- `bindSession` - create or update session binding
- `updateSessionStatus` - change status (suspend/expire/terminate)
- `recordActivity` - heartbeat for active sessions
- `bindSessionInternal` / `terminateSessionInternal` - for background worker

### Queries
- `getByTask`, `getByTaskRun` - lookup by task identifiers
- `getByOrchestration` - all bindings for an orchestration
- `getActiveByProvider` - active sessions by provider type
- `getForResume` - internal query for task retry

### Use Cases
1. Resume a Claude session after task retry
2. Continue a Codex thread for iterative implementation
3. Track which provider session is bound to which task
4. Support mixed-provider teams (Claude for planning, Codex for implementation)

## Test plan
- [x] `bun check` passes
- [ ] Verify schema deploys
- [ ] Verify mutations create/update bindings correctly

## Related
- PR #539-541 - P0-P2 of bridge-inspired architecture
- This PR completes P3 (provider session binding)