### PR TITLE
fix(deploy): redirect imagetools output to step summary only

### DIFF
--- a/.github/workflows/docker-server-build.yml
+++ b/.github/workflows/docker-server-build.yml
@@ -175,23 +175,6 @@ jobs:
           docker buildx imagetools create $(jq -cr '.tags | map(select(startswith("docker.io"))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: Inspect image
-        id: inspect
-        run: |
-          # Disable GitHub Actions command processing for this step
-          # The imagetools output contains colons that get misinterpreted
-          echo "::stop-commands::inspect-output"
-
-          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest || true
-
-          echo "::inspect-output::"
-
-          # Get digest separately
-          digest=$(docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest --format '{{.Manifest.Digest}}' 2>/dev/null || echo "")
-          if [[ -n "$digest" ]]; then
-            echo "digest=${digest}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Output image info
         run: |
           echo "## Docker Image Built (Multi-Arch)" >> $GITHUB_STEP_SUMMARY
@@ -201,6 +184,11 @@ jobs:
           echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Manifest:**" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest >> $GITHUB_STEP_SUMMARY 2>&1 || echo "Failed to inspect" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   trigger-coolify:


### PR DESCRIPTION
Remove the problematic Inspect step that writes to GITHUB_OUTPUT. Instead, redirect the imagetools output directly to GITHUB_STEP_SUMMARY where colons won't be misinterpreted.