### PR TITLE
feat(web-ui): add SSE event stream for orchestration dashboard

### DIFF
--- a/apps/client/src/components/orchestration/OrchestrationDashboard.tsx
+++ b/apps/client/src/components/orchestration/OrchestrationDashboard.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { Users, Plus, List, GitBranch } from "lucide-react";
+import { Users, Plus, List, GitBranch, Radio } from "lucide-react";
 import { OrchestrationSummaryCards } from "./OrchestrationSummaryCards";
 import { OrchestrationTaskList } from "./OrchestrationTaskList";
 import { OrchestrationSpawnDialog } from "./OrchestrationSpawnDialog";
 import { OrchestrationDependencyGraph } from "./OrchestrationDependencyGraph";
+import { OrchestrationEventStream } from "./OrchestrationEventStream";
 import { STATUS_CONFIG, type TaskStatus } from "./status-config";
 import type { Doc, Id } from "@cmux/convex/dataModel";
 
@@ -48,6 +49,7 @@ interface OrchestrationDashboardProps {
   tasks?: OrchestrationTaskWithDeps[];
   tasksLoading: boolean;
   statusFilter: string;
+  orchestrationId?: string;
 }
 
 export function OrchestrationDashboard({
@@ -57,10 +59,12 @@ export function OrchestrationDashboard({
   tasks,
   tasksLoading,
   statusFilter,
+  orchestrationId,
 }: OrchestrationDashboardProps) {
   const navigate = useNavigate();
   const [spawnDialogOpen, setSpawnDialogOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"list" | "graph">("list");
+  const [showEventStream, setShowEventStream] = useState(!!orchestrationId);
 
   const handleStatusFilterChange = (status: string) => {
     void navigate({
@@ -108,6 +112,27 @@ export function OrchestrationDashboard({
             onFilterChange={handleStatusFilterChange}
             activeFilter={statusFilter}
           />
+
+          {/* Event Stream (when orchestrationId provided) */}
+          {orchestrationId && showEventStream && (
+            <OrchestrationEventStream
+              orchestrationId={orchestrationId}
+              teamSlugOrId={teamSlugOrId}
+              onClose={() => setShowEventStream(false)}
+            />
+          )}
+
+          {/* Event Stream toggle (when orchestrationId provided but stream hidden) */}
+          {orchestrationId && !showEventStream && (
+            <button
+              type="button"
+              onClick={() => setShowEventStream(true)}
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-neutral-300 bg-neutral-50 py-2 text-sm text-neutral-500 transition-colors hover:border-neutral-400 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
+            >
+              <Radio className="size-4" />
+              Show Event Stream
+            </button>
+          )}
 
           {/* Active Agents */}
           {summary && summary.activeAgents.length > 0 && (

--- a/apps/client/src/components/orchestration/OrchestrationEventStream.tsx
+++ b/apps/client/src/components/orchestration/OrchestrationEventStream.tsx
@@ -1,0 +1,198 @@
+import { useState } from "react";
+import {
+  Radio,
+  CheckCircle,
+  Clock,
+  AlertTriangle,
+  Wifi,
+  WifiOff,
+  X,
+} from "lucide-react";
+import clsx from "clsx";
+import {
+  useOrchestrationEvents,
+  type OrchestrationEvent,
+} from "@/hooks/useOrchestrationEvents";
+
+interface OrchestrationEventStreamProps {
+  orchestrationId: string;
+  teamSlugOrId: string;
+  onClose?: () => void;
+}
+
+const eventIcons: Record<string, typeof CheckCircle> = {
+  connected: Wifi,
+  task_status: Clock,
+  task_completed: CheckCircle,
+  orchestration_completed: CheckCircle,
+  error: AlertTriangle,
+};
+
+const statusColors: Record<string, string> = {
+  completed: "text-green-500",
+  failed: "text-red-500",
+  cancelled: "text-neutral-500",
+  running: "text-blue-500",
+  pending: "text-amber-500",
+  assigned: "text-amber-500",
+};
+
+function formatTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function OrchestrationEventStream({
+  orchestrationId,
+  teamSlugOrId,
+  onClose,
+}: OrchestrationEventStreamProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const { connected, events, error } = useOrchestrationEvents({
+    orchestrationId,
+    teamSlugOrId,
+    enabled: true,
+  });
+
+  return (
+    <div
+      className={clsx(
+        "rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900",
+        expanded ? "max-h-96" : "max-h-48"
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-neutral-200 px-3 py-2 dark:border-neutral-800">
+        <div className="flex items-center gap-2">
+          <Radio
+            className={clsx(
+              "size-4",
+              connected ? "text-green-500 animate-pulse" : "text-neutral-400"
+            )}
+          />
+          <span className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
+            Event Stream
+          </span>
+          <span
+            className={clsx(
+              "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-xs",
+              connected
+                ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                : "bg-neutral-100 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400"
+            )}
+          >
+            {connected ? (
+              <>
+                <Wifi className="size-3" />
+                Live
+              </>
+            ) : (
+              <>
+                <WifiOff className="size-3" />
+                Disconnected
+              </>
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="rounded px-2 py-0.5 text-xs text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+          >
+            {expanded ? "Collapse" : "Expand"}
+          </button>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800"
+            >
+              <X className="size-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="flex items-center gap-2 bg-red-50 px-3 py-1.5 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-400">
+          <AlertTriangle className="size-3" />
+          {error}
+        </div>
+      )}
+
+      {/* Events list */}
+      <div className="overflow-auto" style={{ maxHeight: expanded ? "calc(24rem - 3rem)" : "calc(12rem - 3rem)" }}>
+        {events.length === 0 ? (
+          <div className="flex items-center justify-center py-6 text-xs text-neutral-400">
+            {connected ? "Waiting for events..." : "Connect to see events"}
+          </div>
+        ) : (
+          <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
+            {events.map((event, idx) => (
+              <EventRow key={`${event.timestamp}-${idx}`} event={event} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EventRow({ event }: { event: OrchestrationEvent }) {
+  const Icon = eventIcons[event.event] ?? Clock;
+  const statusColor = event.status ? statusColors[event.status] ?? "text-neutral-500" : "text-neutral-500";
+
+  return (
+    <div className="px-3 py-2 text-xs">
+      <div className="flex items-center gap-2">
+        <Icon className={clsx("size-3.5", statusColor)} />
+        <span className="font-mono text-neutral-400">
+          {formatTime(event.timestamp)}
+        </span>
+        <span className="font-medium text-neutral-700 dark:text-neutral-300">
+          {event.event.replace(/_/g, " ")}
+        </span>
+        {event.status && (
+          <span className={clsx("font-medium", statusColor)}>
+            {event.status}
+          </span>
+        )}
+      </div>
+      {event.prompt && (
+        <div className="mt-1 pl-5 text-neutral-500 dark:text-neutral-400 line-clamp-1">
+          {event.prompt}
+        </div>
+      )}
+      {event.agentName && (
+        <span className="ml-5 text-neutral-400">
+          {event.agentName}
+        </span>
+      )}
+      {event.result && (
+        <div className="mt-1 pl-5 rounded bg-green-50 px-2 py-1 text-green-700 dark:bg-green-900/20 dark:text-green-400 line-clamp-2">
+          {event.result}
+        </div>
+      )}
+      {event.errorMessage && (
+        <div className="mt-1 pl-5 rounded bg-red-50 px-2 py-1 text-red-700 dark:bg-red-900/20 dark:text-red-400 line-clamp-2">
+          {event.errorMessage}
+        </div>
+      )}
+      {event.aggregatedStatus && (
+        <div className="mt-1 pl-5 flex gap-3 text-neutral-500">
+          <span>Total: {event.aggregatedStatus.total}</span>
+          <span className="text-green-500">Done: {event.aggregatedStatus.completed}</span>
+          <span className="text-blue-500">Running: {event.aggregatedStatus.running}</span>
+          <span className="text-red-500">Failed: {event.aggregatedStatus.failed}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/orchestration/OrchestrationTaskRow.tsx
+++ b/apps/client/src/components/orchestration/OrchestrationTaskRow.tsx
@@ -7,8 +7,10 @@ import {
   XCircle,
   ChevronDown,
   ChevronUp,
+  Radio,
 } from "lucide-react";
 import clsx from "clsx";
+import { Link } from "@tanstack/react-router";
 import { STATUS_CONFIG, type TaskStatus } from "./status-config";
 import type { OrchestrationTaskWithDeps } from "./OrchestrationDashboard";
 import { OrchestrationMessageDialog } from "./OrchestrationMessageDialog";
@@ -36,6 +38,7 @@ export function OrchestrationTaskRow({ task, teamSlugOrId }: OrchestrationTaskRo
   const isBlocked = hasDependencies && task.dependencyInfo && task.dependencyInfo.pendingDeps > 0;
   const canCancel = status === "pending" || status === "assigned";
   const canMessage = status === "running" && task.taskRunId;
+  const orchestrationId = (task.metadata as { orchestrationId?: string } | undefined)?.orchestrationId;
 
   const cancelMutation = useMutation({
     mutationFn: async () => {
@@ -147,6 +150,17 @@ export function OrchestrationTaskRow({ task, teamSlugOrId }: OrchestrationTaskRo
             <span className={isBlocked ? "text-amber-500" : "text-green-500"}>
               {task.dependencyInfo?.completedDeps}/{task.dependencyInfo?.totalDeps} deps complete
             </span>
+          )}
+          {orchestrationId && (
+            <Link
+              to="/$teamSlugOrId/orchestration/$orchestrationId"
+              params={{ teamSlugOrId, orchestrationId }}
+              className="inline-flex items-center gap-1 text-blue-500 hover:text-blue-600 hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Radio className="size-3" />
+              {orchestrationId.slice(0, 8)}...
+            </Link>
           )}
         </div>
 

--- a/apps/client/src/components/orchestration/index.ts
+++ b/apps/client/src/components/orchestration/index.ts
@@ -5,3 +5,4 @@ export { OrchestrationTaskList } from "./OrchestrationTaskList";
 export { OrchestrationTaskRow } from "./OrchestrationTaskRow";
 export { OrchestrationSpawnDialog } from "./OrchestrationSpawnDialog";
 export { OrchestrationMessageDialog } from "./OrchestrationMessageDialog";
+export { OrchestrationEventStream } from "./OrchestrationEventStream";

--- a/apps/client/src/hooks/useOrchestrationEvents.ts
+++ b/apps/client/src/hooks/useOrchestrationEvents.ts
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { authJsonQueryOptions } from "@/contexts/convex/authJsonQueryOptions";
+
+export interface OrchestrationEvent {
+  event: string;
+  taskId?: string;
+  status?: string;
+  previousStatus?: string;
+  prompt?: string;
+  agentName?: string;
+  result?: string;
+  errorMessage?: string;
+  aggregatedStatus?: {
+    total: number;
+    completed: number;
+    running: number;
+    failed: number;
+    pending: number;
+  };
+  timestamp: string;
+}
+
+interface UseOrchestrationEventsOptions {
+  orchestrationId: string;
+  teamSlugOrId: string;
+  enabled?: boolean;
+  onEvent?: (event: OrchestrationEvent) => void;
+  onTaskCompleted?: (taskId: string, status: string, result?: string) => void;
+  onOrchestrationCompleted?: (aggregatedStatus: OrchestrationEvent["aggregatedStatus"]) => void;
+}
+
+export function useOrchestrationEvents({
+  orchestrationId,
+  teamSlugOrId,
+  enabled = true,
+  onEvent,
+  onTaskCompleted,
+  onOrchestrationCompleted,
+}: UseOrchestrationEventsOptions) {
+  const authJsonQuery = useQuery(authJsonQueryOptions());
+  const accessToken = authJsonQuery.data?.accessToken;
+  const [connected, setConnected] = useState(false);
+  const [events, setEvents] = useState<OrchestrationEvent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  const disconnect = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+      setConnected(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !orchestrationId || !teamSlugOrId) {
+      disconnect();
+      return;
+    }
+
+    if (!accessToken) {
+      setError("Not authenticated");
+      return;
+    }
+
+    // Build SSE URL - auth is handled via cookies (withCredentials: true)
+    const baseUrl = import.meta.env.VITE_API_URL || "";
+    const params = new URLSearchParams({ teamSlugOrId });
+    const url = `${baseUrl}/api/orchestrate/events/${orchestrationId}?${params}`;
+
+    const eventSource = new EventSource(url, { withCredentials: true });
+    eventSourceRef.current = eventSource;
+
+    eventSource.addEventListener("connected", (e) => {
+      setConnected(true);
+      setError(null);
+      const data = JSON.parse(e.data) as OrchestrationEvent;
+      setEvents((prev) => [...prev, { ...data, event: "connected" }]);
+      onEvent?.({ ...data, event: "connected" });
+    });
+
+    eventSource.addEventListener("task_status", (e) => {
+      const data = JSON.parse(e.data) as OrchestrationEvent;
+      setEvents((prev) => [...prev, { ...data, event: "task_status" }]);
+      onEvent?.({ ...data, event: "task_status" });
+    });
+
+    eventSource.addEventListener("task_completed", (e) => {
+      const data = JSON.parse(e.data) as OrchestrationEvent;
+      setEvents((prev) => [...prev, { ...data, event: "task_completed" }]);
+      onEvent?.({ ...data, event: "task_completed" });
+      if (data.taskId && data.status) {
+        onTaskCompleted?.(data.taskId, data.status, data.result ?? undefined);
+      }
+    });
+
+    eventSource.addEventListener("orchestration_completed", (e) => {
+      const data = JSON.parse(e.data) as OrchestrationEvent;
+      setEvents((prev) => [...prev, { ...data, event: "orchestration_completed" }]);
+      onEvent?.({ ...data, event: "orchestration_completed" });
+      onOrchestrationCompleted?.(data.aggregatedStatus);
+      // Auto-disconnect when orchestration is complete
+      disconnect();
+    });
+
+    eventSource.addEventListener("heartbeat", (e) => {
+      const data = JSON.parse(e.data) as OrchestrationEvent;
+      onEvent?.({ ...data, event: "heartbeat" });
+    });
+
+    eventSource.addEventListener("error", (e) => {
+      if (e instanceof MessageEvent) {
+        const data = JSON.parse(e.data) as { message: string };
+        setError(data.message);
+      }
+    });
+
+    eventSource.onerror = () => {
+      setConnected(false);
+      setError("Connection lost");
+    };
+
+    return () => {
+      disconnect();
+    };
+  }, [
+    enabled,
+    orchestrationId,
+    teamSlugOrId,
+    accessToken,
+    onEvent,
+    onTaskCompleted,
+    onOrchestrationCompleted,
+    disconnect,
+  ]);
+
+  const clearEvents = useCallback(() => {
+    setEvents([]);
+  }, []);
+
+  return {
+    connected,
+    events,
+    error,
+    clearEvents,
+    disconnect,
+  };
+}

--- a/apps/client/src/routeTree.gen.ts
+++ b/apps/client/src/routeTree.gen.ts
@@ -43,6 +43,7 @@ import { Route as LayoutTeamSlugOrIdSettingsAddMcpServerRouteImport } from './ro
 import { Route as LayoutTeamSlugOrIdProjectsGithubRouteImport } from './routes/_layout.$teamSlugOrId.projects.github'
 import { Route as LayoutTeamSlugOrIdProjectsDashboardRouteImport } from './routes/_layout.$teamSlugOrId.projects.dashboard'
 import { Route as LayoutTeamSlugOrIdProjectsProjectIdRouteImport } from './routes/_layout.$teamSlugOrId.projects.$projectId'
+import { Route as LayoutTeamSlugOrIdOrchestrationOrchestrationIdRouteImport } from './routes/_layout.$teamSlugOrId.orchestration.$orchestrationId'
 import { Route as LayoutTeamSlugOrIdEnvironmentsNewVersionRouteImport } from './routes/_layout.$teamSlugOrId.environments.new-version'
 import { Route as LayoutTeamSlugOrIdEnvironmentsNewRouteImport } from './routes/_layout.$teamSlugOrId.environments.new'
 import { Route as LayoutTeamSlugOrIdEnvironmentsEnvironmentIdRouteImport } from './routes/_layout.$teamSlugOrId.environments.$environmentId'
@@ -245,6 +246,12 @@ const LayoutTeamSlugOrIdProjectsProjectIdRoute =
     path: '/$projectId',
     getParentRoute: () => LayoutTeamSlugOrIdProjectsRoute,
   } as any)
+const LayoutTeamSlugOrIdOrchestrationOrchestrationIdRoute =
+  LayoutTeamSlugOrIdOrchestrationOrchestrationIdRouteImport.update({
+    id: '/$orchestrationId',
+    path: '/$orchestrationId',
+    getParentRoute: () => LayoutTeamSlugOrIdOrchestrationRoute,
+  } as any)
 const LayoutTeamSlugOrIdEnvironmentsNewVersionRoute =
   LayoutTeamSlugOrIdEnvironmentsNewVersionRouteImport.update({
     id: '/new-version',
@@ -363,7 +370,7 @@ export interface FileRoutesByFullPath {
   '/$teamSlugOrId/environments': typeof LayoutTeamSlugOrIdEnvironmentsRouteWithChildren
   '/$teamSlugOrId/logs': typeof LayoutTeamSlugOrIdLogsRoute
   '/$teamSlugOrId/notifications': typeof LayoutTeamSlugOrIdNotificationsRoute
-  '/$teamSlugOrId/orchestration': typeof LayoutTeamSlugOrIdOrchestrationRoute
+  '/$teamSlugOrId/orchestration': typeof LayoutTeamSlugOrIdOrchestrationRouteWithChildren
   '/$teamSlugOrId/previews': typeof LayoutTeamSlugOrIdPreviewsRoute
   '/$teamSlugOrId/projects': typeof LayoutTeamSlugOrIdProjectsRouteWithChildren
   '/$teamSlugOrId/prs': typeof LayoutTeamSlugOrIdPrsRouteWithChildren
@@ -372,6 +379,7 @@ export interface FileRoutesByFullPath {
   '/$teamSlugOrId/environments/$environmentId': typeof LayoutTeamSlugOrIdEnvironmentsEnvironmentIdRoute
   '/$teamSlugOrId/environments/new': typeof LayoutTeamSlugOrIdEnvironmentsNewRoute
   '/$teamSlugOrId/environments/new-version': typeof LayoutTeamSlugOrIdEnvironmentsNewVersionRoute
+  '/$teamSlugOrId/orchestration/$orchestrationId': typeof LayoutTeamSlugOrIdOrchestrationOrchestrationIdRoute
   '/$teamSlugOrId/projects/$projectId': typeof LayoutTeamSlugOrIdProjectsProjectIdRoute
   '/$teamSlugOrId/projects/dashboard': typeof LayoutTeamSlugOrIdProjectsDashboardRoute
   '/$teamSlugOrId/projects/github': typeof LayoutTeamSlugOrIdProjectsGithubRoute
@@ -413,7 +421,7 @@ export interface FileRoutesByTo {
   '/$teamSlugOrId/diff': typeof LayoutTeamSlugOrIdDiffRoute
   '/$teamSlugOrId/logs': typeof LayoutTeamSlugOrIdLogsRoute
   '/$teamSlugOrId/notifications': typeof LayoutTeamSlugOrIdNotificationsRoute
-  '/$teamSlugOrId/orchestration': typeof LayoutTeamSlugOrIdOrchestrationRoute
+  '/$teamSlugOrId/orchestration': typeof LayoutTeamSlugOrIdOrchestrationRouteWithChildren
   '/$teamSlugOrId/previews': typeof LayoutTeamSlugOrIdPreviewsRoute
   '/$teamSlugOrId/prs': typeof LayoutTeamSlugOrIdPrsRouteWithChildren
   '/$teamSlugOrId/settings': typeof LayoutTeamSlugOrIdSettingsRouteWithChildren
@@ -421,6 +429,7 @@ export interface FileRoutesByTo {
   '/$teamSlugOrId/environments/$environmentId': typeof LayoutTeamSlugOrIdEnvironmentsEnvironmentIdRoute
   '/$teamSlugOrId/environments/new': typeof LayoutTeamSlugOrIdEnvironmentsNewRoute
   '/$teamSlugOrId/environments/new-version': typeof LayoutTeamSlugOrIdEnvironmentsNewVersionRoute
+  '/$teamSlugOrId/orchestration/$orchestrationId': typeof LayoutTeamSlugOrIdOrchestrationOrchestrationIdRoute
   '/$teamSlugOrId/projects/$projectId': typeof LayoutTeamSlugOrIdProjectsProjectIdRoute
   '/$teamSlugOrId/projects/dashboard': typeof LayoutTeamSlugOrIdProjectsDashboardRoute
   '/$teamSlugOrId/projects/github': typeof LayoutTeamSlugOrIdProjectsGithubRoute
@@ -464,7 +473,7 @@ export interface FileRoutesById {
   '/_layout/$teamSlugOrId/environments': typeof LayoutTeamSlugOrIdEnvironmentsRouteWithChildren
   '/_layout/$teamSlugOrId/logs': typeof LayoutTeamSlugOrIdLogsRoute
   '/_layout/$teamSlugOrId/notifications': typeof LayoutTeamSlugOrIdNotificationsRoute
-  '/_layout/$teamSlugOrId/orchestration': typeof LayoutTeamSlugOrIdOrchestrationRoute
+  '/_layout/$teamSlugOrId/orchestration': typeof LayoutTeamSlugOrIdOrchestrationRouteWithChildren
   '/_layout/$teamSlugOrId/previews': typeof LayoutTeamSlugOrIdPreviewsRoute
   '/_layout/$teamSlugOrId/projects': typeof LayoutTeamSlugOrIdProjectsRouteWithChildren
   '/_layout/$teamSlugOrId/prs': typeof LayoutTeamSlugOrIdPrsRouteWithChildren
@@ -473,6 +482,7 @@ export interface FileRoutesById {
   '/_layout/$teamSlugOrId/environments/$environmentId': typeof LayoutTeamSlugOrIdEnvironmentsEnvironmentIdRoute
   '/_layout/$teamSlugOrId/environments/new': typeof LayoutTeamSlugOrIdEnvironmentsNewRoute
   '/_layout/$teamSlugOrId/environments/new-version': typeof LayoutTeamSlugOrIdEnvironmentsNewVersionRoute
+  '/_layout/$teamSlugOrId/orchestration/$orchestrationId': typeof LayoutTeamSlugOrIdOrchestrationOrchestrationIdRoute
   '/_layout/$teamSlugOrId/projects/$projectId': typeof LayoutTeamSlugOrIdProjectsProjectIdRoute
   '/_layout/$teamSlugOrId/projects/dashboard': typeof LayoutTeamSlugOrIdProjectsDashboardRoute
   '/_layout/$teamSlugOrId/projects/github': typeof LayoutTeamSlugOrIdProjectsGithubRoute
@@ -526,6 +536,7 @@ export interface FileRouteTypes {
     | '/$teamSlugOrId/environments/$environmentId'
     | '/$teamSlugOrId/environments/new'
     | '/$teamSlugOrId/environments/new-version'
+    | '/$teamSlugOrId/orchestration/$orchestrationId'
     | '/$teamSlugOrId/projects/$projectId'
     | '/$teamSlugOrId/projects/dashboard'
     | '/$teamSlugOrId/projects/github'
@@ -575,6 +586,7 @@ export interface FileRouteTypes {
     | '/$teamSlugOrId/environments/$environmentId'
     | '/$teamSlugOrId/environments/new'
     | '/$teamSlugOrId/environments/new-version'
+    | '/$teamSlugOrId/orchestration/$orchestrationId'
     | '/$teamSlugOrId/projects/$projectId'
     | '/$teamSlugOrId/projects/dashboard'
     | '/$teamSlugOrId/projects/github'
@@ -626,6 +638,7 @@ export interface FileRouteTypes {
     | '/_layout/$teamSlugOrId/environments/$environmentId'
     | '/_layout/$teamSlugOrId/environments/new'
     | '/_layout/$teamSlugOrId/environments/new-version'
+    | '/_layout/$teamSlugOrId/orchestration/$orchestrationId'
     | '/_layout/$teamSlugOrId/projects/$projectId'
     | '/_layout/$teamSlugOrId/projects/dashboard'
     | '/_layout/$teamSlugOrId/projects/github'
@@ -902,6 +915,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutTeamSlugOrIdProjectsProjectIdRouteImport
       parentRoute: typeof LayoutTeamSlugOrIdProjectsRoute
     }
+    '/_layout/$teamSlugOrId/orchestration/$orchestrationId': {
+      id: '/_layout/$teamSlugOrId/orchestration/$orchestrationId'
+      path: '/$orchestrationId'
+      fullPath: '/$teamSlugOrId/orchestration/$orchestrationId'
+      preLoaderRoute: typeof LayoutTeamSlugOrIdOrchestrationOrchestrationIdRouteImport
+      parentRoute: typeof LayoutTeamSlugOrIdOrchestrationRoute
+    }
     '/_layout/$teamSlugOrId/environments/new-version': {
       id: '/_layout/$teamSlugOrId/environments/new-version'
       path: '/new-version'
@@ -1041,6 +1061,21 @@ const LayoutTeamSlugOrIdEnvironmentsRouteWithChildren =
     LayoutTeamSlugOrIdEnvironmentsRouteChildren,
   )
 
+interface LayoutTeamSlugOrIdOrchestrationRouteChildren {
+  LayoutTeamSlugOrIdOrchestrationOrchestrationIdRoute: typeof LayoutTeamSlugOrIdOrchestrationOrchestrationIdRoute
+}
+
+const LayoutTeamSlugOrIdOrchestrationRouteChildren: LayoutTeamSlugOrIdOrchestrationRouteChildren =
+  {
+    LayoutTeamSlugOrIdOrchestrationOrchestrationIdRoute:
+      LayoutTeamSlugOrIdOrchestrationOrchestrationIdRoute,
+  }
+
+const LayoutTeamSlugOrIdOrchestrationRouteWithChildren =
+  LayoutTeamSlugOrIdOrchestrationRoute._addFileChildren(
+    LayoutTeamSlugOrIdOrchestrationRouteChildren,
+  )
+
 interface LayoutTeamSlugOrIdProjectsRouteChildren {
   LayoutTeamSlugOrIdProjectsProjectIdRoute: typeof LayoutTeamSlugOrIdProjectsProjectIdRoute
   LayoutTeamSlugOrIdProjectsDashboardRoute: typeof LayoutTeamSlugOrIdProjectsDashboardRoute
@@ -1145,7 +1180,7 @@ interface LayoutTeamSlugOrIdRouteChildren {
   LayoutTeamSlugOrIdEnvironmentsRoute: typeof LayoutTeamSlugOrIdEnvironmentsRouteWithChildren
   LayoutTeamSlugOrIdLogsRoute: typeof LayoutTeamSlugOrIdLogsRoute
   LayoutTeamSlugOrIdNotificationsRoute: typeof LayoutTeamSlugOrIdNotificationsRoute
-  LayoutTeamSlugOrIdOrchestrationRoute: typeof LayoutTeamSlugOrIdOrchestrationRoute
+  LayoutTeamSlugOrIdOrchestrationRoute: typeof LayoutTeamSlugOrIdOrchestrationRouteWithChildren
   LayoutTeamSlugOrIdPreviewsRoute: typeof LayoutTeamSlugOrIdPreviewsRoute
   LayoutTeamSlugOrIdProjectsRoute: typeof LayoutTeamSlugOrIdProjectsRouteWithChildren
   LayoutTeamSlugOrIdPrsRoute: typeof LayoutTeamSlugOrIdPrsRouteWithChildren
@@ -1164,7 +1199,8 @@ const LayoutTeamSlugOrIdRouteChildren: LayoutTeamSlugOrIdRouteChildren = {
     LayoutTeamSlugOrIdEnvironmentsRouteWithChildren,
   LayoutTeamSlugOrIdLogsRoute: LayoutTeamSlugOrIdLogsRoute,
   LayoutTeamSlugOrIdNotificationsRoute: LayoutTeamSlugOrIdNotificationsRoute,
-  LayoutTeamSlugOrIdOrchestrationRoute: LayoutTeamSlugOrIdOrchestrationRoute,
+  LayoutTeamSlugOrIdOrchestrationRoute:
+    LayoutTeamSlugOrIdOrchestrationRouteWithChildren,
   LayoutTeamSlugOrIdPreviewsRoute: LayoutTeamSlugOrIdPreviewsRoute,
   LayoutTeamSlugOrIdProjectsRoute: LayoutTeamSlugOrIdProjectsRouteWithChildren,
   LayoutTeamSlugOrIdPrsRoute: LayoutTeamSlugOrIdPrsRouteWithChildren,

--- a/apps/client/src/routes/_layout.$teamSlugOrId.orchestration.$orchestrationId.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.orchestration.$orchestrationId.tsx
@@ -1,0 +1,74 @@
+import { FloatingPane } from "@/components/floating-pane";
+import { OrchestrationDashboard } from "@/components/orchestration/OrchestrationDashboard";
+import { TitleBar } from "@/components/TitleBar";
+import { api } from "@cmux/convex/api";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+export const Route = createFileRoute(
+  "/_layout/$teamSlugOrId/orchestration/$orchestrationId"
+)({
+  component: OrchestrationSessionPage,
+  validateSearch: z.object({
+    status: z
+      .enum([
+        "pending",
+        "assigned",
+        "running",
+        "completed",
+        "failed",
+        "cancelled",
+        "all",
+      ])
+      .optional(),
+  }),
+});
+
+function OrchestrationSessionPage() {
+  const { teamSlugOrId, orchestrationId } = Route.useParams();
+  const { status } = Route.useSearch();
+
+  // Prefetch orchestration summary for faster dashboard loading
+  const { data: summary, isLoading: summaryLoading } = useQuery(
+    convexQuery(api.orchestrationQueries.getOrchestrationSummary, {
+      teamSlugOrId,
+    })
+  );
+
+  // Prefetch tasks list filtered by orchestrationId
+  const { data: allTasks, isLoading: tasksLoading } = useQuery(
+    convexQuery(api.orchestrationQueries.listTasksWithDependencyInfo, {
+      teamSlugOrId,
+      status: status === "all" ? undefined : status,
+      limit: 100,
+    })
+  );
+
+  // Filter tasks to only show those belonging to this orchestration
+  const tasks = allTasks?.filter((task) => {
+    const meta = task.metadata as { orchestrationId?: string } | undefined;
+    return meta?.orchestrationId === orchestrationId;
+  });
+
+  return (
+    <FloatingPane
+      header={
+        <TitleBar
+          title={`Orchestration: ${orchestrationId.slice(0, 12)}...`}
+        />
+      }
+    >
+      <OrchestrationDashboard
+        teamSlugOrId={teamSlugOrId}
+        summary={summary}
+        summaryLoading={summaryLoading}
+        tasks={tasks}
+        tasksLoading={tasksLoading}
+        statusFilter={status ?? "all"}
+        orchestrationId={orchestrationId}
+      />
+    </FloatingPane>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `useOrchestrationEvents` hook for managing SSE connections to orchestration event endpoints
- Add `OrchestrationEventStream` component for displaying real-time events
- Add new route `/$teamSlugOrId/orchestration/$orchestrationId` for viewing specific orchestration sessions
- Add link from task rows to their parent orchestration session

## Test plan
- [ ] Navigate to orchestration dashboard
- [ ] Click on an orchestration ID link from a task row
- [ ] Verify event stream connects and shows live events
- [ ] Verify expand/collapse and close buttons work