### PR TITLE
feat(devsh): add orchestrate view command for offline bundle replay

### DIFF
--- a/packages/devsh/internal/cli/orchestrate_view.go
+++ b/packages/devsh/internal/cli/orchestrate_view.go
@@ -1,0 +1,121 @@
+// internal/cli/orchestrate_view.go
+package cli
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	orchestrateViewPort    int
+	orchestrateViewNoBrowser bool
+)
+
+//go:embed orchestrate_view.html
+var viewerHTML embed.FS
+
+var orchestrateViewCmd = &cobra.Command{
+	Use:   "view <bundle.json>",
+	Short: "View an exported orchestration bundle in a local browser",
+	Long: `Open a local HTTP server to view an exported orchestration bundle.
+
+This provides an offline, read-only replay viewer for debugging orchestrations
+without requiring Convex, server, or client services running.
+
+The viewer shows the 3-surface split (Operator/Supervisor/Worker) from the
+exported bundle data.
+
+Examples:
+  devsh orchestrate view ./debug-bundle.json
+  devsh orchestrate view ./debug-bundle.json --port 8080
+  devsh orchestrate view ./debug-bundle.json --no-browser`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bundlePath := args[0]
+
+		// Read and validate bundle
+		data, err := os.ReadFile(bundlePath)
+		if err != nil {
+			return fmt.Errorf("failed to read bundle file: %w", err)
+		}
+
+		var bundle ExportBundle
+		if err := json.Unmarshal(data, &bundle); err != nil {
+			return fmt.Errorf("failed to parse bundle JSON: %w", err)
+		}
+
+		// Find available port
+		port := orchestrateViewPort
+		if port == 0 {
+			port = findAvailablePort(3456)
+		}
+
+		// Create HTTP server
+		mux := http.NewServeMux()
+
+		// Serve the bundle data as JSON
+		mux.HandleFunc("/api/bundle", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			json.NewEncoder(w).Encode(bundle)
+		})
+
+		// Serve the HTML viewer
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			tmpl := template.Must(template.ParseFS(viewerHTML, "orchestrate_view.html"))
+			tmpl.Execute(w, nil)
+		})
+
+		addr := fmt.Sprintf("localhost:%d", port)
+		url := fmt.Sprintf("http://%s", addr)
+
+		fmt.Printf("Orchestration Viewer starting at %s\n", url)
+		fmt.Printf("Bundle: %s\n", bundlePath)
+		fmt.Printf("Tasks: %d (completed: %d, failed: %d)\n",
+			bundle.Summary.TotalTasks,
+			bundle.Summary.CompletedTasks,
+			bundle.Summary.FailedTasks)
+		fmt.Println("Press Ctrl+C to stop")
+
+		// Open browser unless --no-browser
+		if !orchestrateViewNoBrowser {
+			go func() {
+				time.Sleep(500 * time.Millisecond)
+				openBrowser(url)
+			}()
+		}
+
+		server := &http.Server{
+			Addr:    addr,
+			Handler: mux,
+		}
+
+		return server.ListenAndServe()
+	},
+}
+
+func findAvailablePort(startPort int) int {
+	for port := startPort; port < startPort+100; port++ {
+		listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+		if err == nil {
+			listener.Close()
+			return port
+		}
+	}
+	return startPort
+}
+
+func init() {
+	orchestrateViewCmd.Flags().IntVarP(&orchestrateViewPort, "port", "p", 0, "Port to serve on (default: auto-select starting at 3456)")
+	orchestrateViewCmd.Flags().BoolVar(&orchestrateViewNoBrowser, "no-browser", false, "Don't automatically open browser")
+	orchestrateCmd.AddCommand(orchestrateViewCmd)
+}

--- a/packages/devsh/internal/cli/orchestrate_view.html
+++ b/packages/devsh/internal/cli/orchestrate_view.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Orchestration Viewer</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0a;
+      color: #e5e5e5;
+      min-height: 100vh;
+    }
+    .container { max-width: 1400px; margin: 0 auto; padding: 24px; }
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid #262626;
+    }
+    h1 { font-size: 24px; font-weight: 600; }
+    .badge {
+      padding: 4px 12px;
+      border-radius: 9999px;
+      font-size: 12px;
+      font-weight: 500;
+    }
+    .badge-completed { background: #166534; color: #bbf7d0; }
+    .badge-failed { background: #991b1b; color: #fecaca; }
+    .badge-running { background: #1e40af; color: #bfdbfe; }
+    .badge-pending { background: #525252; color: #d4d4d4; }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+    .stat-card {
+      background: #171717;
+      border: 1px solid #262626;
+      border-radius: 8px;
+      padding: 16px;
+      text-align: center;
+    }
+    .stat-value { font-size: 32px; font-weight: 700; }
+    .stat-label { font-size: 12px; color: #a3a3a3; margin-top: 4px; }
+
+    .tabs {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 16px;
+      border-bottom: 1px solid #262626;
+    }
+    .tab {
+      padding: 12px 20px;
+      background: none;
+      border: none;
+      color: #a3a3a3;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+      border-bottom: 2px solid transparent;
+      transition: all 0.2s;
+    }
+    .tab:hover { color: #e5e5e5; }
+    .tab.active { color: #e5e5e5; border-bottom-color: #3b82f6; }
+
+    .surface { display: none; }
+    .surface.active { display: block; }
+
+    .task-list { display: flex; flex-direction: column; gap: 12px; }
+    .task-card {
+      background: #171717;
+      border: 1px solid #262626;
+      border-radius: 8px;
+      padding: 16px;
+      cursor: pointer;
+      transition: border-color 0.2s;
+    }
+    .task-card:hover { border-color: #404040; }
+    .task-card.selected { border-color: #3b82f6; }
+    .task-header { display: flex; justify-content: space-between; align-items: start; margin-bottom: 8px; }
+    .task-id { font-family: monospace; font-size: 12px; color: #737373; }
+    .task-prompt { font-size: 14px; line-height: 1.5; }
+    .task-meta { display: flex; gap: 12px; margin-top: 12px; font-size: 12px; color: #737373; }
+
+    .detail-panel {
+      background: #171717;
+      border: 1px solid #262626;
+      border-radius: 8px;
+      padding: 20px;
+      margin-top: 24px;
+    }
+    .detail-section { margin-bottom: 20px; }
+    .detail-section:last-child { margin-bottom: 0; }
+    .detail-label { font-size: 12px; color: #737373; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
+    .detail-content {
+      background: #0a0a0a;
+      border: 1px solid #262626;
+      border-radius: 6px;
+      padding: 12px;
+      font-family: monospace;
+      font-size: 13px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-word;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    .events-timeline { max-height: 500px; overflow-y: auto; }
+    .event-item {
+      display: flex;
+      gap: 12px;
+      padding: 12px 0;
+      border-bottom: 1px solid #262626;
+    }
+    .event-time { font-family: monospace; font-size: 12px; color: #737373; white-space: nowrap; }
+    .event-type { font-size: 12px; font-weight: 500; }
+    .event-message { font-size: 13px; color: #d4d4d4; }
+
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: #737373;
+    }
+
+    @media (max-width: 768px) {
+      .container { padding: 16px; }
+      .summary { grid-template-columns: repeat(2, 1fr); }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>Orchestration Viewer</h1>
+        <p id="orchestration-id" style="font-family: monospace; font-size: 12px; color: #737373; margin-top: 4px;"></p>
+      </div>
+      <span id="status-badge" class="badge"></span>
+    </header>
+
+    <div class="summary" id="summary"></div>
+
+    <div class="tabs">
+      <button class="tab active" data-surface="operator">Operator Brief</button>
+      <button class="tab" data-surface="tasks">Tasks</button>
+      <button class="tab" data-surface="events">Events</button>
+    </div>
+
+    <div id="operator" class="surface active">
+      <div class="detail-panel">
+        <div class="detail-section">
+          <div class="detail-label">Orchestration Summary</div>
+          <div class="detail-content" id="operator-summary"></div>
+        </div>
+        <div class="detail-section">
+          <div class="detail-label">Export Info</div>
+          <div class="detail-content" id="export-info"></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="tasks" class="surface">
+      <div class="task-list" id="task-list"></div>
+      <div class="detail-panel" id="task-detail" style="display: none;">
+        <div class="detail-section">
+          <div class="detail-label">Prompt</div>
+          <div class="detail-content" id="task-prompt"></div>
+        </div>
+        <div class="detail-section" id="result-section" style="display: none;">
+          <div class="detail-label">Result</div>
+          <div class="detail-content" id="task-result"></div>
+        </div>
+        <div class="detail-section" id="error-section" style="display: none;">
+          <div class="detail-label">Error</div>
+          <div class="detail-content" id="task-error" style="color: #fca5a5;"></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="events" class="surface">
+      <div class="events-timeline" id="events-list"></div>
+    </div>
+  </div>
+
+  <script>
+    let bundle = null;
+    let selectedTaskId = null;
+
+    async function loadBundle() {
+      const res = await fetch('/api/bundle');
+      bundle = await res.json();
+      render();
+    }
+
+    function render() {
+      document.getElementById('orchestration-id').textContent = bundle.orchestration.id;
+
+      const statusBadge = document.getElementById('status-badge');
+      statusBadge.textContent = bundle.orchestration.status;
+      statusBadge.className = 'badge badge-' + bundle.orchestration.status;
+
+      document.getElementById('summary').innerHTML = `
+        <div class="stat-card">
+          <div class="stat-value">${bundle.summary.totalTasks}</div>
+          <div class="stat-label">Total Tasks</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" style="color: #4ade80;">${bundle.summary.completedTasks}</div>
+          <div class="stat-label">Completed</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" style="color: #f87171;">${bundle.summary.failedTasks}</div>
+          <div class="stat-label">Failed</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" style="color: #60a5fa;">${bundle.summary.runningTasks}</div>
+          <div class="stat-label">Running</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" style="color: #a3a3a3;">${bundle.summary.pendingTasks}</div>
+          <div class="stat-label">Pending</div>
+        </div>
+      `;
+
+      document.getElementById('operator-summary').textContent =
+        `Status: ${bundle.orchestration.status}\n` +
+        `Tasks: ${bundle.summary.totalTasks} total\n` +
+        `  - Completed: ${bundle.summary.completedTasks}\n` +
+        `  - Failed: ${bundle.summary.failedTasks}\n` +
+        `  - Running: ${bundle.summary.runningTasks}\n` +
+        `  - Pending: ${bundle.summary.pendingTasks}`;
+
+      document.getElementById('export-info').textContent =
+        `Exported: ${bundle.exportedAt}\nVersion: ${bundle.version}`;
+
+      renderTasks();
+      renderEvents();
+    }
+
+    function renderTasks() {
+      const list = document.getElementById('task-list');
+      if (bundle.tasks.length === 0) {
+        list.innerHTML = '<div class="empty-state">No tasks in this orchestration</div>';
+        return;
+      }
+
+      list.innerHTML = bundle.tasks.map(task => `
+        <div class="task-card ${selectedTaskId === task.taskId ? 'selected' : ''}" data-task-id="${task.taskId}">
+          <div class="task-header">
+            <span class="task-id">${task.taskId}</span>
+            <span class="badge badge-${task.status}">${task.status}</span>
+          </div>
+          <div class="task-prompt">${escapeHtml(truncate(task.prompt, 200))}</div>
+          <div class="task-meta">
+            ${task.agentName ? `<span>Agent: ${task.agentName}</span>` : ''}
+            ${task.taskRunId ? `<span>Run: ${task.taskRunId}</span>` : ''}
+          </div>
+        </div>
+      `).join('');
+    }
+
+    function renderEvents() {
+      const list = document.getElementById('events-list');
+      if (!bundle.events || bundle.events.length === 0) {
+        list.innerHTML = '<div class="empty-state">No events captured in this export</div>';
+        return;
+      }
+
+      list.innerHTML = bundle.events.map(event => `
+        <div class="event-item">
+          <span class="event-time">${formatTime(event.timestamp)}</span>
+          <div>
+            <div class="event-type">${event.type}</div>
+            <div class="event-message">${escapeHtml(event.message)}</div>
+          </div>
+        </div>
+      `).join('');
+    }
+
+    function showTaskDetail(taskId) {
+      const task = bundle.tasks.find(t => t.taskId === taskId);
+      if (!task) return;
+
+      selectedTaskId = taskId;
+      renderTasks();
+
+      document.getElementById('task-prompt').textContent = task.prompt;
+
+      const resultSection = document.getElementById('result-section');
+      const errorSection = document.getElementById('error-section');
+
+      if (task.result) {
+        resultSection.style.display = 'block';
+        document.getElementById('task-result').textContent = task.result;
+      } else {
+        resultSection.style.display = 'none';
+      }
+
+      if (task.errorMessage) {
+        errorSection.style.display = 'block';
+        document.getElementById('task-error').textContent = task.errorMessage;
+      } else {
+        errorSection.style.display = 'none';
+      }
+
+      document.getElementById('task-detail').style.display = 'block';
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function truncate(text, maxLen) {
+      return text.length > maxLen ? text.slice(0, maxLen) + '...' : text;
+    }
+
+    function formatTime(ts) {
+      try {
+        return new Date(ts).toLocaleTimeString();
+      } catch {
+        return ts;
+      }
+    }
+
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.surface').forEach(s => s.classList.remove('active'));
+        tab.classList.add('active');
+        document.getElementById(tab.dataset.surface).classList.add('active');
+      });
+    });
+
+    document.getElementById('task-list').addEventListener('click', (e) => {
+      const card = e.target.closest('.task-card');
+      if (card) showTaskDetail(card.dataset.taskId);
+    });
+
+    loadBundle();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `devsh orchestrate view <bundle.json>` command that serves a local HTTP viewer for exported orchestration bundles
- Enables offline debugging without requiring Convex/server/client services
- Embedded HTML viewer with 3-tab layout (Operator Brief, Tasks, Events)
- Dark theme matching cmux design system

## Motivation
TaskCaptain-inspired local-first debug UX. See `taskcaptain-cmux-fit-analysis` research note.

## Test plan
- [ ] `devsh orchestrate export <id> -o test.json`
- [ ] `devsh orchestrate view test.json`
- [ ] Verify browser opens and displays bundle data
- [ ] Click through tabs, select tasks, verify detail panel