### PR TITLE
fix(ci): use correct Coolify webhook API endpoint

### DIFF
--- a/.github/workflows/docker-server-build.yml
+++ b/.github/workflows/docker-server-build.yml
@@ -216,14 +216,13 @@ jobs:
 
           echo "Triggering Coolify deployment..."
 
+          # Coolify webhook API uses query params: /api/v1/deploy?uuid={uuid}&force=true
           response=$(curl -sS -w "\n%{http_code}" \
             --connect-timeout 10 --max-time 30 \
-            -X POST \
+            -X GET \
             -H "Accept: application/json" \
-            -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
-            -d '{"force":true}' \
-            "${base_url}/api/v1/applications/${COOLIFY_APP_UUID}/deploy" || true)
+            "${base_url}/api/v1/deploy?uuid=${COOLIFY_APP_UUID}&force=true" || true)
 
           http_code=$(echo "$response" | tail -n1)
           body=$(echo "$response" | sed '$d')


### PR DESCRIPTION
## Summary
- Changed Coolify deploy trigger from `/api/v1/applications/{uuid}/deploy` (POST with JSON body)
- To `/api/v1/deploy?uuid={uuid}&force=true` (GET with query params)
- Matches Coolify's actual webhook API format

## Context
The previous workflow used the wrong API endpoint format, causing HTTP 404 errors on deploy trigger.

## Test plan
- [ ] Merge and verify the workflow triggers Coolify deployment successfully