### PR TITLE
feat: add loading skeletons and error boundaries (Q3 Phase 3)

### DIFF
--- a/apps/client/src/components/ErrorBoundary.tsx
+++ b/apps/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,129 @@
+import { Component, type ReactNode, type ErrorInfo } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  /** Component name for error logging */
+  name?: string;
+  /** Callback when error occurs */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Error boundary component that catches JavaScript errors in child components.
+ * Displays a fallback UI instead of crashing the whole app.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    const { name, onError } = this.props;
+    console.error(`[ErrorBoundary${name ? `:${name}` : ""}] Caught error:`, error, errorInfo);
+    onError?.(error, errorInfo);
+  }
+
+  handleRetry = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <ErrorFallback
+          error={this.state.error}
+          name={this.props.name}
+          onRetry={this.handleRetry}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+/**
+ * Default error fallback UI
+ */
+export function ErrorFallback({
+  error,
+  name,
+  onRetry,
+  className,
+}: {
+  error?: Error | null;
+  name?: string;
+  onRetry?: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center gap-3 rounded-lg border border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-950/30 ${className ?? ""}`}
+    >
+      <AlertTriangle className="size-8 text-red-500" />
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-red-700 dark:text-red-400">
+          {name ? `Failed to load ${name}` : "Something went wrong"}
+        </p>
+        {error?.message && (
+          <p className="text-xs text-red-600 dark:text-red-500">
+            {error.message}
+          </p>
+        )}
+      </div>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="inline-flex items-center gap-1.5 rounded-md bg-red-100 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-200 dark:bg-red-900/50 dark:text-red-300 dark:hover:bg-red-900"
+        >
+          <RefreshCw className="size-3" />
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Compact error fallback for inline/card components
+ */
+export function CompactErrorFallback({
+  name,
+  onRetry,
+}: {
+  name?: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-center gap-2 py-4 text-neutral-500 dark:text-neutral-400">
+      <AlertTriangle className="size-4 text-red-500" />
+      <span className="text-xs">
+        {name ? `Failed to load ${name}` : "Error loading content"}
+      </span>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/dashboard/DashboardSkeletons.tsx
+++ b/apps/client/src/components/dashboard/DashboardSkeletons.tsx
@@ -1,0 +1,118 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+/**
+ * Skeleton for SessionActivityCard - shows 6 stat items
+ */
+export function SessionActivityCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("rounded-lg border border-neutral-200 dark:border-neutral-800 p-4", className)}>
+      <div className="mb-4 flex items-center justify-between">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-6 w-20" />
+      </div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <Skeleton className="size-4 rounded" />
+            <div className="flex flex-col gap-1">
+              <Skeleton className="h-6 w-12" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Skeleton for FileChangeHeatmap - shows directory groups with file bars
+ */
+export function FileChangeHeatmapSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("rounded-lg border border-neutral-200 dark:border-neutral-800 p-4", className)}>
+      <div className="mb-4 flex items-center justify-between">
+        <Skeleton className="h-5 w-36" />
+        <Skeleton className="h-6 w-20" />
+      </div>
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, groupIndex) => (
+          <div key={groupIndex} className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Skeleton className="size-4" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <div className="ml-6 space-y-1">
+              {Array.from({ length: 3 }).map((_, fileIndex) => (
+                <div key={fileIndex} className="flex items-center gap-2">
+                  <Skeleton className="size-3.5" />
+                  <Skeleton className="h-3 flex-1 max-w-32" />
+                  <Skeleton className="h-3 w-24" />
+                  <Skeleton className="h-3 w-10" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Skeleton for SessionTimeline - shows timeline events
+ */
+export function SessionTimelineSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("rounded-lg border border-neutral-200 dark:border-neutral-800 p-4", className)}>
+      <div className="mb-4 flex items-center justify-between">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-4 w-16" />
+      </div>
+      <div className="space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="relative flex gap-3">
+            {/* Timeline line */}
+            {i < 3 && (
+              <div className="absolute left-[15px] top-8 h-[calc(100%-8px)] w-0.5 bg-neutral-200 dark:bg-neutral-700" />
+            )}
+            {/* Icon placeholder */}
+            <Skeleton className="relative z-10 size-8 shrink-0 rounded-full" />
+            {/* Content */}
+            <div className="flex-1 space-y-1 pb-4">
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+              <Skeleton className="h-3 w-32" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Skeleton for ActivityStream - shows activity event list
+ */
+export function ActivityStreamSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 p-3">
+          <Skeleton className="size-8 shrink-0 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+            <Skeleton className="h-3 w-full max-w-md" />
+            <Skeleton className="h-3 w-3/4" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/client/src/components/dashboard/FileChangeHeatmap.tsx
+++ b/apps/client/src/components/dashboard/FileChangeHeatmap.tsx
@@ -3,6 +3,7 @@ import { useQuery as useConvexQuery } from "convex/react";
 import { FileCode, FolderOpen } from "lucide-react";
 import { memo, useMemo, useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const TIME_RANGES = [7, 14, 30] as const;
 type TimeRange = (typeof TIME_RANGES)[number];
@@ -239,8 +240,25 @@ function FileChangeHeatmapContent({ teamSlugOrId, days = 7 }: FileChangeHeatmapP
 
   if (!result) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-sm text-neutral-500 dark:text-neutral-400">Loading...</div>
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, groupIndex) => (
+          <div key={groupIndex} className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Skeleton className="size-4" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <div className="ml-6 space-y-1">
+              {Array.from({ length: 3 }).map((_, fileIndex) => (
+                <div key={fileIndex} className="flex items-center gap-2">
+                  <Skeleton className="size-3.5" />
+                  <Skeleton className="h-3 flex-1 max-w-32" />
+                  <Skeleton className="h-3 w-24" />
+                  <Skeleton className="h-3 w-10" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
     );
   }

--- a/apps/client/src/components/dashboard/SessionActivityCard.tsx
+++ b/apps/client/src/components/dashboard/SessionActivityCard.tsx
@@ -3,6 +3,7 @@ import { useQuery as useConvexQuery } from "convex/react";
 import { GitCommit, GitPullRequest, FileCode, Plus, Minus, Clock } from "lucide-react";
 import { memo, useState } from "react";
 import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const TIME_RANGES = [7, 14, 30] as const;
 type TimeRange = (typeof TIME_RANGES)[number];
@@ -45,8 +46,16 @@ function SessionActivityCardContent({ teamSlugOrId, days = 7 }: SessionActivityC
 
   if (!stats) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-sm text-neutral-500 dark:text-neutral-400">Loading...</div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <Skeleton className="size-4 rounded" />
+            <div className="flex flex-col gap-1">
+              <Skeleton className="h-6 w-12" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+        ))}
       </div>
     );
   }

--- a/apps/client/src/components/dashboard/SessionTimeline.tsx
+++ b/apps/client/src/components/dashboard/SessionTimeline.tsx
@@ -14,6 +14,7 @@ import {
 import { memo, useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { formatTime, formatShortDate, formatDuration } from "@/lib/time";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface SessionTimelineProps {
   teamSlugOrId: string;
@@ -268,8 +269,24 @@ function SessionTimelineContent({ teamSlugOrId, limit = 5 }: SessionTimelineProp
 
   if (!result) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-sm text-neutral-500 dark:text-neutral-400">Loading...</div>
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-neutral-200 dark:border-neutral-700 p-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton className="size-4" />
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-3 w-8" />
+                <Skeleton className="h-3 w-8" />
+                <Skeleton className="h-3 w-12" />
+                <Skeleton className="h-3 w-12" />
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     );
   }

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -7,6 +7,7 @@ import { FileChangeHeatmap } from "@/components/dashboard/FileChangeHeatmap";
 import { SessionActivityCard } from "@/components/dashboard/SessionActivityCard";
 import { SessionTimeline } from "@/components/dashboard/SessionTimeline";
 import { TaskList } from "@/components/dashboard/TaskList";
+import { ErrorBoundary, CompactErrorFallback } from "@/components/ErrorBoundary";
 import { WorkspaceCreationButtons } from "@/components/dashboard/WorkspaceCreationButtons";
 import { FloatingPane } from "@/components/floating-pane";
 import { WorkspaceSetupPanel } from "@/components/WorkspaceSetupPanel";
@@ -1481,18 +1482,35 @@ function DashboardComponent() {
           </div>
 
           {/* Session Activity */}
-          <SessionActivityCard teamSlugOrId={teamSlugOrId} className="mb-4" />
+          <ErrorBoundary
+            name="Session Activity"
+            fallback={<CompactErrorFallback name="Session Activity" />}
+          >
+            <SessionActivityCard teamSlugOrId={teamSlugOrId} className="mb-4" />
+          </ErrorBoundary>
 
           {/* Visual Charts */}
           <div className="mb-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
-            <SessionTimeline teamSlugOrId={teamSlugOrId} limit={5} />
-            <FileChangeHeatmap teamSlugOrId={teamSlugOrId} days={7} />
+            <ErrorBoundary
+              name="Session Timeline"
+              fallback={<CompactErrorFallback name="Session Timeline" />}
+            >
+              <SessionTimeline teamSlugOrId={teamSlugOrId} limit={5} />
+            </ErrorBoundary>
+            <ErrorBoundary
+              name="File Change Heatmap"
+              fallback={<CompactErrorFallback name="File Change Heatmap" />}
+            >
+              <FileChangeHeatmap teamSlugOrId={teamSlugOrId} days={7} />
+            </ErrorBoundary>
           </div>
 
           {/* Task List */}
-          <div className="w-full">
-            <TaskList teamSlugOrId={teamSlugOrId} />
-          </div>
+          <ErrorBoundary name="Task List">
+            <div className="w-full">
+              <TaskList teamSlugOrId={teamSlugOrId} />
+            </div>
+          </ErrorBoundary>
         </div>
       </div>
     </FloatingPane>


### PR DESCRIPTION
## Summary
- Add skeleton loading components for dashboard cards (SessionActivityCard, FileChangeHeatmap, SessionTimeline, ActivityStream)
- Create reusable ErrorBoundary component with default and compact fallback UI
- Replace "Loading..." text with proper skeleton loaders matching each card's layout
- Wrap dashboard components with error boundaries for graceful error handling

## Test plan
- [ ] Verify skeleton loaders appear briefly when dashboard loads
- [ ] Verify skeletons match the visual layout of loaded components
- [ ] Test error boundaries by simulating component errors in dev tools
- [ ] Confirm retry functionality works in error fallback UI