### PR TITLE
fix(deploy): add ARM64 support for Docker image

### DIFF
--- a/.github/workflows/docker-server-build.yml
+++ b/.github/workflows/docker-server-build.yml
@@ -27,7 +27,7 @@ jobs:
   build-and-push:
     name: Build and push Docker image
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       image_tag: ${{ steps.meta.outputs.version }}
       image_digest: ${{ steps.build.outputs.digest }}
@@ -36,6 +36,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -82,7 +85,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
       - name: Output image info
         run: |


### PR DESCRIPTION
## Summary

Fixes Coolify deployment failure on ARM64 servers.

## Error Fixed

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

## Changes

- Add `docker/setup-qemu-action@v3` for multi-arch emulation
- Build for both `linux/amd64` and `linux/arm64`
- Increase timeout to 60min (ARM64 Rust compilation via QEMU is slow)

## Test plan

- [ ] Verify workflow builds successfully for both platforms
- [ ] Verify image manifest includes both amd64 and arm64
- [ ] Deploy to ARM64 Coolify server successfully