### PR TITLE
test(shared): add tests for cursor, anthropic, opencode plugins

### DIFF
--- a/packages/shared/src/providers/anthropic/plugin.test.ts
+++ b/packages/shared/src/providers/anthropic/plugin.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { anthropicPlugin } from "./plugin";
+import {
+  ANTHROPIC_API_KEY,
+  ANTHROPIC_BASE_URL_KEY,
+  CLAUDE_CODE_OAUTH_TOKEN,
+} from "../../apiKeys";
+import { CLAUDE_CATALOG } from "./catalog";
+import { CLAUDE_AGENT_CONFIGS } from "./configs";
+
+describe("anthropicPlugin", () => {
+  describe("manifest", () => {
+    it("has id anthropic", () => {
+      expect(anthropicPlugin.manifest.id).toBe("anthropic");
+    });
+
+    it("has name Anthropic", () => {
+      expect(anthropicPlugin.manifest.name).toBe("Anthropic");
+    });
+
+    it("has version 1.0.0", () => {
+      expect(anthropicPlugin.manifest.version).toBe("1.0.0");
+    });
+
+    it("has description", () => {
+      expect(anthropicPlugin.manifest.description).toBe(
+        "Claude Code agents powered by Anthropic's Claude models"
+      );
+    });
+
+    it("has type builtin", () => {
+      expect(anthropicPlugin.manifest.type).toBe("builtin");
+    });
+  });
+
+  describe("provider", () => {
+    it("has defaultBaseUrl for Anthropic API", () => {
+      expect(anthropicPlugin.provider.defaultBaseUrl).toBe(
+        "https://api.anthropic.com"
+      );
+    });
+
+    it("has anthropic apiFormat", () => {
+      expect(anthropicPlugin.provider.apiFormat).toBe("anthropic");
+    });
+
+    it("has ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN as authEnvVars", () => {
+      expect(anthropicPlugin.provider.authEnvVars).toContain("ANTHROPIC_API_KEY");
+      expect(anthropicPlugin.provider.authEnvVars).toContain(
+        "CLAUDE_CODE_OAUTH_TOKEN"
+      );
+    });
+
+    it("includes both API keys in apiKeys array", () => {
+      expect(anthropicPlugin.provider.apiKeys).toContain(ANTHROPIC_API_KEY);
+      expect(anthropicPlugin.provider.apiKeys).toContain(CLAUDE_CODE_OAUTH_TOKEN);
+    });
+
+    it("has baseUrlKey for custom base URL", () => {
+      expect(anthropicPlugin.provider.baseUrlKey).toBe(ANTHROPIC_BASE_URL_KEY);
+    });
+  });
+
+  describe("exports", () => {
+    it("exports CLAUDE_AGENT_CONFIGS as configs", () => {
+      expect(anthropicPlugin.configs).toBe(CLAUDE_AGENT_CONFIGS);
+    });
+
+    it("exports CLAUDE_CATALOG as catalog", () => {
+      expect(anthropicPlugin.catalog).toBe(CLAUDE_CATALOG);
+    });
+  });
+});

--- a/packages/shared/src/providers/cursor/plugin.test.ts
+++ b/packages/shared/src/providers/cursor/plugin.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { cursorPlugin } from "./plugin";
+import { CURSOR_API_KEY } from "../../apiKeys";
+import { CURSOR_CATALOG } from "./catalog";
+import { CURSOR_AGENT_CONFIGS } from "./configs";
+
+describe("cursorPlugin", () => {
+  describe("manifest", () => {
+    it("has id cursor", () => {
+      expect(cursorPlugin.manifest.id).toBe("cursor");
+    });
+
+    it("has name Cursor", () => {
+      expect(cursorPlugin.manifest.name).toBe("Cursor");
+    });
+
+    it("has version 1.0.0", () => {
+      expect(cursorPlugin.manifest.version).toBe("1.0.0");
+    });
+
+    it("has description", () => {
+      expect(cursorPlugin.manifest.description).toBe(
+        "Cursor agent for AI-powered code editing"
+      );
+    });
+
+    it("has type builtin", () => {
+      expect(cursorPlugin.manifest.type).toBe("builtin");
+    });
+  });
+
+  describe("provider", () => {
+    it("has defaultBaseUrl for cursor API", () => {
+      expect(cursorPlugin.provider.defaultBaseUrl).toBe(
+        "https://api.cursor.sh"
+      );
+    });
+
+    it("has passthrough apiFormat", () => {
+      expect(cursorPlugin.provider.apiFormat).toBe("passthrough");
+    });
+
+    it("has CURSOR_API_KEY as authEnvVar", () => {
+      expect(cursorPlugin.provider.authEnvVars).toContain("CURSOR_API_KEY");
+    });
+
+    it("includes CURSOR_API_KEY in apiKeys", () => {
+      expect(cursorPlugin.provider.apiKeys).toContain(CURSOR_API_KEY);
+    });
+  });
+
+  describe("exports", () => {
+    it("exports CURSOR_AGENT_CONFIGS as configs", () => {
+      expect(cursorPlugin.configs).toBe(CURSOR_AGENT_CONFIGS);
+    });
+
+    it("exports CURSOR_CATALOG as catalog", () => {
+      expect(cursorPlugin.catalog).toBe(CURSOR_CATALOG);
+    });
+  });
+});

--- a/packages/shared/src/providers/opencode/plugin.test.ts
+++ b/packages/shared/src/providers/opencode/plugin.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { opencodePlugin } from "./plugin";
+import { OPENROUTER_API_KEY, OPENROUTER_BASE_URL_KEY } from "../../apiKeys";
+import { OPENCODE_CATALOG } from "./catalog";
+import { OPENCODE_AGENT_CONFIGS } from "./configs";
+
+describe("opencodePlugin", () => {
+  describe("manifest", () => {
+    it("has id opencode", () => {
+      expect(opencodePlugin.manifest.id).toBe("opencode");
+    });
+
+    it("has name OpenCode", () => {
+      expect(opencodePlugin.manifest.name).toBe("OpenCode");
+    });
+
+    it("has version 1.0.0", () => {
+      expect(opencodePlugin.manifest.version).toBe("1.0.0");
+    });
+
+    it("has description", () => {
+      expect(opencodePlugin.manifest.description).toBe(
+        "OpenCode agents supporting multiple model providers"
+      );
+    });
+
+    it("has type builtin", () => {
+      expect(opencodePlugin.manifest.type).toBe("builtin");
+    });
+  });
+
+  describe("provider", () => {
+    it("has defaultBaseUrl for OpenRouter API", () => {
+      expect(opencodePlugin.provider.defaultBaseUrl).toBe(
+        "https://openrouter.ai/api/v1"
+      );
+    });
+
+    it("has openai apiFormat", () => {
+      expect(opencodePlugin.provider.apiFormat).toBe("openai");
+    });
+
+    it("has OPENROUTER_API_KEY as authEnvVar", () => {
+      expect(opencodePlugin.provider.authEnvVars).toContain("OPENROUTER_API_KEY");
+    });
+
+    it("includes OPENROUTER_API_KEY in apiKeys", () => {
+      expect(opencodePlugin.provider.apiKeys).toContain(OPENROUTER_API_KEY);
+    });
+
+    it("has baseUrlKey for custom base URL", () => {
+      expect(opencodePlugin.provider.baseUrlKey).toBe(OPENROUTER_BASE_URL_KEY);
+    });
+  });
+
+  describe("exports", () => {
+    it("exports OPENCODE_AGENT_CONFIGS as configs", () => {
+      expect(opencodePlugin.configs).toBe(OPENCODE_AGENT_CONFIGS);
+    });
+
+    it("exports OPENCODE_CATALOG as catalog", () => {
+      expect(opencodePlugin.catalog).toBe(OPENCODE_CATALOG);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for cursor/plugin.ts (11 tests)
- Add unit tests for anthropic/plugin.ts (12 tests)
- Add unit tests for opencode/plugin.ts (12 tests)

## Test plan
- [x] `bun run test` passes (772 tests in packages/shared)
- [x] `bun check` passes