### PR TITLE
fix(policy): address Codex review findings

### DIFF
--- a/apps/client/src/components/settings/sections/PolicyRulesSection.tsx
+++ b/apps/client/src/components/settings/sections/PolicyRulesSection.tsx
@@ -184,7 +184,8 @@ export function PolicyRulesSection({ teamSlugOrId }: PolicyRulesSectionProps) {
 
     setFormError(null);
     upsertMutation.mutate({
-      ruleId: editingRule?.ruleId,
+      id: editingRule?._id, // Use document ID for updates (preferred over ruleId)
+      ruleId: editingRule ? undefined : undefined, // Let backend generate for new rules
       name: form.name.trim(),
       description: form.description.trim() || undefined,
       scope: form.scope,
@@ -371,7 +372,9 @@ export function PolicyRulesSection({ teamSlugOrId }: PolicyRulesSectionProps) {
                     disabled={editingRule?.scope === "system"}
                   >
                     <option value="team">Team</option>
-                    <option value="workspace">Workspace</option>
+                    <option value="workspace" disabled title="Workspace scope requires project context (coming soon)">
+                      Workspace (coming soon)
+                    </option>
                     <option value="user">User</option>
                   </select>
                 </div>

--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -658,10 +658,22 @@ export async function spawnAgent(
         ((): Promise<PolicyRuleForInstructions[] | undefined> => {
           const providerId = getProviderIdFromAgentName(agent.name);
           if (!providerId) return Promise.resolve(undefined);
-          const agentType = providerId === "anthropic" ? "claude"
-            : providerId === "openai" ? "codex"
-            : providerId === "gemini" ? "gemini"
-            : "opencode";
+          // Map provider to agent type - only for explicitly supported providers
+          const providerToAgentType: Record<string, "claude" | "codex" | "gemini" | "opencode"> = {
+            anthropic: "claude",
+            openai: "codex",
+            gemini: "gemini",
+            opencode: "opencode",
+            amp: "opencode", // Amp uses similar patterns to opencode
+            cursor: "opencode", // Cursor uses similar patterns
+            qwen: "opencode", // Qwen uses similar patterns
+            grok: "opencode", // Grok uses similar patterns
+          };
+          const agentType = providerToAgentType[providerId];
+          if (!agentType) {
+            serverLogger.debug(`[AgentSpawner] No policy agent type mapping for provider: ${providerId}`);
+            return Promise.resolve(undefined);
+          }
           return getConvex()
             .query(api.agentPolicyRules.getForSandbox, {
               teamSlugOrId,

--- a/packages/convex/convex/agentPolicyRules.ts
+++ b/packages/convex/convex/agentPolicyRules.ts
@@ -68,53 +68,61 @@ function normalizeRequiredString(fieldName: string, value: string): string {
 
 /**
  * List policy rules for a team (UI display).
+ * Returns all statuses by default so disabled/deprecated rules are visible for management.
  */
 export const list = authQuery({
   args: {
     teamSlugOrId: v.string(),
     scope: v.optional(scopeValidator),
     projectFullName: v.optional(v.string()),
-    status: v.optional(statusValidator),
+    status: v.optional(statusValidator), // Filter by status, or undefined for all
   },
   handler: async (ctx, args) => {
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
     const projectFullName = normalizeOptionalString(args.projectFullName);
 
-    // Get all relevant rules
+    // Helper to filter by status if specified
+    const filterByStatus = <T extends { status: string }>(rules: T[]): T[] => {
+      if (args.status) {
+        return rules.filter((r) => r.status === args.status);
+      }
+      return rules;
+    };
+
+    // Get all relevant rules - query without status filter, then filter in memory
+    // This allows showing all statuses when status arg is undefined
     let rules;
     if (projectFullName) {
-      rules = await ctx.db
+      // Use team_project index for proper isolation
+      const allRules = await ctx.db
         .query("agentPolicyRules")
-        .withIndex("by_project", (q) =>
-          q.eq("projectFullName", projectFullName).eq("status", args.status ?? "active"),
+        .withIndex("by_team_project", (q) =>
+          q.eq("teamId", teamId).eq("projectFullName", projectFullName),
         )
         .collect();
+      rules = filterByStatus(allRules);
     } else if (args.scope) {
-      rules = await ctx.db
+      const allRules = await ctx.db
         .query("agentPolicyRules")
         .withIndex("by_team_scope", (q) =>
-          q
-            .eq("teamId", teamId)
-            .eq("scope", args.scope!)
-            .eq("status", args.status ?? "active"),
+          q.eq("teamId", teamId).eq("scope", args.scope!),
         )
         .collect();
+      rules = filterByStatus(allRules);
     } else {
-      rules = await ctx.db
+      const allRules = await ctx.db
         .query("agentPolicyRules")
-        .withIndex("by_team", (q) =>
-          q.eq("teamId", teamId).eq("status", args.status ?? "active"),
-        )
+        .withIndex("by_team", (q) => q.eq("teamId", teamId))
         .collect();
+      rules = filterByStatus(allRules);
     }
 
     // Also include system rules (always visible)
-    const systemRules = await ctx.db
+    const allSystemRules = await ctx.db
       .query("agentPolicyRules")
-      .withIndex("by_scope", (q) =>
-        q.eq("scope", "system").eq("status", args.status ?? "active"),
-      )
+      .withIndex("by_scope", (q) => q.eq("scope", "system"))
       .collect();
+    const systemRules = filterByStatus(allSystemRules);
 
     // Combine and dedupe (team rules override system rules with same ruleId)
     const ruleMap = new Map<string, (typeof rules)[number]>();
@@ -211,12 +219,12 @@ async function getForSandboxImpl(
         q.eq("teamId", args.teamId).eq("scope", "team").eq("status", "active"),
       )
       .collect(),
-    // Workspace rules (if projectFullName provided)
+    // Workspace rules (if projectFullName provided) - use team_project index for isolation
     args.projectFullName
       ? ctx.db
           .query("agentPolicyRules")
-          .withIndex("by_project", (q) =>
-            q.eq("projectFullName", args.projectFullName).eq("status", "active"),
+          .withIndex("by_team_project", (q) =>
+            q.eq("teamId", args.teamId).eq("projectFullName", args.projectFullName).eq("status", "active"),
           )
           .collect()
           .then((rules) => rules.filter((r) => r.scope === "workspace"))
@@ -302,10 +310,12 @@ async function getForSandboxImpl(
 
 /**
  * Create or update a policy rule.
+ * For updates, pass the document _id directly instead of ruleId to avoid ambiguity.
  */
 export const upsert = authMutation({
   args: {
-    ruleId: v.optional(v.string()), // If provided, updates existing rule
+    id: v.optional(v.id("agentPolicyRules")), // Document ID for updates (preferred)
+    ruleId: v.optional(v.string()), // For creating with specific ruleId (new rules only)
     name: v.string(),
     description: v.optional(v.string()),
     scope: scopeValidator,
@@ -337,43 +347,44 @@ export const upsert = authMutation({
     if (args.scope === "team" && !teamId) {
       throw new Error("Team scope requires teamSlugOrId");
     }
-    if (args.scope === "workspace" && !projectFullName) {
-      throw new Error("Workspace scope requires projectFullName");
+    if (args.scope === "workspace" && (!projectFullName || !teamId)) {
+      throw new Error("Workspace scope requires both teamSlugOrId and projectFullName");
     }
     if (args.scope === "user" && !teamId) {
       throw new Error("User scope requires teamSlugOrId");
     }
 
-    // Check for existing rule if ruleId provided
-    if (args.ruleId) {
-      const existingRules = await ctx.db
-        .query("agentPolicyRules")
-        .filter((q) => q.eq(q.field("ruleId"), args.ruleId))
-        .collect();
-      const existing = existingRules[0];
-
-      if (existing) {
-        // Update existing rule
-        await ctx.db.patch(existing._id, {
-          name,
-          description,
-          scope: args.scope,
-          teamId: args.scope === "system" ? undefined : teamId,
-          projectFullName: args.scope === "workspace" ? projectFullName : undefined,
-          userId: args.scope === "user" ? userId : undefined,
-          agents: args.agents,
-          contexts: args.contexts,
-          category: args.category,
-          ruleText,
-          priority: args.priority,
-          status: args.status ?? existing.status,
-          updatedAt: now,
-        });
-        return existing._id;
+    // Update existing rule if document ID provided
+    if (args.id) {
+      const existing = await ctx.db.get(args.id);
+      if (!existing) {
+        throw new Error("Policy rule not found");
       }
+
+      // Prevent modifying system rules (except by seed script)
+      if (existing.scope === "system" && args.scope !== "system") {
+        throw new Error("Cannot change scope of system rules");
+      }
+
+      await ctx.db.patch(args.id, {
+        name,
+        description,
+        scope: args.scope,
+        teamId: args.scope === "system" ? undefined : teamId,
+        projectFullName: args.scope === "workspace" ? projectFullName : undefined,
+        userId: args.scope === "user" ? userId : undefined,
+        agents: args.agents,
+        contexts: args.contexts,
+        category: args.category,
+        ruleText,
+        priority: args.priority,
+        status: args.status ?? existing.status,
+        updatedAt: now,
+      });
+      return args.id;
     }
 
-    // Generate new ruleId if not provided or not found
+    // Generate new ruleId if not provided
     const ruleId = args.ruleId ?? generateRuleId();
 
     // Create new rule

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -2078,7 +2078,9 @@ const convexSchema = defineSchema({
     .index("by_team", ["teamId", "status"])
     .index("by_team_scope", ["teamId", "scope", "status"])
     .index("by_project", ["projectFullName", "status"])
-    .index("by_user", ["userId", "status"]),
+    .index("by_team_project", ["teamId", "projectFullName", "status"]) // Workspace scope with team isolation
+    .index("by_user", ["userId", "status"])
+    .index("by_ruleId", ["ruleId"]), // For upsert lookups
 });
 
 export default convexSchema;

--- a/packages/convex/convex/seedPolicyRules.ts
+++ b/packages/convex/convex/seedPolicyRules.ts
@@ -85,15 +85,15 @@ export const seed = internalMutation({
     let updated = 0;
 
     for (const rule of SYSTEM_POLICY_RULES) {
-      // Check if rule already exists
+      // Check if rule already exists by ruleId (regardless of status)
+      // Use the by_ruleId index for efficient lookup
       const existing = await ctx.db
         .query("agentPolicyRules")
-        .withIndex("by_scope", (q) => q.eq("scope", "system").eq("status", "active"))
-        .filter((q) => q.eq(q.field("ruleId"), rule.ruleId))
+        .withIndex("by_ruleId", (q) => q.eq("ruleId", rule.ruleId))
         .first();
 
       if (existing) {
-        // Update existing rule
+        // Update existing rule (reactivate if it was disabled/deprecated)
         await ctx.db.patch(existing._id, {
           name: rule.name,
           description: rule.description,
@@ -101,6 +101,7 @@ export const seed = internalMutation({
           contexts: rule.contexts,
           ruleText: rule.ruleText,
           priority: rule.priority,
+          status: "active", // Reactivate if disabled
           updatedAt: now,
         });
         updated++;


### PR DESCRIPTION
## Summary
Fixes issues identified by Codex review of PR #548 (centralized agent policy management).

## Fixes

### High Priority
- **ruleId update collision**: Use document `_id` for upsert updates instead of `ruleId` to prevent patching wrong row when duplicate ruleIds exist across scopes
- **Workspace team leak**: Add `by_team_project` composite index and update workspace rules query to enforce team isolation

### Medium Priority
- **Provider mapping fallback**: Explicitly map all providers (grok, amp, cursor, qwen) instead of falling back to "opencode" for unknowns
- **Workspace scope in UI**: Disable workspace option (requires project context not yet available)
- **Workspace validation**: Require both `teamSlugOrId` AND `projectFullName` for workspace scope

### Low Priority
- **Hidden disabled rules**: List query returns all statuses by default so disabled/deprecated rules are visible for management
- **Seed duplicates**: Lookup by `ruleId` regardless of status to prevent inserting duplicates
- **Index efficiency**: Add `by_ruleId` index for efficient seed lookups

## Test plan
- [ ] Verify `bun check` passes
- [ ] Deploy to Convex and verify indexes created
- [ ] Test UI: disabled/deprecated rules now visible
- [ ] Test UI: workspace scope is disabled in dropdown
- [ ] Test upsert: editing existing rule uses `_id`