### PR TITLE
fix(convex): persist isOrchestrationHead flag to task runs

### DIFF
--- a/packages/convex/convex/cmux_http.ts
+++ b/packages/convex/convex/cmux_http.ts
@@ -1938,6 +1938,7 @@ export const createTask = httpAction(async (ctx, req) => {
     prTitle?: string;
     environmentId?: string;
     isCloudWorkspace?: boolean;
+    isOrchestrationHead?: boolean; // Whether this is a head agent for multi-agent orchestration
     images?: Array<{
       storageId: string;
       fileName?: string;
@@ -2065,6 +2066,7 @@ export const createTask = httpAction(async (ctx, req) => {
           agentName,
           environmentId,
           parentRunId,
+          isOrchestrationHead: body.isOrchestrationHead,
         }) as { taskRunId: Id<"taskRuns">; jwt: string };
 
         taskRuns.push({

--- a/packages/convex/convex/orchestration_http.ts
+++ b/packages/convex/convex/orchestration_http.ts
@@ -60,6 +60,7 @@ const CreateTaskAndRunSchema = z.object({
   newBranch: z.string().optional(),
   environmentId: z.string().optional(),
   pullRequestTitle: z.string().optional(),
+  isOrchestrationHead: z.boolean().optional(), // Whether this is a head agent for orchestration
 });
 
 type CreateTaskAndRunInput = z.infer<typeof CreateTaskAndRunSchema>;
@@ -153,6 +154,7 @@ export const createTaskAndRun = httpAction(async (ctx, req) => {
         agentName: payload.agentName,
         newBranch: payload.newBranch,
         environmentId: payload.environmentId as Id<"environments"> | undefined,
+        isOrchestrationHead: payload.isOrchestrationHead,
       }
     );
 

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -530,6 +530,7 @@ export const createInternal = internalMutation({
     newBranch: v.optional(v.string()),
     environmentId: v.optional(v.id("environments")),
     parentRunId: v.optional(v.id("taskRuns")), // Agent Teams (D4) - parent-child relationships
+    isOrchestrationHead: v.optional(v.boolean()), // Whether this is a head agent for orchestration
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -564,6 +565,7 @@ export const createInternal = internalMutation({
       environmentId: args.environmentId,
       isLocalWorkspace: task.isLocalWorkspace,
       isCloudWorkspace: task.isCloudWorkspace,
+      isOrchestrationHead: args.isOrchestrationHead,
     });
 
     // Update task's lastActivityAt and selectedTaskRunId


### PR DESCRIPTION
## Summary

- `isOrchestrationHead` was being passed through the spawn flow but never persisted to taskRuns
- This meant head agents couldn't be identified after spawn, breaking MCP env passthrough (PR #591)
- Adds the flag to all task run creation paths

## Changes

**packages/convex/convex/taskRuns.ts**
- Accept `isOrchestrationHead` in `createInternal` args
- Store it in the taskRuns table insert

**packages/convex/convex/cmux_http.ts**
- Accept `isOrchestrationHead` in the request body type
- Pass it to `taskRuns.createInternal`

**packages/convex/convex/orchestration_http.ts**
- Add `isOrchestrationHead` to `CreateTaskAndRunSchema`
- Pass it through to `taskRuns.createInternal`

## Test plan

- [x] `bun check` passes
- [ ] E2E: spawn head agent with `--cloud-workspace`, verify `isOrchestrationHead: true` in taskRuns
- [ ] E2E: verify `spawn_agent` MCP tool works with env passthrough

## Related

- Follows PR #591 (MCP env passthrough)
- Root cause: isOrchestrationHead was extracted but never stored