### PR TITLE
docs: add README for apps (server, client, routers, proxy)

### DIFF
--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -1,0 +1,82 @@
+# @cmux/client
+
+React frontend for cmux - the web UI for managing coding agents and orchestration.
+
+## Overview
+
+This is the main web application that provides:
+
+- **Dashboard**: View and manage active sessions and tasks
+- **Orchestration UI**: Monitor agent teams and task progress
+- **Settings**: Configure agents, rules, and preferences
+- **Terminal**: Embedded terminal for sandbox interaction
+
+## Tech Stack
+
+- **React 19** with TypeScript
+- **TanStack Router** for routing
+- **TanStack Query** for data fetching
+- **Convex** for real-time subscriptions
+- **Shadcn UI** + Tailwind CSS for styling
+- **Vite** for development and builds
+
+## Development
+
+```bash
+# Start dev server (from workspace root)
+./scripts/dev.sh
+
+# Or run directly
+cd apps/client
+bun run dev
+```
+
+The client runs on `http://localhost:5173` by default.
+
+### Testing
+
+```bash
+cd apps/client
+bun run test        # Run tests (116 tests)
+bun run typecheck   # Type check
+```
+
+## Key Components
+
+### Dashboard
+
+| Component | Description |
+|-----------|-------------|
+| `TaskItem.tsx` | Individual task card |
+| `SessionList.tsx` | Active session list |
+| `TaskFilters.tsx` | Filter and search tasks |
+
+### Orchestration
+
+| Component | Description |
+|-----------|-------------|
+| `OrchestrationDashboard.tsx` | Main orchestration view |
+| `OrchestrationTaskDetail.tsx` | 3-surface task detail |
+| `OrchestrationEventStream.tsx` | Real-time event log |
+| `OrchestrationDependencyGraph.tsx` | Task dependency visualization |
+
+### Settings
+
+| Component | Description |
+|-----------|-------------|
+| `OrchestrationRulesSection.tsx` | Manage learning rules |
+| `AgentConfigsSection.tsx` | Agent configurations |
+| `SupervisorProfilesSection.tsx` | Supervisor settings |
+
+## Environment
+
+| Variable | Description |
+|----------|-------------|
+| `VITE_CONVEX_URL` | Convex backend URL |
+| `VITE_SERVER_URL` | Server API URL |
+
+## Related
+
+- `apps/server/` - Backend server
+- `packages/convex/` - Convex functions
+- `apps/www/` - Landing page and auth

--- a/apps/edge-router-pvelxc/README.md
+++ b/apps/edge-router-pvelxc/README.md
@@ -1,0 +1,43 @@
+# edge-router-pvelxc
+
+Cloudflare Worker edge router for cmux PVE-LXC sandboxes.
+
+## Overview
+
+This is a Cloudflare Worker that routes requests to self-hosted PVE-LXC sandbox instances. It's a fork of `edge-router` adapted for Proxmox VE containers.
+
+## Deployment
+
+```bash
+cd apps/edge-router-pvelxc
+bun run deploy
+```
+
+Deploys to Cloudflare Workers via Wrangler. Routes to `*.alphasolves.com`.
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PVE_API_URL` | Proxmox VE API endpoint |
+| `PVE_API_TOKEN` | API token for authentication |
+
+## Routes
+
+| Pattern | Target |
+|---------|--------|
+| `<id>.alphasolves.com/*` | PVE-LXC container HTTP |
+| `<id>.alphasolves.com/ws/*` | PVE-LXC container WebSocket |
+
+## Differences from edge-router
+
+- Routes to PVE-LXC containers instead of Morph VMs
+- Uses Cloudflare Tunnel for connectivity
+- Deployed to `alphasolves.com` domain
+
+## Related
+
+- `apps/edge-router/` - Morph Cloud variant
+- `packages/pve-lxc-client/` - PVE-LXC API client

--- a/apps/edge-router/README.md
+++ b/apps/edge-router/README.md
@@ -1,0 +1,50 @@
+# edge-router
+
+Cloudflare Worker edge router for cmux Morph sandboxes.
+
+## Overview
+
+This is a Cloudflare Worker that routes requests to Morph Cloud sandbox instances. It handles:
+
+- **Subdomain Routing**: Routes `<sandbox-id>.cmux.sh` to the correct instance
+- **WebSocket Proxying**: Terminal and real-time connections
+- **Health Checks**: Instance availability monitoring
+
+## Deployment
+
+```bash
+cd apps/edge-router
+bun run deploy
+```
+
+Deploys to Cloudflare Workers via Wrangler.
+
+## Configuration
+
+### wrangler.toml
+
+```toml
+name = "cmux-edge-router"
+main = "src/index.ts"
+
+[vars]
+MORPH_API_URL = "https://api.morphvm.cloud"
+```
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MORPH_API_KEY` | Morph Cloud API key (secret) |
+
+## Routes
+
+| Pattern | Target |
+|---------|--------|
+| `<id>.cmux.sh/*` | Morph instance HTTP |
+| `<id>.cmux.sh/ws/*` | Morph instance WebSocket |
+
+## Related
+
+- `apps/edge-router-pvelxc/` - PVE-LXC variant
+- `packages/morphcloud-openapi-client/` - Morph API client

--- a/apps/global-proxy/README.md
+++ b/apps/global-proxy/README.md
@@ -1,0 +1,61 @@
+# global-proxy
+
+Rust-based reverse proxy for cmux sandbox routing.
+
+## Overview
+
+A high-performance reverse proxy written in Rust that routes requests to sandbox instances across multiple providers. Designed for deployment on Google Cloud Run.
+
+## Features
+
+- **Multi-Provider Routing**: Routes to Morph, E2B, and PVE-LXC backends
+- **WebSocket Support**: Full WebSocket proxying for terminals
+- **Auto-Scaling**: Scales automatically on Cloud Run
+- **Zero Downtime**: Rolling deployments with health checks
+
+## Development
+
+```bash
+cd apps/global-proxy
+cargo build
+cargo test
+cargo run
+```
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PORT` | Listen port (injected by Cloud Run) |
+| `GLOBAL_PROXY_BACKEND_SCHEME` | Backend scheme (`https`) |
+| `GLOBAL_PROXY_MORPH_DOMAIN_SUFFIX` | Morph domain suffix |
+| `GLOBAL_PROXY_WORKSPACE_DOMAIN_SUFFIX` | Workspace domain suffix |
+
+## Deployment
+
+See [DEPLOYMENT.md](./DEPLOYMENT.md) for Cloud Run deployment instructions.
+
+```bash
+# Build and push
+docker build -t REGION-docker.pkg.dev/PROJECT/cmux/global-proxy:TAG .
+docker push REGION-docker.pkg.dev/PROJECT/cmux/global-proxy:TAG
+
+# Deploy to Cloud Run
+gcloud run deploy global-proxy --image=IMAGE_URL
+```
+
+## Architecture
+
+```
+Request → global-proxy → Provider Backend
+              ↓
+         Route by subdomain pattern:
+         - *.morph.so → Morph Cloud
+         - *.e2b.dev → E2B
+         - *.alphasolves.com → PVE-LXC
+```
+
+## Related
+
+- `apps/edge-router/` - Cloudflare Worker router (Morph)
+- `apps/edge-router-pvelxc/` - Cloudflare Worker router (PVE-LXC)

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,88 @@
+# @cmux/server
+
+Backend server for cmux - handles agent spawning, orchestration, and real-time communication.
+
+## Overview
+
+This is the main backend server that powers cmux. It provides:
+
+- **Agent Spawning**: Create and manage sandbox instances across providers
+- **Orchestration API**: JWT-authenticated endpoints for head agents
+- **Real-time Updates**: Socket.io for live session updates
+- **Git Integration**: Diff capture and repository management
+
+## Architecture
+
+```
+src/
+├── agentSpawner.ts       # Agent spawn logic and provider routing
+├── http-api.ts           # Hono HTTP API routes
+├── socket-handlers.ts    # Socket.io event handlers
+├── realtime.ts           # Real-time update broadcasting
+├── diffs/                # Git diff utilities
+├── providers/            # Sandbox provider implementations
+└── vscode/               # VS Code server integration
+```
+
+## Key Modules
+
+### Agent Spawning
+
+| File | Description |
+|------|-------------|
+| `agentSpawner.ts` | Main spawn orchestration |
+| `agentSpawnerSDK.ts` | SDK for programmatic spawning |
+
+### HTTP API
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /api/orchestrate/spawn` | Spawn new agent (JWT auth) |
+| `GET /api/orchestrate/status/:id` | Get task status |
+| `POST /api/orchestrate/cancel/:id` | Cancel running task |
+| `GET /api/orchestrate/events/:id` | SSE event stream |
+
+### Providers
+
+The server routes spawn requests to configured providers:
+
+- **E2B**: Cloud sandbox (primary)
+- **PVE-LXC**: Self-hosted Proxmox containers
+- **Morph**: Morph Cloud VMs (deprioritized)
+
+## Development
+
+```bash
+# Start dev server (from workspace root)
+./scripts/dev.sh
+
+# Or run directly
+cd apps/server
+bun run dev
+```
+
+### Testing
+
+```bash
+cd apps/server
+bun run test        # Run tests (~150 tests)
+bun run typecheck   # Type check
+```
+
+### Environment
+
+Key environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `NEXT_PUBLIC_CONVEX_URL` | Convex backend URL |
+| `E2B_API_KEY` | E2B provider key |
+| `PVE_API_URL` | Proxmox API endpoint |
+| `CMUX_TASK_RUN_JWT_SECRET` | JWT signing secret |
+
+## Related
+
+- `packages/convex/` - Convex backend functions
+- `apps/client/` - React frontend
+- `packages/e2b-client/` - E2B client library
+- `packages/pve-lxc-client/` - PVE-LXC client library


### PR DESCRIPTION
## Summary
Add documentation for the main application packages in `apps/`.

## Apps Documented
- `@cmux/server` - Backend API, agent spawning, orchestration endpoints
- `@cmux/client` - React frontend with dashboard, orchestration UI, settings
- `edge-router` - Cloudflare Worker for Morph sandbox routing
- `edge-router-pvelxc` - Cloudflare Worker for PVE-LXC sandbox routing
- `global-proxy` - Rust reverse proxy for Cloud Run deployment

## Note
`apps/landing` and `apps/www` were skipped:
- `landing` has no package.json (empty/deprecated)
- `www` already has inline documentation in routes

## Test plan
- [x] `bun check` passes
- [x] Documentation-only change