### PR TITLE
test(e2b-client): add tests for createE2BHealthCheck function

### DIFF
--- a/packages/e2b-client/src/health.test.ts
+++ b/packages/e2b-client/src/health.test.ts
@@ -242,3 +242,76 @@ describe("E2BHealthMonitor", () => {
     });
   });
 });
+
+describe("createE2BHealthCheck", () => {
+  it("should create a health check function", async () => {
+    const { createE2BHealthCheck } = await import("./health");
+    const healthCheck = createE2BHealthCheck("test-api-key");
+    expect(typeof healthCheck).toBe("function");
+  });
+
+  it("should throw on non-ok response", async () => {
+    const { createE2BHealthCheck } = await import("./health");
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: false,
+        status: 401,
+      } as Response)
+    );
+
+    try {
+      const healthCheck = createE2BHealthCheck("invalid-key");
+      await expect(healthCheck()).rejects.toThrow("E2B API returned 401");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("should succeed on ok response", async () => {
+    const { createE2BHealthCheck } = await import("./health");
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+      } as Response)
+    );
+
+    try {
+      const healthCheck = createE2BHealthCheck("valid-key");
+      await expect(healthCheck()).resolves.toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("should call E2B API with correct headers", async () => {
+    const { createE2BHealthCheck } = await import("./health");
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+      } as Response)
+    );
+    globalThis.fetch = mockFetch;
+
+    try {
+      const healthCheck = createE2BHealthCheck("my-api-key");
+      await healthCheck();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.e2b.dev/sandboxes",
+        {
+          method: "GET",
+          headers: {
+            "X-API-Key": "my-api-key",
+          },
+        }
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 tests for the previously untested `createE2BHealthCheck` function
- Increases E2B client test coverage from 60 to 64 tests

## Tests added
1. Function creation verification
2. Error handling on non-ok response (401)
3. Success on ok response (200)
4. Correct API headers verification (X-API-Key)

## Test plan
- [x] bun check passes
- [x] E2B client tests pass (64/64)