### PR TITLE
fix(spawner): add CMUX_API_BASE_URL env var for MCP orchestration API

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -48,7 +48,7 @@ import {
   getEditorSettingsUpload,
   type UserUploadedEditorSettings,
 } from "./utils/editorSettings";
-import { env } from "./utils/server-env";
+import { env, getWwwBaseUrl } from "./utils/server-env";
 import { getWwwClient } from "./utils/wwwClient";
 import { getWwwOpenApiModule } from "./utils/wwwOpenApiModule";
 import { buildSystemTimezoneStartupCommand } from "./utils/timezone";
@@ -464,6 +464,7 @@ export async function spawnAgent(
       CMUX_TASK_RUN_JWT: taskRunJwt,
       CMUX_CALLBACK_URL: callbackUrl,
       CMUX_SERVER_URL: cmuxServerUrl, // devsh CLI target (apps/server HTTP API)
+      CMUX_API_BASE_URL: getWwwBaseUrl(), // MCP orchestration API target (apps/www HTTP API)
       CMUX_AGENT_NAME: agent.name,
       PROMPT: processedTaskDescription,
     };


### PR DESCRIPTION
## Summary
- Add `CMUX_API_BASE_URL` environment variable to sandbox spawns
- Uses `getWwwBaseUrl()` to point to the apps/www API server
- Enables MCP orchestration tools (bind_provider_session, push/pull sync) to work correctly

## Problem
The devsh-memory-mcp server defaults `CMUX_API_BASE_URL` to `https://cmux.sh`, which fails for:
- Self-hosted deployments
- Development environments
- Any non-production deployment

This caused 405 errors when agents called orchestration MCP tools.

## Test plan
- [ ] Deploy to staging
- [ ] Spawn task and verify MCP tools can reach orchestration API
- [ ] Verify bind_provider_session works in regular task sandbox