### PR TITLE
feat(pr-heatmap): add PR number support via gh CLI

### DIFF
--- a/packages/devsh/internal/cli/review.go
+++ b/packages/devsh/internal/cli/review.go
@@ -52,15 +52,13 @@ Examples:
 			return fmt.Errorf("OPENAI_API_KEY environment variable is required")
 		}
 
-		// If a PR number is given, we could fetch the PR diff
-		// For now, we use the local git diff
-		if len(args) > 0 {
-			// TODO: Support `gh pr diff` for PR numbers
-			fmt.Fprintf(os.Stderr, "Note: PR number argument not yet supported, using local git diff\n")
-		}
-
 		// Build args for pr-heatmap
 		heatmapArgs := []string{}
+
+		// If a PR number is given, pass it to pr-heatmap
+		if len(args) > 0 && isPRNumber(args[0]) {
+			heatmapArgs = append(heatmapArgs, "-p", args[0])
+		}
 		if reviewBase != "" {
 			heatmapArgs = append(heatmapArgs, "-b", reviewBase)
 		}

--- a/packages/pr-heatmap/README.md
+++ b/packages/pr-heatmap/README.md
@@ -22,6 +22,10 @@ export OPENAI_API_KEY=your-key
 # Generate heatmap for changes against origin/main
 bunx pr-heatmap
 
+# Analyze a specific GitHub PR (requires gh CLI)
+bunx pr-heatmap 123
+bunx pr-heatmap -p 456
+
 # Custom base branch
 bunx pr-heatmap -b main
 
@@ -36,6 +40,7 @@ bunx pr-heatmap -o ./review-output
 
 ```bash
 devsh review                    # Review changes against origin/main
+devsh review 123                # Review PR #123 via gh CLI
 devsh review -b main -v         # Custom base, verbose
 devsh review -m gpt-4o          # Use GPT-4o model
 devsh review --json             # JSON output for scripting
@@ -45,6 +50,7 @@ devsh review --json             # JSON output for scripting
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `-p, --pr <number>` | GitHub PR number (requires gh CLI) | - |
 | `-b, --base <ref>` | Base ref to diff against | `origin/main` |
 | `-c, --concurrency <n>` | Parallel AI calls | `3` |
 | `-m, --model <model>` | OpenAI model | `gpt-4o-mini` |

--- a/packages/pr-heatmap/src/cli.ts
+++ b/packages/pr-heatmap/src/cli.ts
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { generatePRHeatmap } from "./heatmap-generator.js";
 import type { HeatmapOptions, PRHeatmapResult } from "./types.js";
 
-function parseArgs(): HeatmapOptions & { help: boolean } {
+interface ParsedArgs extends HeatmapOptions {
+  help: boolean;
+  prNumber?: string;
+}
+
+function parseArgs(): ParsedArgs {
   const args = process.argv.slice(2);
-  const options: HeatmapOptions & { help: boolean } = {
+  const options: ParsedArgs = {
     base: "origin/main",
     concurrency: 3,
     model: "gpt-4o-mini",
@@ -42,6 +48,16 @@ function parseArgs(): HeatmapOptions & { help: boolean } {
       case "--output":
         options.outputDir = args[++i];
         break;
+      case "-p":
+      case "--pr":
+        options.prNumber = args[++i];
+        break;
+      default:
+        // Check if it's a PR number (positional argument)
+        if (/^\d+$/.test(arg)) {
+          options.prNumber = arg;
+        }
+        break;
     }
   }
 
@@ -52,10 +68,11 @@ function printHelp(): void {
   console.log(`
 pr-heatmap - Generate AI-powered code review heatmaps for PR diffs
 
-Usage: pr-heatmap [options]
+Usage: pr-heatmap [options] [pr-number]
 
 Options:
   -h, --help              Show this help message
+  -p, --pr <number>       GitHub PR number to analyze (requires gh CLI)
   -b, --base <ref>        Base ref to diff against (default: origin/main)
   -c, --concurrency <n>   Number of parallel AI calls (default: 3)
   -m, --model <model>     OpenAI model to use (default: gpt-4o-mini)
@@ -67,6 +84,8 @@ Environment:
 
 Examples:
   pr-heatmap                          # Diff against origin/main
+  pr-heatmap 123                      # Analyze PR #123 via gh CLI
+  pr-heatmap -p 456                   # Analyze PR #456 via gh CLI
   pr-heatmap -b main -v               # Diff against local main, verbose
   pr-heatmap -m gpt-4o -c 5           # Use GPT-4o with 5 concurrent calls
 `);
@@ -133,6 +152,24 @@ function writeOutput(result: PRHeatmapResult, outputDir: string): void {
   console.log(`Wrote ${result.files.length} file heatmaps to: ${outputDir}/`);
 }
 
+/**
+ * Fetch PR diff using gh CLI
+ */
+function getPRDiff(prNumber: string): string {
+  try {
+    return execSync(`gh pr diff ${prNumber}`, {
+      encoding: "utf-8",
+      maxBuffer: 50 * 1024 * 1024, // 50MB for large PRs
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to get PR diff. Ensure gh CLI is installed and authenticated.\n${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
 async function main(): Promise<void> {
   const options = parseArgs();
 
@@ -144,6 +181,20 @@ async function main(): Promise<void> {
   if (!process.env.OPENAI_API_KEY) {
     console.error("Error: OPENAI_API_KEY environment variable is required");
     process.exit(1);
+  }
+
+  // If PR number provided, fetch diff via gh CLI
+  if (options.prNumber) {
+    if (options.verbose) {
+      console.error(`Fetching diff for PR #${options.prNumber} via gh CLI...`);
+    }
+    try {
+      options.diffText = getPRDiff(options.prNumber);
+      options.diffLabel = `PR #${options.prNumber}`;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
   }
 
   try {

--- a/packages/pr-heatmap/src/heatmap-generator.ts
+++ b/packages/pr-heatmap/src/heatmap-generator.ts
@@ -149,14 +149,28 @@ export async function generatePRHeatmap(
     concurrency = DEFAULT_CONCURRENCY,
     model = DEFAULT_MODEL,
     verbose = false,
+    diffText: providedDiff,
+    diffLabel,
   } = options;
 
-  if (verbose) {
-    console.error(`Fetching diff from ${base}...`);
+  // Use provided diff text or fetch from git
+  let diffText: string;
+  let diffSource: string;
+
+  if (providedDiff) {
+    diffText = providedDiff;
+    diffSource = diffLabel ?? "provided diff";
+    if (verbose) {
+      console.error(`Analyzing ${diffSource}...`);
+    }
+  } else {
+    if (verbose) {
+      console.error(`Fetching diff from ${base}...`);
+    }
+    diffText = getGitDiff(base);
+    diffSource = base;
   }
 
-  // Get and parse the diff
-  const diffText = getGitDiff(base);
   const files = parseDiff(diffText);
 
   if (verbose) {
@@ -192,9 +206,13 @@ export async function generatePRHeatmap(
   const allFocusAreas = fileResults.flatMap((f) => f.heatmap.suggestedFocusAreas);
   const topFocusAreas = [...new Set(allFocusAreas)].slice(0, 5);
 
+  // Use appropriate labels based on diff source
+  const baseLabel = providedDiff ? diffSource : getMergeBase(base);
+  const headLabel = providedDiff ? "HEAD" : getHeadCommit();
+
   return {
-    base: getMergeBase(base),
-    head: getHeadCommit(),
+    base: baseLabel,
+    head: headLabel,
     generatedAt: new Date().toISOString(),
     files: fileResults,
     summary: {

--- a/packages/pr-heatmap/src/types.ts
+++ b/packages/pr-heatmap/src/types.ts
@@ -105,4 +105,14 @@ export interface HeatmapOptions {
   model?: string;
   verbose?: boolean;
   outputDir?: string;
+  /**
+   * Raw diff text to analyze instead of computing via git diff.
+   * When provided, `base` is ignored for diff generation.
+   */
+  diffText?: string;
+  /**
+   * Label for the diff source (e.g., "PR #123" or "origin/main").
+   * Used in output metadata when diffText is provided.
+   */
+  diffLabel?: string;
 }


### PR DESCRIPTION
## Summary
- Add `-p, --pr <number>` flag to pr-heatmap CLI for analyzing GitHub PRs
- Support PR number as positional argument (`pr-heatmap 123`)
- Wire PR number support through devsh review command
- Update README with new options and examples

## Changes
- `packages/pr-heatmap/src/types.ts`: Add `diffText` and `diffLabel` options
- `packages/pr-heatmap/src/heatmap-generator.ts`: Support external diff source
- `packages/pr-heatmap/src/cli.ts`: Add PR number parsing and gh CLI integration
- `packages/devsh/internal/cli/review.go`: Forward PR number to pr-heatmap
- `packages/pr-heatmap/README.md`: Document new flags

## Test plan
- [x] `bun check` passes
- [x] `go build ./...` passes
- [x] pr-heatmap unit tests pass
- [ ] Manual: `pr-heatmap 123` fetches and analyzes PR diff