### PR TITLE
test(shared): add tests for gemini, anthropic, cursor agent configs

### DIFF
--- a/packages/shared/src/providers/anthropic/configs.test.ts
+++ b/packages/shared/src/providers/anthropic/configs.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { CLAUDE_AGENT_CONFIGS, createApplyClaudeApiKeys } from "./configs";
+import { ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN } from "../../apiKeys";
+
+describe("CLAUDE_AGENT_CONFIGS", () => {
+  it("is a non-empty array", () => {
+    expect(CLAUDE_AGENT_CONFIGS).toBeInstanceOf(Array);
+    expect(CLAUDE_AGENT_CONFIGS.length).toBeGreaterThan(0);
+  });
+
+  describe("config structure", () => {
+    it("all configs have names starting with claude/", () => {
+      for (const config of CLAUDE_AGENT_CONFIGS) {
+        expect(config.name).toMatch(/^claude\//);
+      }
+    });
+
+    it("all configs use claude command", () => {
+      for (const config of CLAUDE_AGENT_CONFIGS) {
+        expect(config.command).toBe("claude");
+      }
+    });
+
+    it("all configs have --model and permission flags", () => {
+      for (const config of CLAUDE_AGENT_CONFIGS) {
+        expect(config.args).toContain("--model");
+        expect(config.args).toContain("--allow-dangerously-skip-permissions");
+        expect(config.args).toContain("--dangerously-skip-permissions");
+      }
+    });
+
+    it("all configs have --ide flag", () => {
+      for (const config of CLAUDE_AGENT_CONFIGS) {
+        expect(config.args).toContain("--ide");
+      }
+    });
+
+    it("all configs have both OAuth and API key in apiKeys", () => {
+      for (const config of CLAUDE_AGENT_CONFIGS) {
+        expect(config.apiKeys).toContain(CLAUDE_CODE_OAUTH_TOKEN);
+        expect(config.apiKeys).toContain(ANTHROPIC_API_KEY);
+      }
+    });
+
+    it("all configs have applyApiKeys function", () => {
+      for (const config of CLAUDE_AGENT_CONFIGS) {
+        expect(config.applyApiKeys).toBeInstanceOf(Function);
+      }
+    });
+
+    it("all configs have checkRequirements function", () => {
+      for (const config of CLAUDE_AGENT_CONFIGS) {
+        expect(config.checkRequirements).toBeInstanceOf(Function);
+      }
+    });
+
+    it("all configs have completionDetector function", () => {
+      for (const config of CLAUDE_AGENT_CONFIGS) {
+        expect(config.completionDetector).toBeInstanceOf(Function);
+      }
+    });
+  });
+
+  describe("model variations", () => {
+    it("includes opus-4.6 model", () => {
+      const config = CLAUDE_AGENT_CONFIGS.find(
+        (c) => c.name === "claude/opus-4.6"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("claude-opus-4-6");
+    });
+
+    it("includes opus-4.5 model", () => {
+      const config = CLAUDE_AGENT_CONFIGS.find(
+        (c) => c.name === "claude/opus-4.5"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("claude-opus-4-5-20251101");
+    });
+
+    it("includes haiku-4.5 model", () => {
+      const config = CLAUDE_AGENT_CONFIGS.find(
+        (c) => c.name === "claude/haiku-4.5"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("claude-haiku-4-5-20251001");
+    });
+  });
+});
+
+describe("createApplyClaudeApiKeys", () => {
+  it("returns a function", () => {
+    const applyApiKeys = createApplyClaudeApiKeys();
+    expect(applyApiKeys).toBeInstanceOf(Function);
+  });
+
+  describe("key priority", () => {
+    it("prioritizes OAuth token over API key", async () => {
+      const applyApiKeys = createApplyClaudeApiKeys();
+      const result = await applyApiKeys({
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-123",
+        ANTHROPIC_API_KEY: "sk-api-key-456",
+      });
+
+      expect(result.env).toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token-123");
+      expect(result.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+    });
+
+    it("falls back to API key when OAuth not provided", async () => {
+      const applyApiKeys = createApplyClaudeApiKeys();
+      const result = await applyApiKeys({
+        ANTHROPIC_API_KEY: "sk-api-key-456",
+      });
+
+      expect(result.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-api-key-456");
+      expect(result.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    });
+
+    it("returns empty env when no credentials provided", async () => {
+      const applyApiKeys = createApplyClaudeApiKeys();
+      const result = await applyApiKeys({});
+
+      expect(result.env).toEqual({});
+    });
+
+    it("ignores empty OAuth token", async () => {
+      const applyApiKeys = createApplyClaudeApiKeys();
+      const result = await applyApiKeys({
+        CLAUDE_CODE_OAUTH_TOKEN: "",
+        ANTHROPIC_API_KEY: "sk-api-key-456",
+      });
+
+      expect(result.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-api-key-456");
+    });
+
+    it("ignores whitespace-only OAuth token", async () => {
+      const applyApiKeys = createApplyClaudeApiKeys();
+      const result = await applyApiKeys({
+        CLAUDE_CODE_OAUTH_TOKEN: "   ",
+        ANTHROPIC_API_KEY: "sk-api-key-456",
+      });
+
+      expect(result.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-api-key-456");
+    });
+  });
+
+  describe("unsetEnv", () => {
+    it("includes unsetEnv in result", async () => {
+      const applyApiKeys = createApplyClaudeApiKeys();
+      const result = await applyApiKeys({
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-123",
+      });
+
+      expect(result.unsetEnv).toBeInstanceOf(Array);
+    });
+
+    it("adds ANTHROPIC_API_KEY to unsetEnv when using OAuth", async () => {
+      const applyApiKeys = createApplyClaudeApiKeys();
+      const result = await applyApiKeys({
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-123",
+      });
+
+      expect(result.unsetEnv).toContain("ANTHROPIC_API_KEY");
+    });
+  });
+});

--- a/packages/shared/src/providers/cursor/configs.test.ts
+++ b/packages/shared/src/providers/cursor/configs.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { CURSOR_AGENT_CONFIGS } from "./configs";
+import { CURSOR_API_KEY } from "../../apiKeys";
+
+describe("CURSOR_AGENT_CONFIGS", () => {
+  it("is a non-empty array", () => {
+    expect(CURSOR_AGENT_CONFIGS).toBeInstanceOf(Array);
+    expect(CURSOR_AGENT_CONFIGS.length).toBeGreaterThan(0);
+  });
+
+  describe("config structure", () => {
+    it("all configs have names starting with cursor/", () => {
+      for (const config of CURSOR_AGENT_CONFIGS) {
+        expect(config.name).toMatch(/^cursor\//);
+      }
+    });
+
+    it("all configs use cursor-agent command path", () => {
+      for (const config of CURSOR_AGENT_CONFIGS) {
+        expect(config.command).toBe("/root/.local/bin/cursor-agent");
+      }
+    });
+
+    it("all configs have --force and --model args", () => {
+      for (const config of CURSOR_AGENT_CONFIGS) {
+        expect(config.args).toContain("--force");
+        expect(config.args).toContain("--model");
+      }
+    });
+
+    it("all configs have CURSOR_API_KEY in apiKeys", () => {
+      for (const config of CURSOR_AGENT_CONFIGS) {
+        expect(config.apiKeys).toContain(CURSOR_API_KEY);
+      }
+    });
+
+    it("all configs have environment function", () => {
+      for (const config of CURSOR_AGENT_CONFIGS) {
+        expect(config.environment).toBeInstanceOf(Function);
+      }
+    });
+
+    it("all configs have checkRequirements function", () => {
+      for (const config of CURSOR_AGENT_CONFIGS) {
+        expect(config.checkRequirements).toBeInstanceOf(Function);
+      }
+    });
+
+    it("all configs have waitForString set to Ready", () => {
+      for (const config of CURSOR_AGENT_CONFIGS) {
+        expect(config.waitForString).toBe("Ready");
+      }
+    });
+  });
+
+  describe("model variations", () => {
+    it("includes opus-4.1 model", () => {
+      const config = CURSOR_AGENT_CONFIGS.find(
+        (c) => c.name === "cursor/opus-4.1"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("opus-4.1");
+    });
+
+    it("includes gpt-5 model", () => {
+      const config = CURSOR_AGENT_CONFIGS.find(
+        (c) => c.name === "cursor/gpt-5"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("gpt-5");
+    });
+
+    it("includes sonnet-4 model", () => {
+      const config = CURSOR_AGENT_CONFIGS.find(
+        (c) => c.name === "cursor/sonnet-4"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("sonnet-4");
+    });
+
+    it("includes sonnet-4-thinking model", () => {
+      const config = CURSOR_AGENT_CONFIGS.find(
+        (c) => c.name === "cursor/sonnet-4-thinking"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("sonnet-4-thinking");
+    });
+  });
+});

--- a/packages/shared/src/providers/gemini/configs.test.ts
+++ b/packages/shared/src/providers/gemini/configs.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { GEMINI_AGENT_CONFIGS } from "./configs";
+import { GEMINI_API_KEY } from "../../apiKeys";
+
+describe("GEMINI_AGENT_CONFIGS", () => {
+  it("is a non-empty array", () => {
+    expect(GEMINI_AGENT_CONFIGS).toBeInstanceOf(Array);
+    expect(GEMINI_AGENT_CONFIGS.length).toBeGreaterThan(0);
+  });
+
+  describe("config structure", () => {
+    it("all configs have names starting with gemini/", () => {
+      for (const config of GEMINI_AGENT_CONFIGS) {
+        expect(config.name).toMatch(/^gemini\//);
+      }
+    });
+
+    it("all configs use gemini command", () => {
+      for (const config of GEMINI_AGENT_CONFIGS) {
+        expect(config.command).toBe("gemini");
+      }
+    });
+
+    it("all configs have --model and --yolo args", () => {
+      for (const config of GEMINI_AGENT_CONFIGS) {
+        expect(config.args).toContain("--model");
+        expect(config.args).toContain("--yolo");
+      }
+    });
+
+    it("all configs have telemetry args", () => {
+      for (const config of GEMINI_AGENT_CONFIGS) {
+        expect(config.args).toContain("--telemetry");
+        expect(config.args).toContain("--telemetry-target=local");
+        expect(config.args).toContain("--telemetry-log-prompts");
+      }
+    });
+
+    it("all configs have GEMINI_API_KEY in apiKeys", () => {
+      for (const config of GEMINI_AGENT_CONFIGS) {
+        expect(config.apiKeys).toContain(GEMINI_API_KEY);
+      }
+    });
+
+    it("all configs have environment function", () => {
+      for (const config of GEMINI_AGENT_CONFIGS) {
+        expect(config.environment).toBeInstanceOf(Function);
+      }
+    });
+
+    it("all configs have checkRequirements function", () => {
+      for (const config of GEMINI_AGENT_CONFIGS) {
+        expect(config.checkRequirements).toBeInstanceOf(Function);
+      }
+    });
+
+    it("all configs have completionDetector function", () => {
+      for (const config of GEMINI_AGENT_CONFIGS) {
+        expect(config.completionDetector).toBeInstanceOf(Function);
+      }
+    });
+  });
+
+  describe("model variations", () => {
+    it("includes 3.1-pro-preview model", () => {
+      const config = GEMINI_AGENT_CONFIGS.find(
+        (c) => c.name === "gemini/3.1-pro-preview"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("gemini-3.1-pro-preview");
+    });
+
+    it("includes 2.5-flash model", () => {
+      const config = GEMINI_AGENT_CONFIGS.find(
+        (c) => c.name === "gemini/2.5-flash"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("gemini-2.5-flash");
+    });
+
+    it("includes 2.5-pro model", () => {
+      const config = GEMINI_AGENT_CONFIGS.find(
+        (c) => c.name === "gemini/2.5-pro"
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("gemini-2.5-pro");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for gemini/configs.ts (12 tests)
- Add unit tests for anthropic/configs.ts (20 tests including createApplyClaudeApiKeys)
- Add unit tests for cursor/configs.ts (12 tests)

## Test plan
- [x] `bun run test` passes (781 tests in packages/shared)
- [x] `bun check` passes