### PR TITLE
fix(spawn): use X-Task-Run-JWT header and skip teamSlugOrId for JWT auth

### DIFF
--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -780,14 +780,21 @@ async function handleOrchestrationSpawn(
 
   const { teamSlugOrId, prompt, agent, repo, branch, prTitle, environmentId, isCloudMode = true, dependsOn, priority, orchestrationId, isCloudWorkspace, isOrchestrationHead } = body;
 
-  if (!teamSlugOrId || !prompt || !agent) {
-    jsonResponse(res, 400, { error: "Missing required fields: teamSlugOrId, prompt, agent" });
-    return;
-  }
-
   // Check for JWT auth first (allows agents to spawn sub-agents)
   const taskRunJwt = extractTaskRunJwt(req.headers as Record<string, string | string[] | undefined>);
   const authToken = parseAuthHeader(req);
+
+  // For JWT auth, teamSlugOrId is embedded in the token, so only require prompt and agent
+  // For Bearer auth, all three are required
+  if (!prompt || !agent) {
+    jsonResponse(res, 400, { error: "Missing required fields: prompt, agent" });
+    return;
+  }
+
+  if (!taskRunJwt && !teamSlugOrId) {
+    jsonResponse(res, 400, { error: "Missing required field: teamSlugOrId (required for Bearer auth)" });
+    return;
+  }
 
   if (!taskRunJwt && !authToken) {
     jsonResponse(res, 401, { error: "Unauthorized: Missing Bearer token or X-Task-Run-JWT header" });

--- a/packages/devsh-memory-mcp/package.json
+++ b/packages/devsh-memory-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devsh-memory-mcp",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "MCP server for devsh/cmux agent memory - enables Claude Desktop and external clients to access sandbox memory and orchestrate multi-agent workflows",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/devsh-memory-mcp/src/index.ts
+++ b/packages/devsh-memory-mcp/src/index.ts
@@ -1440,7 +1440,7 @@ export function createMemoryMcpServer(config?: Partial<MemoryMcpConfig>) {
           const response = await fetch(url, {
             method: "POST",
             headers: {
-              "Authorization": `Bearer ${jwt}`,
+              "X-Task-Run-JWT": jwt,
               "Content-Type": "application/json",
             },
             body: JSON.stringify({


### PR DESCRIPTION
## Summary

Two issues prevented `spawn_agent` MCP tool from working:

1. **Server** required `teamSlugOrId` in request body even for JWT auth,
   but for JWT auth the teamId is embedded in the token itself.
   Now only requires `prompt` and `agent` for JWT-authenticated requests.

2. **MCP tool** sent `Authorization: Bearer` header instead of `X-Task-Run-JWT`.
   The server's `extractTaskRunJwt()` only checks for `X-Task-Run-JWT` header.

## Test plan

- [ ] Deploy server changes
- [ ] Publish devsh-memory-mcp@0.3.3 to npm
- [ ] Create test task with prompt using spawn_agent MCP tool
- [ ] Verify sub-agents are spawned successfully