### PR TITLE
feat: add provider-neutral lifecycle events

### DIFF
--- a/packages/convex/convex/agentMemoryFreshness.ts
+++ b/packages/convex/convex/agentMemoryFreshness.ts
@@ -495,6 +495,79 @@ export const emitMemoryLoaded = internalMutation({
 });
 
 /**
+ * Emit a memory pruned event.
+ * Called when stale memory entries are cleaned up.
+ */
+export const emitMemoryPruned = internalMutation({
+  args: {
+    orchestrationId: v.string(),
+    taskRunId: v.optional(v.id("taskRuns")),
+    teamId: v.string(),
+    prunedCount: v.number(),
+    memoryTypes: v.array(v.string()),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const eventId = `evt_${now}_${Math.random().toString(36).slice(2, 8)}`;
+
+    await ctx.db.insert("orchestrationEvents", {
+      eventId,
+      orchestrationId: args.orchestrationId,
+      eventType: "memory_pruned",
+      teamId: args.teamId,
+      taskRunId: args.taskRunId,
+      payload: {
+        prunedCount: args.prunedCount,
+        memoryTypes: args.memoryTypes,
+        reason: args.reason,
+      },
+      createdAt: now,
+    });
+
+    return { eventId };
+  },
+});
+
+/**
+ * Emit a session stop blocked event.
+ * Called when an agent session cannot stop due to pending work.
+ */
+export const emitSessionStopBlocked = internalMutation({
+  args: {
+    orchestrationId: v.string(),
+    taskRunId: v.id("taskRuns"),
+    teamId: v.string(),
+    blockedReason: v.union(
+      v.literal("pending_approval"),
+      v.literal("uncommitted_changes"),
+      v.literal("running_subprocess"),
+      v.literal("pending_sync")
+    ),
+    details: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const eventId = `evt_${now}_${Math.random().toString(36).slice(2, 8)}`;
+
+    await ctx.db.insert("orchestrationEvents", {
+      eventId,
+      orchestrationId: args.orchestrationId,
+      eventType: "session_stop_blocked",
+      teamId: args.teamId,
+      taskRunId: args.taskRunId,
+      payload: {
+        blockedReason: args.blockedReason,
+        details: args.details,
+      },
+      createdAt: now,
+    });
+
+    return { eventId };
+  },
+});
+
+/**
  * Daily maintenance job: update freshness scores and demote stale rules.
  * Called by cron job to process all teams.
  */

--- a/packages/convex/convex/orchestrationEvents.ts
+++ b/packages/convex/convex/orchestrationEvents.ts
@@ -28,7 +28,12 @@ const eventTypeValidator = v.union(
   v.literal("approval_resolved"),
   v.literal("plan_updated"),
   v.literal("orchestration_completed"),
-  v.literal("provider_session_bound")
+  v.literal("provider_session_bound"),
+  // Phase 4: Context health and lifecycle events
+  v.literal("context_warning"), // Context approaching limit
+  v.literal("memory_loaded"), // Memory seeded into sandbox
+  v.literal("memory_pruned"), // Stale memory entries removed
+  v.literal("session_stop_blocked") // Session stop blocked by pending work
 );
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Completes Phase 4 lifecycle events for provider-neutral hook support
- Adds event types: `context_warning`, `memory_loaded`, `memory_pruned`, `session_stop_blocked`
- Adds `emitMemoryPruned` and `emitSessionStopBlocked` mutations

## Test plan
- [ ] Verify typecheck passes (`bun check`)
- [ ] Verify event validators in schema and orchestrationEvents match