### PR TITLE
fix(devsh): pass isOrchestrationHead flag to Convex task creation

### DIFF
--- a/packages/devsh/internal/cli/task_create.go
+++ b/packages/devsh/internal/cli/task_create.go
@@ -243,6 +243,7 @@ Examples:
 			PRTitle:                     taskCreatePRTitle,
 			EnvironmentID:               environmentID,
 			IsCloudWorkspace:            taskCreateCloudWorkspace,
+			IsOrchestrationHead:         taskCreateCloudWorkspace, // Cloud workspaces are orchestration heads
 			DependsOn:                   taskCreateDependsOn,
 			Priority:                    taskCreatePriority,
 			GithubProjectId:             taskCreateGHProjectId,

--- a/packages/devsh/internal/vm/client.go
+++ b/packages/devsh/internal/vm/client.go
@@ -822,14 +822,15 @@ type Environment struct {
 
 // CreateTaskOptions represents options for creating a task
 type CreateTaskOptions struct {
-	Prompt           string
-	Repository       string
-	BaseBranch       string
-	Agents           []string
-	Images           []TaskImage
-	PRTitle          string
-	EnvironmentID    string
-	IsCloudWorkspace bool
+	Prompt              string
+	Repository          string
+	BaseBranch          string
+	Agents              []string
+	Images              []TaskImage
+	PRTitle             string
+	EnvironmentID       string
+	IsCloudWorkspace    bool
+	IsOrchestrationHead bool // Whether this is a head agent for orchestration
 	// Orchestration dependency tracking
 	DependsOn []string
 	Priority  int
@@ -987,6 +988,9 @@ func (c *Client) CreateTask(ctx context.Context, opts CreateTaskOptions) (*Creat
 	}
 	if opts.IsCloudWorkspace {
 		body["isCloudWorkspace"] = true
+	}
+	if opts.IsOrchestrationHead {
+		body["isOrchestrationHead"] = true
 	}
 	if opts.GithubProjectId != "" {
 		body["githubProjectId"] = opts.GithubProjectId


### PR DESCRIPTION
## Summary

- devsh CLI was passing `isOrchestrationHead` to apps/server for sandbox spawning
- But NOT to Convex for task/taskRun creation
- This meant the flag was never persisted even after PR #592

## Changes

**packages/devsh/internal/vm/client.go**
- Add `IsOrchestrationHead` field to `CreateTaskOptions` struct
- Include `isOrchestrationHead` in request body when true

**packages/devsh/internal/cli/task_create.go**
- Set `IsOrchestrationHead: taskCreateCloudWorkspace` (cloud workspaces are orchestration heads)

## Test plan

- [x] `bun check` passes
- [x] `make install-devsh-dev` succeeds
- [ ] E2E: `devsh task create --cloud-workspace` creates task with `isOrchestrationHead: true`
- [ ] E2E: verify `spawn_agent` MCP tool works

## Related

- Follows PR #591 (MCP env passthrough)
- Follows PR #592 (Convex field persistence)
- Completes the full chain: CLI -> Convex -> agentSpawner -> MCP config