### PR TITLE
test: add tests for diff-colors and editorDetection

### DIFF
--- a/apps/client/src/lib/diff-colors.test.ts
+++ b/apps/client/src/lib/diff-colors.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { diffColors, getDiffColorPalette } from "./diff-colors";
+
+describe("diffColors", () => {
+  describe("structure validation", () => {
+    it("has light and dark themes", () => {
+      expect(diffColors).toHaveProperty("light");
+      expect(diffColors).toHaveProperty("dark");
+    });
+
+    it("each theme has addition, deletion, and collapsed sections", () => {
+      for (const theme of ["light", "dark"] as const) {
+        expect(diffColors[theme]).toHaveProperty("addition");
+        expect(diffColors[theme]).toHaveProperty("deletion");
+        expect(diffColors[theme]).toHaveProperty("collapsed");
+      }
+    });
+
+    it("addition and deletion have required tone properties", () => {
+      const requiredToneProps = [
+        "lineBackground",
+        "gutterBackground",
+        "textBackground",
+        "lineNumberForeground",
+      ];
+
+      for (const theme of ["light", "dark"] as const) {
+        for (const section of ["addition", "deletion"] as const) {
+          for (const prop of requiredToneProps) {
+            expect(diffColors[theme][section]).toHaveProperty(prop);
+            expect(typeof diffColors[theme][section][prop as keyof typeof diffColors.light.addition]).toBe("string");
+          }
+        }
+      }
+    });
+
+    it("collapsed has required properties", () => {
+      for (const theme of ["light", "dark"] as const) {
+        expect(diffColors[theme].collapsed).toHaveProperty("background");
+        expect(diffColors[theme].collapsed).toHaveProperty("foreground");
+        expect(typeof diffColors[theme].collapsed.background).toBe("string");
+        expect(typeof diffColors[theme].collapsed.foreground).toBe("string");
+      }
+    });
+  });
+
+  describe("color format validation", () => {
+    it("light theme colors are valid hex codes", () => {
+      // Light theme uses full hex codes
+      expect(diffColors.light.addition.lineBackground).toMatch(/^#[0-9a-fA-F]{6}$/);
+      expect(diffColors.light.deletion.lineBackground).toMatch(/^#[0-9a-fA-F]{6}$/);
+    });
+
+    it("dark theme colors are valid hex codes (with alpha)", () => {
+      // Dark theme uses hex with alpha channel
+      expect(diffColors.dark.addition.lineBackground).toMatch(/^#[0-9a-fA-F]{6,8}$/);
+      expect(diffColors.dark.deletion.lineBackground).toMatch(/^#[0-9a-fA-F]{6,8}$/);
+    });
+  });
+
+  describe("semantic correctness", () => {
+    it("light theme addition uses green-ish tones", () => {
+      // Green components should be prominent in addition colors
+      const lineNumberFg = diffColors.light.addition.lineNumberForeground;
+      expect(lineNumberFg.toLowerCase()).toMatch(/#[0-9a-f]{2}[6-9a-f][0-9a-f]{3}/);
+    });
+
+    it("light theme deletion uses red-ish tones", () => {
+      // Red components should be prominent in deletion colors
+      const bg = diffColors.light.deletion.lineBackground;
+      expect(bg.toLowerCase()).toMatch(/#f/);
+    });
+  });
+});
+
+describe("getDiffColorPalette", () => {
+  it("returns light palette for light theme", () => {
+    const palette = getDiffColorPalette("light");
+    expect(palette).toBe(diffColors.light);
+  });
+
+  it("returns dark palette for dark theme", () => {
+    const palette = getDiffColorPalette("dark");
+    expect(palette).toBe(diffColors.dark);
+  });
+
+  it("returns a valid DiffColorPalette structure", () => {
+    const palette = getDiffColorPalette("light");
+
+    // Type check via property access
+    expect(palette.addition).toBeDefined();
+    expect(palette.deletion).toBeDefined();
+    expect(palette.collapsed).toBeDefined();
+
+    expect(palette.addition.lineBackground).toBe("#dafbe1");
+    expect(palette.deletion.lineBackground).toBe("#ffebe9");
+  });
+
+  it("returns different palettes for different themes", () => {
+    const lightPalette = getDiffColorPalette("light");
+    const darkPalette = getDiffColorPalette("dark");
+
+    expect(lightPalette).not.toBe(darkPalette);
+    expect(lightPalette.addition.lineBackground).not.toBe(
+      darkPalette.addition.lineBackground
+    );
+  });
+});

--- a/apps/server/src/utils/editorDetection.test.ts
+++ b/apps/server/src/utils/editorDetection.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { macAppBin, pathExists } from "./editorDetection";
+
+describe("macAppBin", () => {
+  it("returns empty string on non-darwin platforms", () => {
+    // Since we're running on linux, this should return empty
+    if (process.platform !== "darwin") {
+      expect(macAppBin("Visual Studio Code", "code")).toBe("");
+    }
+  });
+
+  it("constructs correct path structure on darwin", () => {
+    // We can only verify the path construction logic
+    if (process.platform === "darwin") {
+      const result = macAppBin("Cursor", "cursor");
+      expect(result).toBe(
+        "/Applications/Cursor.app/Contents/Resources/app/bin/cursor"
+      );
+    }
+  });
+
+  it("handles special characters in app name", () => {
+    if (process.platform === "darwin") {
+      const result = macAppBin("Visual Studio Code", "code");
+      expect(result).toContain("Visual Studio Code.app");
+    }
+  });
+});
+
+describe("pathExists", () => {
+  it("returns false for empty string", async () => {
+    expect(await pathExists("")).toBe(false);
+  });
+
+  it("returns true for existing path", async () => {
+    // Current directory should always exist
+    expect(await pathExists(process.cwd())).toBe(true);
+  });
+
+  it("returns true for existing file", async () => {
+    // This test file should exist
+    expect(await pathExists(import.meta.filename)).toBe(true);
+  });
+
+  it("returns false for non-existent path", async () => {
+    expect(await pathExists("/nonexistent/path/to/file")).toBe(false);
+  });
+
+  it("returns false for null-like values", async () => {
+    // Empty string check is the guard for falsy paths
+    expect(await pathExists("")).toBe(false);
+  });
+});


### PR DESCRIPTION
Add unit tests for:
- `apps/client/src/lib/diff-colors.ts`: 12 tests for color palette structure and getDiffColorPalette
- `apps/server/src/utils/editorDetection.ts`: 8 tests for macAppBin and pathExists utilities