### PR TITLE
feat: add PR Comment → Agent webhook handler (Phase 1)

### DIFF
--- a/packages/convex/convex/github_pr_comments.ts
+++ b/packages/convex/convex/github_pr_comments.ts
@@ -1773,3 +1773,45 @@ export const addScreenshotCommentToPr = internalAction({
     }
   },
 });
+
+/**
+ * Add a reaction to a GitHub issue/PR comment.
+ * Used by PR Comment → Agent to acknowledge @cmux mentions.
+ */
+export const addReactionToComment = internalAction({
+  args: {
+    installationId: v.number(),
+    repoFullName: v.string(),
+    commentId: v.number(),
+    reaction: v.union(
+      v.literal("+1"),
+      v.literal("-1"),
+      v.literal("laugh"),
+      v.literal("confused"),
+      v.literal("heart"),
+      v.literal("hooray"),
+      v.literal("rocket"),
+      v.literal("eyes"),
+    ),
+  },
+  handler: async (_ctx, args) => {
+    const { installationId, repoFullName, commentId, reaction } = args;
+
+    const [owner, repo] = repoFullName.split("/");
+    if (!owner || !repo) {
+      throw new Error(`Invalid repoFullName: ${repoFullName}`);
+    }
+
+    const accessToken = await fetchInstallationAccessToken(installationId);
+    const octokit = new Octokit({ auth: accessToken });
+
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      content: reaction,
+    });
+
+    return { ok: true };
+  },
+});

--- a/packages/convex/convex/github_webhook.ts
+++ b/packages/convex/convex/github_webhook.ts
@@ -4,7 +4,9 @@ import type {
   DeploymentStatusEvent,
   InstallationEvent,
   InstallationRepositoriesEvent,
+  IssueCommentEvent,
   PullRequestEvent,
+  PullRequestReviewCommentEvent,
   PushEvent,
   StatusEvent,
   WebhookEvent,
@@ -24,7 +26,12 @@ const DEBUG_FLAGS = {
 
 const FEATURE_FLAGS = {
   githubEyesReactionOnPrOpen: true,
+  // PR Comment → Agent: trigger agent from @cmux mentions in PR comments
+  prCommentTriggerEnabled: true,
 };
+
+// Bot mention pattern - matches @cmux or @cmux-bot followed by the prompt
+const CMUX_MENTION_PATTERN = /@cmux(?:-bot)?\s+(.+)/is;
 
 async function verifySignature(
   secret: string,
@@ -215,9 +222,155 @@ export const githubWebhook = httpAction(async (_ctx, req) => {
       case "repository":
       case "create":
       case "delete":
-      case "pull_request_review":
+      case "pull_request_review": {
+        break;
+      }
       case "pull_request_review_comment":
       case "issue_comment": {
+        // PR Comment → Agent: trigger agent from @cmux mentions
+        if (!FEATURE_FLAGS.prCommentTriggerEnabled) {
+          break;
+        }
+
+        try {
+          const commentPayload = body as IssueCommentEvent | PullRequestReviewCommentEvent;
+          const action = commentPayload.action;
+
+          // Only process new comments (not edits or deletes)
+          if (action !== "created") {
+            break;
+          }
+
+          // Get comment body
+          const commentBody = commentPayload.comment?.body ?? "";
+          const match = commentBody.match(CMUX_MENTION_PATTERN);
+          if (!match) {
+            break; // No @cmux mention
+          }
+
+          const prompt = match[1].trim();
+          if (!prompt) {
+            console.log("[issue_comment] Empty prompt after @cmux mention", { delivery });
+            break;
+          }
+
+          // Get repo and installation info
+          const repoFullName = String(commentPayload.repository?.full_name ?? "");
+          const installation = Number(commentPayload.installation?.id ?? 0);
+          const commentId = Number(commentPayload.comment?.id ?? 0);
+          const commentUrl = String(commentPayload.comment?.html_url ?? "");
+          const commentAuthor = String(commentPayload.comment?.user?.login ?? "");
+
+          if (!repoFullName || !installation || !commentId) {
+            console.warn("[issue_comment] Missing required fields", {
+              repoFullName,
+              installation,
+              commentId,
+              delivery,
+            });
+            break;
+          }
+
+          // Get PR info (for issue_comment on a PR, or pull_request_review_comment)
+          let prNumber: number | undefined;
+          let prBranch: string | undefined;
+          let baseBranch: string | undefined;
+
+          if ("issue" in commentPayload && commentPayload.issue?.pull_request) {
+            // issue_comment on a PR
+            prNumber = commentPayload.issue.number;
+          } else if ("pull_request" in commentPayload && commentPayload.pull_request) {
+            // pull_request_review_comment
+            const pr = commentPayload.pull_request;
+            prNumber = pr.number;
+            prBranch = pr.head?.ref;
+            baseBranch = pr.base?.ref;
+          }
+
+          // Find team from installation
+          const conn = await _ctx.runQuery(
+            internal.github_app.getProviderConnectionByInstallationId,
+            { installationId: installation },
+          );
+          const teamId = conn?.teamId;
+
+          if (!teamId) {
+            console.warn("[issue_comment] No team found for installation", {
+              installation,
+              delivery,
+            });
+            break;
+          }
+
+          // Find a default user for this team (use team owner)
+          const teamDoc = await _ctx.runQuery(internal.teams.getByIdInternal, { id: teamId });
+          const userId = teamDoc?.ownerUserId;
+
+          if (!userId) {
+            console.warn("[issue_comment] No owner found for team", { teamId, delivery });
+            break;
+          }
+
+          console.log("[issue_comment] Creating task from @cmux mention", {
+            repoFullName,
+            prNumber,
+            commentAuthor,
+            promptPreview: prompt.substring(0, 100),
+            delivery,
+          });
+
+          // Create task
+          const { taskId } = await _ctx.runMutation(internal.tasks.createInternal, {
+            teamId,
+            userId,
+            text: prompt,
+            description: `Triggered by @${commentAuthor} in ${repoFullName}${prNumber ? ` PR #${prNumber}` : ""}`,
+            projectFullName: repoFullName,
+            baseBranch: baseBranch ?? "main",
+          });
+
+          // Create task run with default agent and link to source comment
+          await _ctx.runMutation(internal.taskRuns.createInternal, {
+            taskId,
+            teamId,
+            userId,
+            prompt,
+            agentName: "claude/sonnet-4", // Default agent
+            newBranch: prBranch, // Use PR head branch if available
+            githubCommentId: commentId,
+            githubCommentUrl: commentUrl,
+          });
+
+          // Add eyes reaction to acknowledge the comment
+          try {
+            await _ctx.runAction(internal.github_pr_comments.addReactionToComment, {
+              installationId: installation,
+              repoFullName,
+              commentId,
+              reaction: "eyes",
+            });
+          } catch (reactionErr) {
+            console.warn("[issue_comment] Failed to add reaction", { reactionErr, delivery });
+          }
+
+          // Capture analytics
+          capturePosthogEvent({
+            distinctId: teamId,
+            event: "pr_comment_agent_triggered",
+            properties: {
+              repo: repoFullName,
+              prNumber,
+              commentAuthor,
+              promptLength: prompt.length,
+            },
+          });
+
+        } catch (commentErr) {
+          console.error("[issue_comment] Handler failed", {
+            err: commentErr,
+            delivery,
+          });
+        }
         break;
       }
       case "workflow_run": {

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -382,6 +382,9 @@ const convexSchema = defineSchema({
       )
     ),
     codexThreadId: v.optional(v.string()), // Codex CLI thread-id for session resume
+    // PR Comment → Agent: link back to source comment for result posting
+    githubCommentId: v.optional(v.number()), // GitHub comment ID that triggered this run
+    githubCommentUrl: v.optional(v.string()), // URL to the source comment
   })
     .index("by_task", ["taskId", "createdAt"])
     .index("by_parent", ["parentRunId"])

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -531,6 +531,9 @@ export const createInternal = internalMutation({
     environmentId: v.optional(v.id("environments")),
     parentRunId: v.optional(v.id("taskRuns")), // Agent Teams (D4) - parent-child relationships
     isOrchestrationHead: v.optional(v.boolean()), // Whether this is a head agent for orchestration
+    // PR Comment → Agent: link back to source comment for result posting
+    githubCommentId: v.optional(v.number()),
+    githubCommentUrl: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -566,6 +569,8 @@ export const createInternal = internalMutation({
       isLocalWorkspace: task.isLocalWorkspace,
       isCloudWorkspace: task.isCloudWorkspace,
       isOrchestrationHead: args.isOrchestrationHead,
+      githubCommentId: args.githubCommentId,
+      githubCommentUrl: args.githubCommentUrl,
     });
 
     // Update task's lastActivityAt and selectedTaskRunId

--- a/packages/convex/convex/teams.ts
+++ b/packages/convex/convex/teams.ts
@@ -140,6 +140,32 @@ export const getByTeamIdInternal = internalQuery({
   },
 });
 
+// Internal helper to fetch team by ID with owner userId (used by webhook handlers)
+export const getByIdInternal = internalQuery({
+  args: { id: v.string() },
+  handler: async (ctx, { id }) => {
+    const team = await ctx.db
+      .query("teams")
+      .withIndex("by_teamId", (q) => q.eq("teamId", id))
+      .first();
+    if (!team) return null;
+
+    // Find the owner from team memberships
+    const ownerMembership = await ctx.db
+      .query("teamMemberships")
+      .withIndex("by_team", (q) => q.eq("teamId", id))
+      .filter((q) => q.eq(q.field("role"), "owner"))
+      .first();
+
+    return {
+      teamId: team.teamId,
+      slug: team.slug ?? null,
+      displayName: team.displayName ?? null,
+      ownerUserId: ownerMembership?.userId ?? null,
+    };
+  },
+});
+
 // Internal helper to fetch team memberships by userId (used by HTTP handlers)
 export const getMembershipsByUserIdInternal = internalQuery({
   args: { userId: v.string() },


### PR DESCRIPTION
## Summary
Enables @cmux mentions in GitHub PR comments to trigger coding agent tasks.

**What it does:**
1. GitHub webhook receives `issue_comment` or `pull_request_review_comment` event
2. Parses for `@cmux <prompt>` pattern
3. Creates task with linked repo and base branch
4. Creates task run with default agent (claude/sonnet-4)
5. Adds eyes reaction to acknowledge the mention
6. Stores comment ID/URL for result posting back to PR

**Files changed:**
- `packages/convex/convex/github_webhook.ts` - Add comment handler
- `packages/convex/convex/github_pr_comments.ts` - Add reaction action
- `packages/convex/convex/taskRuns.ts` - Add comment fields to createInternal
- `packages/convex/convex/teams.ts` - Add getByIdInternal for owner lookup
- `packages/convex/convex/schema.ts` - Add githubCommentId/Url fields

## Test plan
- [ ] Comment `@cmux fix the typo in README` on a PR
- [ ] Verify eyes reaction appears on comment
- [ ] Verify task appears in cmux dashboard
- [ ] Verify agent runs and creates PR (result posting is next PR)