### PR TITLE
feat(policy): add centralized agent policy management system

### DIFF
--- a/apps/client/src/components/settings/SettingsSidebar.tsx
+++ b/apps/client/src/components/settings/SettingsSidebar.tsx
@@ -7,7 +7,7 @@ import {
 import { isElectron } from "@/lib/electron";
 import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
-import { Archive, ArrowLeft, FolderGit2, GitBranch, KeyRound, Layers, Plug, Settings } from "lucide-react";
+import { Archive, ArrowLeft, FolderGit2, GitBranch, KeyRound, Layers, Plug, Settings, Shield } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -25,6 +25,7 @@ export type SettingsSection =
   | "models"
   | "model-catalog"
   | "mcp-servers"
+  | "policy-rules"
   | "git"
   | "worktrees"
   | "archived";
@@ -68,6 +69,11 @@ const allNavItems: SettingsSidebarNavItem[] = [
     label: "MCP Servers",
     section: "mcp-servers",
     icon: Plug,
+  },
+  {
+    label: "Policy Rules",
+    section: "policy-rules",
+    icon: Shield,
   },
   {
     label: "Git",

--- a/apps/client/src/components/settings/sections/PolicyRulesSection.tsx
+++ b/apps/client/src/components/settings/sections/PolicyRulesSection.tsx
@@ -1,0 +1,480 @@
+import { SettingSection } from "@/components/settings/SettingSection";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { api } from "@cmux/convex/api";
+import type { Doc } from "@cmux/convex/dataModel";
+import { convexQuery } from "@convex-dev/react-query";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useConvex } from "convex/react";
+import { Loader2, Pencil, Plus, Trash2, X } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+type PolicyRule = Doc<"agentPolicyRules">;
+type PolicyScope = "system" | "team" | "workspace" | "user";
+type PolicyCategory = "git_policy" | "security" | "workflow" | "tool_restriction" | "custom";
+type PolicyContext = "task_sandbox" | "cloud_workspace" | "local_dev";
+type PolicyStatus = "active" | "disabled" | "deprecated";
+
+interface PolicyRulesSectionProps {
+  teamSlugOrId: string;
+}
+
+interface FormState {
+  name: string;
+  description: string;
+  scope: PolicyScope;
+  category: PolicyCategory;
+  contexts: PolicyContext[];
+  ruleText: string;
+  priority: number;
+  status: PolicyStatus;
+}
+
+const SCOPE_LABELS: Record<PolicyScope, string> = {
+  system: "System",
+  team: "Team",
+  workspace: "Workspace",
+  user: "User",
+};
+
+const CATEGORY_LABELS: Record<PolicyCategory, string> = {
+  git_policy: "Git Policy",
+  security: "Security",
+  workflow: "Workflow",
+  tool_restriction: "Tool Restrictions",
+  custom: "Custom",
+};
+
+const CONTEXT_LABELS: Record<PolicyContext, string> = {
+  task_sandbox: "Task Sandbox",
+  cloud_workspace: "Cloud Workspace",
+  local_dev: "Local Dev",
+};
+
+const STATUS_LABELS: Record<PolicyStatus, string> = {
+  active: "Active",
+  disabled: "Disabled",
+  deprecated: "Deprecated",
+};
+
+const SCOPE_BADGE_STYLES: Record<PolicyScope, string> = {
+  system: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+  team: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  workspace: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+  user: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300",
+};
+
+function buildEmptyForm(): FormState {
+  return {
+    name: "",
+    description: "",
+    scope: "team",
+    category: "workflow",
+    contexts: ["task_sandbox", "cloud_workspace"],
+    ruleText: "",
+    priority: 50,
+    status: "active",
+  };
+}
+
+function buildFormFromRule(rule: PolicyRule): FormState {
+  return {
+    name: rule.name,
+    description: rule.description ?? "",
+    scope: rule.scope,
+    category: rule.category,
+    contexts: (rule.contexts as PolicyContext[]) ?? [],
+    ruleText: rule.ruleText,
+    priority: rule.priority,
+    status: rule.status,
+  };
+}
+
+export function PolicyRulesSection({ teamSlugOrId }: PolicyRulesSectionProps) {
+  const convex = useConvex();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingRule, setEditingRule] = useState<PolicyRule | null>(null);
+  const [form, setForm] = useState<FormState>(buildEmptyForm());
+  const [formError, setFormError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<PolicyRule | null>(null);
+  const [activeScope, setActiveScope] = useState<PolicyScope | "all">("all");
+
+  const { data: rules, refetch, isLoading } = useQuery(
+    convexQuery(api.agentPolicyRules.list, { teamSlugOrId })
+  );
+
+  const upsertMutation = useMutation({
+    mutationFn: async (
+      payload: Parameters<typeof convex.mutation<typeof api.agentPolicyRules.upsert>>[1]
+    ) => {
+      return await convex.mutation(api.agentPolicyRules.upsert, payload);
+    },
+    onSuccess: async () => {
+      await refetch();
+      setDialogOpen(false);
+      setEditingRule(null);
+      setForm(buildEmptyForm());
+      toast.success(editingRule ? "Policy rule updated" : "Policy rule created");
+    },
+    onError: (error) => {
+      toast.error(`Failed to save: ${error.message}`);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: PolicyRule["_id"]) => {
+      return await convex.mutation(api.agentPolicyRules.remove, { id });
+    },
+    onSuccess: async () => {
+      await refetch();
+      setDeleteTarget(null);
+      toast.success("Policy rule deleted");
+    },
+    onError: (error) => {
+      toast.error(`Failed to delete: ${error.message}`);
+    },
+  });
+
+  const visibleRules = useMemo(() => {
+    if (!rules) return [];
+    if (activeScope === "all") return rules;
+    return rules.filter((rule) => rule.scope === activeScope);
+  }, [rules, activeScope]);
+
+  const scopeCounts = useMemo(() => {
+    const counts: Record<PolicyScope | "all", number> = {
+      all: 0,
+      system: 0,
+      team: 0,
+      workspace: 0,
+      user: 0,
+    };
+    for (const rule of rules ?? []) {
+      counts[rule.scope]++;
+      counts.all++;
+    }
+    return counts;
+  }, [rules]);
+
+  const openCreateDialog = useCallback(() => {
+    setEditingRule(null);
+    setForm(buildEmptyForm());
+    setFormError(null);
+    setDialogOpen(true);
+  }, []);
+
+  const openEditDialog = useCallback((rule: PolicyRule) => {
+    setEditingRule(rule);
+    setForm(buildFormFromRule(rule));
+    setFormError(null);
+    setDialogOpen(true);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    if (!form.name.trim()) {
+      setFormError("Name is required");
+      return;
+    }
+    if (!form.ruleText.trim()) {
+      setFormError("Rule text is required");
+      return;
+    }
+
+    setFormError(null);
+    upsertMutation.mutate({
+      ruleId: editingRule?.ruleId,
+      name: form.name.trim(),
+      description: form.description.trim() || undefined,
+      scope: form.scope,
+      teamSlugOrId: form.scope !== "system" ? teamSlugOrId : undefined,
+      category: form.category,
+      contexts: form.contexts.length > 0 ? form.contexts : undefined,
+      ruleText: form.ruleText.trim(),
+      priority: form.priority,
+      status: form.status,
+    });
+  }, [form, editingRule, teamSlugOrId, upsertMutation]);
+
+  const toggleContext = useCallback((context: PolicyContext) => {
+    setForm((prev) => ({
+      ...prev,
+      contexts: prev.contexts.includes(context)
+        ? prev.contexts.filter((c) => c !== context)
+        : [...prev.contexts, context],
+    }));
+  }, []);
+
+  return (
+    <SettingSection
+      title="Agent Policy Rules"
+      description="Centralized rules that apply to all spawned agents. System rules cannot be modified."
+      headerAction={
+        <Button size="sm" onClick={openCreateDialog}>
+          <Plus className="mr-1.5 h-4 w-4" />
+          Add Rule
+        </Button>
+      }
+    >
+      {/* Scope filter tabs */}
+      <div className="border-b border-neutral-200 px-4 py-2 dark:border-neutral-800">
+        <div className="flex gap-1">
+          {(["all", "system", "team", "workspace", "user"] as const).map((scope) => (
+            <button
+              key={scope}
+              onClick={() => setActiveScope(scope)}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                activeScope === scope
+                  ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900"
+                  : "text-neutral-600 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800"
+              }`}
+            >
+              {scope === "all" ? "All" : SCOPE_LABELS[scope]} ({scopeCounts[scope]})
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Rules list */}
+      <div className="divide-y divide-neutral-200 dark:divide-neutral-800">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-neutral-400" />
+          </div>
+        ) : visibleRules.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-neutral-500">
+            No policy rules found. Click "Add Rule" to create one.
+          </div>
+        ) : (
+          visibleRules.map((rule) => (
+            <div
+              key={rule._id}
+              className="flex items-start justify-between gap-4 px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                    {rule.name}
+                  </span>
+                  <span
+                    className={`rounded px-1.5 py-0.5 text-xs ${SCOPE_BADGE_STYLES[rule.scope]}`}
+                  >
+                    {SCOPE_LABELS[rule.scope]}
+                  </span>
+                  <span className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
+                    {CATEGORY_LABELS[rule.category]}
+                  </span>
+                  {rule.status !== "active" && (
+                    <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-xs text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300">
+                      {STATUS_LABELS[rule.status]}
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400 line-clamp-2">
+                  {rule.ruleText}
+                </p>
+                {rule.contexts && rule.contexts.length > 0 && (
+                  <div className="mt-1.5 flex gap-1">
+                    {rule.contexts.map((ctx) => (
+                      <span
+                        key={ctx}
+                        className="rounded bg-neutral-50 px-1.5 py-0.5 text-xs text-neutral-500 dark:bg-neutral-900 dark:text-neutral-500"
+                      >
+                        {CONTEXT_LABELS[ctx as PolicyContext]}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="flex items-center gap-1">
+                {rule.scope !== "system" && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => openEditDialog(rule)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-red-600 hover:text-red-700"
+                      onClick={() => setDeleteTarget(rule)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Create/Edit Dialog */}
+      <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg bg-white p-6 shadow-xl dark:bg-neutral-900">
+            <Dialog.Title className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+              {editingRule ? "Edit Policy Rule" : "Create Policy Rule"}
+            </Dialog.Title>
+            <Dialog.Close className="absolute right-4 top-4 text-neutral-400 hover:text-neutral-600">
+              <X className="h-5 w-5" />
+            </Dialog.Close>
+
+            <div className="mt-4 space-y-4">
+              {formError && (
+                <div className="rounded bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+                  {formError}
+                </div>
+              )}
+
+              <div>
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                  Name
+                </label>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                  className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                  placeholder="e.g., No Force Push"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                  Description (optional)
+                </label>
+                <input
+                  type="text"
+                  value={form.description}
+                  onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+                  className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                  placeholder="Brief description"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                    Scope
+                  </label>
+                  <select
+                    value={form.scope}
+                    onChange={(e) => setForm((f) => ({ ...f, scope: e.target.value as PolicyScope }))}
+                    className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                    disabled={editingRule?.scope === "system"}
+                  >
+                    <option value="team">Team</option>
+                    <option value="workspace">Workspace</option>
+                    <option value="user">User</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                    Category
+                  </label>
+                  <select
+                    value={form.category}
+                    onChange={(e) => setForm((f) => ({ ...f, category: e.target.value as PolicyCategory }))}
+                    className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                  >
+                    {Object.entries(CATEGORY_LABELS).map(([value, label]) => (
+                      <option key={value} value={value}>
+                        {label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                  Applies to Contexts
+                </label>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {(Object.entries(CONTEXT_LABELS) as [PolicyContext, string][]).map(
+                    ([value, label]) => (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => toggleContext(value)}
+                        className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                          form.contexts.includes(value)
+                            ? "bg-blue-600 text-white"
+                            : "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    )
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-neutral-500">
+                  Leave empty to apply to all contexts
+                </p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                  Priority (lower = higher priority)
+                </label>
+                <input
+                  type="number"
+                  value={form.priority}
+                  onChange={(e) => setForm((f) => ({ ...f, priority: parseInt(e.target.value) || 50 }))}
+                  className="mt-1 w-24 rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                  min={1}
+                  max={100}
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                  Rule Text (Markdown)
+                </label>
+                <textarea
+                  value={form.ruleText}
+                  onChange={(e) => setForm((f) => ({ ...f, ruleText: e.target.value }))}
+                  className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm font-mono dark:border-neutral-700 dark:bg-neutral-800"
+                  rows={5}
+                  placeholder="**Rule**: Description of what agents should or should not do..."
+                />
+              </div>
+
+              <div className="flex justify-end gap-2 pt-2">
+                <Button variant="outline" onClick={() => setDialogOpen(false)}>
+                  Cancel
+                </Button>
+                <Button onClick={handleSubmit} disabled={upsertMutation.isPending}>
+                  {upsertMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {editingRule ? "Save Changes" : "Create Rule"}
+                </Button>
+              </div>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      {/* Delete Confirmation */}
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        title="Delete Policy Rule"
+        description={`Are you sure you want to delete "${deleteTarget?.name}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (deleteTarget) {
+            deleteMutation.mutate(deleteTarget._id);
+          }
+        }}
+      />
+    </SettingSection>
+  );
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.settings.tsx
@@ -9,6 +9,7 @@ import {
 import { ArchivedTasksSection } from "@/components/settings/sections/ArchivedTasksSection";
 import { GitSection } from "@/components/settings/sections/GitSection";
 import { McpServersSection } from "@/components/settings/sections/McpServersSection";
+import { PolicyRulesSection } from "@/components/settings/sections/PolicyRulesSection";
 import { ModelCatalogSection } from "@/components/settings/sections/ModelCatalogSection";
 import { ModelManagementSection } from "@/components/settings/sections/ModelManagementSection";
 import { WorktreesSection } from "@/components/settings/sections/WorktreesSection";
@@ -47,6 +48,7 @@ export const settingsSectionSchema = z.enum([
   "models",
   "model-catalog",
   "mcp-servers",
+  "policy-rules",
   "git",
   "worktrees",
   "archived",
@@ -878,6 +880,8 @@ function SettingsComponent() {
             <ModelCatalogSection teamSlugOrId={teamSlugOrId} />
           ) : activeSection === "mcp-servers" ? (
             <McpServersSection teamSlugOrId={teamSlugOrId} />
+          ) : activeSection === "policy-rules" ? (
+            <PolicyRulesSection teamSlugOrId={teamSlugOrId} />
           ) : activeSection === "git" ? (
             <GitSection
               branchPrefix={branchPrefix}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.tsx
@@ -108,6 +108,7 @@ function LayoutComponent() {
     sectionFromSearch === "models" ? "models" :
     sectionFromSearch === "model-catalog" ? "model-catalog" :
     sectionFromSearch === "mcp-servers" ? "mcp-servers" :
+    sectionFromSearch === "policy-rules" ? "policy-rules" :
     sectionFromSearch === "git" ? "git" :
     sectionFromSearch === "worktrees" ? "worktrees" :
     sectionFromSearch === "archived" ? "archived" : "general";

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -6,6 +6,7 @@ import {
   type EnvironmentResult,
 } from "@cmux/shared/agentConfig";
 import type { McpServerConfig } from "@cmux/shared";
+import type { PolicyRuleForInstructions } from "@cmux/shared/agent-memory-protocol";
 import {
   getProviderIdFromAgentName,
   getProviderRegistry,
@@ -133,6 +134,8 @@ export interface PreFetchedSpawnConfig {
   previousKnowledge: string | null;
   previousMailbox: string | null;
   previousBehavior: string | null;
+  /** Centralized policy rules (Agent Policy Management) */
+  policyRules?: PolicyRuleForInstructions[];
 }
 
 /** Autopilot mode configuration for long-running agent sessions (Phase 6) */
@@ -563,6 +566,7 @@ export async function spawnAgent(
     let previousKnowledge: string | null;
     let previousMailbox: string | null;
     let previousBehavior: string | null;
+    let policyRules: PolicyRuleForInstructions[] | undefined;
 
     if (options.preFetchedConfig) {
       // Use pre-fetched config (JWT auth path - Stack Auth not available)
@@ -574,6 +578,7 @@ export async function spawnAgent(
       previousKnowledge = options.preFetchedConfig.previousKnowledge;
       previousMailbox = options.preFetchedConfig.previousMailbox;
       previousBehavior = options.preFetchedConfig.previousBehavior;
+      policyRules = options.preFetchedConfig.policyRules;
     } else {
       // Fetch from Convex (Stack Auth available)
       const results = await Promise.all([
@@ -649,6 +654,26 @@ export async function spawnAgent(
             );
             return null;
           }),
+        // Query centralized policy rules (Agent Policy Management)
+        ((): Promise<PolicyRuleForInstructions[] | undefined> => {
+          const providerId = getProviderIdFromAgentName(agent.name);
+          if (!providerId) return Promise.resolve(undefined);
+          const agentType = providerId === "anthropic" ? "claude"
+            : providerId === "openai" ? "codex"
+            : providerId === "gemini" ? "gemini"
+            : "opencode";
+          return getConvex()
+            .query(api.agentPolicyRules.getForSandbox, {
+              teamSlugOrId,
+              agentType,
+              ...(task?.projectFullName ? { projectFullName: task.projectFullName } : {}),
+              context: options.isCloudMode ? "cloud_workspace" : "task_sandbox",
+            })
+            .catch((error) => {
+              serverLogger.warn("[AgentSpawner] Failed to fetch policy rules", error);
+              return undefined;
+            });
+        })(),
       ]);
       userApiKeys = results[0];
       workspaceSettings = results[1];
@@ -657,6 +682,7 @@ export async function spawnAgent(
       previousKnowledge = results[4];
       previousMailbox = results[5];
       previousBehavior = results[6];
+      policyRules = results[7];
     }
 
     if (previousKnowledge) {
@@ -672,6 +698,11 @@ export async function spawnAgent(
     if (previousBehavior) {
       serverLogger.info(
         `[AgentSpawner] Found previous behavior HOT (${previousBehavior.length} chars) for cross-run seeding`
+      );
+    }
+    if (policyRules && policyRules.length > 0) {
+      serverLogger.info(
+        `[AgentSpawner] Loaded ${policyRules.length} centralized policy rules`
       );
     }
 
@@ -767,6 +798,8 @@ export async function spawnAgent(
         previousMailbox: previousMailbox ?? undefined,
         previousBehavior: previousBehavior ?? undefined,
         orchestrationOptions: options.orchestrationOptions,
+        // Centralized policy rules (Agent Policy Management)
+        policyRules,
         // GitHub Projects v2 context (Phase 5: Sandbox Project Integration)
         githubProjectContext:
           task?.githubProjectId &&

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -12,6 +12,8 @@ import type * as admin from "../admin.js";
 import type * as agentBehaviorMutations from "../agentBehaviorMutations.js";
 import type * as agentMemoryQueries from "../agentMemoryQueries.js";
 import type * as agentMemory_http from "../agentMemory_http.js";
+import type * as agentPolicyRules from "../agentPolicyRules.js";
+import type * as agentPolicyRules_http from "../agentPolicyRules_http.js";
 import type * as analytics from "../analytics.js";
 import type * as anthropic_http from "../anthropic_http.js";
 import type * as apiKeys from "../apiKeys.js";
@@ -94,6 +96,7 @@ import type * as sandboxInstanceMaintenance from "../sandboxInstanceMaintenance.
 import type * as sandboxInstances from "../sandboxInstances.js";
 import type * as screenshots_http from "../screenshots_http.js";
 import type * as seed from "../seed.js";
+import type * as seedPolicyRules from "../seedPolicyRules.js";
 import type * as sessionActivity from "../sessionActivity.js";
 import type * as sessionActivity_http from "../sessionActivity_http.js";
 import type * as sourceRepoMappings from "../sourceRepoMappings.js";
@@ -131,6 +134,8 @@ declare const fullApi: ApiFromModules<{
   agentBehaviorMutations: typeof agentBehaviorMutations;
   agentMemoryQueries: typeof agentMemoryQueries;
   agentMemory_http: typeof agentMemory_http;
+  agentPolicyRules: typeof agentPolicyRules;
+  agentPolicyRules_http: typeof agentPolicyRules_http;
   analytics: typeof analytics;
   anthropic_http: typeof anthropic_http;
   apiKeys: typeof apiKeys;
@@ -213,6 +218,7 @@ declare const fullApi: ApiFromModules<{
   sandboxInstances: typeof sandboxInstances;
   screenshots_http: typeof screenshots_http;
   seed: typeof seed;
+  seedPolicyRules: typeof seedPolicyRules;
   sessionActivity: typeof sessionActivity;
   sessionActivity_http: typeof sessionActivity_http;
   sourceRepoMappings: typeof sourceRepoMappings;

--- a/packages/convex/convex/agentPolicyRules.ts
+++ b/packages/convex/convex/agentPolicyRules.ts
@@ -1,0 +1,457 @@
+/**
+ * Agent Policy Rules - Convex Queries and Mutations
+ *
+ * Centralized management of agent policy rules that apply to spawned sandboxes.
+ * Follows scope hierarchy: system > team > workspace > user (most specific wins).
+ */
+
+import { v } from "convex/values";
+import { internalQuery, type QueryCtx } from "./_generated/server";
+import { resolveTeamIdLoose } from "../_shared/team";
+import { authMutation, authQuery } from "./users/utils";
+
+// Validators for policy rule fields
+const scopeValidator = v.union(
+  v.literal("system"),
+  v.literal("team"),
+  v.literal("workspace"),
+  v.literal("user"),
+);
+
+const contextValidator = v.union(
+  v.literal("task_sandbox"),
+  v.literal("cloud_workspace"),
+  v.literal("local_dev"),
+);
+
+const categoryValidator = v.union(
+  v.literal("git_policy"),
+  v.literal("security"),
+  v.literal("workflow"),
+  v.literal("tool_restriction"),
+  v.literal("custom"),
+);
+
+const statusValidator = v.union(
+  v.literal("active"),
+  v.literal("disabled"),
+  v.literal("deprecated"),
+);
+
+const agentTypeValidator = v.union(
+  v.literal("claude"),
+  v.literal("codex"),
+  v.literal("gemini"),
+  v.literal("opencode"),
+);
+
+type AgentType = "claude" | "codex" | "gemini" | "opencode";
+type PolicyContext = "task_sandbox" | "cloud_workspace" | "local_dev";
+type PolicyScope = "system" | "team" | "workspace" | "user";
+
+// Scope priority for merging (lower index = broader scope, later scopes override)
+const SCOPE_PRIORITY: PolicyScope[] = ["system", "team", "workspace", "user"];
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeRequiredString(fieldName: string, value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${fieldName} is required`);
+  }
+  return trimmed;
+}
+
+/**
+ * List policy rules for a team (UI display).
+ */
+export const list = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    scope: v.optional(scopeValidator),
+    projectFullName: v.optional(v.string()),
+    status: v.optional(statusValidator),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const projectFullName = normalizeOptionalString(args.projectFullName);
+
+    // Get all relevant rules
+    let rules;
+    if (projectFullName) {
+      rules = await ctx.db
+        .query("agentPolicyRules")
+        .withIndex("by_project", (q) =>
+          q.eq("projectFullName", projectFullName).eq("status", args.status ?? "active"),
+        )
+        .collect();
+    } else if (args.scope) {
+      rules = await ctx.db
+        .query("agentPolicyRules")
+        .withIndex("by_team_scope", (q) =>
+          q
+            .eq("teamId", teamId)
+            .eq("scope", args.scope!)
+            .eq("status", args.status ?? "active"),
+        )
+        .collect();
+    } else {
+      rules = await ctx.db
+        .query("agentPolicyRules")
+        .withIndex("by_team", (q) =>
+          q.eq("teamId", teamId).eq("status", args.status ?? "active"),
+        )
+        .collect();
+    }
+
+    // Also include system rules (always visible)
+    const systemRules = await ctx.db
+      .query("agentPolicyRules")
+      .withIndex("by_scope", (q) =>
+        q.eq("scope", "system").eq("status", args.status ?? "active"),
+      )
+      .collect();
+
+    // Combine and dedupe (team rules override system rules with same ruleId)
+    const ruleMap = new Map<string, (typeof rules)[number]>();
+    for (const rule of systemRules) {
+      ruleMap.set(rule.ruleId, rule);
+    }
+    for (const rule of rules) {
+      ruleMap.set(rule.ruleId, rule);
+    }
+
+    return Array.from(ruleMap.values()).sort((a, b) => {
+      // Sort by scope priority, then by priority number, then by name
+      const scopeDiff =
+        SCOPE_PRIORITY.indexOf(a.scope) - SCOPE_PRIORITY.indexOf(b.scope);
+      if (scopeDiff !== 0) return scopeDiff;
+      const priorityDiff = a.priority - b.priority;
+      if (priorityDiff !== 0) return priorityDiff;
+      return a.name.localeCompare(b.name);
+    });
+  },
+});
+
+/**
+ * Get policy rules for a sandbox spawn (filtered by agent type, context).
+ * Returns rules merged by scope hierarchy with deduplication.
+ */
+export const getForSandbox = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    agentType: agentTypeValidator,
+    projectFullName: v.optional(v.string()),
+    context: contextValidator,
+  },
+  handler: async (ctx, args) => {
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+    return await getForSandboxImpl(ctx, {
+      teamId,
+      userId,
+      agentType: args.agentType,
+      projectFullName: normalizeOptionalString(args.projectFullName),
+      context: args.context,
+    });
+  },
+});
+
+/**
+ * Internal query for sandbox policy fetching (no auth required).
+ * Used by worker/orchestration paths that already have validated teamId.
+ */
+export const getForSandboxInternal = internalQuery({
+  args: {
+    teamId: v.string(),
+    userId: v.optional(v.string()),
+    agentType: agentTypeValidator,
+    projectFullName: v.optional(v.string()),
+    context: contextValidator,
+  },
+  handler: async (ctx, args) => {
+    return await getForSandboxImpl(ctx, {
+      teamId: args.teamId,
+      userId: args.userId,
+      agentType: args.agentType,
+      projectFullName: normalizeOptionalString(args.projectFullName),
+      context: args.context,
+    });
+  },
+});
+
+/**
+ * Shared implementation for getForSandbox queries.
+ */
+async function getForSandboxImpl(
+  ctx: QueryCtx,
+  args: {
+    teamId: string;
+    userId?: string;
+    agentType: AgentType;
+    projectFullName?: string;
+    context: PolicyContext;
+  },
+) {
+  // Fetch rules from each scope level
+  const [systemRules, teamRules, workspaceRules, userRules] = await Promise.all([
+    // System rules (always apply)
+    ctx.db
+      .query("agentPolicyRules")
+      .withIndex("by_scope", (q) => q.eq("scope", "system").eq("status", "active"))
+      .collect(),
+    // Team rules
+    ctx.db
+      .query("agentPolicyRules")
+      .withIndex("by_team_scope", (q) =>
+        q.eq("teamId", args.teamId).eq("scope", "team").eq("status", "active"),
+      )
+      .collect(),
+    // Workspace rules (if projectFullName provided)
+    args.projectFullName
+      ? ctx.db
+          .query("agentPolicyRules")
+          .withIndex("by_project", (q) =>
+            q.eq("projectFullName", args.projectFullName).eq("status", "active"),
+          )
+          .collect()
+          .then((rules) => rules.filter((r) => r.scope === "workspace"))
+      : Promise.resolve([]),
+    // User rules (if userId provided)
+    args.userId
+      ? ctx.db
+          .query("agentPolicyRules")
+          .withIndex("by_user", (q) =>
+            q.eq("userId", args.userId).eq("status", "active"),
+          )
+          .collect()
+      : Promise.resolve([]),
+  ]);
+
+  // Combine all rules
+  const allRules = [...systemRules, ...teamRules, ...workspaceRules, ...userRules];
+
+  // Filter by agent type and context
+  const filteredRules = allRules.filter((rule) => {
+    // Agent filter: if agents array is set, agent must be included
+    if (rule.agents && rule.agents.length > 0) {
+      if (!rule.agents.includes(args.agentType)) {
+        return false;
+      }
+    }
+
+    // Context filter: if contexts array is set, context must be included
+    if (rule.contexts && rule.contexts.length > 0) {
+      if (!rule.contexts.includes(args.context)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  // Dedupe by ruleId, keeping the most specific scope
+  // Within same scope, keep the one with lowest priority number
+  const ruleMap = new Map<
+    string,
+    { rule: (typeof filteredRules)[number]; scopeIndex: number }
+  >();
+
+  for (const rule of filteredRules) {
+    const scopeIndex = SCOPE_PRIORITY.indexOf(rule.scope);
+    const existing = ruleMap.get(rule.ruleId);
+
+    if (!existing) {
+      ruleMap.set(rule.ruleId, { rule, scopeIndex });
+    } else if (scopeIndex > existing.scopeIndex) {
+      // More specific scope wins
+      ruleMap.set(rule.ruleId, { rule, scopeIndex });
+    } else if (
+      scopeIndex === existing.scopeIndex &&
+      rule.priority < existing.rule.priority
+    ) {
+      // Same scope, lower priority number wins
+      ruleMap.set(rule.ruleId, { rule, scopeIndex });
+    }
+  }
+
+  // Sort by priority within each category
+  const result = Array.from(ruleMap.values())
+    .map(({ rule }) => ({
+      ruleId: rule.ruleId,
+      name: rule.name,
+      category: rule.category,
+      ruleText: rule.ruleText,
+      priority: rule.priority,
+      scope: rule.scope,
+    }))
+    .sort((a, b) => {
+      // Sort by category, then priority
+      if (a.category !== b.category) {
+        return a.category.localeCompare(b.category);
+      }
+      return a.priority - b.priority;
+    });
+
+  return result;
+}
+
+/**
+ * Create or update a policy rule.
+ */
+export const upsert = authMutation({
+  args: {
+    ruleId: v.optional(v.string()), // If provided, updates existing rule
+    name: v.string(),
+    description: v.optional(v.string()),
+    scope: scopeValidator,
+    teamSlugOrId: v.optional(v.string()), // For team/workspace/user scope
+    projectFullName: v.optional(v.string()), // For workspace scope
+    agents: v.optional(v.array(agentTypeValidator)),
+    contexts: v.optional(v.array(contextValidator)),
+    category: categoryValidator,
+    ruleText: v.string(),
+    priority: v.number(),
+    status: v.optional(statusValidator),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const now = Date.now();
+
+    // Resolve teamId for non-system scopes
+    let teamId: string | undefined;
+    if (args.scope !== "system" && args.teamSlugOrId) {
+      teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    }
+
+    const name = normalizeRequiredString("name", args.name);
+    const ruleText = normalizeRequiredString("ruleText", args.ruleText);
+    const description = normalizeOptionalString(args.description);
+    const projectFullName = normalizeOptionalString(args.projectFullName);
+
+    // Validate scope requirements
+    if (args.scope === "team" && !teamId) {
+      throw new Error("Team scope requires teamSlugOrId");
+    }
+    if (args.scope === "workspace" && !projectFullName) {
+      throw new Error("Workspace scope requires projectFullName");
+    }
+    if (args.scope === "user" && !teamId) {
+      throw new Error("User scope requires teamSlugOrId");
+    }
+
+    // Check for existing rule if ruleId provided
+    if (args.ruleId) {
+      const existingRules = await ctx.db
+        .query("agentPolicyRules")
+        .filter((q) => q.eq(q.field("ruleId"), args.ruleId))
+        .collect();
+      const existing = existingRules[0];
+
+      if (existing) {
+        // Update existing rule
+        await ctx.db.patch(existing._id, {
+          name,
+          description,
+          scope: args.scope,
+          teamId: args.scope === "system" ? undefined : teamId,
+          projectFullName: args.scope === "workspace" ? projectFullName : undefined,
+          userId: args.scope === "user" ? userId : undefined,
+          agents: args.agents,
+          contexts: args.contexts,
+          category: args.category,
+          ruleText,
+          priority: args.priority,
+          status: args.status ?? existing.status,
+          updatedAt: now,
+        });
+        return existing._id;
+      }
+    }
+
+    // Generate new ruleId if not provided or not found
+    const ruleId = args.ruleId ?? generateRuleId();
+
+    // Create new rule
+    return ctx.db.insert("agentPolicyRules", {
+      ruleId,
+      name,
+      description,
+      scope: args.scope,
+      teamId: args.scope === "system" ? undefined : teamId,
+      projectFullName: args.scope === "workspace" ? projectFullName : undefined,
+      userId: args.scope === "user" ? userId : undefined,
+      agents: args.agents,
+      contexts: args.contexts,
+      category: args.category,
+      ruleText,
+      priority: args.priority,
+      status: args.status ?? "active",
+      createdAt: now,
+      updatedAt: now,
+      createdBy: userId,
+    });
+  },
+});
+
+/**
+ * Delete a policy rule.
+ */
+export const remove = authMutation({
+  args: {
+    id: v.id("agentPolicyRules"),
+  },
+  handler: async (ctx, args) => {
+    const rule = await ctx.db.get(args.id);
+    if (!rule) {
+      throw new Error("Policy rule not found");
+    }
+
+    // System rules can only be deleted by admin (TODO: add admin check)
+    if (rule.scope === "system") {
+      throw new Error("System rules cannot be deleted");
+    }
+
+    await ctx.db.delete(args.id);
+    return { success: true };
+  },
+});
+
+/**
+ * Update rule status (enable/disable/deprecate).
+ */
+export const updateStatus = authMutation({
+  args: {
+    id: v.id("agentPolicyRules"),
+    status: statusValidator,
+  },
+  handler: async (ctx, args) => {
+    const rule = await ctx.db.get(args.id);
+    if (!rule) {
+      throw new Error("Policy rule not found");
+    }
+
+    await ctx.db.patch(args.id, {
+      status: args.status,
+      updatedAt: Date.now(),
+    });
+
+    return { success: true };
+  },
+});
+
+/**
+ * Generate a new rule ID in the format "apr_xxx".
+ */
+function generateRuleId(): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let suffix = "";
+  for (let i = 0; i < 12; i++) {
+    suffix += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return `apr_${suffix}`;
+}

--- a/packages/convex/convex/agentPolicyRules_http.ts
+++ b/packages/convex/convex/agentPolicyRules_http.ts
@@ -1,0 +1,86 @@
+/**
+ * HTTP endpoint for fetching agent policy rules from sandboxes.
+ * Used by the refresh_policy_rules MCP tool to get latest rules at runtime.
+ *
+ * GET /api/agent/policy-rules
+ * Auth: x-cmux-token header with valid task run JWT
+ *
+ * Query params:
+ *   agentType: "claude" | "codex" | "gemini" | "opencode" (required)
+ *   projectFullName?: string (owner/repo format)
+ *   context: "task_sandbox" | "cloud_workspace" | "local_dev" (required)
+ *
+ * Returns: { ok: true, rules: PolicyRule[] } on success
+ */
+
+import { z } from "zod";
+import { jsonResponse } from "../_shared/http-utils";
+import { internal } from "./_generated/api";
+import { httpAction } from "./_generated/server";
+import { getWorkerAuth } from "./users/utils/getWorkerAuth";
+
+const GetPolicyRulesQuerySchema = z.object({
+  agentType: z.enum(["claude", "codex", "gemini", "opencode"]),
+  projectFullName: z.string().optional(),
+  context: z.enum(["task_sandbox", "cloud_workspace", "local_dev"]),
+});
+
+/**
+ * HTTP GET endpoint for sandbox agents to fetch their policy rules.
+ * The teamId and userId are extracted from the JWT for security.
+ */
+export const getPolicyRules = httpAction(async (ctx, req) => {
+  const auth = await getWorkerAuth(req, {
+    loggerPrefix: "[convex.agentPolicyRules]",
+  });
+  if (!auth) {
+    console.error("[convex.agentPolicyRules] Auth failed for policy rules fetch");
+    return jsonResponse({ code: 401, message: "Unauthorized" }, 401);
+  }
+
+  // Parse query parameters from URL
+  const url = new URL(req.url);
+  const queryParams = {
+    agentType: url.searchParams.get("agentType"),
+    projectFullName: url.searchParams.get("projectFullName") || undefined,
+    context: url.searchParams.get("context"),
+  };
+
+  const validation = GetPolicyRulesQuerySchema.safeParse(queryParams);
+  if (!validation.success) {
+    console.warn(
+      "[convex.agentPolicyRules] Invalid query params",
+      validation.error.format()
+    );
+    return jsonResponse(
+      {
+        code: 400,
+        message: "Invalid query parameters",
+        errors: validation.error.issues.map((i) => i.message),
+      },
+      400
+    );
+  }
+
+  try {
+    // Use the internal query - teamId comes from JWT, not user input
+    const rules = await ctx.runQuery(
+      internal.agentPolicyRules.getForSandboxInternal,
+      {
+        teamId: auth.payload.teamId,
+        userId: auth.payload.userId,
+        agentType: validation.data.agentType,
+        projectFullName: validation.data.projectFullName,
+        context: validation.data.context,
+      }
+    );
+
+    return jsonResponse({ ok: true, rules });
+  } catch (error) {
+    console.error("[convex.agentPolicyRules] Failed to fetch policy rules:", error);
+    return jsonResponse(
+      { code: 500, message: "Internal server error" },
+      500
+    );
+  }
+});

--- a/packages/convex/convex/http.ts
+++ b/packages/convex/convex/http.ts
@@ -8,6 +8,7 @@ import {
 } from "./crown_http";
 import { agentStopped } from "./notifications_http";
 import { syncMemory } from "./agentMemory_http";
+import { getPolicyRules } from "./agentPolicyRules_http";
 import { createScreenshotUploadUrl, uploadScreenshot } from "./screenshots_http";
 import {
   codeReviewFileCallback,
@@ -141,6 +142,12 @@ http.route({
   path: "/api/memory/sync",
   method: "POST",
   handler: syncMemory,
+});
+
+http.route({
+  path: "/api/agent/policy-rules",
+  method: "GET",
+  handler: getPolicyRules,
 });
 
 http.route({

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -2014,6 +2014,71 @@ const convexSchema = defineSchema({
     .index("by_session", ["sessionId"])
     .index("by_team", ["teamId"])
     .index("by_team_time", ["teamId", "startedAt"]),
+
+  // Centralized agent policy rules (Phase: Agent Policy Management)
+  // Manages rules that apply to spawned agent sandboxes with scope hierarchy:
+  // system > team > workspace > user (most specific wins)
+  agentPolicyRules: defineTable({
+    // Identity
+    ruleId: v.string(), // "apr_xxx" format for stable external references
+    name: v.string(), // Human-readable name
+    description: v.optional(v.string()),
+
+    // Scope hierarchy: system > team > workspace > user
+    scope: v.union(
+      v.literal("system"), // Applies to all sandboxes (cmux-managed)
+      v.literal("team"), // Applies to team workspaces
+      v.literal("workspace"), // Applies to specific repo
+      v.literal("user") // User-specific override
+    ),
+
+    // Targeting fields (set based on scope)
+    teamId: v.optional(v.string()), // For team/workspace/user scope
+    projectFullName: v.optional(v.string()), // For workspace scope (owner/repo)
+    userId: v.optional(v.string()), // For user scope
+
+    // Agent targeting (empty = all agents)
+    agents: v.optional(v.array(v.string())), // ["claude", "codex", "gemini", "opencode"]
+
+    // Environment context targeting
+    contexts: v.optional(
+      v.array(
+        v.union(
+          v.literal("task_sandbox"), // Regular task spawns
+          v.literal("cloud_workspace"), // Head agent / long-running workspaces
+          v.literal("local_dev") // Desktop/local development
+        )
+      )
+    ),
+
+    // Rule content
+    category: v.union(
+      v.literal("git_policy"),
+      v.literal("security"),
+      v.literal("workflow"),
+      v.literal("tool_restriction"),
+      v.literal("custom")
+    ),
+    ruleText: v.string(), // Markdown text to inject into agent instructions
+    priority: v.number(), // Lower = higher priority (for conflict resolution within same scope)
+
+    // Status
+    status: v.union(
+      v.literal("active"),
+      v.literal("disabled"),
+      v.literal("deprecated")
+    ),
+
+    // Audit fields
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    createdBy: v.optional(v.string()), // userId who created the rule
+  })
+    .index("by_scope", ["scope", "status"])
+    .index("by_team", ["teamId", "status"])
+    .index("by_team_scope", ["teamId", "scope", "status"])
+    .index("by_project", ["projectFullName", "status"])
+    .index("by_user", ["userId", "status"]),
 });
 
 export default convexSchema;

--- a/packages/convex/convex/seedPolicyRules.ts
+++ b/packages/convex/convex/seedPolicyRules.ts
@@ -1,0 +1,129 @@
+/**
+ * Seed script for initial system-level agent policy rules.
+ * Run with: bunx convex run seedPolicyRules:seed --env-file ../../.env
+ */
+
+import { internalMutation } from "./_generated/server";
+
+interface PolicyRuleSeed {
+  ruleId: string;
+  name: string;
+  description: string;
+  scope: "system";
+  category: "git_policy" | "security" | "workflow" | "tool_restriction" | "custom";
+  contexts: Array<"task_sandbox" | "cloud_workspace" | "local_dev">;
+  ruleText: string;
+  priority: number;
+}
+
+const SYSTEM_POLICY_RULES: PolicyRuleSeed[] = [
+  // PR Creation Policy for Task Sandboxes
+  {
+    ruleId: "apr_git_no_pr_task_sandbox",
+    name: "No Manual PR Creation (Task Sandbox)",
+    description: "Prevents manual PR creation in task sandboxes - cmux handles PR creation automatically",
+    scope: "system",
+    category: "git_policy",
+    contexts: ["task_sandbox"],
+    ruleText: `**NO manual PR creation from task sandboxes** - cmux creates or updates the task PR automatically when you push to your feature branch. Do not run \`gh pr create\` or create PRs through the GitHub UI. Simply push your changes and cmux will handle the rest.`,
+    priority: 10,
+  },
+  // PR Creation Policy for Cloud Workspaces
+  {
+    ruleId: "apr_git_pr_cloud_workspace",
+    name: "Manual PR Creation Allowed (Cloud Workspace)",
+    description: "Cloud workspaces (head agents) can create PRs manually",
+    scope: "system",
+    category: "git_policy",
+    contexts: ["cloud_workspace"],
+    ruleText: `**Manual PR creation allowed** - As a cloud workspace (head agent), you CAN create PRs manually using \`gh pr create --base main\`. You may also coordinate sub-agents to push changes that you then consolidate into a PR.`,
+    priority: 10,
+  },
+  // Branch Policy
+  {
+    ruleId: "apr_git_no_direct_main",
+    name: "No Direct Commits to Main",
+    description: "Prevents direct commits to main/master branches",
+    scope: "system",
+    category: "git_policy",
+    contexts: ["task_sandbox", "cloud_workspace", "local_dev"],
+    ruleText: `**NO direct commits to main/master** - Always create a feature branch first using \`git checkout -b <type>/<description>\`. Push to feature branches only. Never force push to main/master.`,
+    priority: 5,
+  },
+  // Merge Policy
+  {
+    ruleId: "apr_git_no_auto_merge",
+    name: "No Auto-Merge Without Approval",
+    description: "Requires explicit user approval before merging PRs",
+    scope: "system",
+    category: "git_policy",
+    contexts: ["task_sandbox", "cloud_workspace"],
+    ruleText: `**NO merging PRs without explicit user approval** - After creating a PR, STOP and wait for user approval. Only merge after the user explicitly says "merge", "approve", or similar confirmation.`,
+    priority: 15,
+  },
+  // Security: No Credentials in Commits
+  {
+    ruleId: "apr_security_no_credentials",
+    name: "No Credentials in Commits",
+    description: "Prevents committing sensitive files",
+    scope: "system",
+    category: "security",
+    contexts: ["task_sandbox", "cloud_workspace", "local_dev"],
+    ruleText: `**Never commit credentials or secrets** - Do not commit \`.env\` files, API keys, tokens, passwords, or other sensitive data. Check \`git diff --staged\` before committing to ensure no secrets are included.`,
+    priority: 1,
+  },
+];
+
+/**
+ * Seeds system-level policy rules. Safe to run multiple times - uses upsert logic.
+ */
+export const seed = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    let inserted = 0;
+    let updated = 0;
+
+    for (const rule of SYSTEM_POLICY_RULES) {
+      // Check if rule already exists
+      const existing = await ctx.db
+        .query("agentPolicyRules")
+        .withIndex("by_scope", (q) => q.eq("scope", "system").eq("status", "active"))
+        .filter((q) => q.eq(q.field("ruleId"), rule.ruleId))
+        .first();
+
+      if (existing) {
+        // Update existing rule
+        await ctx.db.patch(existing._id, {
+          name: rule.name,
+          description: rule.description,
+          category: rule.category,
+          contexts: rule.contexts,
+          ruleText: rule.ruleText,
+          priority: rule.priority,
+          updatedAt: now,
+        });
+        updated++;
+      } else {
+        // Insert new rule
+        await ctx.db.insert("agentPolicyRules", {
+          ruleId: rule.ruleId,
+          name: rule.name,
+          description: rule.description,
+          scope: "system",
+          category: rule.category,
+          contexts: rule.contexts,
+          ruleText: rule.ruleText,
+          priority: rule.priority,
+          status: "active",
+          createdAt: now,
+          updatedAt: now,
+        });
+        inserted++;
+      }
+    }
+
+    console.log(`[seedPolicyRules] Seeded ${inserted} new rules, updated ${updated} existing rules`);
+    return { inserted, updated, total: SYSTEM_POLICY_RULES.length };
+  },
+});

--- a/packages/devsh-memory-mcp/src/index.ts
+++ b/packages/devsh-memory-mcp/src/index.ts
@@ -48,7 +48,6 @@ export function createMemoryMcpServer(config?: Partial<MemoryMcpConfig>) {
   // Helper functions
   function readFile(filePath: string): string | null {
     try {
-      if (!fs.existsSync(filePath)) return null;
       return fs.readFileSync(filePath, "utf-8");
     } catch {
       return null;
@@ -726,6 +725,16 @@ export function createMemoryMcpServer(config?: Partial<MemoryMcpConfig>) {
             },
           },
           required: ["requestId", "resolution"],
+        },
+      },
+      {
+        name: "refresh_policy_rules",
+        description:
+          "Fetch the latest centralized policy rules from the server and update local instruction files. " +
+          "Use this to get updated policies without restarting the sandbox. Requires CMUX_TASK_RUN_JWT.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {},
         },
       },
     ],
@@ -1940,6 +1949,233 @@ export function createMemoryMcpServer(config?: Partial<MemoryMcpConfig>) {
             content: [{
               type: "text",
               text: `Error resolving approval: ${errorMsg}`,
+            }],
+          };
+        }
+      }
+
+      case "refresh_policy_rules": {
+        const jwt = process.env.CMUX_TASK_RUN_JWT;
+        // CMUX_CALLBACK_URL is the Convex HTTP endpoint URL
+        const callbackUrl = process.env.CMUX_CALLBACK_URL;
+        const agentNameFull = process.env.CMUX_AGENT_NAME; // e.g., "claude/sonnet-4"
+        const isOrchestrationHead = process.env.CMUX_IS_ORCHESTRATION_HEAD === "1";
+
+        if (!jwt) {
+          return {
+            content: [{
+              type: "text",
+              text: "CMUX_TASK_RUN_JWT environment variable not set. This tool requires JWT authentication.",
+            }],
+          };
+        }
+
+        if (!callbackUrl) {
+          return {
+            content: [{
+              type: "text",
+              text: "CMUX_CALLBACK_URL environment variable not set. Cannot reach policy server.",
+            }],
+          };
+        }
+
+        if (!agentNameFull) {
+          return {
+            content: [{
+              type: "text",
+              text: "CMUX_AGENT_NAME environment variable not set. Cannot determine agent type.",
+            }],
+          };
+        }
+
+        // Extract agent type from full name (e.g., "claude/sonnet-4" -> "claude")
+        const agentType = agentNameFull.split("/")[0];
+        const validAgentTypes = ["claude", "codex", "gemini", "opencode"];
+        if (!validAgentTypes.includes(agentType)) {
+          return {
+            content: [{
+              type: "text",
+              text: `Unknown agent type '${agentType}'. Expected one of: ${validAgentTypes.join(", ")}`,
+            }],
+          };
+        }
+
+        // Determine context from environment
+        // Head agents run in cloud_workspace context, sub-agents run in task_sandbox
+        const context = isOrchestrationHead ? "cloud_workspace" : "task_sandbox";
+
+        try {
+          // Build URL with required query parameters
+          const url = new URL(`${callbackUrl}/api/agent/policy-rules`);
+          url.searchParams.set("agentType", agentType);
+          url.searchParams.set("context", context);
+
+          // Fetch latest policy rules from server
+          const response = await fetch(url.toString(), {
+            method: "GET",
+            headers: {
+              "x-cmux-token": jwt,
+              "Convex-Client": "node-1.0.0",
+            },
+          });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            return {
+              content: [{
+                type: "text",
+                text: `Failed to fetch policy rules: ${response.status} ${errorText}`,
+              }],
+            };
+          }
+
+          const result = await response.json() as {
+            rules: Array<{
+              ruleId: string;
+              name: string;
+              category: string;
+              ruleText: string;
+              priority: number;
+              scope: string;
+            }>;
+          };
+
+          if (!result.rules || result.rules.length === 0) {
+            return {
+              content: [{
+                type: "text",
+                text: "No policy rules found for this context.",
+              }],
+            };
+          }
+
+          // Format rules as markdown and update instruction files
+          const categoryOrder: Record<string, number> = {
+            git_policy: 1,
+            security: 2,
+            workflow: 3,
+            tool_restriction: 4,
+            custom: 5,
+          };
+          const categoryLabels: Record<string, string> = {
+            git_policy: "Git Policy",
+            security: "Security",
+            workflow: "Workflow",
+            tool_restriction: "Tool Restrictions",
+            custom: "Custom",
+          };
+
+          // Group rules by category
+          const byCategory = new Map<string, typeof result.rules>();
+          for (const rule of result.rules) {
+            const existing = byCategory.get(rule.category) ?? [];
+            existing.push(rule);
+            byCategory.set(rule.category, existing);
+          }
+
+          // Sort rules within each category by priority
+          for (const rules of byCategory.values()) {
+            rules.sort((a, b) => a.priority - b.priority);
+          }
+
+          // Build markdown
+          let markdown = "# Agent Policy Rules\n\n";
+          markdown += "> These rules are centrally managed by cmux and override repo-level rules.\n";
+          markdown += `> Last refreshed: ${new Date().toISOString()}\n\n`;
+
+          const sortedCategories = Array.from(byCategory.keys()).sort(
+            (a, b) => (categoryOrder[a] ?? 99) - (categoryOrder[b] ?? 99)
+          );
+
+          for (const category of sortedCategories) {
+            const rules = byCategory.get(category);
+            if (!rules || rules.length === 0) continue;
+
+            const label = categoryLabels[category] ?? category;
+            markdown += `## ${label}\n\n`;
+
+            for (const rule of rules) {
+              markdown += `${rule.ruleText}\n\n`;
+            }
+          }
+
+          // Try to update local instruction files
+          const updates: string[] = [];
+          const claudeMdPath = path.join(process.env.HOME ?? "/root", ".claude", "CLAUDE.md");
+          const codexMdPath = path.join(process.env.HOME ?? "/root", ".codex", "instructions.md");
+
+          // Read existing file, find policy rules section, and replace it
+          const updateInstructionFile = (filePath: string): boolean => {
+            try {
+              let content: string;
+              try {
+                content = fs.readFileSync(filePath, "utf-8");
+              } catch {
+                // File doesn't exist
+                return false;
+              }
+              const policyMarkerStart = "# Agent Policy Rules";
+              const startIdx = content.indexOf(policyMarkerStart);
+
+              if (startIdx === -1) {
+                // No existing policy section, prepend it after the first heading
+                const firstHeadingEnd = content.indexOf("\n\n");
+                if (firstHeadingEnd > 0) {
+                  content = content.slice(0, firstHeadingEnd + 2) + markdown + "\n" + content.slice(firstHeadingEnd + 2);
+                } else {
+                  content = markdown + "\n" + content;
+                }
+              } else {
+                // Find the end of the policy section (next top-level heading or memory protocol)
+                const nextHeadingMatch = content.slice(startIdx + policyMarkerStart.length).match(/\n# [A-Z]/);
+                const memoryProtocolMatch = content.slice(startIdx + policyMarkerStart.length).match(/\n## cmux Agent Memory Protocol/);
+
+                let endIdx: number;
+                if (memoryProtocolMatch && memoryProtocolMatch.index !== undefined) {
+                  endIdx = startIdx + policyMarkerStart.length + memoryProtocolMatch.index;
+                } else if (nextHeadingMatch && nextHeadingMatch.index !== undefined) {
+                  endIdx = startIdx + policyMarkerStart.length + nextHeadingMatch.index;
+                } else {
+                  endIdx = content.length;
+                }
+
+                content = content.slice(0, startIdx) + markdown + content.slice(endIdx);
+              }
+
+              fs.writeFileSync(filePath, content, "utf-8");
+              return true;
+            } catch {
+              return false;
+            }
+          };
+
+          if (updateInstructionFile(claudeMdPath)) {
+            updates.push("~/.claude/CLAUDE.md");
+          }
+          if (updateInstructionFile(codexMdPath)) {
+            updates.push("~/.codex/instructions.md");
+          }
+
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                refreshed: true,
+                rulesCount: result.rules.length,
+                categories: sortedCategories,
+                updatedFiles: updates,
+                message: updates.length > 0
+                  ? `Successfully refreshed ${result.rules.length} policy rules. Updated: ${updates.join(", ")}`
+                  : `Fetched ${result.rules.length} policy rules but could not update local files.`,
+              }, null, 2),
+            }],
+          };
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{
+              type: "text",
+              text: `Error refreshing policy rules: ${errorMsg}`,
             }],
           };
         }

--- a/packages/shared/src/agent-memory-protocol.ts
+++ b/packages/shared/src/agent-memory-protocol.ts
@@ -2505,3 +2505,84 @@ export function getProjectContextFile(context: {
     mode: "644",
   };
 }
+
+/**
+ * Agent Policy Rule interface for instruction generation.
+ * This mirrors the Convex table structure but only includes fields needed for injection.
+ */
+export interface PolicyRuleForInstructions {
+  ruleId: string;
+  name: string;
+  category: "git_policy" | "security" | "workflow" | "tool_restriction" | "custom";
+  ruleText: string;
+  priority: number;
+  scope: "system" | "team" | "workspace" | "user";
+}
+
+/**
+ * Category display configuration for policy rules.
+ */
+const POLICY_CATEGORY_CONFIG: Record<
+  PolicyRuleForInstructions["category"],
+  { label: string; order: number }
+> = {
+  git_policy: { label: "Git Policy", order: 1 },
+  security: { label: "Security", order: 2 },
+  workflow: { label: "Workflow", order: 3 },
+  tool_restriction: { label: "Tool Restrictions", order: 4 },
+  custom: { label: "Custom", order: 5 },
+};
+
+/**
+ * Generate markdown instructions from centralized policy rules.
+ * Groups rules by category and renders them in a consistent format.
+ *
+ * @param policyRules - Array of policy rules fetched from Convex
+ * @returns Markdown string to inject into agent instruction files
+ */
+export function getPolicyRulesInstructions(
+  policyRules: PolicyRuleForInstructions[],
+): string {
+  if (!policyRules || policyRules.length === 0) {
+    return "";
+  }
+
+  // Group rules by category
+  const byCategory = new Map<PolicyRuleForInstructions["category"], PolicyRuleForInstructions[]>();
+  for (const rule of policyRules) {
+    const existing = byCategory.get(rule.category) ?? [];
+    existing.push(rule);
+    byCategory.set(rule.category, existing);
+  }
+
+  // Sort rules within each category by priority
+  for (const rules of byCategory.values()) {
+    rules.sort((a, b) => a.priority - b.priority);
+  }
+
+  // Build markdown output
+  let output = "# Agent Policy Rules\n\n";
+  output +=
+    "> These rules are centrally managed by cmux and override repo-level rules.\n";
+  output += "> Last updated at spawn time. Use refresh_policy_rules MCP tool to fetch latest.\n\n";
+
+  // Render categories in order
+  const sortedCategories = Array.from(byCategory.keys()).sort(
+    (a, b) => POLICY_CATEGORY_CONFIG[a].order - POLICY_CATEGORY_CONFIG[b].order,
+  );
+
+  for (const category of sortedCategories) {
+    const rules = byCategory.get(category);
+    if (!rules || rules.length === 0) continue;
+
+    const { label } = POLICY_CATEGORY_CONFIG[category];
+    output += `## ${label}\n\n`;
+
+    for (const rule of rules) {
+      // Add rule text directly (it's already markdown)
+      output += `${rule.ruleText}\n\n`;
+    }
+  }
+
+  return output;
+}

--- a/packages/shared/src/agent-policy.ts
+++ b/packages/shared/src/agent-policy.ts
@@ -1,0 +1,135 @@
+/**
+ * Agent Policy Types
+ *
+ * Centralized policy management for agent sandboxes.
+ * Rules apply with scope hierarchy: system > team > workspace > user
+ * Within same scope, lower priority numbers take precedence.
+ */
+
+/** Scope hierarchy for policy rules (most specific wins) */
+export type AgentPolicyScope = "system" | "team" | "workspace" | "user";
+
+/** Environment contexts where rules apply */
+export type AgentPolicyContext = "task_sandbox" | "cloud_workspace" | "local_dev";
+
+/** Rule categories for organization and display */
+export type AgentPolicyCategory =
+  | "git_policy"
+  | "security"
+  | "workflow"
+  | "tool_restriction"
+  | "custom";
+
+/** Rule lifecycle status */
+export type AgentPolicyStatus = "active" | "disabled" | "deprecated";
+
+/** Agent types for targeting */
+export type AgentPolicyAgentType = "claude" | "codex" | "gemini" | "opencode";
+
+/**
+ * Agent policy rule as stored in Convex and used at runtime.
+ */
+export interface AgentPolicyRule {
+  /** Stable external reference ID (format: "apr_xxx") */
+  ruleId: string;
+  /** Human-readable name */
+  name: string;
+  /** Optional description */
+  description?: string;
+
+  /** Scope hierarchy: system > team > workspace > user */
+  scope: AgentPolicyScope;
+
+  /** Team ID for team/workspace/user scoped rules */
+  teamId?: string;
+  /** Project full name for workspace scoped rules (e.g., "owner/repo") */
+  projectFullName?: string;
+  /** User ID for user scoped rules */
+  userId?: string;
+
+  /** Agent types this rule applies to (empty = all agents) */
+  agents?: AgentPolicyAgentType[];
+
+  /** Environment contexts this rule applies to (empty = all contexts) */
+  contexts?: AgentPolicyContext[];
+
+  /** Rule category for organization */
+  category: AgentPolicyCategory;
+  /** Markdown text injected into agent instructions */
+  ruleText: string;
+  /** Priority within scope (lower = higher priority) */
+  priority: number;
+
+  /** Rule status */
+  status: AgentPolicyStatus;
+
+  /** Timestamps */
+  createdAt: number;
+  updatedAt: number;
+  /** User who created the rule */
+  createdBy?: string;
+}
+
+/**
+ * Parameters for querying policy rules for a sandbox spawn.
+ */
+export interface GetPolicyRulesForSandboxParams {
+  /** Team slug or ID */
+  teamSlugOrId: string;
+  /** Agent type (claude, codex, gemini, opencode) */
+  agentType: AgentPolicyAgentType;
+  /** Project full name for workspace-scoped rules */
+  projectFullName?: string;
+  /** User ID for user-scoped rules */
+  userId?: string;
+  /** Environment context */
+  context: AgentPolicyContext;
+}
+
+/**
+ * Scope priority ordering (lower index = broader scope).
+ * Used for merging rules from different scopes.
+ */
+export const SCOPE_PRIORITY: AgentPolicyScope[] = [
+  "system",
+  "team",
+  "workspace",
+  "user",
+];
+
+/**
+ * Check if a scope is more specific than another.
+ * More specific scopes override broader scopes.
+ */
+export function isScopeMoreSpecific(
+  scope: AgentPolicyScope,
+  than: AgentPolicyScope,
+): boolean {
+  return SCOPE_PRIORITY.indexOf(scope) > SCOPE_PRIORITY.indexOf(than);
+}
+
+/**
+ * Category display order and labels for UI.
+ */
+export const CATEGORY_CONFIG: Record<
+  AgentPolicyCategory,
+  { label: string; order: number }
+> = {
+  git_policy: { label: "Git Policy", order: 1 },
+  security: { label: "Security", order: 2 },
+  workflow: { label: "Workflow", order: 3 },
+  tool_restriction: { label: "Tool Restrictions", order: 4 },
+  custom: { label: "Custom", order: 5 },
+};
+
+/**
+ * Generate a new rule ID in the format "apr_xxx".
+ */
+export function generateRuleId(): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let suffix = "";
+  for (let i = 0; i < 12; i++) {
+    suffix += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return `apr_${suffix}`;
+}

--- a/packages/shared/src/providers/amp/environment.ts
+++ b/packages/shared/src/providers/amp/environment.ts
@@ -11,6 +11,7 @@ import {
   getMemorySeedFiles,
   getMemoryProtocolInstructions,
   getProjectContextFile,
+  getPolicyRulesInstructions,
 } from "../../agent-memory-protocol";
 import { getTaskSandboxWrapperFiles } from "../common/task-sandbox-wrappers";
 
@@ -123,8 +124,11 @@ export async function getAmpEnvironment(
   }
 
   // Add AMP.md with memory protocol instructions for the project
+  const policyRulesSection = ctx.policyRules && ctx.policyRules.length > 0
+    ? `\n${getPolicyRulesInstructions(ctx.policyRules)}\n`
+    : "";
   const ampMdContent = `# cmux Project Instructions
-
+${policyRulesSection}
 ${getMemoryProtocolInstructions()}
 `;
   files.push({

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -12,6 +12,7 @@ import {
   getMemoryProtocolInstructions,
   getProjectContextFile,
   getCrossToolSymlinkCommands,
+  getPolicyRulesInstructions,
 } from "../../agent-memory-protocol";
 import { buildMergedClaudeConfig } from "../../mcp-preview";
 
@@ -452,8 +453,11 @@ echo ${apiKeyToOutput}`;
   // - User memory (~/.claude/CLAUDE.md) applies to all projects
   // - Stored outside git workspace to avoid pollution
   // See: https://code.claude.com/docs/en/memory.md
+  const policyRulesSection = ctx.policyRules && ctx.policyRules.length > 0
+    ? `\n${getPolicyRulesInstructions(ctx.policyRules)}\n`
+    : "";
   const claudeMdContent = `# cmux Agent Instructions
-
+${policyRulesSection}
 ${getMemoryProtocolInstructions()}
 `;
   files.push({

--- a/packages/shared/src/providers/common/environment-result.ts
+++ b/packages/shared/src/providers/common/environment-result.ts
@@ -1,5 +1,6 @@
 import type { AuthFile } from "../../worker-schemas";
 import type { McpServerConfig } from "../../mcp-server-config";
+import type { PolicyRuleForInstructions } from "../../agent-memory-protocol";
 
 export interface EnvironmentResult {
   files: AuthFile[];
@@ -77,4 +78,10 @@ export type EnvironmentContext = {
    * @default false
    */
   useHostConfig?: boolean;
+  /**
+   * Centralized policy rules from Convex (Phase: Agent Policy Management).
+   * These are merged by scope hierarchy and filtered by agent type and context.
+   * Rules are injected into agent instruction files (e.g., ~/.claude/CLAUDE.md).
+   */
+  policyRules?: PolicyRuleForInstructions[];
 };

--- a/packages/shared/src/providers/cursor/environment.ts
+++ b/packages/shared/src/providers/cursor/environment.ts
@@ -7,6 +7,7 @@ import {
   getMemorySeedFiles,
   getMemoryProtocolInstructions,
   getProjectContextFile,
+  getPolicyRulesInstructions,
 } from "../../agent-memory-protocol";
 import { getTaskSandboxWrapperFiles } from "../common/task-sandbox-wrappers";
 
@@ -136,8 +137,11 @@ export async function getCursorEnvironment(
   }
 
   // Add CURSOR.md with memory protocol instructions for the project
+  const policyRulesSection = ctx.policyRules && ctx.policyRules.length > 0
+    ? `\n${getPolicyRulesInstructions(ctx.policyRules)}\n`
+    : "";
   const cursorMdContent = `# cmux Project Instructions
-
+${policyRulesSection}
 ${getMemoryProtocolInstructions()}
 `;
   files.push({

--- a/packages/shared/src/providers/gemini/environment.ts
+++ b/packages/shared/src/providers/gemini/environment.ts
@@ -9,6 +9,7 @@ import {
   getMemoryProtocolInstructions,
   getProjectContextFile,
   getCrossToolSymlinkCommands,
+  getPolicyRulesInstructions,
 } from "../../agent-memory-protocol";
 import { buildGeminiMcpServers } from "../../mcp-injection";
 import { getTaskSandboxWrapperFiles } from "../common/task-sandbox-wrappers";
@@ -265,8 +266,11 @@ export async function getGeminiEnvironment(
   // This is created at user-level ~/.gemini/GEMINI.md (not in workspace)
   // If Claude's CLAUDE.md exists, the symlink from getCrossToolSymlinkCommands()
   // will override this file, ensuring all tools share the same instructions
+  const policyRulesSection = ctx.policyRules && ctx.policyRules.length > 0
+    ? `\n${getPolicyRulesInstructions(ctx.policyRules)}\n`
+    : "";
   const geminiMdContent = `# cmux Project Instructions
-
+${policyRulesSection}
 ${getMemoryProtocolInstructions()}
 `;
   files.push({

--- a/packages/shared/src/providers/grok/environment.ts
+++ b/packages/shared/src/providers/grok/environment.ts
@@ -7,6 +7,7 @@ import {
   getMemorySeedFiles,
   getMemoryProtocolInstructions,
   getProjectContextFile,
+  getPolicyRulesInstructions,
 } from "../../agent-memory-protocol";
 import { getTaskSandboxWrapperFiles } from "../common/task-sandbox-wrappers";
 
@@ -99,8 +100,11 @@ async function makeGrokEnvironment(
     );
   }
 
+  const policyRulesSection = ctx.policyRules && ctx.policyRules.length > 0
+    ? `\n${getPolicyRulesInstructions(ctx.policyRules)}\n`
+    : "";
   const grokMdContent = `# cmux Project Instructions
-
+${policyRulesSection}
 ${getMemoryProtocolInstructions()}
 `;
   files.push({

--- a/packages/shared/src/providers/openai/environment.ts
+++ b/packages/shared/src/providers/openai/environment.ts
@@ -8,6 +8,7 @@ import {
   getMemoryProtocolInstructions,
   getProjectContextFile,
   getCrossToolSymlinkCommands,
+  getPolicyRulesInstructions,
 } from "../../agent-memory-protocol";
 import { buildMergedCodexConfigToml } from "../../mcp-preview";
 export { stripFilteredConfigKeys } from "../../mcp-preview";
@@ -411,9 +412,13 @@ log "Autopilot completed after \$ITER turns"
       console.warn("Failed to read .codex/instructions.md:", error);
     }
   }
+  const policyRulesSection = ctx.policyRules && ctx.policyRules.length > 0
+    ? getPolicyRulesInstructions(ctx.policyRules) + "\n\n"
+    : "";
   const fullInstructions =
     instructionsContent +
     (instructionsContent ? "\n\n" : "") +
+    policyRulesSection +
     getMemoryProtocolInstructions();
   files.push({
     destinationPath: "$HOME/.codex/instructions.md",

--- a/packages/shared/src/providers/opencode/environment.ts
+++ b/packages/shared/src/providers/opencode/environment.ts
@@ -7,6 +7,7 @@ import {
   getMemorySeedFiles,
   getMemoryProtocolInstructions,
   getProjectContextFile,
+  getPolicyRulesInstructions,
 } from "../../agent-memory-protocol";
 import { buildOpencodeMcpConfig } from "../../mcp-injection";
 
@@ -487,8 +488,11 @@ log "Post-start script end"
   }
 
   // Add AGENTS.md with memory protocol instructions at the user-level OpenCode path
+  const policyRulesSection = ctx.policyRules && ctx.policyRules.length > 0
+    ? `\n${getPolicyRulesInstructions(ctx.policyRules)}\n`
+    : "";
   const opencodeAgentsContent = `# cmux Project Instructions
-
+${policyRulesSection}
 ${getMemoryProtocolInstructions()}
 `;
   files.push({

--- a/packages/shared/src/providers/qwen/environment.ts
+++ b/packages/shared/src/providers/qwen/environment.ts
@@ -7,6 +7,7 @@ import {
   getMemorySeedFiles,
   getMemoryProtocolInstructions,
   getProjectContextFile,
+  getPolicyRulesInstructions,
 } from "../../agent-memory-protocol";
 import { getTaskSandboxWrapperFiles } from "../common/task-sandbox-wrappers";
 
@@ -103,8 +104,11 @@ async function makeQwenEnvironment(
   }
 
   // Add QWEN.md with memory protocol instructions for the project
+  const policyRulesSection = ctx.policyRules && ctx.policyRules.length > 0
+    ? `\n${getPolicyRulesInstructions(ctx.policyRules)}\n`
+    : "";
   const qwenMdContent = `# cmux Project Instructions
-
+${policyRulesSection}
 ${getMemoryProtocolInstructions()}
 `;
   files.push({


### PR DESCRIPTION
## Summary

Implements centralized policy rules that apply to all spawned agents, solving the problem of stale repo-level rules in long-running cloud workspaces.

- Schema: `agentPolicyRules` table with scope hierarchy (system > team > workspace > user)
- API: CRUD queries/mutations + HTTP endpoint for runtime refresh
- Integration: All 8 providers inject rules at spawn time
- MCP: `refresh_policy_rules` tool for agents to get latest rules
- UI: Settings > Policy Rules admin interface
- Seeded 5 system rules for git policy and security

## Test plan

- [x] `bun check` passes
- [x] `bun run convex:deploy` successful
- [x] `bunx convex run seedPolicyRules:seed` inserts 5 rules
- [x] Verified rules in DB via `bunx convex data agentPolicyRules`
- [ ] Manual test: spawn agent and verify policy rules in instructions
- [ ] Manual test: Settings > Policy Rules UI displays seeded rules