### PR TITLE
docs: clarify system policy rules protection

### DIFF
--- a/packages/convex/convex/agentPolicyRules.ts
+++ b/packages/convex/convex/agentPolicyRules.ts
@@ -422,7 +422,7 @@ export const remove = authMutation({
       throw new Error("Policy rule not found");
     }
 
-    // System rules can only be deleted by admin (TODO: add admin check)
+    // System rules are protected and cannot be deleted by any user
     if (rule.scope === "system") {
       throw new Error("System rules cannot be deleted");
     }


### PR DESCRIPTION
## Summary
- Removes misleading TODO comment about admin checks
- Clarifies that system rules are intentionally protected and cannot be deleted

The current behavior is correct - system rules should not be deletable.

## Test plan
- [ ] Verify typecheck passes (`bun check`)