### PR TITLE
fix(hooks): gate Codex autopilot on CMUX_AUTOPILOT_ENABLED flag

### DIFF
--- a/.codex/hooks/autopilot-stop.sh
+++ b/.codex/hooks/autopilot-stop.sh
@@ -13,4 +13,15 @@ export CMUX_AUTOPILOT_ENABLE_REVIEW_WINDOW="${CMUX_AUTOPILOT_ENABLE_REVIEW_WINDO
 export CMUX_AUTOPILOT_INLINE_WRAPUP="${CMUX_AUTOPILOT_INLINE_WRAPUP:-1}"
 export CMUX_SESSION_ACTIVITY_SCRIPT="${CMUX_SESSION_ACTIVITY_SCRIPT:-$PROJECT_DIR/.claude/hooks/session-activity-capture.sh}"
 
+# Codex launches hook commands through the user's login shell. If shell startup
+# exports stale AUTOPILOT_* defaults, ordinary interactive sessions can be
+# forced into autopilot unexpectedly. Gate Codex autopilot on the cmux-scoped
+# flag and only allow the generic env var path when the wrapper is explicitly
+# enabled by the autopilot runner.
+if [ "$CMUX_AUTOPILOT_ENABLED" = "1" ]; then
+  export AUTOPILOT_KEEP_RUNNING_DISABLED="${AUTOPILOT_KEEP_RUNNING_DISABLED:-0}"
+else
+  export AUTOPILOT_KEEP_RUNNING_DISABLED="1"
+fi
+
 exec "$PROJECT_DIR/scripts/hooks/cmux-autopilot-stop-core.sh"

--- a/.codex/skills/autopilot_reset/SKILL.md
+++ b/.codex/skills/autopilot_reset/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when the user asks for `$autopilot_reset` or wants autopilot stat
 ## Defaults
 
 - Target: the current Codex autopilot session
-- Default mode: `status`
+- Default mode: `reset`
 
 ## Supported modes
 
@@ -26,7 +26,7 @@ Use this skill when the user asks for `$autopilot_reset` or wants autopilot stat
 ## Workflow
 
 1. Parse the requested mode.
-2. If no mode is provided, use `status`.
+2. If no mode is provided, use `reset`.
 3. Run the shared repo script with the Codex target baked in:
 
 ```bash
@@ -39,6 +39,7 @@ AUTOPILOT_PROVIDER=codex bash "$ROOT"/scripts/autopilot-reset.sh <mode>
 ## Examples
 
 ```bash
+$autopilot_reset
 $autopilot_reset status
 $autopilot_reset stop
 $autopilot_reset debug-on


### PR DESCRIPTION
## Summary

- Gate Codex autopilot on `CMUX_AUTOPILOT_ENABLED=1` flag
- Prevent stale login shell env vars from accidentally enabling autopilot
- Change autopilot_reset skill default from `status` to `reset`

## Problem

Codex launches hook commands through the user's login shell. If shell startup exports stale `AUTOPILOT_*` defaults, ordinary interactive Codex sessions would be forced into autopilot unexpectedly.

## Solution

Only enable autopilot when `CMUX_AUTOPILOT_ENABLED=1` is explicitly set by the cmux autopilot runner.

## Test plan

- [x] Manual verification: interactive Codex sessions no longer auto-loop
- [x] `CMUX_AUTOPILOT_ENABLED=1` enables autopilot as expected