### PR TITLE
fix(mcp): pass orchestration env vars to devsh-memory MCP subprocess

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -863,6 +863,13 @@ export async function spawnAgent(
         orchestrationRules,
         // Shell wrappers disabled by default - must be explicitly enabled in settings
         enableShellWrappers: workspaceSettings?.enableShellWrappers ?? false,
+        // Orchestration environment for MCP server passthrough (spawn_agent needs these)
+        isOrchestrationHead: options.isOrchestrationHead,
+        orchestrationEnv: {
+          CMUX_SERVER_URL: cmuxServerUrl,
+          CMUX_API_BASE_URL: getWwwBaseUrl(),
+          CMUX_ORCHESTRATION_ID: options.orchestrationOptions?.orchestrationId,
+        },
         // GitHub Projects v2 context (Phase 5: Sandbox Project Integration)
         githubProjectContext:
           task?.githubProjectId &&

--- a/packages/shared/src/mcp-preview.ts
+++ b/packages/shared/src/mcp-preview.ts
@@ -71,6 +71,17 @@ export type BuildMergedPreviewOptions = {
   hostConfigText?: string;
   mcpServerConfigs: McpServerConfig[];
   agentName?: string;
+  /**
+   * Orchestration environment variables to pass to the managed devsh-memory MCP server.
+   * These are needed for spawn_agent and other orchestration tools to authenticate.
+   */
+  orchestrationEnv?: {
+    CMUX_TASK_RUN_JWT?: string;
+    CMUX_SERVER_URL?: string;
+    CMUX_API_BASE_URL?: string;
+    CMUX_IS_ORCHESTRATION_HEAD?: string;
+    CMUX_ORCHESTRATION_ID?: string;
+  };
 };
 
 export type WebPreviewAgent = "claude" | "codex" | "opencode";
@@ -329,18 +340,79 @@ function getManagedMemoryArgs(agentName?: string): string[] {
     : ["-y", "devsh-memory-mcp@latest"];
 }
 
-function getManagedClaudeMemoryServer(agentName?: string): JsonObject {
-  return {
+function getManagedClaudeMemoryServer(
+  agentName?: string,
+  orchestrationEnv?: BuildMergedPreviewOptions["orchestrationEnv"],
+): JsonObject {
+  const server: JsonObject = {
     command: "npx",
     args: getManagedMemoryArgs(agentName),
   };
+
+  // Pass orchestration env vars to the MCP server process
+  // These are needed for spawn_agent and other orchestration tools
+  if (orchestrationEnv) {
+    const env: Record<string, string> = {};
+    if (orchestrationEnv.CMUX_TASK_RUN_JWT) {
+      env.CMUX_TASK_RUN_JWT = orchestrationEnv.CMUX_TASK_RUN_JWT;
+    }
+    if (orchestrationEnv.CMUX_SERVER_URL) {
+      env.CMUX_SERVER_URL = orchestrationEnv.CMUX_SERVER_URL;
+    }
+    if (orchestrationEnv.CMUX_API_BASE_URL) {
+      env.CMUX_API_BASE_URL = orchestrationEnv.CMUX_API_BASE_URL;
+    }
+    if (orchestrationEnv.CMUX_IS_ORCHESTRATION_HEAD) {
+      env.CMUX_IS_ORCHESTRATION_HEAD = orchestrationEnv.CMUX_IS_ORCHESTRATION_HEAD;
+    }
+    if (orchestrationEnv.CMUX_ORCHESTRATION_ID) {
+      env.CMUX_ORCHESTRATION_ID = orchestrationEnv.CMUX_ORCHESTRATION_ID;
+    }
+    if (Object.keys(env).length > 0) {
+      server.env = env;
+    }
+  }
+
+  return server;
 }
 
-function getManagedCodexMemoryBlock(agentName?: string): string {
-  return `[mcp_servers.${MANAGED_MEMORY_SERVER_NAME}]
-type = "stdio"
-command = "npx"
-args = ${JSON.stringify(getManagedMemoryArgs(agentName))}`;
+function getManagedCodexMemoryBlock(
+  agentName?: string,
+  orchestrationEnv?: BuildMergedPreviewOptions["orchestrationEnv"],
+): string {
+  const lines = [
+    `[mcp_servers.${MANAGED_MEMORY_SERVER_NAME}]`,
+    `type = "stdio"`,
+    `command = "npx"`,
+    `args = ${JSON.stringify(getManagedMemoryArgs(agentName))}`,
+  ];
+
+  // Pass orchestration env vars to the MCP server process
+  if (orchestrationEnv) {
+    const envEntries: string[] = [];
+    if (orchestrationEnv.CMUX_TASK_RUN_JWT) {
+      envEntries.push(`CMUX_TASK_RUN_JWT = ${JSON.stringify(orchestrationEnv.CMUX_TASK_RUN_JWT)}`);
+    }
+    if (orchestrationEnv.CMUX_SERVER_URL) {
+      envEntries.push(`CMUX_SERVER_URL = ${JSON.stringify(orchestrationEnv.CMUX_SERVER_URL)}`);
+    }
+    if (orchestrationEnv.CMUX_API_BASE_URL) {
+      envEntries.push(`CMUX_API_BASE_URL = ${JSON.stringify(orchestrationEnv.CMUX_API_BASE_URL)}`);
+    }
+    if (orchestrationEnv.CMUX_IS_ORCHESTRATION_HEAD) {
+      envEntries.push(`CMUX_IS_ORCHESTRATION_HEAD = ${JSON.stringify(orchestrationEnv.CMUX_IS_ORCHESTRATION_HEAD)}`);
+    }
+    if (orchestrationEnv.CMUX_ORCHESTRATION_ID) {
+      envEntries.push(`CMUX_ORCHESTRATION_ID = ${JSON.stringify(orchestrationEnv.CMUX_ORCHESTRATION_ID)}`);
+    }
+    if (envEntries.length > 0) {
+      lines.push("");
+      lines.push(`[mcp_servers.${MANAGED_MEMORY_SERVER_NAME}.env]`);
+      lines.push(...envEntries);
+    }
+  }
+
+  return lines.join("\n");
 }
 
 function parseHostJsonConfig(hostConfigText?: string): JsonObject {
@@ -612,7 +684,10 @@ export function buildMergedClaudeConfig(
     mcpServers: {
       ...buildClaudeMcpServers(options.mcpServerConfigs),
       ...existingMcpServers,
-      [MANAGED_MEMORY_SERVER_NAME]: getManagedClaudeMemoryServer(options.agentName),
+      [MANAGED_MEMORY_SERVER_NAME]: getManagedClaudeMemoryServer(
+        options.agentName,
+        options.orchestrationEnv,
+      ),
     },
   };
 }
@@ -709,9 +784,10 @@ export function stripMcpServerBlocksByName(toml: string, names: string[]): strin
 export function ensureManagedMemoryMcpServerConfig(
   toml: string,
   agentName?: string,
+  orchestrationEnv?: BuildMergedPreviewOptions["orchestrationEnv"],
 ): string {
   const normalizedToml = stripManagedMemoryMcpBlock(toml);
-  const managedMemoryBlock = getManagedCodexMemoryBlock(agentName);
+  const managedMemoryBlock = getManagedCodexMemoryBlock(agentName, orchestrationEnv);
 
   if (!normalizedToml) {
     return `${managedMemoryBlock}\n`;
@@ -744,7 +820,7 @@ export function buildMergedCodexConfigToml(
   const filteredToml = stripFilteredConfigKeys(options.hostConfigText ?? "");
   let toml = ensureCodexDefaults(filteredToml);
   toml = stripModelMigrations(toml) + generateModelMigrations();
-  toml = ensureManagedMemoryMcpServerConfig(toml, options.agentName);
+  toml = ensureManagedMemoryMcpServerConfig(toml, options.agentName, options.orchestrationEnv);
 
   const managedConfigs = options.mcpServerConfigs.filter(
     (config) => config.name !== MANAGED_MEMORY_SERVER_NAME,

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -99,10 +99,20 @@ export async function getClaudeEnvironment(
     }
 
     // Build base config from host + MCP servers
+    // Pass orchestration env vars for MCP server passthrough (spawn_agent needs JWT)
     const baseConfig = buildMergedClaudeConfig({
       hostConfigText,
       mcpServerConfigs: ctx.mcpServerConfigs ?? [],
       agentName: ctx.agentName,
+      orchestrationEnv: ctx.isOrchestrationHead
+        ? {
+            CMUX_TASK_RUN_JWT: ctx.taskRunJwt,
+            CMUX_SERVER_URL: ctx.orchestrationEnv?.CMUX_SERVER_URL,
+            CMUX_API_BASE_URL: ctx.orchestrationEnv?.CMUX_API_BASE_URL,
+            CMUX_IS_ORCHESTRATION_HEAD: "1",
+            CMUX_ORCHESTRATION_ID: ctx.orchestrationOptions?.orchestrationId,
+          }
+        : undefined,
     });
 
     // Deep merge user config (user config takes precedence)

--- a/packages/shared/src/providers/common/environment-result.ts
+++ b/packages/shared/src/providers/common/environment-result.ts
@@ -115,4 +115,15 @@ export type EnvironmentContext = {
    * @default false
    */
   enableShellWrappers?: boolean;
+  /**
+   * Orchestration environment variables for MCP server passthrough.
+   * These are passed to the devsh-memory MCP server to enable spawn_agent
+   * and other orchestration tools to authenticate.
+   */
+  orchestrationEnv?: {
+    CMUX_SERVER_URL?: string;
+    CMUX_API_BASE_URL?: string;
+    CMUX_IS_ORCHESTRATION_HEAD?: string;
+    CMUX_ORCHESTRATION_ID?: string;
+  };
 };

--- a/packages/shared/src/providers/openai/environment.ts
+++ b/packages/shared/src/providers/openai/environment.ts
@@ -457,10 +457,20 @@ log "Autopilot completed after \$ITER turns"
     ? `${hostConfigToml}\n\n${userConfigToml}`
     : hostConfigToml;
 
+  // Pass orchestration env vars for MCP server passthrough (spawn_agent needs JWT)
   let toml = buildMergedCodexConfigToml({
     hostConfigText: mergedHostConfig,
     mcpServerConfigs: codexMcpConfigs,
     agentName: ctx.agentName,
+    orchestrationEnv: ctx.isOrchestrationHead
+      ? {
+          CMUX_TASK_RUN_JWT: ctx.taskRunJwt,
+          CMUX_SERVER_URL: ctx.orchestrationEnv?.CMUX_SERVER_URL,
+          CMUX_API_BASE_URL: ctx.orchestrationEnv?.CMUX_API_BASE_URL,
+          CMUX_IS_ORCHESTRATION_HEAD: "1",
+          CMUX_ORCHESTRATION_ID: ctx.orchestrationOptions?.orchestrationId,
+        }
+      : undefined,
   });
 
   // Inject custom provider config if user has a custom base URL


### PR DESCRIPTION
## Summary

- MCP servers run as child processes that don't inherit the parent environment
- For `spawn_agent` to authenticate, the devsh-memory MCP server needs `CMUX_TASK_RUN_JWT` and related orchestration env vars
- This PR adds orchestration env var passthrough to Claude and Codex MCP configs

## Changes

**packages/shared/src/mcp-preview.ts**
- Add `orchestrationEnv` to `BuildMergedPreviewOptions` type
- `getManagedClaudeMemoryServer()` now accepts and injects env vars into MCP config
- `getManagedCodexMemoryBlock()` generates `[mcp_servers.devsh-memory.env]` TOML section
- `buildMergedClaudeConfig` and `buildMergedCodexConfigToml` pass env through

**packages/shared/src/providers/common/environment-result.ts**
- Add `orchestrationEnv` field to `EnvironmentContext` type

**packages/shared/src/providers/anthropic/environment.ts**
- Pass `orchestrationEnv` to `buildMergedClaudeConfig` when `isOrchestrationHead` is true

**packages/shared/src/providers/openai/environment.ts**
- Pass `orchestrationEnv` to `buildMergedCodexConfigToml` when `isOrchestrationHead` is true

**apps/server/src/agentSpawner.ts**
- Add `isOrchestrationHead` and `orchestrationEnv` to environment context
- Pass `CMUX_SERVER_URL`, `CMUX_API_BASE_URL`, `CMUX_ORCHESTRATION_ID`

## Test plan

- [x] `bun check` passes
- [x] `bun test packages/shared/src/mcp-preview.test.ts` passes (21 tests)
- [x] `bun test packages/shared/src/providers/anthropic/environment.test.ts` passes (8 tests)
- [x] `bun test packages/shared/src/providers/openai/environment.test.ts` passes (40 tests)
- [ ] E2E: spawn head agent with `--cloud-workspace`, verify `spawn_agent` MCP tool works

## Related

- Follows PR #590 (isOrchestrationHead flag propagation)
- Root cause documented in Obsidian: `5️⃣-Projects/GitHub/cmux/dev-log/2026-03-17-next-actions-review.md`