### PR TITLE
docs: add README for shared and pve-lxc-client packages

### DIFF
--- a/packages/pve-lxc-client/README.md
+++ b/packages/pve-lxc-client/README.md
@@ -1,0 +1,109 @@
+# @cmux/pve-lxc-client
+
+Proxmox VE LXC client for managing containers on self-hosted Proxmox infrastructure.
+
+## Overview
+
+This client provides a consistent interface for managing LXC containers on Proxmox VE, mirroring the MorphCloudClient API for seamless provider switching between cloud (Morph, E2B) and self-hosted (PVE-LXC) sandboxes.
+
+## Features
+
+- **Container Lifecycle**: Create, start, stop, and delete LXC containers
+- **Command Execution**: Run commands inside containers via `lxc-attach`
+- **HTTP Services**: Expose and manage HTTP services from containers
+- **Snapshot Support**: Clone containers from templates using canonical snapshot IDs
+- **Cloudflare Integration**: Optional public domain routing via Cloudflare Tunnel
+
+## Installation
+
+This is a private workspace package. Import from other packages:
+
+```typescript
+import { PveLxcClient, PveLxcInstance } from "@cmux/pve-lxc-client";
+```
+
+## Configuration
+
+```typescript
+const client = new PveLxcClient({
+  apiUrl: "https://pve.example.com:8006",
+  apiToken: "user@pam!tokenid=secret-token-uuid",
+  node: "pve",
+  publicDomain: "example.com", // Optional: for Cloudflare Tunnel
+  verifyTls: true,
+});
+```
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PVE_API_URL` | Proxmox VE API endpoint |
+| `PVE_API_TOKEN` | API token in `user@realm!tokenid=secret` format |
+| `PVE_PUBLIC_DOMAIN` | Public domain for Cloudflare Tunnel (optional) |
+
+## Usage
+
+### Create a Container
+
+```typescript
+const instance = await client.startContainer({
+  snapshotId: "snapshot_abc123",
+  metadata: {
+    app: "cmux",
+    teamId: "team_123",
+  },
+});
+
+console.log(instance.id); // "pvelxc-xyz789"
+console.log(instance.networking.httpServices);
+```
+
+### Execute Commands
+
+```typescript
+const result = await instance.exec("echo hello");
+console.log(result.stdout); // "hello"
+console.log(result.exit_code); // 0
+```
+
+### Stop and Delete
+
+```typescript
+await instance.stop();
+await instance.delete();
+```
+
+## API Reference
+
+### PveLxcClient
+
+| Method | Description |
+|--------|-------------|
+| `startContainer(options)` | Create and start a new container from snapshot |
+| `getInstance(id)` | Get an existing container instance |
+| `listInstances()` | List all managed containers |
+| `stopContainer(id)` | Stop a running container |
+| `deleteContainer(id)` | Delete a container |
+
+### PveLxcInstance
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | string | Instance ID (e.g., "pvelxc-abc123") |
+| `vmid` | number | Proxmox VMID |
+| `status` | ContainerStatus | "running", "stopped", "paused", "unknown" |
+| `networking` | ContainerNetworking | HTTP services and hostname |
+| `metadata` | ContainerMetadata | Custom metadata tags |
+
+| Method | Description |
+|--------|-------------|
+| `exec(command)` | Execute command in container |
+| `stop()` | Stop the container |
+| `delete()` | Delete the container |
+
+## Related
+
+- `apps/edge-router-pvelxc/` - Edge router for PVE-LXC sandboxes
+- `scripts/snapshot-pvelxc.py` - Snapshot builder script
+- `scripts/pve/pve-lxc-setup.sh` - Template setup script

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,84 @@
+# @cmux/shared
+
+Shared utilities, types, and modules used across the cmux monorepo.
+
+## Overview
+
+This package provides common functionality including:
+
+- **Agent Configuration**: Agent catalogs, configs, and policy rules
+- **Socket Communication**: WebSocket client/server for real-time updates
+- **Provider Types**: Sandbox provider interfaces and presets
+- **Memory Protocol**: Agent memory system for cross-session persistence
+- **Model Usage**: Token counting and usage tracking
+- **Crown Evaluation**: Code review and task completion scoring
+- **Resilience**: Circuit breakers, retry logic, rate limiting
+
+## Installation
+
+This is a private workspace package. Import from other packages in the monorepo:
+
+```typescript
+import { agentCatalog } from "@cmux/shared/agent-catalog";
+import { CircuitBreaker } from "@cmux/shared/resilience";
+```
+
+## Key Modules
+
+### Agent System
+
+| Export | Description |
+|--------|-------------|
+| `agent-catalog` | Registry of supported AI agents (Claude, Codex, Gemini, etc.) |
+| `agentConfig` | Agent configuration schemas and types |
+| `agent-policy` | Policy rules for agent behavior |
+| `agent-memory-protocol` | Cross-session memory persistence |
+
+### Communication
+
+| Export | Description |
+|--------|-------------|
+| `socket` | WebSocket client for browser |
+| `node/socket` | WebSocket server for Node.js |
+| `agent-comm-events` | Inter-agent communication event types |
+
+### Providers
+
+| Export | Description |
+|--------|-------------|
+| `provider-types` | Sandbox provider interfaces |
+| `sandbox-presets` | Pre-configured sandbox templates |
+| `e2b-templates` | E2B sandbox template definitions |
+
+### Resilience
+
+| Export | Description |
+|--------|-------------|
+| `resilience` | Circuit breakers, retry with backoff |
+| `resilience/circuit-breaker` | Circuit breaker implementation |
+| `resilience/retry` | Retry with exponential backoff and jitter |
+
+### Utilities
+
+| Export | Description |
+|--------|-------------|
+| `utils/typed-zid` | Type-safe Zod ID generation |
+| `utils/reserved-cmux-ports` | Port allocation constants |
+| `obsidian-reader` | Obsidian vault parsing utilities |
+
+## Development
+
+```bash
+cd packages/shared
+bun run test        # Run tests (439 tests)
+bun run typecheck   # Type check
+```
+
+## Test Coverage
+
+The package has comprehensive test coverage including:
+- Agent catalog validation
+- Memory protocol operations
+- Circuit breaker state transitions
+- Retry logic with jitter
+- WebSocket event handling


### PR DESCRIPTION
## Summary
- Add README for `@cmux/shared` package documenting key modules and exports
- Add README for `@cmux/pve-lxc-client` package documenting API and usage

## Details

### @cmux/shared README
- Overview of 47 exports across 60 source files
- Key modules table: agent system, communication, providers, resilience, utilities
- Development and test commands

### @cmux/pve-lxc-client README
- Configuration and environment variables
- Usage examples for container lifecycle
- API reference for client and instance classes
- Related files and scripts

## Test plan
- [x] `bun check` passes
- [x] Documentation-only change, no runtime impact