### PR TITLE
chore(devsh-memory-mcp): bump version to 0.3.9

### DIFF
--- a/packages/devsh-memory-mcp/package.json
+++ b/packages/devsh-memory-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devsh-memory-mcp",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "MCP server for devsh/cmux agent memory - enables Claude Desktop and external clients to access sandbox memory and orchestrate multi-agent workflows",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes in 0.3.9

- Fix context bloat from large TASKS.json (PR #720)
- `read_memory(type: "tasks")` now returns only open tasks by default
- Added `includeCompleted` and `limit` parameters for pagination

## Publish

After merge:
```bash
cd packages/devsh-memory-mcp
npm publish
```