### PR TITLE
fix(vnc): add vncconfig to enable X11 clipboard sync to VNC

### DIFF
--- a/configs/systemd/cmux-tigervnc.service
+++ b/configs/systemd/cmux-tigervnc.service
@@ -9,6 +9,8 @@ Environment=DISPLAY=:1
 ExecStartPre=/bin/mkdir -p /var/log/cmux
 ExecStart=/usr/bin/Xtigervnc :1 -geometry 1920x1080 -depth 24 -localhost -SecurityTypes None -rfbport 5901 -AlwaysShared -AcceptSetDesktopSize=1 -nolisten tcp
 ExecStartPost=/bin/sh -c 'command -v xsetroot >/dev/null 2>&1 && xsetroot -display :1 -solid "#000000" || true'
+ExecStartPost=/bin/sh -c 'for i in 1 2 3 4 5; do xdpyinfo -display :1 >/dev/null 2>&1 && break; sleep 1; done; vncconfig -display :1 -nowin &'
+ExecStopPost=/bin/sh -c 'pkill -f "vncconfig -display :1" || true'
 Restart=always
 RestartSec=3
 StandardOutput=append:/var/log/cmux/tigervnc.log


### PR DESCRIPTION
## Summary

- Adds `vncconfig -nowin` to TigerVNC service startup to enable X11 clipboard synchronization
- Without vncconfig, X11 clipboard changes (when user copies text) don't propagate to VNC server
- This is required for the VNC → Mac clipboard sync feature from PR #569 to work

## Root Cause

The bidirectional clipboard sync in #569 relies on noVNC's RFB `clipboard` event. This event only fires when the **VNC server** sends clipboard data. However, X11 clipboard changes (PRIMARY/CLIPBOARD selections) aren't automatically sent to VNC - `vncconfig` is needed to bridge them.

## Changes

- `configs/systemd/cmux-tigervnc.service`: Added `ExecStartPost` to start `vncconfig -nowin` after VNC server is ready

## Test Plan

- [ ] Create new sandbox after snapshot rebuild
- [ ] Copy text in VNC session (e.g., select text in terminal, Ctrl+Shift+C)
- [ ] Verify text appears in local macOS clipboard (Cmd+V)