### PR TITLE
feat: add Codex error surfacing to activity stream

### DIFF
--- a/.claude/plans/dev-direction-2026-q2.md
+++ b/.claude/plans/dev-direction-2026-q2.md
@@ -1,0 +1,270 @@
+# Dev Direction: cmux Q2 2026
+
+## Vision
+
+cmux evolves from "spawn parallel coding agents" to **the platform where AI agents produce verified, reviewable changes through automated testing and human-in-the-loop code review**.
+
+The three launch pillars:
+1. **PR Comment → Agent** (GitHub-native feedback loop)
+2. **Operator Visual Verification** (browser automation screenshots on PRs)
+3. **Swipe Code Review** (mobile-first review UX with merge queue)
+
+## Current State (2026-03-19)
+
+### What's Complete
+- Cloud orchestration: SSE events, JWT auth, 31 MCP tools, background worker
+- Local captain mode: 32 devsh orchestrate subcommands, supervise-local, view --live
+- Agent memory: devsh-memory-mcp v0.3.8, learning pipeline, behavior memory
+- Test coverage: ~1200 tests + 20 PRs passing (ready to merge)
+- Documentation: 14 packages + 9 apps documented
+- Deployment: Docker build decoupled from Coolify, multi-arch (amd64+arm64)
+- Providers: PVE-LXC (active), E2B (active, 64 tests), Morph (stale)
+
+### What's Missing (Dev Direction Gaps)
+- No PR comment → agent pipeline (GitHub webhook stubs exist but are no-ops)
+- No browser automation post-run (magnitude-core exists but not integrated)
+- No mobile-friendly review UX (current diff viewer is desktop-focused)
+- Memory freshness/forgetting not implemented
+- Provider-neutral lifecycle events not implemented
+- Vercel deployment cap still bottlenecking apps/www and apps/client
+- 20 test PRs need merging
+
+## Confirmed Priority Order (2026-03-19)
+
+```
+Phase 0:   Housekeeping (merge 20 test PRs, Coolify start)
+Phase 0.5: Native Workflow Dashboard ← FOUNDATION FOR EVERYTHING
+Phase 1:   PR Comment → Agent (Launch 1)
+Phase 2:   Operator Screenshots (Launch 2)
+Phase 3:   Swipe Code Review (Launch 3)
+Phase 4:   Memory Quality & Lifecycle
+```
+
+> Decision: Native workflow view comes first. All 3 launches build on top of it.
+> Without Phase 0.5, users can't see what agents are doing — the dashboard is blind.
+> See `.claude/plans/native-workflow-dashboard.md` for detailed Phase 0.5 architecture.
+
+---
+
+## Phase 0: Housekeeping (This Week)
+
+### 0.1 Merge Test Sprint PRs
+- 20 open PRs all passing checks
+- Batch merge with `gh pr merge --squash --auto` for each
+- Validates CI pipeline handles concurrent merges
+
+### 0.2 Coolify Web Stack Migration (Start)
+- Move `apps/client` to Coolify stack first (Vite SPA, minimal coupling)
+- Then `apps/www` after removing `hono/vercel` adapter
+- Unblocks Vercel deployment cap (~100/day limit)
+- Reference: [[cmux-coolify-all-in-one-stack-study]]
+
+## Phase 1: PR Comment → Agent ("Launch 1")
+
+### What
+GitHub PR/issue comments mentioning `@cmux` trigger a coding agent to work on the described change, then post results back to the PR.
+
+### Architecture
+```
+PR Comment (@cmux fix the auth bug)
+  → GitHub Webhook (issue_comment event)
+  → Parse mention + extract prompt
+  → Create task (with PR context: repo, branch, diff)
+  → Spawn agent in sandbox
+  → Agent produces code changes
+  → Post result comment to original PR
+  → Optional: Crown evaluation picks best result
+```
+
+### What Already Exists
+- GitHub App webhook handler (`github_webhook.ts`) — stubs for `issue_comment` and `pull_request_review_comment`
+- Task creation flow: Task → TaskRun → Sandbox → PR
+- PR comment posting: 1400+ lines in `github_pr_comments.ts`
+- Crown evaluation system for picking winners
+- Preview system with screenshot comments
+
+### What Needs Building
+1. **Enable issue_comment webhook handler** — parse `@cmux` mentions
+2. **createTaskFromComment action** — extract prompt, PR context, link back
+3. **Result posting pipeline** — comment on original PR with agent's work
+4. **Vercel pill UI** — optional GitHub App rendering for visual trigger
+
+### Files to Modify
+- `packages/convex/convex/github_webhook.ts` — enable comment handler
+- `packages/convex/convex/github_pr_comments.ts` — add createTaskFromComment
+- `packages/convex/convex/tasks.ts` — ensure cloud workspace creation from comment
+- `apps/www/lib/routes/` — webhook route for GitHub App
+
+### Detailed Implementation (from codebase research)
+
+**Existing code to reuse:**
+- `github_webhook.ts` line ~220: `issue_comment` case exists (currently no-op)
+- `previewRuns.enqueueFromWebhook()`: webhook → preview run pattern (exact template)
+- `github_pr_comments.ts` (1,776 lines): `postInitialPreviewComment()`, `updatePreviewComment()`, `postPreviewComment()` - video upload to GitHub Release Assets, markdown sanitization, comment history collapsing
+- `crown/actions.ts`: multi-candidate evaluation with Mermaid summary
+
+**Implementation steps:**
+1. Enable `issue_comment` handler → parse `@cmux` mentions (2-4 hours)
+2. New `createTaskFromComment` internal action → call `tasks.create` with cloud workspace + comment ID for linking (2-3 hours)
+3. Result posting → reuse existing `postPreviewComment` (1 hour integration)
+4. Testing (2-3 hours)
+5. Optional UI pill via GitHub App renderer (4-6 hours)
+
+### Effort: 2-3 days for MVP pipeline, 1 week for polish
+
+## Phase 2: Operator Visual Verification ("Launch 2")
+
+### What
+After agents complete their work, spin up a browser automation agent that navigates the preview environment, takes screenshots, and posts them to the PR for easy visual verification.
+
+### Architecture
+```
+Agent completes task → PR created
+  → Trigger operator verification
+  → Spin up sandbox with browser (Chrome CDP on port 39381/39382)
+  → Navigate preview URL
+  → Take screenshots of key pages
+  → Post screenshot gallery to PR as comment
+  → Update task status with visual verification results
+```
+
+### What Already Exists
+- Browser automation infra: magnitude-core/patchright in sandbox
+- Chrome CDP ports: 39381, 39382 exposed in edge routers
+- noVNC on port 39380 for visual debugging
+- Preview comment system: uploads to GitHub Release Assets
+- Crown evaluation with video uploads
+
+### What Needs Building
+1. **Operator agent profile** — specialized for browser testing, not coding
+2. **Screenshot capture pipeline** — CDP → screenshots → GitHub comment
+3. **Preview URL resolution** — map PR to Vercel preview or local dev URL
+4. **Visual verification task type** — separate from coding tasks
+
+### Detailed Infrastructure (from codebase research)
+
+**Already ready:**
+- `magnitude-core@^0.3.0` in `apps/worker/package.json` with `startBrowserAgent()`
+- `runBrowserAgentFromPrompt.ts`: connects to Chrome via CDP, uses Claude as reasoning engine
+- CDP ports: 39381 (HTTP), 39382 (target protocol) - exposed in edge routers
+- `@cmux/host-screenshot-collector`: raw video recording, click events, cursor overlay, ffmpeg post-processing, GIF preview
+- `screenshotCollector/`: orchestrates capture, uploads to Convex storage
+- `docker-run-browser-agent.sh`: Docker container launcher with all ports exposed
+- `evals/screenshot/`: LLM-as-judge evaluation system for screenshot quality
+- VNC stack: tigervnc + xvfb + fluxbox + noVNC
+
+**What to compose:**
+1. Post-task trigger: after coding agents complete → create operator verification task
+2. Pass PR link + changed files + preview URL to operator agent
+3. magnitude-core navigates and screenshots at key interaction points
+4. Post screenshot gallery to PR using existing `postPreviewComment()` pipeline
+
+### Effort: 1-2 weeks (mostly orchestration, infra exists)
+
+## Phase 3: Swipe Code Review ("Launch 3")
+
+### What
+Mobile-first code review UX where reviewers swipe through changes, approve/reject files, with AI-assisted review scoring (heatmap) and optional merge queue.
+
+### Architecture
+```
+PR ready for review
+  → Generate AI review heatmap (packages/pr-heatmap)
+  → Present changes in swipe-able card format
+  → Each file/change is a card: swipe right (approve), left (request changes)
+  → AI highlights risk areas via heatmap confidence scores
+  → After all files reviewed, option to merge
+  → Merge queue for ordered, safe merging
+```
+
+### What Already Exists
+- `packages/pr-heatmap`: AI-powered code review with Vercel AI SDK
+- `devsh review` command (hidden): CLI wrapper for pr-heatmap
+- Git diff viewer with heatmap overlay (`git-diff-viewer-with-heatmap.tsx`)
+- Crown evaluation for automated quality scoring
+- Diff computation via Rust native module in apps/server
+
+### What Needs Building
+1. **Card-based review component** — mobile-optimized swipe UI
+2. **Review state management** — track per-file approve/reject
+3. **Merge queue backend** — ordered merge with check gate
+4. **Push notification** — notify reviewer when PR ready
+
+### Detailed Implementation (from codebase research)
+
+**Existing review infrastructure:**
+- `packages/pr-heatmap/src/heatmap-generator.ts` (246 lines): GPT-4o-mini line-level scoring (0-10)
+- `heatmap-diff-viewer.tsx` (1,037 lines): split-view with 100-step gradient coloring, per-line tooltips, character-level highlighting
+- `git-diff-review-viewer.tsx` (2,176 lines): file tree sidebar, Shift+J/K keyboard navigation, intersection observer auto-scrolling
+- `code-review.route.ts`: POST `/api/code-review/start` + GET `/api/code-review/stream` (SSE)
+- `devsh review` command (hidden): CLI wrapper
+
+**What's missing for swipe UX:**
+1. Review decision state (approve/reject per file) + Convex persistence
+2. Swipe gesture layer (touch events or A/X keyboard shortcuts) with undo stack
+3. Merge queue: new `pr_review_queue` Convex table ranked by heatmap risk + approval rate
+4. GitHub API integration for PR status checks + merge gate
+5. Batch actions: "Approve all" / "Request changes for all"
+
+### Effort: 2-3 weeks
+
+## Upstream Context (March 2026)
+
+### Key Upstream Changes
+
+| Tool | Version | What Changed | cmux Impact |
+|------|---------|-------------|-------------|
+| **Claude Code** | v2.1.79 (Mar 18) | 10 releases in 13 days: `SendMessage` replaces `resume`, MCP elicitation, `StopFailure` hook, `InstructionsLoaded` hook, `${CLAUDE_PLUGIN_DATA}`, 45% faster resume | Update agent messaging to align with `SendMessage` pattern |
+| **Codex** | v0.115.0 (Mar 16) | Guardian subagent approvals, subagent sandbox inheritance, v0.116.0 alpha imminent | Verify compatibility, update approval flow |
+| **Gemini CLI** | v0.36.0-nightly | Subagent support, A2A server with gRPC, Linux sandbox (bubblewrap/seccomp/LXC/gVisor) | Monitor A2A protocol, ensure sandbox passthrough |
+| **Cursor** | Automations (Mar 19) | Always-on trigger-based agents (Slack, Linear, GitHub), MCP marketplace (30+ plugins), Composer 2 | Closest orchestration competitor, validate scheduling features |
+| **Opencode** | v1.2.27 (Mar 16) | VCS watcher, session management across worktrees, Azure support | Minor integration updates |
+
+### Industry Trends to React To
+
+1. **Sub-agent/Guardian patterns** — Both Claude and Codex converging on sub-agent coordination. cmux already does this but should ensure MAILBOX.json maps to upstream `SendMessage` patterns
+2. **Hook standardization** — Claude has 10+ hook types. cmux should map sandbox lifecycle events to provider hook configs
+3. **Always-on/Cron agents** — Claude `/loop` + Cursor Automations. cmux could add scheduled task support
+4. **A2A/ACP protocols** — Google pushing A2A (gRPC), Cursor pushing ACP. Worth prototyping A2A for cross-CLI coordination
+5. **MCP as plugin standard** — Confirmed dominant. cmux's MCP server (31 tools) is well-positioned
+6. **Sandbox security convergence** — All CLIs investing in isolation. cmux's multi-provider abstraction remains a differentiator
+
+## Phase 4: Memory Quality & Lifecycle (Infrastructure)
+
+### What
+Make agent memory smarter: freshness scoring, forgetting policies, context health visibility. Normalize lifecycle events across providers.
+
+### Why Now
+The competition (Claude Code v2.1.79, Codex 0.115.0) is converging on memory curation, not accumulation. cmux already has the memory infrastructure — the quality layer is the differentiator.
+
+### Changes
+1. **Memory freshness**: Add `updated_at`, `last_used_at`, `confidence` metadata
+2. **Forgetting policy**: Demote stale P2 entries, prune unused behavior rules
+3. **Context health**: Provider-neutral warnings in `AgentCommEvent`
+4. **Lifecycle events**: `session_stop_blocked`, `context_warning`, `memory_loaded`
+
+### Reference
+- [[cmux-context-health-lifecycle-design]]
+- [[codex-vs-claude-operator-architecture-2026-03]]
+- [[research-weekly-2026-03-19]]
+
+### Effort: 1-2 weeks
+
+## Priority Matrix
+
+| Phase | Feature | User Impact | Effort | Dependencies |
+|-------|---------|-------------|--------|--------------|
+| 0.1 | Merge test PRs | CI hygiene | 1 hour | None |
+| 0.2 | Coolify migration (start) | Deployment unblock | 1 week | None |
+| **0.5** | **Native workflow dashboard** | **Critical** (foundation) | **2 weeks** | **Phase 0** |
+| 1 | PR Comment → Agent | **High** (new user loop) | 1 week | Phase 0.5 |
+| 2 | Operator verification | **High** (visual proof) | 2 weeks | Phase 0.5 |
+| 3 | Swipe code review | **Medium** (UX innovation) | 3 weeks | Phase 0.5 |
+| 4 | Memory quality | **Medium** (agent reliability) | 2 weeks | Current memory |
+
+## Success Metrics
+
+- **Launch 1**: First PR comment triggers agent within 30 seconds
+- **Launch 2**: Screenshots posted to PR within 5 minutes of task completion
+- **Launch 3**: Reviewer can review a 10-file PR in under 2 minutes on mobile
+- **Memory**: Agents make 30% fewer repeated mistakes with freshness scoring

--- a/.claude/plans/native-workflow-dashboard.md
+++ b/.claude/plans/native-workflow-dashboard.md
@@ -1,0 +1,241 @@
+# Native Workflow Dashboard Plan
+
+## Problem
+
+The cmux web dashboard is a task launcher, not a workflow surface. Agent execution is trapped inside the VS Code iframe. Users see "Running..." for 10-30 minutes with no visibility into what the agent is doing.
+
+`taskRunLogChunks` (the original log streaming mechanism) was deprecated - `appendChunk()` is a no-op.
+
+## Goal
+
+Surface agent workflow **natively in the cmux web app** so users can see:
+1. What the agent is currently doing (live activity stream)
+2. What code is changing (live diffs)
+3. What tests pass/fail (structured results)
+4. What errors occurred (surfaced alerts, not buried in terminal)
+5. What sub-agents are spawning (real-time orchestration view)
+
+VS Code iframe becomes an optional "deep dive" tool, not the primary workflow surface.
+
+## Architecture
+
+```
+Agent in Sandbox
+  ├── Terminal output ──→ SSE/WebSocket ──→ Dashboard: Live Log Panel
+  ├── Tool calls ───────→ Convex events ──→ Dashboard: Activity Timeline
+  ├── File edits ───────→ Git diff stream → Dashboard: Live Diff Panel
+  ├── Test results ─────→ Structured data → Dashboard: Test Results Badge
+  ├── Errors ───────────→ Convex alerts ──→ Dashboard: Error Banner
+  └── Git commits ──────→ Convex events ──→ Dashboard: Commit Timeline
+```
+
+## Phase 1: Agent Activity Stream (Foundation)
+
+### What
+A real-time activity stream showing what the agent is doing right now.
+
+### Data Sources (Already Available)
+- `orchestrationEvents` table in Convex (SSE streaming exists)
+- Socket.IO events from apps/server (task lifecycle)
+- `taskRunLogChunks` table structure (exists, write path disabled)
+
+### Implementation
+
+1. **Revive log chunk streaming**
+   - Fix `appendChunk()` in `taskRunLogChunks.ts` (currently no-op)
+   - Or: new SSE endpoint that streams from sandbox xterm
+   - Or: pipe sandbox stdout/stderr to Convex via HTTP POST (like memory sync)
+
+2. **Agent activity event types**
+   ```typescript
+   type AgentActivityEvent = {
+     type: "tool_call" | "file_edit" | "file_read" | "bash_command" |
+           "test_run" | "git_commit" | "error" | "thinking" | "sub_agent_spawn";
+     timestamp: number;
+     summary: string;        // "Edit src/auth/middleware.ts (+12/-3)"
+     detail?: string;        // Full diff or command output
+     duration_ms?: number;
+   };
+   ```
+
+3. **Dashboard component: ActivityStream**
+   - Route: alongside existing task run panels (new tab or always-visible sidebar)
+   - Real-time updates via Convex subscription
+   - Expandable entries (click to see full diff/output)
+   - Auto-scroll to latest with "pin to bottom" toggle
+
+### Files to Create/Modify
+- `packages/convex/convex/taskRunActivity.ts` — NEW: activity event mutations + queries
+- `packages/convex/convex/schema.ts` — NEW table: `taskRunActivity`
+- `apps/client/src/components/ActivityStream.tsx` — NEW: real-time activity view
+- `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.activity.tsx` — NEW route
+
+### Concrete Implementation (from codebase research 2026-03-19)
+
+#### Data Flow
+
+```
+Claude PostToolUse hook → activity-hook.sh
+  → curl POST /api/task-run/activity (JWT auth)
+  → Convex taskRunActivity.insert()
+  → Convex real-time subscription
+  → Dashboard ActivityStream component
+```
+
+#### Step 1: Convex table `taskRunActivity`
+
+File: `packages/convex/convex/schema.ts`
+
+```typescript
+taskRunActivity: defineTable({
+  taskRunId: v.id("taskRuns"),
+  type: v.string(),  // tool_call, file_edit, bash_command, test_run, git_commit, error
+  toolName: v.optional(v.string()),
+  summary: v.string(),  // "Edit src/auth.ts (+12/-3)"
+  detail: v.optional(v.string()),
+  durationMs: v.optional(v.number()),
+  teamId: v.string(),
+  createdAt: v.number(),
+}).index("by_task_run", ["taskRunId", "createdAt"])
+```
+
+#### Step 2: HTTP endpoint
+
+File: `packages/convex/convex/taskRunActivity_http.ts` (NEW)
+
+Copy the proven pattern from `notifications_http.ts`:
+- `getWorkerAuth(req)` for JWT validation
+- Zod schema for request body
+- `ctx.runMutation(internal.taskRunActivity.insert, ...)`
+
+Register in `packages/convex/convex/http.ts`:
+```typescript
+http.route({ path: "/api/task-run/activity", method: "POST", handler: postTaskRunActivity });
+```
+
+#### Step 3: Claude PostToolUse hook
+
+File: `packages/shared/src/providers/anthropic/environment.ts` (line ~393)
+
+Existing PostToolUse only hooks `ExitPlanMode`. Expand matcher to `".*"` (all tools):
+
+```typescript
+PostToolUse: [{
+  matcher: ".*",
+  hooks: [{ type: "command", command: `${claudeLifecycleDir}/activity-hook.sh` }],
+}],
+```
+
+The `activity-hook.sh` script:
+- Reads tool_use JSON from stdin
+- Extracts tool name + input summary
+- Background POST to `/api/task-run/activity` with JWT auth
+- Non-blocking (runs in background, exits immediately)
+
+Auth pattern already proven: `CMUX_CALLBACK_URL` + `x-cmux-token: ${CMUX_TASK_RUN_JWT}`
+
+#### Step 4: Codex fallback
+
+Codex writes `/root/lifecycle/codex-turns.jsonl` per turn. Background process parses this file and POSTs activity events. Lower fidelity than Claude hooks but works.
+
+#### Step 5: Dashboard component
+
+Files:
+- `apps/client/src/components/ActivityStream.tsx` (NEW)
+- `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.activity.tsx` (NEW route)
+
+Uses `useQuery(api.taskRunActivity.getByTaskRunId)` for real-time Convex subscription.
+
+#### Files Summary
+
+| Action | File | What |
+|--------|------|------|
+| CREATE | `packages/convex/convex/taskRunActivity.ts` | Mutations + queries |
+| CREATE | `packages/convex/convex/taskRunActivity_http.ts` | HTTP endpoint |
+| CREATE | `apps/client/src/components/ActivityStream.tsx` | Dashboard UI |
+| CREATE | `apps/client/src/routes/...activity.tsx` | Route |
+| MODIFY | `packages/convex/convex/schema.ts` | Add table |
+| MODIFY | `packages/convex/convex/http.ts` | Register route |
+| MODIFY | `packages/shared/src/providers/anthropic/environment.ts` | Add hook |
+
+#### Why This Works
+
+- Reuses proven JWT + HTTP POST + Convex mutation pattern (same as crown/complete, notifications)
+- Claude PostToolUse hook already exists for ExitPlanMode — just expand the matcher
+- Convex real-time subscriptions give instant UI updates
+- Non-blocking: hook script runs in background, doesn't slow agent
+
+### Effort: 3-5 days for Claude foundation, +2 days for Codex fallback
+
+## Phase 2: Live Diff Panel
+
+### What
+Show code changes as they happen, without needing the VS Code iframe.
+
+### Implementation
+- Use existing Rust git diff module (`apps/server/native/core`)
+- Add SSE endpoint: `/api/task-run/:id/diff-stream`
+- Poll git status every 5 seconds in sandbox, POST diff summary
+- Render with existing `heatmap-diff-viewer.tsx` component (already works outside iframe)
+
+### Effort: 3-5 days
+
+## Phase 3: Structured Test Results
+
+### What
+Parse test output into structured pass/fail badges.
+
+### Implementation
+- Parse terminal output for common test runner formats (vitest, jest, pytest, go test)
+- POST structured results: `{ passed: 12, failed: 1, skipped: 0, details: [...] }`
+- Dashboard shows green/red badges with expandable failure details
+
+### Effort: 2-3 days
+
+## Phase 4: Error Surfacing
+
+### What
+Agent errors visible immediately in dashboard, not buried in terminal scroll.
+
+### Implementation
+- Claude: `StopFailure` hook event (already exists in v2.1.78)
+- Codex: Error patterns in terminal output
+- POST error events to Convex → real-time subscription in dashboard
+- Red banner with "Agent encountered error" + expandable details
+
+### Effort: 1-2 days
+
+## Updated Priority Matrix
+
+| Priority | Feature | Why First |
+|----------|---------|-----------|
+| **P0** | Activity stream (Phase 1) | Foundation for all workflow visibility |
+| **P0** | Error surfacing (Phase 4) | Users need to know when things fail |
+| **P1** | Live diff panel (Phase 2) | Most requested: "what code changed?" |
+| **P1** | Launch 1: PR Comment → Agent | First user-facing launch |
+| **P2** | Test results (Phase 3) | Nice-to-have structured view |
+| **P2** | Launch 2: Operator screenshots | Builds on activity stream |
+| **P3** | Launch 3: Swipe review | Builds on diff panel |
+
+## Design Constraint
+
+Keep the iframe as an option. Some users will always want full VS Code. The native dashboard should be the **default view** with a "Open in VS Code" button for deep dives.
+
+```
+┌─ Task Run View ──────────────────────────────────┐
+│                                                    │
+│  Tabs: [Activity] [Diff] [Memory] [VS Code]       │
+│                                                    │
+│  Activity (default):                               │
+│  ┌──────────────────────────────────────────────┐ │
+│  │ 10:01 ● Agent started (claude/opus-4.6)      │ │
+│  │ 10:02 ○ Read src/auth/middleware.ts           │ │
+│  │ 10:03 ● Edit src/auth/middleware.ts (+12/-3)  │ │
+│  │ 10:04 ○ Run: bun test auth → ✓ 3 passed      │ │
+│  │ 10:05 ○ Commit: "fix: validate JWT expiry"   │ │
+│  │ 10:06 ● PR created: #123                      │ │
+│  └──────────────────────────────────────────────┘ │
+│                                                    │
+│  [Open in VS Code]  [View Full Diff]  [Stop Agent] │
+└────────────────────────────────────────────────────┘
+```

--- a/.claude/plans/phase-0.5-activity-stream-impl.md
+++ b/.claude/plans/phase-0.5-activity-stream-impl.md
@@ -1,0 +1,224 @@
+# Phase 0.5.1: Activity Stream Implementation Spec
+
+## Overview
+Add real-time agent activity events to the cmux web dashboard.
+Claude PostToolUse hook → HTTP POST → Convex → real-time subscription → ActivityStream component.
+
+## Files to Create
+
+### 1. `packages/convex/convex/taskRunActivity.ts`
+
+```typescript
+import { v } from "convex/values";
+import { internalMutation, query } from "./_generated/server";
+
+// Schema addition for schema.ts:
+// taskRunActivity: defineTable({
+//   taskRunId: v.id("taskRuns"),
+//   type: v.string(),
+//   toolName: v.optional(v.string()),
+//   summary: v.string(),
+//   detail: v.optional(v.string()),
+//   durationMs: v.optional(v.number()),
+//   teamId: v.string(),
+//   createdAt: v.number(),
+// })
+//   .index("by_task_run", ["taskRunId", "createdAt"])
+//   .index("by_team", ["teamId", "createdAt"]),
+
+export const insert = internalMutation({
+  args: {
+    taskRunId: v.id("taskRuns"),
+    type: v.string(),
+    toolName: v.optional(v.string()),
+    summary: v.string(),
+    detail: v.optional(v.string()),
+    durationMs: v.optional(v.number()),
+    teamId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.insert("taskRunActivity", {
+      ...args,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const getByTaskRun = query({
+  args: {
+    taskRunId: v.id("taskRuns"),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("taskRunActivity")
+      .withIndex("by_task_run", (q) => q.eq("taskRunId", args.taskRunId))
+      .order("desc")
+      .take(args.limit ?? 100);
+  },
+});
+```
+
+### 2. `packages/convex/convex/taskRunActivity_http.ts`
+
+Copy pattern from `notifications_http.ts` (line 23-100):
+
+```typescript
+import { z } from "zod";
+import { jsonResponse } from "../_shared/http-utils";
+import { internal } from "./_generated/api";
+import { httpAction, internalMutation } from "./_generated/server";
+import { getWorkerAuth } from "./users/utils/getWorkerAuth";
+import { typedZid } from "@cmux/shared/utils/typed-zid";
+
+const ActivityEventSchema = z.object({
+  taskRunId: typedZid("taskRuns"),
+  type: z.enum(["tool_call", "file_edit", "file_read", "bash_command",
+                 "test_run", "git_commit", "error", "thinking"]),
+  toolName: z.string().optional(),
+  summary: z.string().max(500),
+  detail: z.string().max(10000).optional(),
+  durationMs: z.number().optional(),
+});
+
+export const postActivity = httpAction(async (ctx, req) => {
+  const auth = await getWorkerAuth(req, { loggerPrefix: "[taskRunActivity]" });
+  if (!auth) return jsonResponse({ code: 401, message: "Unauthorized" }, 401);
+
+  // Content-Type check
+  const ct = req.headers.get("content-type") ?? "";
+  if (!ct.toLowerCase().includes("application/json")) {
+    return jsonResponse({ code: 415, message: "Content-Type must be application/json" }, 415);
+  }
+
+  let json: unknown;
+  try { json = await req.json(); } catch {
+    return jsonResponse({ code: 400, message: "Invalid JSON" }, 400);
+  }
+
+  const validation = ActivityEventSchema.safeParse(json);
+  if (!validation.success) {
+    return jsonResponse({ code: 400, message: "Invalid input" }, 400);
+  }
+
+  const { taskRunId, ...eventData } = validation.data;
+
+  // Verify ownership
+  if (auth.payload.taskRunId !== taskRunId) {
+    return jsonResponse({ code: 401, message: "Unauthorized" }, 401);
+  }
+
+  await ctx.runMutation(internal.taskRunActivity.insert, {
+    taskRunId,
+    teamId: auth.payload.teamId,
+    ...eventData,
+  });
+
+  return jsonResponse({ ok: true }, 200);
+});
+```
+
+### 3. Register route in `packages/convex/convex/http.ts`
+
+After line 141 (agent-stopped route):
+
+```typescript
+import { postActivity } from "./taskRunActivity_http";
+
+http.route({
+  path: "/api/task-run/activity",
+  method: "POST",
+  handler: postActivity,
+});
+```
+
+### 4. Activity hook script in `packages/shared/src/providers/anthropic/environment.ts`
+
+Add to the lifecycle scripts section (alongside plan-hook.sh, stop-hook.sh):
+
+```bash
+#!/bin/bash
+# activity-hook.sh - Posts agent tool-use events to cmux dashboard
+set -eu
+EVENT=$(cat)
+TOOL_NAME=$(echo "$EVENT" | jq -r '.tool_use.name // "unknown"')
+TOOL_INPUT=$(echo "$EVENT" | jq -r '.tool_use.input | tostring' | head -c 200)
+
+# Map tool names to activity types
+case "$TOOL_NAME" in
+  Edit|Write|NotebookEdit) TYPE="file_edit" ;;
+  Read)                     TYPE="file_read" ;;
+  Bash)                     TYPE="bash_command" ;;
+  Grep|Glob)                TYPE="file_read" ;;
+  *)                        TYPE="tool_call" ;;
+esac
+
+# Build summary from tool input
+case "$TOOL_NAME" in
+  Edit)  SUMMARY="Edit $(echo "$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
+  Read)  SUMMARY="Read $(echo "$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
+  Write) SUMMARY="Write $(echo "$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
+  Bash)  SUMMARY="Run: $(echo "$EVENT" | jq -r '.tool_use.input.command // ""' | head -c 80)" ;;
+  *)     SUMMARY="$TOOL_NAME" ;;
+esac
+
+# Non-blocking POST
+(
+  curl -s -X POST "${CMUX_CALLBACK_URL}/api/task-run/activity" \
+    -H "Content-Type: application/json" \
+    -H "x-cmux-token: ${CMUX_TASK_RUN_JWT}" \
+    -d "$(jq -n --arg trid "$CMUX_TASK_RUN_ID" --arg type "$TYPE" \
+           --arg tool "$TOOL_NAME" --arg summary "$SUMMARY" \
+           '{taskRunId: $trid, type: $type, toolName: $tool, summary: $summary}')" \
+    >> /root/lifecycle/activity-hook.log 2>&1 || true
+) &
+exit 0
+```
+
+### 5. Expand PostToolUse matcher in environment.ts
+
+Change line 395 from:
+```typescript
+matcher: "ExitPlanMode",
+```
+To:
+```typescript
+matcher: "Edit|Write|Bash|Read|Grep|Glob|NotebookEdit|Agent",
+```
+
+Keep ExitPlanMode hook separate (it has its own logic). Add new entry:
+```typescript
+PostToolUse: [
+  {
+    matcher: "ExitPlanMode",
+    hooks: [{ type: "command", command: `${claudeLifecycleDir}/plan-hook.sh` }],
+  },
+  {
+    matcher: "Edit|Write|Bash|Read|Grep|Glob|NotebookEdit|Agent",
+    hooks: [{ type: "command", command: `${claudeLifecycleDir}/activity-hook.sh` }],
+  },
+],
+```
+
+### 6. `apps/client/src/components/ActivityStream.tsx`
+
+React component using Convex real-time subscription:
+
+```tsx
+// Key props: taskRunId
+// Uses: useQuery(api.taskRunActivity.getByTaskRun, { taskRunId })
+// Renders: timeline of events with icons per type
+// Features: auto-scroll, expandable detail, relative timestamps
+```
+
+### 7. Route: `apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.activity.tsx`
+
+New tab alongside existing vscode/memory/orchestration tabs.
+
+## Testing
+
+- `packages/convex/convex/taskRunActivity.test.ts` — insert + query
+- `packages/convex/convex/taskRunActivity_http.test.ts` — auth + validation
+- Manual: run task with Claude, verify events appear in dashboard
+
+## Effort: 3-5 days

--- a/packages/shared/src/providers/openai/environment.ts
+++ b/packages/shared/src/providers/openai/environment.ts
@@ -349,16 +349,34 @@ ${CODEX_AUTOPILOT_TURN_SUMMARY_LINE}"
 
   # Check if there's a session to resume
   SESSION_FILE="/root/lifecycle/codex-session-id.txt"
+  CODEX_EXIT=0
   if [ "\$ITER" -gt 1 ] && [ -f "\$SESSION_FILE" ]; then
     THREAD_ID=\$(cat "\$SESSION_FILE")
     if [ -n "\$THREAD_ID" ]; then
       log "Resuming session: \$THREAD_ID"
-      codex exec resume --last "\$PROMPT" 2>&1 | tee -a "\$TURN_FILE" || true
+      codex exec resume --last "\$PROMPT" 2>&1 | tee -a "\$TURN_FILE" || CODEX_EXIT=\$?
     else
-      codex exec "\$PROMPT" 2>&1 | tee -a "\$TURN_FILE" || true
+      codex exec "\$PROMPT" 2>&1 | tee -a "\$TURN_FILE" || CODEX_EXIT=\$?
     fi
   else
-    codex exec "\$PROMPT" 2>&1 | tee -a "\$TURN_FILE" || true
+    codex exec "\$PROMPT" 2>&1 | tee -a "\$TURN_FILE" || CODEX_EXIT=\$?
+  fi
+
+  # Report errors to dashboard
+  if [ "\$CODEX_EXIT" -ne 0 ] && [ -n "\$CMUX_CALLBACK_URL" ] && [ -n "\$CMUX_TASK_RUN_JWT" ] && [ -n "\${CMUX_TASK_RUN_ID:-}" ]; then
+    ERROR_MSG="Codex exited with code \$CODEX_EXIT (turn \$ITER)"
+    # Try to extract last error line from turn log
+    LAST_ERR=\$(tail -5 "\$TURN_FILE" 2>/dev/null | grep -i "error\\|fail\\|exception" | tail -1 || true)
+    if [ -n "\$LAST_ERR" ]; then
+      ERROR_MSG="\$ERROR_MSG: \$LAST_ERR"
+    fi
+    curl -s -X POST "\$CMUX_CALLBACK_URL/api/task-run/activity" \\
+      -H "Content-Type: application/json" \\
+      -H "x-cmux-token: \$CMUX_TASK_RUN_JWT" \\
+      -d "\$(jq -n --arg trid "\$CMUX_TASK_RUN_ID" --arg summary "Error: \$ERROR_MSG" \\
+           '{taskRunId: \$trid, type: "error", toolName: "codex", summary: \$summary}')" \\
+      >> /root/lifecycle/activity-hook.log 2>&1 || true
+    log "Error reported: \$ERROR_MSG"
   fi
 
   send_heartbeat


### PR DESCRIPTION
## Summary
- Captures Codex exit codes in autopilot script
- Extracts error messages from turn logs
- Posts error events to dashboard activity stream

## Test plan
- [ ] Run Codex task that fails (e.g., invalid API key)
- [ ] Verify error appears in Activity tab with red highlight