### PR TITLE
feat(sandbox): add timezone support to all sandbox Dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,10 @@ FROM node:24-bookworm
 ARG IDE_DEPS_CHANNEL=stable
 ENV IDE_DEPS_CHANNEL=${IDE_DEPS_CHANNEL}
 
-RUN apt-get update && apt-get install -y \
+# Default timezone (can be overridden via TZ env var at runtime)
+ENV TZ=Asia/Hong_Kong
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3 \
     make \
     g++ \
@@ -14,6 +17,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     sudo \
     docker.io \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -637,10 +637,10 @@ ARG NODE_VERSION
 ARG NVM_VERSION
 ARG CODE_RELEASE
 
-# Install runtime dependencies only
+# Install runtime dependencies only (including tzdata for timezone support)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get update && apt-get install -y --no-install-recommends \
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   ca-certificates \
   curl \
   wget \
@@ -665,6 +665,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   dbus \
   kmod \
   util-linux \
+  tzdata \
   tigervnc-standalone-server \
   tigervnc-common \
   xvfb \
@@ -697,6 +698,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   libxss1 \
   libxtst6 \
   zram-tools
+
+# Default timezone (can be overridden via TZ env var at runtime)
+ENV TZ=Asia/Hong_Kong
 
 ENV RUSTUP_HOME=/usr/local/rustup \
   CARGO_HOME=/usr/local/cargo \

--- a/crates/cmux-env/Dockerfile.demo
+++ b/crates/cmux-env/Dockerfile.demo
@@ -13,8 +13,10 @@ RUN cargo build --release --locked
 
 FROM debian:bookworm-slim AS runtime
 ENV DEBIAN_FRONTEND=noninteractive
+# Default timezone (can be overridden via TZ env var at runtime)
+ENV TZ=Asia/Hong_Kong
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      bash zsh fish ca-certificates tini tmux && \
+      bash zsh fish ca-certificates tini tmux tzdata && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/envd /usr/local/bin/envd

--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -202,6 +202,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   openssh-server \
   jq \
   findutils \
+  tzdata \
   tigervnc-standalone-server \
   openbox \
   xterm \
@@ -232,6 +233,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && apt-get update \
   && apt-get install -y --no-install-recommends gh \
   && rm -rf /var/lib/apt/lists/*
+
+# Default timezone (can be overridden via TZ env var at runtime)
+ENV TZ=Asia/Hong_Kong
 
 # Install Google Chrome (optional, may not be available on ARM64)
 RUN arch="$(uname -m)"; \


### PR DESCRIPTION
## Summary
- Add `tzdata` package and `TZ=Asia/Hong_Kong` to all sandbox-related Dockerfiles
- Consistent with server Dockerfile timezone config merged in PR #562

## Files Changed
| File | Change |
|------|--------|
| `Dockerfile` (main) | Add tzdata, ENV TZ=Asia/Hong_Kong |
| `packages/sandbox/Dockerfile` | Add tzdata, ENV TZ=Asia/Hong_Kong |
| `.devcontainer/Dockerfile` | Add tzdata, ENV TZ=Asia/Hong_Kong |
| `crates/cmux-env/Dockerfile.demo` | Add tzdata, ENV TZ=Asia/Hong_Kong |

## Test plan
- [ ] Build main Dockerfile and verify `date` shows HKT
- [ ] Build sandbox Dockerfile and verify timezone
- [ ] Verify TZ can be overridden at runtime with `-e TZ=America/Los_Angeles`