### PR TITLE
feat(client): enable task checkbox and pin button with bulk actions

### DIFF
--- a/apps/client/src/components/dashboard/TaskItem.tsx
+++ b/apps/client/src/components/dashboard/TaskItem.tsx
@@ -36,11 +36,17 @@ import { EnvironmentName } from "./EnvironmentName";
 interface TaskItemProps {
   task: Doc<"tasks">;
   teamSlugOrId: string;
+  isSelected?: boolean;
+  onSelectionChange?: (taskId: string, selected: boolean) => void;
+  showCheckbox?: boolean;
 }
 
 export const TaskItem = memo(function TaskItem({
   task,
   teamSlugOrId,
+  isSelected = false,
+  onSelectionChange,
+  showCheckbox = false,
 }: TaskItemProps) {
   const clipboard = useClipboard({ timeout: 2000 });
   const { archiveWithUndo, unarchive, isArchiving } =
@@ -285,6 +291,26 @@ export const TaskItem = memo(function TaskItem({
     });
   }, [unpinTask, teamSlugOrId, task._id]);
 
+  const handleCheckboxChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      e.stopPropagation();
+      onSelectionChange?.(task._id, e.target.checked);
+    },
+    [onSelectionChange, task._id]
+  );
+
+  const handlePinClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (task.pinned) {
+        unpinTask({ teamSlugOrId, id: task._id });
+      } else {
+        pinTask({ teamSlugOrId, id: task._id });
+      }
+    },
+    [task.pinned, pinTask, unpinTask, teamSlugOrId, task._id]
+  );
+
   return (
     <div className="relative group w-full">
       <ContextMenu.Root>
@@ -306,11 +332,13 @@ export const TaskItem = memo(function TaskItem({
             <div className="flex items-center justify-center pl-1 -mr-2 relative">
               <input
                 type="checkbox"
-                className="peer w-3 h-3 cursor-pointer border border-neutral-400 dark:border-neutral-500 rounded bg-white dark:bg-neutral-900 appearance-none checked:bg-neutral-500 checked:border-neutral-500 dark:checked:bg-neutral-400 dark:checked:border-neutral-400 invisible"
+                checked={isSelected}
+                className={clsx(
+                  "peer w-3 h-3 cursor-pointer border border-neutral-400 dark:border-neutral-500 rounded bg-white dark:bg-neutral-900 appearance-none checked:bg-neutral-500 checked:border-neutral-500 dark:checked:bg-neutral-400 dark:checked:border-neutral-400",
+                  showCheckbox ? "visible" : "invisible group-hover:visible"
+                )}
                 onClick={(e) => e.stopPropagation()}
-                onChange={() => {
-                  // TODO: Implement checkbox functionality
-                }}
+                onChange={handleCheckboxChange}
               />
               <Check
                 className="absolute w-2.5 h-2.5 text-white pointer-events-none transition-opacity peer-checked:opacity-100 opacity-0"
@@ -552,6 +580,33 @@ export const TaskItem = memo(function TaskItem({
             className="group-hover:opacity-100 aria-expanded:opacity-100 opacity-0"
           />
 
+          {/* Pin/Unpin button */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={handlePinClick}
+                className={clsx(
+                  "p-1 rounded",
+                  "bg-neutral-100 dark:bg-neutral-700",
+                  task.pinned
+                    ? "text-amber-600 dark:text-amber-400"
+                    : "text-neutral-600 dark:text-neutral-400",
+                  "hover:bg-neutral-200 dark:hover:bg-neutral-600",
+                  "group-hover:opacity-100 opacity-0"
+                )}
+              >
+                {task.pinned ? (
+                  <PinOff className="w-3.5 h-3.5" />
+                ) : (
+                  <Pin className="w-3.5 h-3.5" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {task.pinned ? "Unpin task" : "Pin task"}
+            </TooltipContent>
+          </Tooltip>
+
           {/* Keep-alive button */}
           {runWithVSCode && hasActiveVSCode && (
             <Tooltip>
@@ -565,8 +620,7 @@ export const TaskItem = memo(function TaskItem({
                       ? "text-blue-600 dark:text-blue-400"
                       : "text-neutral-600 dark:text-neutral-400",
                     "hover:bg-neutral-200 dark:hover:bg-neutral-600",
-                    "group-hover:opacity-100 opacity-0",
-                    "hidden" // TODO: show this button
+                    "group-hover:opacity-100 opacity-0"
                   )}
                 >
                   <Pin className="w-3.5 h-3.5" />

--- a/apps/client/src/components/dashboard/TaskList.tsx
+++ b/apps/client/src/components/dashboard/TaskList.tsx
@@ -1,9 +1,10 @@
 import { api } from "@cmux/convex/api";
 import type { Doc, Id } from "@cmux/convex/dataModel";
 import { useLocalStorage } from "@mantine/hooks";
-import { usePaginatedQuery, useQuery } from "convex/react";
+import { usePaginatedQuery, useQuery, useMutation } from "convex/react";
 import clsx from "clsx";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Archive, Pin, X } from "lucide-react";
 
 // Custom hook for infinite scroll that only triggers after user has scrolled
 function useInfiniteScroll(
@@ -77,6 +78,7 @@ function useInfiniteScroll(
 import { TaskItem } from "./TaskItem";
 import { PreviewItem } from "./PreviewItem";
 import { ChevronRight, Loader2 } from "lucide-react";
+import { useArchiveTask } from "@/hooks/useArchiveTask";
 import { env } from "../../client-env";
 
 type TaskCategoryKey =
@@ -261,6 +263,31 @@ export const TaskList = memo(function TaskList({
   // In web mode, exclude local workspaces from the task list
   const excludeLocalWorkspaces = env.NEXT_PUBLIC_WEB_MODE || undefined;
 
+  // Selection state for bulk actions
+  const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
+  const hasSelection = selectedTaskIds.size > 0;
+
+  // Bulk action mutations
+  const pinTask = useMutation(api.tasks.pin);
+  const unpinTask = useMutation(api.tasks.unpin);
+  const { archiveWithUndo } = useArchiveTask(teamSlugOrId);
+
+  const handleSelectionChange = useCallback((taskId: string, selected: boolean) => {
+    setSelectedTaskIds(prev => {
+      const next = new Set(prev);
+      if (selected) {
+        next.add(taskId);
+      } else {
+        next.delete(taskId);
+      }
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedTaskIds(new Set());
+  }, []);
+
   // Paginated query for main tasks (replaces non-paginated api.tasks.get)
   const {
     results: allTasks,
@@ -282,6 +309,32 @@ export const TaskList = memo(function TaskList({
     { initialNumItems: PREVIEW_PAGE_SIZE },
   );
   const [tab, setTab] = useState<"all" | "previews">("all");
+
+  // Bulk actions
+  const handleBulkPin = useCallback(async () => {
+    const promises = Array.from(selectedTaskIds).map(id =>
+      pinTask({ teamSlugOrId, id: id as Id<"tasks"> })
+    );
+    await Promise.all(promises);
+    clearSelection();
+  }, [selectedTaskIds, pinTask, teamSlugOrId, clearSelection]);
+
+  const handleBulkUnpin = useCallback(async () => {
+    const promises = Array.from(selectedTaskIds).map(id =>
+      unpinTask({ teamSlugOrId, id: id as Id<"tasks"> })
+    );
+    await Promise.all(promises);
+    clearSelection();
+  }, [selectedTaskIds, unpinTask, teamSlugOrId, clearSelection]);
+
+  const handleBulkArchive = useCallback(async () => {
+    // Get selected tasks from allTasks
+    const selectedTasks = allTasks.filter(t => selectedTaskIds.has(t._id));
+    for (const task of selectedTasks) {
+      archiveWithUndo(task);
+    }
+    clearSelection();
+  }, [selectedTaskIds, allTasks, archiveWithUndo, clearSelection]);
 
   // Infinite scroll for preview runs
   const previewScrollRef = useRef<HTMLDivElement>(null);
@@ -470,6 +523,43 @@ export const TaskList = memo(function TaskList({
           </button>
         </div>
       </div>
+
+      {/* Bulk actions toolbar */}
+      {hasSelection && tab === "all" && (
+        <div className="mx-4 mb-3 flex items-center gap-2 rounded-md bg-neutral-100 dark:bg-neutral-800 px-3 py-2">
+          <span className="text-xs font-medium text-neutral-600 dark:text-neutral-300">
+            {selectedTaskIds.size} selected
+          </span>
+          <div className="flex-1" />
+          <button
+            onClick={handleBulkPin}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-neutral-600 hover:bg-neutral-200 dark:text-neutral-300 dark:hover:bg-neutral-700"
+          >
+            <Pin className="h-3 w-3" />
+            Pin
+          </button>
+          <button
+            onClick={handleBulkUnpin}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-neutral-600 hover:bg-neutral-200 dark:text-neutral-300 dark:hover:bg-neutral-700"
+          >
+            <Pin className="h-3 w-3" />
+            Unpin
+          </button>
+          <button
+            onClick={handleBulkArchive}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-neutral-600 hover:bg-neutral-200 dark:text-neutral-300 dark:hover:bg-neutral-700"
+          >
+            <Archive className="h-3 w-3" />
+            Archive
+          </button>
+          <button
+            onClick={clearSelection}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-neutral-500 hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      )}
       <div className="flex flex-col gap-1 w-full">
         {tab === "previews" ? (
           previewRunsStatus === "LoadingFirstPage" ? (
@@ -534,6 +624,8 @@ export const TaskList = memo(function TaskList({
                     expanded={Boolean(expandedCategories[categoryKey])}
                     onToggleExpanded={toggleCategoryExpanded}
                     initialDisplayCount={CATEGORY_INITIAL_DISPLAY_COUNT}
+                    selectedTaskIds={selectedTaskIds}
+                    onSelectionChange={handleSelectionChange}
                   />
                 );
               })}
@@ -566,6 +658,8 @@ function TaskCategorySection({
   expanded,
   onToggleExpanded,
   initialDisplayCount,
+  selectedTaskIds,
+  onSelectionChange,
 }: {
   categoryKey: TaskCategoryKey;
   tasks: Doc<"tasks">[];
@@ -575,6 +669,8 @@ function TaskCategorySection({
   expanded: boolean;
   onToggleExpanded: (key: TaskCategoryKey) => void;
   initialDisplayCount: number;
+  selectedTaskIds: Set<string>;
+  onSelectionChange: (taskId: string, selected: boolean) => void;
 }) {
   const meta = CATEGORY_META[categoryKey];
   const handleToggle = useCallback(
@@ -629,7 +725,14 @@ function TaskCategorySection({
       {collapsed ? null : tasks.length > 0 ? (
         <div id={contentId} className="flex flex-col w-full">
           {visibleTasks.map((task) => (
-            <TaskItem key={task._id} task={task} teamSlugOrId={teamSlugOrId} />
+            <TaskItem
+              key={task._id}
+              task={task}
+              teamSlugOrId={teamSlugOrId}
+              isSelected={selectedTaskIds.has(task._id)}
+              onSelectionChange={onSelectionChange}
+              showCheckbox={selectedTaskIds.size > 0}
+            />
           ))}
           {hasOverflow && (
             <button


### PR DESCRIPTION
## Summary
Phase 1 of Q3 2026 Task UX Polish - enables previously hidden task selection and pin functionality.

## Changes
- **TaskItem.tsx**: 
  - Make checkbox visible on hover (always visible when any task is selected)
  - Add pin/unpin button to hover actions with amber color when pinned
  - Add props for selection state management
- **TaskList.tsx**:
  - Add selection state (`selectedTaskIds` Set)
  - Add bulk actions toolbar showing when tasks are selected
  - Bulk pin, unpin, and archive actions
  - Pass selection props through TaskCategorySection

## Test plan
- [x] `bun check` passes
- [ ] CI passes
- [ ] Hover over task to see checkbox and pin button appear
- [ ] Click checkbox to select task, see bulk actions toolbar
- [ ] Select multiple tasks and use bulk pin/archive
- [ ] Pin button shows amber color when task is pinned