### PR TITLE
docs: add README for remaining packages

### DIFF
--- a/packages/host-screenshot-collector/README.md
+++ b/packages/host-screenshot-collector/README.md
@@ -1,0 +1,67 @@
+# @cmux/host-screenshot-collector
+
+Screenshot and video recording collector for cmux sandbox environments.
+
+## Overview
+
+This package provides tools for capturing and processing screen recordings in cmux sandboxes. It monitors Claude agent activity and creates workflow videos with cursor overlays.
+
+## Features
+
+- **Screenshot Collection**: Captures screenshots during agent execution
+- **Video Recording**: Records screen activity as MP4
+- **Cursor Overlay**: Adds cursor animation based on click events
+- **GIF Generation**: Creates preview GIFs for GitHub comments
+- **Post-Processing**: Trims inactive sections and adjusts playback speed
+
+## Installation
+
+```bash
+cd packages/host-screenshot-collector
+bun install
+bun run build
+```
+
+## Usage
+
+The collector runs inside sandbox environments and is typically started automatically by the sandbox runtime.
+
+### Manual Execution
+
+```bash
+# Run the collector
+bun run dist/index.js
+```
+
+### Output Files
+
+Screenshots and videos are stored in `/root/screenshots/`:
+
+| File | Description |
+|------|-------------|
+| `raw.mp4` | Raw screen recording |
+| `events.log` | JSON-lines click event log |
+| `workflow.mp4` | Processed video with cursor overlay |
+| `workflow.gif` | Animated GIF preview |
+| `video-metadata.json` | Recording metadata |
+
+## Post-Processing
+
+The embedded Python script handles video post-processing:
+
+1. Parses click events from `events.log`
+2. Overlays cursor animation at click positions
+3. Trims inactive sections
+4. Speeds up transitions
+5. Generates GIF preview (< 20MB for Convex storage)
+
+## Dependencies
+
+- `@anthropic-ai/claude-agent-sdk` - Agent query interface
+- `ffmpeg` - Video processing (runtime dependency)
+- `python3` - Post-processing script
+
+## Related
+
+- `packages/sandbox/` - Sandbox runtime that invokes the collector
+- `apps/server/` - Receives and stores processed recordings

--- a/packages/morphcloud-openapi-client/README.md
+++ b/packages/morphcloud-openapi-client/README.md
@@ -1,0 +1,49 @@
+# @cmux/morphcloud-openapi-client
+
+Auto-generated TypeScript client for the Morph Cloud API.
+
+## Overview
+
+This package provides type-safe API bindings for [Morph Cloud](https://morphvm.cloud), a cloud VM provider used by cmux for sandbox provisioning.
+
+## Generation
+
+This client is auto-generated from the Morph Cloud OpenAPI specification using `@hey-api/openapi-ts`.
+
+```bash
+# Regenerate client (if spec changes)
+cd packages/morphcloud-openapi-client
+bun run generate
+```
+
+## Usage
+
+```typescript
+import { createClient } from "@cmux/morphcloud-openapi-client";
+
+const client = createClient({
+  baseUrl: "https://api.morphvm.cloud",
+  headers: {
+    Authorization: `Bearer ${process.env.MORPH_API_KEY}`,
+  },
+});
+
+// Create a VM instance
+const instance = await client.POST("/instances", {
+  body: { snapshotId: "snapshot_abc123" },
+});
+```
+
+## API Coverage
+
+The client provides typed bindings for:
+
+- Instance lifecycle (create, start, stop, delete)
+- Snapshot management
+- Command execution
+- HTTP service exposure
+
+## Related
+
+- `apps/server/src/providers/morph.ts` - Morph provider implementation
+- `packages/shared/src/provider-types.ts` - Provider interface types

--- a/packages/www-openapi-client/README.md
+++ b/packages/www-openapi-client/README.md
@@ -1,0 +1,53 @@
+# @cmux/www-openapi-client
+
+Auto-generated TypeScript client for the cmux WWW API.
+
+## Overview
+
+This package provides type-safe API bindings for the cmux web application's Hono backend (`apps/www`).
+
+## Generation
+
+This client is auto-generated from the OpenAPI specification produced by the Hono app. The generator runs automatically when the dev server is running.
+
+```bash
+# Manual regeneration
+cd apps/www
+bun run generate-openapi-client
+```
+
+## Usage
+
+```typescript
+import { createClient } from "@cmux/www-openapi-client";
+
+const client = createClient({
+  baseUrl: process.env.NEXT_PUBLIC_WWW_ORIGIN,
+});
+
+// Example: Create a task
+const task = await client.POST("/api/tasks", {
+  body: { prompt: "Fix the bug", repo: "owner/repo" },
+});
+```
+
+## API Coverage
+
+The client provides typed bindings for:
+
+- Task management (create, list, status)
+- GitHub integration (repos, PRs, projects)
+- Vault operations (notes, search)
+- User settings and preferences
+
+## Development Notes
+
+- The client types are generated from Zod schemas in `apps/www/lib/routes/`
+- Changes to API routes require dev server restart to regenerate
+- Type exports are available at `@cmux/www-openapi-client/types`
+
+## Related
+
+- `apps/www/lib/hono-app.ts` - Hono app definition
+- `apps/www/lib/routes/` - API route handlers
+- `apps/client/` - React frontend that uses this client


### PR DESCRIPTION
## Summary
Complete package documentation coverage with READMEs for the last 3 packages.

## Packages
- `@cmux/host-screenshot-collector` - Screenshot/video collection for sandboxes
- `@cmux/morphcloud-openapi-client` - Auto-generated Morph Cloud API client
- `@cmux/www-openapi-client` - Auto-generated WWW API client

## Result
All packages in `packages/` now have README documentation.

## Test plan
- [x] `bun check` passes
- [x] Documentation-only change