### PR TITLE
fix(vnc): improve clipboard paste for LXC containers

### DIFF
--- a/configs/systemd/cmux-clipboard.service
+++ b/configs/systemd/cmux-clipboard.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Cmux X11 clipboard manager (parcellite)
+After=cmux-tigervnc.service cmux-openbox.service
+Requires=cmux-tigervnc.service
+
+[Service]
+Type=simple
+Environment=DISPLAY=:1
+Environment=HOME=/root
+ExecStartPre=/bin/mkdir -p /var/log/cmux
+# Wait for X server to be fully ready
+ExecStartPre=/bin/sh -c 'for i in 1 2 3 4 5; do xdpyinfo -display :1 >/dev/null 2>&1 && exit 0; sleep 1; done; exit 1'
+ExecStart=/usr/bin/parcellite
+Restart=always
+RestartSec=3
+StandardOutput=append:/var/log/cmux/clipboard.log
+StandardError=append:/var/log/cmux/clipboard.log
+
+[Install]
+WantedBy=cmux.target

--- a/packages/sandbox/scripts/vnc-clipboard-bridge.js
+++ b/packages/sandbox/scripts/vnc-clipboard-bridge.js
@@ -18,6 +18,7 @@
  * - XK_Super_L: 0xffeb
  * - XK_Super_R: 0xffec
  * - XK_v: 0x0076
+ * - XK_Shift_L: 0xffe1
  */
 
 (function () {
@@ -34,10 +35,17 @@
   var XK_Super_L = 0xffeb;
   var XK_Super_R = 0xffec;
   var XK_Control_L = 0xffe3;
+  var XK_Shift_L = 0xffe1;
   var XK_v = 0x0076;
 
   // Debounce timeout ID to prevent stacking rapid paste requests
   var pendingPasteTimeout = null;
+
+  // Flag to track if we should use sendKey fallback for typing
+  var useSendKeyFallback = false;
+
+  // Maximum text length for sendKey fallback (longer texts should use clipboard)
+  var SENDKEY_FALLBACK_MAX_LENGTH = 500;
 
   /**
    * Get the RFB instance from noVNC.
@@ -59,10 +67,117 @@
   }
 
   /**
+   * Map a character to its X11 keysym.
+   * Returns an object with keysym and whether shift is required.
+   *
+   * @param {string} char - Single character to map
+   * @returns {{ keysym: number, shift: boolean } | null}
+   */
+  function charToKeysym(char) {
+    var code = char.charCodeAt(0);
+
+    // ASCII printable range (32-126)
+    if (code >= 32 && code <= 126) {
+      // Lowercase letters: a-z (keysym 0x61-0x7a)
+      if (code >= 97 && code <= 122) {
+        return { keysym: code, shift: false };
+      }
+      // Uppercase letters: A-Z (keysym 0x41-0x5a)
+      if (code >= 65 && code <= 90) {
+        return { keysym: code, shift: true };
+      }
+      // Digits: 0-9 (keysym 0x30-0x39)
+      if (code >= 48 && code <= 57) {
+        return { keysym: code, shift: false };
+      }
+      // Special characters that require shift on US keyboard
+      var shiftChars = '~!@#$%^&*()_+{}|:"<>?';
+      var noShiftEquiv = '`1234567890-=[]\\;\',./';
+      var shiftIdx = shiftChars.indexOf(char);
+      if (shiftIdx !== -1) {
+        return { keysym: noShiftEquiv.charCodeAt(shiftIdx), shift: true };
+      }
+      // Other printable ASCII (space, punctuation without shift)
+      return { keysym: code, shift: false };
+    }
+
+    // Common special keysyms
+    switch (code) {
+      case 10:  // LF
+      case 13:  // CR
+        return { keysym: 0xff0d, shift: false }; // XK_Return
+      case 9:   // Tab
+        return { keysym: 0xff09, shift: false }; // XK_Tab
+      case 8:   // Backspace
+        return { keysym: 0xff08, shift: false }; // XK_BackSpace
+      default:
+        // For Unicode characters, use Unicode keysym (0x01000000 + code)
+        if (code > 126) {
+          return { keysym: 0x01000000 + code, shift: false };
+        }
+        return null;
+    }
+  }
+
+  /**
+   * Type text character by character using sendKey.
+   * This is a fallback when clipboardPasteFrom + Ctrl+V doesn't work.
+   *
+   * @param {object} rfb - The noVNC RFB instance
+   * @param {string} text - The text to type
+   */
+  function typeTextViaSendKey(rfb, text) {
+    if (typeof rfb.sendKey !== 'function') {
+      console.warn('[VNC Clipboard Bridge] sendKey not available for fallback typing');
+      return;
+    }
+
+    var i = 0;
+    var delay = 10; // ms between keystrokes
+
+    function typeNextChar() {
+      if (i >= text.length) {
+        console.log('[VNC Clipboard Bridge] Finished typing ' + text.length + ' characters');
+        return;
+      }
+
+      var char = text[i];
+      var keyInfo = charToKeysym(char);
+
+      if (keyInfo) {
+        try {
+          // Press shift if needed
+          if (keyInfo.shift) {
+            rfb.sendKey(XK_Shift_L, 'ShiftLeft', true);
+          }
+          // Press and release the key
+          rfb.sendKey(keyInfo.keysym, null, true);
+          rfb.sendKey(keyInfo.keysym, null, false);
+          // Release shift if it was pressed
+          if (keyInfo.shift) {
+            rfb.sendKey(XK_Shift_L, 'ShiftLeft', false);
+          }
+        } catch (e) {
+          console.warn('[VNC Clipboard Bridge] Error sending key for char "' + char + '":', e);
+        }
+      }
+
+      i++;
+      setTimeout(typeNextChar, delay);
+    }
+
+    console.log('[VNC Clipboard Bridge] Starting sendKey fallback typing for ' + text.length + ' characters');
+    typeNextChar();
+  }
+
+  /**
    * Inject clipboard text into the VNC session.
    *
-   * Uses noVNC's clipboardPasteFrom() to set the remote clipboard,
+   * Primary method: Uses noVNC's clipboardPasteFrom() to set the remote clipboard,
    * then simulates Ctrl+V to trigger paste in the remote session.
+   *
+   * Fallback: If useSendKeyFallback is enabled and text is short enough,
+   * types the text character by character using sendKey().
    *
    * @param {string} text - The text to paste
    */
@@ -73,12 +188,25 @@
       return;
     }
 
+    // If fallback mode is enabled and text is short, type directly
+    if (useSendKeyFallback && text.length <= SENDKEY_FALLBACK_MAX_LENGTH) {
+      console.log('[VNC Clipboard Bridge] Using sendKey fallback mode');
+      typeTextViaSendKey(rfb, text);
+      return;
+    }
+
     try {
       // Set the clipboard text on the remote server
       if (typeof rfb.clipboardPasteFrom === 'function') {
         rfb.clipboardPasteFrom(text);
+        console.log('[VNC Clipboard Bridge] Set remote clipboard via clipboardPasteFrom');
       } else {
         console.warn('[VNC Clipboard Bridge] clipboardPasteFrom not available');
+        // Fall back to typing if clipboard method isn't available
+        if (text.length <= SENDKEY_FALLBACK_MAX_LENGTH) {
+          console.log('[VNC Clipboard Bridge] Falling back to sendKey typing');
+          typeTextViaSendKey(rfb, text);
+        }
         return;
       }
 
@@ -109,9 +237,16 @@
         rfb.sendKey(XK_v, 'KeyV', true);
         rfb.sendKey(XK_v, 'KeyV', false);
         rfb.sendKey(XK_Control_L, 'ControlLeft', false);
+
+        console.log('[VNC Clipboard Bridge] Sent Ctrl+V keystroke');
       }, 50);
     } catch (error) {
       console.error('[VNC Clipboard Bridge] Error injecting clipboard:', error);
+      // Try fallback on error if text is short enough
+      if (text.length <= SENDKEY_FALLBACK_MAX_LENGTH) {
+        console.log('[VNC Clipboard Bridge] Attempting sendKey fallback after error');
+        typeTextViaSendKey(rfb, text);
+      }
     }
   }
 
@@ -148,11 +283,18 @@
 
     var data = event.data;
 
-    if (!isVncClipboardPasteMessage(data)) {
+    // Handle clipboard paste message
+    if (isVncClipboardPasteMessage(data)) {
+      injectClipboard(data.text);
       return;
     }
 
-    injectClipboard(data.text);
+    // Handle fallback mode toggle
+    if (typeof data === 'object' && data !== null && data.type === 'vnc-clipboard-fallback') {
+      useSendKeyFallback = !!data.enabled;
+      console.log('[VNC Clipboard Bridge] Fallback mode ' + (useSendKeyFallback ? 'enabled' : 'disabled'));
+      return;
+    }
   }
 
   // Listen for messages from parent window

--- a/scripts/pve/pve-lxc-setup.sh
+++ b/scripts/pve/pve-lxc-setup.sh
@@ -304,7 +304,7 @@ elif command -v Xvfb &>/dev/null; then
     mark_done "06-vnc"
 else
     echo "[6/10] Installing VNC and X11..."
-    apt-get install -y -qq xvfb tigervnc-standalone-server tigervnc-common x11-utils xterm dbus-x11
+    apt-get install -y -qq xvfb tigervnc-standalone-server tigervnc-common x11-utils xterm dbus-x11 xclip xsel
     mark_done "06-vnc"
 fi
 

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -2077,7 +2077,7 @@ async def task_install_base_packages(ctx: PveTaskContext) -> None:
             tigervnc-standalone-server tigervnc-common \
             xvfb \
             x11-xserver-utils xterm novnc \
-            dbus-x11 openbox \
+            dbus-x11 openbox xclip xsel parcellite \
             tmux \
             gh \
             zsh \
@@ -2108,6 +2108,93 @@ async def task_install_base_packages(ctx: PveTaskContext) -> None:
         """
     )
     await ctx.run("install-base-packages", cmd)
+
+
+@registry.task(
+    name="upgrade-novnc",
+    deps=("install-base-packages",),
+    description="Upgrade noVNC to 1.7.0-beta for improved clipboard sync",
+)
+@update_registry.task(
+    name="upgrade-novnc",
+    deps=(),  # Safe to run anytime in update mode
+    description="Upgrade noVNC to 1.7.0-beta for improved clipboard sync",
+)
+async def task_upgrade_novnc(ctx: PveTaskContext) -> None:
+    """
+    Upgrade noVNC from Ubuntu's 1.3.0 to GitHub's 1.7.0-beta.
+
+    The newer version includes PR #1993 which adds automatic clipboard sync
+    between the browser and VNC session, improving clipboard paste reliability.
+    See: https://github.com/novnc/noVNC/pull/1993
+    """
+    cmd = textwrap.dedent(
+        """
+        set -eux
+
+        NOVNC_VERSION="v1.7.0-beta"
+        NOVNC_DIR="/usr/share/novnc"
+
+        # Check if already upgraded by looking for version marker
+        MARKER_FILE="${NOVNC_DIR}/.cmux-novnc-version"
+        if [ -f "$MARKER_FILE" ] && grep -qF "$NOVNC_VERSION" "$MARKER_FILE" 2>/dev/null; then
+            echo "[upgrade-novnc] Already at $NOVNC_VERSION, skipping"
+            exit 0
+        fi
+
+        echo "[upgrade-novnc] Downloading noVNC $NOVNC_VERSION from GitHub..."
+        cd /tmp
+        rm -rf noVNC-* novnc-*.tar.gz
+
+        # Download and extract noVNC release
+        curl -fsSL "https://github.com/novnc/noVNC/archive/refs/tags/${NOVNC_VERSION}.tar.gz" -o novnc.tar.gz
+        tar xzf novnc.tar.gz
+        EXTRACTED_DIR="$(ls -d noVNC-* 2>/dev/null | head -1)"
+
+        if [ -z "$EXTRACTED_DIR" ] || [ ! -d "$EXTRACTED_DIR" ]; then
+            echo "[upgrade-novnc] Failed to extract noVNC archive" >&2
+            exit 1
+        fi
+
+        # Backup original vnc.html if it has our bridge script (will be re-injected later)
+        HAD_BRIDGE=0
+        if grep -q "vnc-clipboard-bridge" "$NOVNC_DIR/vnc.html" 2>/dev/null; then
+            HAD_BRIDGE=1
+        fi
+
+        # Replace noVNC installation
+        echo "[upgrade-novnc] Installing noVNC $NOVNC_VERSION to $NOVNC_DIR..."
+
+        # Preserve any custom configuration symlinks
+        OLD_INDEX=""
+        if [ -L "$NOVNC_DIR/index.html" ]; then
+            OLD_INDEX="$(readlink -f "$NOVNC_DIR/index.html" 2>/dev/null || true)"
+        fi
+
+        # Clear and replace
+        rm -rf "${NOVNC_DIR:?}"/*
+        cp -r "$EXTRACTED_DIR"/* "$NOVNC_DIR/"
+
+        # Re-create vnc.html symlink as index.html if it existed
+        if [ -n "$OLD_INDEX" ] && [ -f "$NOVNC_DIR/vnc.html" ]; then
+            ln -sf vnc.html "$NOVNC_DIR/index.html"
+        fi
+
+        # Write version marker
+        echo "$NOVNC_VERSION" > "$MARKER_FILE"
+
+        # Cleanup
+        rm -rf /tmp/noVNC-* /tmp/novnc.tar.gz
+
+        echo "[upgrade-novnc] Successfully installed noVNC $NOVNC_VERSION"
+
+        # Note: vnc-clipboard-bridge will be re-injected by install-vnc-clipboard-bridge task
+        if [ "$HAD_BRIDGE" = "1" ]; then
+            echo "[upgrade-novnc] Note: clipboard bridge will be re-injected"
+        fi
+        """
+    )
+    await ctx.run("upgrade-novnc", cmd)
 
 
 @registry.task(
@@ -3152,12 +3239,12 @@ async def task_configure_openbox(ctx: PveTaskContext) -> None:
 
 @registry.task(
     name="install-vnc-clipboard-bridge",
-    deps=("upload-repo", "install-base-packages"),
+    deps=("upload-repo", "upgrade-novnc"),
     description="Install VNC clipboard bridge for cross-origin paste support",
 )
 @update_registry.task(
     name="install-vnc-clipboard-bridge",
-    deps=("upload-repo",),  # novnc already installed
+    deps=("upload-repo", "upgrade-novnc"),
     description="Install VNC clipboard bridge for cross-origin paste support",
 )
 async def task_install_vnc_clipboard_bridge(ctx: PveTaskContext) -> None:
@@ -3556,6 +3643,7 @@ async def task_install_systemd_units(ctx: PveTaskContext) -> None:
         install -Dm0644 {repo}/configs/systemd/cmux-xvfb.service /usr/lib/systemd/system/cmux-xvfb.service
         install -Dm0644 {repo}/configs/systemd/cmux-tigervnc.service /usr/lib/systemd/system/cmux-tigervnc.service
         install -Dm0644 {repo}/configs/systemd/cmux-openbox.service /usr/lib/systemd/system/cmux-openbox.service
+        install -Dm0644 {repo}/configs/systemd/cmux-clipboard.service /usr/lib/systemd/system/cmux-clipboard.service
         install -Dm0644 {repo}/configs/systemd/cmux-vnc-proxy.service /usr/lib/systemd/system/cmux-vnc-proxy.service
         install -Dm0644 {repo}/configs/systemd/cmux-cdp-proxy.service /usr/lib/systemd/system/cmux-cdp-proxy.service
         install -Dm0644 {repo}/configs/systemd/cmux-pty.service /usr/lib/systemd/system/cmux-pty.service
@@ -3584,6 +3672,7 @@ async def task_install_systemd_units(ctx: PveTaskContext) -> None:
         ln -sf /usr/lib/systemd/system/cmux-devtools.service /etc/systemd/system/cmux.target.wants/cmux-devtools.service
         ln -sf /usr/lib/systemd/system/cmux-tigervnc.service /etc/systemd/system/cmux.target.wants/cmux-tigervnc.service
         ln -sf /usr/lib/systemd/system/cmux-openbox.service /etc/systemd/system/cmux.target.wants/cmux-openbox.service
+        ln -sf /usr/lib/systemd/system/cmux-clipboard.service /etc/systemd/system/cmux.target.wants/cmux-clipboard.service
         ln -sf /usr/lib/systemd/system/cmux-vnc-proxy.service /etc/systemd/system/cmux.target.wants/cmux-vnc-proxy.service
         ln -sf /usr/lib/systemd/system/cmux-cdp-proxy.service /etc/systemd/system/cmux.target.wants/cmux-cdp-proxy.service
         ln -sf /usr/lib/systemd/system/cmux-pty.service /etc/systemd/system/cmux.target.wants/cmux-pty.service


### PR DESCRIPTION
## Summary
- Add xclip, xsel, parcellite packages to base template and snapshot builds
- Add `upgrade-novnc` task to replace Ubuntu noVNC 1.3.0 with GitHub 1.7.0-beta (includes PR #1993 automatic clipboard sync)
- Enhance vnc-clipboard-bridge.js with sendKey fallback for character-by-character typing when clipboardPasteFrom fails
- Add cmux-clipboard.service for parcellite clipboard manager daemon

## Test plan
- [ ] Rebuild snapshot: `uv run --env-file .env ./scripts/snapshot-pvelxc.py --template-vmid 9000`
- [ ] Spawn new task: `devsh task create --repo karlorz/testing-repo-1 --agent claude/haiku-4.5 --prompt "test"`
- [ ] Open browser panel, copy text, focus VNC, press Cmd+V
- [ ] Verify text pastes correctly into terminal/editor
- [ ] Check container logs: `devsh exec <id> "journalctl -u cmux-clipboard -n 20"`