### PR TITLE
test(shared): add tests for openai catalog and completion-detector

### DIFF
--- a/packages/shared/src/providers/openai/catalog.test.ts
+++ b/packages/shared/src/providers/openai/catalog.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { CODEX_CATALOG } from "./catalog";
+
+describe("CODEX_CATALOG", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(CODEX_CATALOG)).toBe(true);
+    expect(CODEX_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("all entries have required fields", () => {
+    for (const entry of CODEX_CATALOG) {
+      expect(entry.name).toBeTruthy();
+      expect(entry.displayName).toBeTruthy();
+      expect(entry.vendor).toBe("openai");
+      expect(Array.isArray(entry.requiredApiKeys)).toBe(true);
+      expect(entry.tier).toBeTruthy();
+    }
+  });
+
+  it("all entries require OPENAI_API_KEY and CODEX_AUTH_JSON", () => {
+    for (const entry of CODEX_CATALOG) {
+      expect(entry.requiredApiKeys).toContain("OPENAI_API_KEY");
+      expect(entry.requiredApiKeys).toContain("CODEX_AUTH_JSON");
+    }
+  });
+
+  it("has unique model names", () => {
+    const names = CODEX_CATALOG.map((e) => e.name);
+    const uniqueNames = new Set(names);
+    expect(names.length).toBe(uniqueNames.size);
+  });
+
+  it("all names follow codex/ prefix pattern", () => {
+    for (const entry of CODEX_CATALOG) {
+      expect(entry.name).toMatch(/^codex\//);
+    }
+  });
+
+  it("includes GPT-5.4 xhigh as latest", () => {
+    const gpt54xhigh = CODEX_CATALOG.find(
+      (e) => e.name === "codex/gpt-5.4-xhigh"
+    );
+    expect(gpt54xhigh).toBeDefined();
+    expect(gpt54xhigh?.tags).toContain("latest");
+  });
+
+  it("includes GPT-5.1 codex mini", () => {
+    const mini = CODEX_CATALOG.find((e) => e.name === "codex/gpt-5.1-codex-mini");
+    expect(mini).toBeDefined();
+    expect(mini?.displayName).toBe("GPT-5.1 Codex Mini");
+  });
+
+  it("all tiers are paid", () => {
+    for (const entry of CODEX_CATALOG) {
+      expect(entry.tier).toBe("paid");
+    }
+  });
+
+  it("models with reasoning tag have xhigh, high, medium, or low suffix", () => {
+    for (const entry of CODEX_CATALOG) {
+      if (entry.tags?.includes("reasoning")) {
+        const hasReasoningSuffix =
+          entry.name.endsWith("-xhigh") ||
+          entry.name.endsWith("-high") ||
+          entry.name.endsWith("-medium") ||
+          entry.name.endsWith("-low");
+        expect(hasReasoningSuffix).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/shared/src/providers/openai/completion-detector.test.ts
+++ b/packages/shared/src/providers/openai/completion-detector.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the file-marker-detector module to avoid filesystem access
+vi.mock("../common/file-marker-detector", () => ({
+  createFileMarkerDetector: vi.fn(() => Promise.resolve()),
+}));
+
+import {
+  createCodexDetector,
+  startCodexCompletionDetector,
+} from "./completion-detector";
+import { createFileMarkerDetector } from "../common/file-marker-detector";
+
+describe("createCodexDetector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("is a function", () => {
+    expect(typeof createCodexDetector).toBe("function");
+  });
+
+  it("returns a Promise", () => {
+    const result = createCodexDetector({
+      taskRunId: "test-task-id",
+      startTime: Date.now(),
+    });
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("calls createFileMarkerDetector with correct options", async () => {
+    const taskRunId = "task_codex123";
+    await createCodexDetector({
+      taskRunId,
+      startTime: Date.now(),
+    });
+
+    expect(createFileMarkerDetector).toHaveBeenCalledWith({
+      markerPath: "/root/lifecycle/codex-done.txt",
+      watchDir: "/root/lifecycle",
+      markerFilename: "codex-done.txt",
+      onComplete: expect.any(Function),
+    });
+  });
+
+  it("uses fixed marker path regardless of task ID", async () => {
+    await createCodexDetector({
+      taskRunId: "any-task-id",
+      startTime: Date.now(),
+    });
+
+    expect(createFileMarkerDetector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        markerPath: "/root/lifecycle/codex-done.txt",
+        markerFilename: "codex-done.txt",
+      })
+    );
+  });
+});
+
+describe("startCodexCompletionDetector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("is a function", () => {
+    expect(typeof startCodexCompletionDetector).toBe("function");
+  });
+
+  it("returns a Promise", () => {
+    const result = startCodexCompletionDetector("test-task-id");
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("delegates to createCodexDetector", async () => {
+    await startCodexCompletionDetector("task_xyz_456");
+
+    expect(createFileMarkerDetector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        markerPath: "/root/lifecycle/codex-done.txt",
+        watchDir: "/root/lifecycle",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds tests for `packages/shared/src/providers/openai/catalog.ts` (9 tests)
- Adds tests for `packages/shared/src/providers/openai/completion-detector.ts` (7 tests)

## Test Coverage
- `catalog.test.ts`: Validates CODEX_CATALOG structure, required fields, API keys, naming patterns, model tiers
- `completion-detector.test.ts`: Tests createCodexDetector and startCodexCompletionDetector functions with mocked file-marker-detector

## Test plan
- [x] `bun check` passes
- [x] `bun run vitest run packages/shared/src/providers/openai/` passes (16 new tests)