### PR TITLE
fix(vnc): expose window.UI for clipboard bridge RFB access

### DIFF
--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -3351,7 +3351,13 @@ with open(bridge_script_path, "r") as f:
 with open(vnc_html_path, "r") as f:
     html = f.read()
 
-script_tag = f'''<script id="vnc-clipboard-bridge">
+script_tag = f'''<script type="module" id="vnc-clipboard-bridge-init">
+// Expose UI to window for clipboard bridge access
+// noVNC loads UI as ES module, not exposed globally by default
+import UI from './app/ui.js';
+window.UI = UI;
+</script>
+<script id="vnc-clipboard-bridge">
 {{bridge_js}}
 </script>
 '''

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1812,7 +1812,13 @@ with open(bridge_script_path, "r") as f:
 with open(vnc_html_path, "r") as f:
     html = f.read()
 
-script_tag = f'''<script id="vnc-clipboard-bridge">
+script_tag = f'''<script type="module" id="vnc-clipboard-bridge-init">
+// Expose UI to window for clipboard bridge access
+// noVNC loads UI as ES module, not exposed globally by default
+import UI from './app/ui.js';
+window.UI = UI;
+</script>
+<script id="vnc-clipboard-bridge">
 {{bridge_js}}
 </script>
 '''


### PR DESCRIPTION
## Summary
- Fix VNC clipboard bridge not working - `getRfbInstance()` was returning `null`
- noVNC loads UI as ES module, not exposed to `window` by default
- Add module script to import UI and set `window.UI = UI`

## Root Cause
Console showed: `[VNC Clipboard Bridge] RFB instance not available`

The clipboard bridge script checks `window.UI.rfb` to access noVNC's RFB API, but noVNC uses ES modules and doesn't expose `UI` globally.

## Fix
Add `<script type="module">` before the clipboard bridge that:
```javascript
import UI from './app/ui.js';
window.UI = UI;
```

## Test plan
- [ ] Rebuild PVE-LXC snapshot with updated script
- [ ] Test Cmd+V paste in VNC browser panel
- [ ] Verify console shows clipboard bridge success logs