### PR TITLE
feat(client): add mobile hamburger navigation

### DIFF
--- a/apps/client/src/components/Sidebar.tsx
+++ b/apps/client/src/components/Sidebar.tsx
@@ -18,7 +18,7 @@ import { api } from "@cmux/convex/api";
 import { useQuery } from "convex/react";
 import type { LinkProps } from "@tanstack/react-router";
 import { Link } from "@tanstack/react-router";
-import { Bell, ChevronLeft, FolderKanban, Home, Plus, Server, Settings, Users } from "lucide-react";
+import { Bell, ChevronLeft, FolderKanban, Home, Plus, Server, Settings, Users, X } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -331,12 +331,13 @@ export function Sidebar({ tasks, teamSlugOrId, onToggleHidden }: SidebarProps) {
           className="flex items-center gap-1 ml-2"
           style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
         >
+          {/* Desktop: collapse chevron */}
           <Tooltip delayDuration={200}>
             <TooltipTrigger asChild>
               <button
                 type="button"
                 onClick={onToggleHidden}
-                className="w-[25px] h-[25px] border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-900 rounded-lg flex items-center justify-center transition-colors cursor-default"
+                className="hidden md:flex w-[25px] h-[25px] border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-900 rounded-lg items-center justify-center transition-colors cursor-default"
                 aria-label="Toggle sidebar"
               >
                 <ChevronLeft
@@ -353,6 +354,19 @@ export function Sidebar({ tasks, teamSlugOrId, onToggleHidden }: SidebarProps) {
               Toggle sidebar Ctrl+Shift+S
             </TooltipContent>
           </Tooltip>
+
+          {/* Mobile: close X button */}
+          <button
+            type="button"
+            onClick={onToggleHidden}
+            className="flex md:hidden w-[25px] h-[25px] border border-neutral-200 dark:border-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-900 rounded-lg items-center justify-center transition-colors cursor-default"
+            aria-label="Close menu"
+          >
+            <X
+              className="w-4 h-4 text-neutral-700 dark:text-neutral-300"
+              aria-hidden="true"
+            />
+          </button>
 
           <Tooltip delayDuration={200}>
             <TooltipTrigger asChild>

--- a/apps/client/src/components/TitleBar.tsx
+++ b/apps/client/src/components/TitleBar.tsx
@@ -6,7 +6,7 @@ import {
 import { useSidebarOptional } from "@/contexts/sidebar/SidebarContext";
 import { isElectron } from "@/lib/electron";
 import { Link, useParams } from "@tanstack/react-router";
-import { ChevronRight, Plus } from "lucide-react";
+import { ChevronRight, Menu, Plus } from "lucide-react";
 import type { CSSProperties, ReactNode } from "react";
 import CmuxLogoMark from "./logo/cmux-logo-mark";
 
@@ -30,10 +30,37 @@ export function TitleBar({
       className="h-[38px] border-b border-neutral-200/70 dark:border-neutral-800/50 flex items-center justify-center relative select-none"
       style={{ WebkitAppRegion: "drag" } as CSSProperties}
     >
-      {/* Left side: toggle icons when sidebar hidden - same X position as sidebar header icons */}
+      {/* Mobile hamburger menu - visible only on small screens when sidebar is hidden */}
+      {teamSlugOrId && (
+        <div
+          className="absolute inset-y-0 left-3 flex items-center md:hidden"
+          style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
+        >
+          <Tooltip delayDuration={200}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => sidebar?.setIsHidden(false)}
+                className="w-[32px] h-[32px] hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-lg flex items-center justify-center transition-colors cursor-default"
+                aria-label="Open menu"
+              >
+                <Menu
+                  className="w-5 h-5 text-neutral-700 dark:text-neutral-300"
+                  aria-hidden="true"
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" showArrow={false}>
+              Open menu
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+
+      {/* Left side: toggle icons when sidebar hidden - same X position as sidebar header icons (desktop only) */}
       {showSidebarToggle && (
         <div
-          className={`absolute inset-y-0 flex items-center -translate-y-px ${isElectron ? "" : "pl-3"}`}
+          className={`absolute inset-y-0 hidden md:flex items-center -translate-y-px ${isElectron ? "" : "pl-3"}`}
           style={{
             WebkitAppRegion: "no-drag",
             // Offset FloatingPane's left gutter: 1px border + 0.375rem (6px) pane padding.


### PR DESCRIPTION
## Summary
Phase 2 of Q3 2026 - adds mobile-friendly navigation with hamburger menu.

## Changes
- **TitleBar.tsx**: 
  - Add hamburger menu button (Menu icon) visible only on mobile (`md:hidden`)
  - Hide desktop sidebar toggle controls on mobile
- **Sidebar.tsx**:
  - Add close (X) button visible only on mobile for easy sidebar dismissal
  - Keep desktop collapse chevron hidden on mobile

## Mobile UX
- On mobile: hamburger icon in title bar opens sidebar, X button closes it
- On desktop: existing collapse/expand behavior unchanged

## Test plan
- [x] `bun check` passes
- [ ] CI passes
- [ ] On mobile viewport: hamburger visible, clicking opens sidebar
- [ ] On mobile: X button in sidebar header closes sidebar
- [ ] On desktop: no visual changes, chevron toggle works