### PR TITLE
fix(deploy): prevent Docker builds from being cancelled

### DIFF
--- a/.github/workflows/docker-server-build.yml
+++ b/.github/workflows/docker-server-build.yml
@@ -3,6 +3,20 @@ name: Docker (cmux-server)
 on:
   push:
     branches: [main]
+    paths:
+      # Server application
+      - 'apps/server/**'
+      # Shared packages used by server
+      - 'packages/shared/**'
+      - 'packages/convex/**'
+      - 'packages/www-openapi-client/**'
+      - 'packages/e2b-client/**'
+      # Root dependencies
+      - 'package.json'
+      - 'bun.lock'
+      - '.npmrc'
+      # This workflow
+      - '.github/workflows/docker-server-build.yml'
   workflow_dispatch:
     inputs:
       force_deploy:
@@ -16,7 +30,7 @@ permissions:
 
 concurrency:
   group: docker-cmux-server-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   IMAGE_NAME: cmux-server


### PR DESCRIPTION
## Problem

Docker builds keep getting cancelled by unrelated commits:

```
in_progress     -       2026-03-19T06:50:43Z    8123911 (chore: gitignore)
cancelled       -       2026-03-19T06:49:18Z    86190b8 (chore: stop tracking)
cancelled       -       2026-03-19T06:43:47Z    f48b390 (parallel builds)
cancelled       -       2026-03-19T05:51:06Z    3d32d4a (arm64 support)
success         -       2026-03-19T04:09:41Z    b00982b (initial)
```

## Solution

1. **Path filtering** - Only trigger on server-related changes:
   - `apps/server/**`
   - `packages/shared/**`, `packages/convex/**`, etc.
   - `package.json`, `bun.lock`
   - This workflow file

2. **Disable cancel-in-progress** - Let builds complete even if new commits arrive

## Result

- Test PRs, docs, chore commits won't trigger or cancel builds
- Server changes trigger builds that run to completion

## Test plan

- [ ] Verify workflow only triggers on server-related changes
- [ ] Verify builds complete without cancellation