### PR TITLE
fix(sandbox): preserve yaml/doc directory needed by opentelemetry

### DIFF
--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -322,7 +322,7 @@ RUN bun add -g \
   find /usr/local/lib/bun/node_modules -type d -name 'tests' -exec rm -rf {} + 2>/dev/null || true && \
   find /usr/local/lib/bun/node_modules -name '*.md' -type f -delete 2>/dev/null || true && \
   find /usr/local/lib/bun/node_modules -type d -name 'docs' -exec rm -rf {} + 2>/dev/null || true && \
-  find /usr/local/lib/bun/node_modules -type d -name 'doc' -exec rm -rf {} + 2>/dev/null || true && \
+  find /usr/local/lib/bun/node_modules -type d -name 'doc' ! -path '*/yaml/*' -exec rm -rf {} + 2>/dev/null || true && \
   find /usr/local/lib/bun/node_modules -type d -name 'example' -exec rm -rf {} + 2>/dev/null || true && \
   find /usr/local/lib/bun/node_modules -type d -name 'examples' -exec rm -rf {} + 2>/dev/null || true && \
   find /usr/local/lib/bun/node_modules -name '*.d.ts' -type f -delete 2>/dev/null || true && \


### PR DESCRIPTION
## Summary
Fix sandbox Docker build failure caused by aggressive node_modules cleanup.

## Problem
The `yaml` package's `doc/` directory contains runtime JS files (`directives.js`) required by `@opentelemetry/configuration`. The cleanup step was deleting all `doc/` directories, causing:
```
Error: Cannot find module '../doc/directives.js'
```

## Fix
Exclude `*/yaml/*` from the `doc` directory cleanup.

## Test plan
- [ ] Verify sandbox Docker image builds successfully on both amd64 and arm64