### PR TITLE
test(shared): add tests for gemini telemetry, amp constants, reserved ports

### DIFF
--- a/packages/shared/src/providers/amp/constants.test.ts
+++ b/packages/shared/src/providers/amp/constants.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_AMP_PROXY_PORT, DEFAULT_AMP_PROXY_URL } from "./constants";
+
+describe("DEFAULT_AMP_PROXY_PORT", () => {
+  it("is 39400", () => {
+    expect(DEFAULT_AMP_PROXY_PORT).toBe(39400);
+  });
+
+  it("is a number", () => {
+    expect(typeof DEFAULT_AMP_PROXY_PORT).toBe("number");
+  });
+});
+
+describe("DEFAULT_AMP_PROXY_URL", () => {
+  it("contains localhost", () => {
+    expect(DEFAULT_AMP_PROXY_URL).toContain("localhost");
+  });
+
+  it("uses http protocol", () => {
+    expect(DEFAULT_AMP_PROXY_URL).toMatch(/^http:\/\//);
+  });
+
+  it("includes the default port", () => {
+    expect(DEFAULT_AMP_PROXY_URL).toContain(String(DEFAULT_AMP_PROXY_PORT));
+  });
+
+  it("matches expected URL format", () => {
+    expect(DEFAULT_AMP_PROXY_URL).toBe("http://localhost:39400");
+  });
+});

--- a/packages/shared/src/providers/gemini/telemetry.test.ts
+++ b/packages/shared/src/providers/gemini/telemetry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  GEMINI_TELEMETRY_OUTFILE_TEMPLATE,
+  getGeminiTelemetryPath,
+} from "./telemetry";
+
+describe("GEMINI_TELEMETRY_OUTFILE_TEMPLATE", () => {
+  it("contains task run ID placeholder", () => {
+    expect(GEMINI_TELEMETRY_OUTFILE_TEMPLATE).toContain("$CMUX_TASK_RUN_ID");
+  });
+
+  it("is in /tmp directory", () => {
+    expect(GEMINI_TELEMETRY_OUTFILE_TEMPLATE).toMatch(/^\/tmp\//);
+  });
+
+  it("has .log extension", () => {
+    expect(GEMINI_TELEMETRY_OUTFILE_TEMPLATE).toMatch(/\.log$/);
+  });
+});
+
+describe("getGeminiTelemetryPath", () => {
+  it("returns path with task run ID substituted", () => {
+    const taskRunId = "task_abc123";
+    const result = getGeminiTelemetryPath(taskRunId);
+    expect(result).toBe("/tmp/gemini-telemetry-task_abc123.log");
+  });
+
+  it("returns path in /tmp directory", () => {
+    const result = getGeminiTelemetryPath("any-id");
+    expect(result).toMatch(/^\/tmp\//);
+  });
+
+  it("includes gemini-telemetry prefix", () => {
+    const result = getGeminiTelemetryPath("test");
+    expect(result).toContain("gemini-telemetry");
+  });
+
+  it("handles empty task run ID", () => {
+    const result = getGeminiTelemetryPath("");
+    expect(result).toBe("/tmp/gemini-telemetry-.log");
+  });
+});

--- a/packages/shared/src/utils/reserved-cmux-ports.test.ts
+++ b/packages/shared/src/utils/reserved-cmux-ports.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  RESERVED_CMUX_PORTS,
+  RESERVED_CMUX_PORT_SET,
+} from "./reserved-cmux-ports";
+
+describe("RESERVED_CMUX_PORTS", () => {
+  it("is a non-empty array", () => {
+    expect(RESERVED_CMUX_PORTS).toBeInstanceOf(Array);
+    expect(RESERVED_CMUX_PORTS.length).toBeGreaterThan(0);
+  });
+
+  it("contains only numbers", () => {
+    for (const port of RESERVED_CMUX_PORTS) {
+      expect(typeof port).toBe("number");
+    }
+  });
+
+  it("contains ports in valid range (1-65535)", () => {
+    for (const port of RESERVED_CMUX_PORTS) {
+      expect(port).toBeGreaterThanOrEqual(1);
+      expect(port).toBeLessThanOrEqual(65535);
+    }
+  });
+
+  it("contains expected reserved ports", () => {
+    expect(RESERVED_CMUX_PORTS).toContain(39375);
+    expect(RESERVED_CMUX_PORTS).toContain(39378);
+  });
+
+  it("has no duplicate entries", () => {
+    const uniquePorts = new Set(RESERVED_CMUX_PORTS);
+    expect(uniquePorts.size).toBe(RESERVED_CMUX_PORTS.length);
+  });
+});
+
+describe("RESERVED_CMUX_PORT_SET", () => {
+  it("is a Set", () => {
+    expect(RESERVED_CMUX_PORT_SET).toBeInstanceOf(Set);
+  });
+
+  it("has same size as RESERVED_CMUX_PORTS array", () => {
+    expect(RESERVED_CMUX_PORT_SET.size).toBe(RESERVED_CMUX_PORTS.length);
+  });
+
+  it("contains all ports from the array", () => {
+    for (const port of RESERVED_CMUX_PORTS) {
+      expect(RESERVED_CMUX_PORT_SET.has(port)).toBe(true);
+    }
+  });
+
+  it("can check port membership efficiently", () => {
+    expect(RESERVED_CMUX_PORT_SET.has(39375)).toBe(true);
+    expect(RESERVED_CMUX_PORT_SET.has(8080)).toBe(false);
+    expect(RESERVED_CMUX_PORT_SET.has(3000)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for gemini/telemetry.ts (7 tests)
- Add unit tests for amp/constants.ts (6 tests)
- Add unit tests for reserved-cmux-ports.ts (11 tests)

## Test plan
- [x] `bun run test` passes (794 tests in packages/shared)
- [x] `bun check` passes