### PR TITLE
fix(e2b-client): add missing test script

### DIFF
--- a/packages/e2b-client/package.json
+++ b/packages/e2b-client/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
+    "test": "bun test",
     "typecheck": "bunx tsgo --noEmit -p tsconfig.json",
     "lint": "eslint ."
   },


### PR DESCRIPTION
## Summary
- Add `test` script to e2b-client package.json
- Package has 64 tests using `bun:test` but no way to run them via `bun run test`

## Test plan
- [x] `bun run test` runs 64 tests, all pass
- [x] `bun check` passes