### PR TITLE
fix(hooks): keep Codex autopilot looping

### DIFF
--- a/.codex/hooks/test-autopilot-stop.sh
+++ b/.codex/hooks/test-autopilot-stop.sh
@@ -112,18 +112,20 @@ assert "Legacy CLAUDE alias creates max-turn wrapup marker" grep -q "max-turns" 
 
 cleanup
 
-# Pre-seed turn count to 1 so stop_hook_active=true check passes (requires turn >= 2)
+# Pre-seed turn count to 1 to simulate a repeated Stop event on the same session
 echo "1" > "/tmp/codex-autopilot-turns-${TEST_SESSION}"
 
 STOP_ACTIVE_OUTPUT=$(run_enabled_hook \
-  "{\"session_id\":\"${TEST_SESSION}\",\"stop_hook_active\":true}" || true)
+  "{\"session_id\":\"${TEST_SESSION}\",\"stop_hook_active\":true}" \
+  AUTOPILOT_MAX_TURNS=99999)
 
-assert "Codex repeated stop with stop_hook_active=true allows stop (turn>=2)" test -z "$STOP_ACTIVE_OUTPUT"
-assert "Repeated codex stop does not recreate blocked flag" test ! -f "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+assert "Codex repeated stop with stop_hook_active=true still blocks" jq -e '.decision == "block"' <<<"$STOP_ACTIVE_OUTPUT"
+assert "Repeated codex stop recreates blocked flag" test -f "/tmp/codex-autopilot-blocked-${TEST_SESSION}"
+assert "Repeated codex stop increments turn counter to 2" grep -q '^2$' "/tmp/codex-autopilot-turns-${TEST_SESSION}"
 
 cleanup
 
-# Test stop_hook_active=true on turn 1 should NOT allow stop (blocks instead)
+# Test stop_hook_active=true on turn 1 should also block
 STOP_ACTIVE_TURN1_OUTPUT=$(run_enabled_hook \
   "{\"session_id\":\"${TEST_SESSION}\",\"stop_hook_active\":true}" \
   AUTOPILOT_MAX_TURNS=99999)

--- a/scripts/hooks/cmux-autopilot-stop-core.sh
+++ b/scripts/hooks/cmux-autopilot-stop-core.sh
@@ -55,8 +55,9 @@ case "${AUTOPILOT_KEEP_RUNNING_DISABLED:-}" in
 esac
 
 INPUT=$(cat)
-# Parse session_id and stop_hook_active in a single jq call
-read -r SESSION_ID STOP_HOOK_ACTIVE < <(echo "$INPUT" | jq -r '[.session_id // "default", .stop_hook_active // false] | @tsv' 2>/dev/null || echo "default false")
+# Parse only the session id. Codex may also send stop_hook_active, but the
+# shared autopilot loop intentionally ignores that field.
+SESSION_ID="$(echo "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null || echo "default")"
 SESSION_ID="${SESSION_ID:-default}"
 PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
 
@@ -187,17 +188,9 @@ fi
 TURN_COUNT=$((TURN_COUNT + 1))
 printf '%s\n' "$TURN_COUNT" > "$TURN_FILE"
 
-# Codex stop_hook_active=true: allow stop only after completing at least one full turn
-# This prevents immediate exit on re-invocation while still breaking infinite loops
-if [ "$PROVIDER" = "codex" ] && [ "$STOP_HOOK_ACTIVE" = "true" ] && [ "$STOP_REQUESTED" -eq 0 ] && [ -z "$WRAPUP_SOURCE" ]; then
-  if [ "$TURN_COUNT" -ge 2 ]; then
-    log_debug "allowing stop because codex stop_hook_active=true and turn_count=$TURN_COUNT >= 2"
-    cleanup_runtime_state
-    exit 0
-  else
-    log_debug "ignoring stop_hook_active=true because turn_count=$TURN_COUNT < 2"
-  fi
-fi
+# Codex exposes stop_hook_active on repeated Stop events, but cmux autopilot
+# intentionally ignores it so Codex keeps looping until normal stop conditions
+# apply: explicit stop request, idle detection, or max turns / wrap-up.
 
 if [ -z "$WRAPUP_SOURCE" ]; then
   CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "unknown")


### PR DESCRIPTION
## Summary
- remove the Codex-specific early exit on repeated Stop events
- keep Codex autopilot running until the normal stop conditions fire
- update the Codex smoke test to assert repeated Stop events still block

## Validation
- bash .codex/hooks/test-autopilot-stop.sh
- bash scripts/test-autopilot-wrap-up.sh
- bash .claude/hooks/test-completed-marker.sh
- bash scripts/test-stop-hooks.sh
- bun check