### PR TITLE
fix(sandbox): increase PVE-LXC service startup timeout to 45s

### DIFF
--- a/apps/www/lib/routes/sandboxes.route.ts
+++ b/apps/www/lib/routes/sandboxes.route.ts
@@ -108,7 +108,8 @@ async function waitForVSCodeReady(
   vscodeUrl: string,
   options: { timeoutMs?: number; intervalMs?: number } = {}
 ): Promise<boolean> {
-  const { timeoutMs = 15_000, intervalMs = 500 } = options;
+  // PVE-LXC containers need more time for services to start after clone
+  const { timeoutMs = 45_000, intervalMs = 500 } = options;
   const start = Date.now();
 
   while (Date.now() - start < timeoutMs) {
@@ -140,7 +141,8 @@ async function waitForWorkerReady(
   workerUrl: string,
   options: { timeoutMs?: number; intervalMs?: number } = {}
 ): Promise<boolean> {
-  const { timeoutMs = 15_000, intervalMs = 500 } = options;
+  // PVE-LXC containers need more time for services to start after clone
+  const { timeoutMs = 45_000, intervalMs = 500 } = options;
   const start = Date.now();
 
   while (Date.now() - start < timeoutMs) {


### PR DESCRIPTION
## Summary
PVE-LXC containers need more time for services (VSCode, Worker) to start after clone. The 15s timeout was too short, causing "Worker socket not available" errors.

- Increased `waitForVSCodeReady` default timeout from 15s to 45s
- Increased `waitForWorkerReady` default timeout from 15s to 45s

## Root Cause
After PVE-LXC container clone, systemd services (cmux-ide.service, cmux-worker.service) take longer to start than the 15s timeout. The sandbox start code was proceeding anyway, resulting in "Worker socket not available" when the agent spawner tried to connect.

## Test plan
- [ ] Create a task with any agent on PVE-LXC
- [ ] Verify services become ready within 45s
- [ ] Verify no "Worker socket not available" errors