### PR TITLE
test(shared): add tests for anthropic catalog and opencode free-models

### DIFF
--- a/packages/shared/src/providers/anthropic/catalog.test.ts
+++ b/packages/shared/src/providers/anthropic/catalog.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { CLAUDE_CATALOG } from "./catalog";
+
+describe("CLAUDE_CATALOG", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(CLAUDE_CATALOG)).toBe(true);
+    expect(CLAUDE_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("all entries have required fields", () => {
+    for (const entry of CLAUDE_CATALOG) {
+      expect(entry.name).toBeTruthy();
+      expect(entry.displayName).toBeTruthy();
+      expect(entry.vendor).toBe("anthropic");
+      expect(Array.isArray(entry.requiredApiKeys)).toBe(true);
+      expect(entry.tier).toBeTruthy();
+    }
+  });
+
+  it("all entries require CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY", () => {
+    for (const entry of CLAUDE_CATALOG) {
+      const hasClaudeToken = entry.requiredApiKeys.includes(
+        "CLAUDE_CODE_OAUTH_TOKEN"
+      );
+      const hasAnthropicKey = entry.requiredApiKeys.includes("ANTHROPIC_API_KEY");
+      expect(hasClaudeToken || hasAnthropicKey).toBe(true);
+    }
+  });
+
+  it("has unique model names", () => {
+    const names = CLAUDE_CATALOG.map((e) => e.name);
+    const uniqueNames = new Set(names);
+    expect(names.length).toBe(uniqueNames.size);
+  });
+
+  it("all names follow claude/ prefix pattern", () => {
+    for (const entry of CLAUDE_CATALOG) {
+      expect(entry.name).toMatch(/^claude\//);
+    }
+  });
+
+  it("includes Opus 4.6 as latest and recommended", () => {
+    const opus46 = CLAUDE_CATALOG.find((e) => e.name === "claude/opus-4.6");
+    expect(opus46).toBeDefined();
+    expect(opus46?.tags).toContain("latest");
+    expect(opus46?.tags).toContain("recommended");
+  });
+
+  it("includes Haiku 4.5 with fast tag", () => {
+    const haiku = CLAUDE_CATALOG.find((e) => e.name === "claude/haiku-4.5");
+    expect(haiku).toBeDefined();
+    expect(haiku?.tags).toContain("fast");
+  });
+
+  it("all tiers are paid", () => {
+    for (const entry of CLAUDE_CATALOG) {
+      expect(entry.tier).toBe("paid");
+    }
+  });
+});

--- a/packages/shared/src/providers/opencode/free-models.test.ts
+++ b/packages/shared/src/providers/opencode/free-models.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  OPENCODE_KNOWN_FREE,
+  isOpencodeFreeModel,
+  OPENCODE_FREE_MODEL_IDS,
+} from "./free-models";
+
+describe("OPENCODE_KNOWN_FREE", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(OPENCODE_KNOWN_FREE)).toBe(true);
+    expect(OPENCODE_KNOWN_FREE.length).toBeGreaterThan(0);
+  });
+
+  it("contains big-pickle", () => {
+    expect(OPENCODE_KNOWN_FREE).toContain("big-pickle");
+  });
+
+  it("contains gpt-5-nano", () => {
+    expect(OPENCODE_KNOWN_FREE).toContain("gpt-5-nano");
+  });
+});
+
+describe("isOpencodeFreeModel", () => {
+  describe("returns true for free models", () => {
+    it("matches models with -free suffix", () => {
+      expect(isOpencodeFreeModel("glm-5-free")).toBe(true);
+      expect(isOpencodeFreeModel("kimi-k2.5-free")).toBe(true);
+      expect(isOpencodeFreeModel("some-model-free")).toBe(true);
+    });
+
+    it("matches known free models without suffix", () => {
+      expect(isOpencodeFreeModel("big-pickle")).toBe(true);
+      expect(isOpencodeFreeModel("gpt-5-nano")).toBe(true);
+    });
+  });
+
+  describe("returns false for paid models", () => {
+    it("rejects models without -free suffix", () => {
+      expect(isOpencodeFreeModel("glm-5")).toBe(false);
+      expect(isOpencodeFreeModel("gpt-5")).toBe(false);
+    });
+
+    it("rejects models with free elsewhere in name", () => {
+      expect(isOpencodeFreeModel("free-model")).toBe(false);
+      expect(isOpencodeFreeModel("model-freedom")).toBe(false);
+    });
+
+    it("rejects empty string", () => {
+      expect(isOpencodeFreeModel("")).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles case sensitivity", () => {
+      // -free suffix is lowercase
+      expect(isOpencodeFreeModel("model-FREE")).toBe(false);
+      expect(isOpencodeFreeModel("BIG-PICKLE")).toBe(false);
+    });
+
+    it("handles partial suffix match", () => {
+      expect(isOpencodeFreeModel("model-fre")).toBe(false);
+      expect(isOpencodeFreeModel("modelfree")).toBe(false);
+    });
+  });
+});
+
+describe("OPENCODE_FREE_MODEL_IDS", () => {
+  it("is same as OPENCODE_KNOWN_FREE for backwards compatibility", () => {
+    expect(OPENCODE_FREE_MODEL_IDS).toBe(OPENCODE_KNOWN_FREE);
+  });
+});


### PR DESCRIPTION
Add tests for provider catalogs:

- `anthropic/catalog.test.ts`: 8 tests for CLAUDE_CATALOG
- `opencode/free-models.test.ts`: 11 tests for isOpencodeFreeModel and OPENCODE_KNOWN_FREE