### PR TITLE
fix(global-proxy): allow clippy::result_large_err in tests

### DIFF
--- a/apps/global-proxy/tests/proxy_tests.rs
+++ b/apps/global-proxy/tests/proxy_tests.rs
@@ -1,3 +1,6 @@
+// Allow large error types in test closures - not worth optimizing for tests
+#![allow(clippy::result_large_err)]
+
 use std::{
     net::{Ipv4Addr, SocketAddr},
     sync::{Arc, Mutex},


### PR DESCRIPTION
## Summary
Fix clippy error in global-proxy test file by allowing large error types in test closures.

## Problem
The Rust clippy check fails with `result_large_err` because the WebSocket handshake closures return `hyper::Response<Option<String>>` which is 136 bytes.

## Solution
Add `#![allow(clippy::result_large_err)]` to the test file. This is acceptable for tests and not worth optimizing.

## Test plan
- [x] `bun check` passes
- [ ] Rust checks should pass with this fix