### PR TITLE
fix: pass isCloudWorkspace and isOrchestrationHead to spawn flow

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -1940,6 +1940,8 @@ export async function spawnAllAgents(
     }>;
     theme?: "dark" | "light" | "system";
     autopilotOptions?: AutopilotOptions;
+    isCloudWorkspace?: boolean;
+    isOrchestrationHead?: boolean;
   },
   teamSlugOrId: string
 ): Promise<AgentSpawnResult[]> {

--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -73,6 +73,9 @@ interface StartTaskRequest {
   autopilotMinutes?: number;
   autopilotTurnMinutes?: number;
   autopilotWrapUp?: number;
+  // Cloud workspace and orchestration head flags
+  isCloudWorkspace?: boolean;
+  isOrchestrationHead?: boolean;
 }
 
 interface StartTaskResponse {
@@ -212,6 +215,8 @@ async function handleStartTask(
     autopilotMinutes,
     autopilotTurnMinutes,
     autopilotWrapUp,
+    isCloudWorkspace,
+    isOrchestrationHead,
   } = body;
 
   // taskDescription can be empty string for cloud workspaces (interactive TUI session)
@@ -434,6 +439,8 @@ async function handleStartTask(
                 wrapUpMinutes: autopilotWrapUp ?? 3,
               }
             : undefined,
+          isCloudWorkspace,
+          isOrchestrationHead,
         },
         teamSlugOrId
       );

--- a/packages/devsh/internal/cli/task_create.go
+++ b/packages/devsh/internal/cli/task_create.go
@@ -381,6 +381,8 @@ Examples:
 					AutopilotMinutes:     taskCreateAutopilotMinutes,
 					AutopilotTurnMinutes: taskCreateAutopilotTurnMinutes,
 					AutopilotWrapUp:      taskCreateAutopilotWrapUp,
+					IsCloudWorkspace:    taskCreateCloudWorkspace,
+					IsOrchestrationHead: taskCreateCloudWorkspace, // Cloud workspaces are orchestration heads
 				})
 
 				if err != nil {

--- a/packages/devsh/internal/vm/client.go
+++ b/packages/devsh/internal/vm/client.go
@@ -1630,6 +1630,9 @@ type StartTaskAgentsOptions struct {
 	AutopilotMinutes     int
 	AutopilotTurnMinutes int
 	AutopilotWrapUp      int
+	// Cloud workspace and orchestration head flags
+	IsCloudWorkspace    bool
+	IsOrchestrationHead bool
 }
 
 // StartTaskAgentsResult represents the result of starting task agents
@@ -1750,6 +1753,13 @@ func (c *Client) StartTaskAgents(ctx context.Context, opts StartTaskAgentsOption
 		body["autopilotMinutes"] = opts.AutopilotMinutes
 		body["autopilotTurnMinutes"] = opts.AutopilotTurnMinutes
 		body["autopilotWrapUp"] = opts.AutopilotWrapUp
+	}
+	// Cloud workspace and orchestration head flags
+	if opts.IsCloudWorkspace {
+		body["isCloudWorkspace"] = true
+	}
+	if opts.IsOrchestrationHead {
+		body["isOrchestrationHead"] = true
 	}
 
 	resp, err := c.doServerRequest(ctx, "POST", "/api/start-task", body)


### PR DESCRIPTION
## Summary

- Fix: Cloud workspace tasks now properly inject orchestration head environment variables
- When `--cloud-workspace` flag is set, `isOrchestrationHead` is also set to enable JWT-based sub-agent spawning
- Propagate both flags through the full spawn flow: devsh CLI → apps/server HTTP API → agentSpawner

## Changes

**apps/server/src/http-api.ts**
- Add `isCloudWorkspace` and `isOrchestrationHead` to `StartTaskRequest` interface
- Extract and pass these flags to `spawnAllAgents`

**apps/server/src/agentSpawner.ts**
- Add flags to `spawnAllAgents` options type

**packages/devsh/internal/vm/client.go**
- Add fields to `StartTaskAgentsOptions` struct
- Send flags in request body to `/api/start-task`

**packages/devsh/internal/cli/task_create.go**
- Set both flags when `--cloud-workspace` is used

## Test plan

- [x] `bun check` passes
- [x] Local E2E test with `devsh task create --cloud-workspace` creates sandbox
- [ ] Verify spawn_agent MCP tool works in cloud workspace environment