### PR TITLE
test(shared): add tests for grok, amp, cursor, qwen, opencode catalogs

### DIFF
--- a/packages/shared/src/providers/amp/catalog.test.ts
+++ b/packages/shared/src/providers/amp/catalog.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { AMP_CATALOG } from "./catalog";
+
+describe("AMP_CATALOG", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(AMP_CATALOG)).toBe(true);
+    expect(AMP_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("all entries have required fields", () => {
+    for (const entry of AMP_CATALOG) {
+      expect(entry.name).toBeTruthy();
+      expect(entry.displayName).toBeTruthy();
+      expect(entry.vendor).toBe("amp");
+      expect(Array.isArray(entry.requiredApiKeys)).toBe(true);
+      expect(entry.tier).toBeTruthy();
+    }
+  });
+
+  it("all entries require AMP_API_KEY", () => {
+    for (const entry of AMP_CATALOG) {
+      expect(entry.requiredApiKeys).toContain("AMP_API_KEY");
+    }
+  });
+
+  it("has unique model names", () => {
+    const names = AMP_CATALOG.map((e) => e.name);
+    const uniqueNames = new Set(names);
+    expect(names.length).toBe(uniqueNames.size);
+  });
+
+  it("includes base amp entry", () => {
+    const base = AMP_CATALOG.find((e) => e.name === "amp");
+    expect(base).toBeDefined();
+    expect(base?.displayName).toBe("AMP");
+  });
+
+  it("includes amp/gpt-5 variant", () => {
+    const gpt5 = AMP_CATALOG.find((e) => e.name === "amp/gpt-5");
+    expect(gpt5).toBeDefined();
+  });
+
+  it("all tiers are paid", () => {
+    for (const entry of AMP_CATALOG) {
+      expect(entry.tier).toBe("paid");
+    }
+  });
+});

--- a/packages/shared/src/providers/cursor/catalog.test.ts
+++ b/packages/shared/src/providers/cursor/catalog.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { CURSOR_CATALOG } from "./catalog";
+
+describe("CURSOR_CATALOG", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(CURSOR_CATALOG)).toBe(true);
+    expect(CURSOR_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("all entries have required fields", () => {
+    for (const entry of CURSOR_CATALOG) {
+      expect(entry.name).toBeTruthy();
+      expect(entry.displayName).toBeTruthy();
+      expect(entry.vendor).toBe("cursor");
+      expect(Array.isArray(entry.requiredApiKeys)).toBe(true);
+      expect(entry.tier).toBeTruthy();
+    }
+  });
+
+  it("all entries require CURSOR_API_KEY", () => {
+    for (const entry of CURSOR_CATALOG) {
+      expect(entry.requiredApiKeys).toContain("CURSOR_API_KEY");
+    }
+  });
+
+  it("has unique model names", () => {
+    const names = CURSOR_CATALOG.map((e) => e.name);
+    const uniqueNames = new Set(names);
+    expect(names.length).toBe(uniqueNames.size);
+  });
+
+  it("all names follow cursor/ prefix pattern", () => {
+    for (const entry of CURSOR_CATALOG) {
+      expect(entry.name).toMatch(/^cursor\//);
+    }
+  });
+
+  it("includes sonnet-4-thinking with reasoning tag", () => {
+    const thinking = CURSOR_CATALOG.find(
+      (e) => e.name === "cursor/sonnet-4-thinking"
+    );
+    expect(thinking).toBeDefined();
+    expect(thinking?.tags).toContain("reasoning");
+  });
+
+  it("all tiers are paid", () => {
+    for (const entry of CURSOR_CATALOG) {
+      expect(entry.tier).toBe("paid");
+    }
+  });
+});

--- a/packages/shared/src/providers/grok/catalog.test.ts
+++ b/packages/shared/src/providers/grok/catalog.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { GROK_CATALOG } from "./catalog";
+
+describe("GROK_CATALOG", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(GROK_CATALOG)).toBe(true);
+    expect(GROK_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("all entries have required fields", () => {
+    for (const entry of GROK_CATALOG) {
+      expect(entry.name).toBeTruthy();
+      expect(entry.displayName).toBeTruthy();
+      expect(entry.vendor).toBe("xai");
+      expect(Array.isArray(entry.requiredApiKeys)).toBe(true);
+      expect(entry.tier).toBeTruthy();
+    }
+  });
+
+  it("all entries require XAI_API_KEY", () => {
+    for (const entry of GROK_CATALOG) {
+      expect(entry.requiredApiKeys).toContain("XAI_API_KEY");
+    }
+  });
+
+  it("has unique model names", () => {
+    const names = GROK_CATALOG.map((e) => e.name);
+    const uniqueNames = new Set(names);
+    expect(names.length).toBe(uniqueNames.size);
+  });
+
+  it("all names follow grok/ prefix pattern", () => {
+    for (const entry of GROK_CATALOG) {
+      expect(entry.name).toMatch(/^grok\//);
+    }
+  });
+
+  it("includes grok-code-fast-1 as default", () => {
+    const fast = GROK_CATALOG.find((e) => e.name === "grok/grok-code-fast-1");
+    expect(fast).toBeDefined();
+    expect(fast?.tags).toContain("default");
+  });
+
+  it("includes grok-4-latest with latest tag", () => {
+    const latest = GROK_CATALOG.find((e) => e.name === "grok/grok-4-latest");
+    expect(latest).toBeDefined();
+    expect(latest?.tags).toContain("latest");
+  });
+
+  it("all tiers are paid", () => {
+    for (const entry of GROK_CATALOG) {
+      expect(entry.tier).toBe("paid");
+    }
+  });
+});

--- a/packages/shared/src/providers/opencode/catalog.test.ts
+++ b/packages/shared/src/providers/opencode/catalog.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { OPENCODE_CATALOG } from "./catalog";
+import { OPENCODE_KNOWN_FREE } from "./free-models";
+
+describe("OPENCODE_CATALOG", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(OPENCODE_CATALOG)).toBe(true);
+    expect(OPENCODE_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("has same length as OPENCODE_KNOWN_FREE", () => {
+    expect(OPENCODE_CATALOG.length).toBe(OPENCODE_KNOWN_FREE.length);
+  });
+
+  it("all entries have required fields", () => {
+    for (const entry of OPENCODE_CATALOG) {
+      expect(entry.name).toBeTruthy();
+      expect(entry.displayName).toBeTruthy();
+      expect(entry.vendor).toBe("opencode");
+      expect(Array.isArray(entry.requiredApiKeys)).toBe(true);
+      expect(entry.tier).toBe("free");
+    }
+  });
+
+  it("all entries require no API keys (free models)", () => {
+    for (const entry of OPENCODE_CATALOG) {
+      expect(entry.requiredApiKeys).toHaveLength(0);
+    }
+  });
+
+  it("all names follow opencode/ prefix pattern", () => {
+    for (const entry of OPENCODE_CATALOG) {
+      expect(entry.name).toMatch(/^opencode\//);
+    }
+  });
+
+  it("all entries have free tag", () => {
+    for (const entry of OPENCODE_CATALOG) {
+      expect(entry.tags).toContain("free");
+    }
+  });
+
+  it("includes big-pickle", () => {
+    const bigPickle = OPENCODE_CATALOG.find(
+      (e) => e.name === "opencode/big-pickle"
+    );
+    expect(bigPickle).toBeDefined();
+    expect(bigPickle?.tier).toBe("free");
+  });
+
+  it("includes gpt-5-nano", () => {
+    const gpt5Nano = OPENCODE_CATALOG.find(
+      (e) => e.name === "opencode/gpt-5-nano"
+    );
+    expect(gpt5Nano).toBeDefined();
+    expect(gpt5Nano?.tier).toBe("free");
+  });
+
+  it("generates entries from OPENCODE_KNOWN_FREE", () => {
+    for (const modelId of OPENCODE_KNOWN_FREE) {
+      const entry = OPENCODE_CATALOG.find(
+        (e) => e.name === `opencode/${modelId}`
+      );
+      expect(entry).toBeDefined();
+    }
+  });
+});

--- a/packages/shared/src/providers/qwen/catalog.test.ts
+++ b/packages/shared/src/providers/qwen/catalog.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { QWEN_CATALOG } from "./catalog";
+
+describe("QWEN_CATALOG", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(QWEN_CATALOG)).toBe(true);
+    expect(QWEN_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("all entries have required fields", () => {
+    for (const entry of QWEN_CATALOG) {
+      expect(entry.name).toBeTruthy();
+      expect(entry.displayName).toBeTruthy();
+      expect(entry.vendor).toBe("qwen");
+      expect(Array.isArray(entry.requiredApiKeys)).toBe(true);
+      expect(entry.tier).toBeTruthy();
+    }
+  });
+
+  it("has unique model names", () => {
+    const names = QWEN_CATALOG.map((e) => e.name);
+    const uniqueNames = new Set(names);
+    expect(names.length).toBe(uniqueNames.size);
+  });
+
+  it("all names follow qwen/ prefix pattern", () => {
+    for (const entry of QWEN_CATALOG) {
+      expect(entry.name).toMatch(/^qwen\//);
+    }
+  });
+
+  it("includes free tier model", () => {
+    const freeModels = QWEN_CATALOG.filter((e) => e.tier === "free");
+    expect(freeModels.length).toBeGreaterThan(0);
+  });
+
+  it("free model uses OPENROUTER_API_KEY", () => {
+    const freeModel = QWEN_CATALOG.find((e) => e.tier === "free");
+    expect(freeModel?.requiredApiKeys).toContain("OPENROUTER_API_KEY");
+  });
+
+  it("paid model uses MODEL_STUDIO_API_KEY", () => {
+    const paidModel = QWEN_CATALOG.find((e) => e.tier === "paid");
+    expect(paidModel?.requiredApiKeys).toContain("MODEL_STUDIO_API_KEY");
+  });
+
+  it("free model has free tag", () => {
+    const freeModel = QWEN_CATALOG.find((e) => e.tier === "free");
+    expect(freeModel?.tags).toContain("free");
+  });
+});


### PR DESCRIPTION
Add tests for provider catalogs:

- `grok/catalog.test.ts`: 8 tests for GROK_CATALOG
- `amp/catalog.test.ts`: 7 tests for AMP_CATALOG
- `cursor/catalog.test.ts`: 7 tests for CURSOR_CATALOG
- `qwen/catalog.test.ts`: 8 tests for QWEN_CATALOG (free/paid mix)
- `opencode/catalog.test.ts`: 9 tests for OPENCODE_CATALOG (free models)