### PR TITLE
feat: add Live Diff and Test Results panels (Phase 0.5)

### DIFF
--- a/apps/client/src/components/LiveDiffPanel.tsx
+++ b/apps/client/src/components/LiveDiffPanel.tsx
@@ -1,0 +1,170 @@
+import { useMemo } from "react";
+import { useQuery as useTanstackQuery } from "@tanstack/react-query";
+import { useLiveDiff } from "@/hooks/useLiveDiff";
+import { gitDiffQueryOptions } from "@/queries/git-diff";
+import { normalizeGitRef } from "@/lib/refWithOrigin";
+import { NewGitDiffViewerWithSidebar } from "./git-diff-view";
+import type { ReplaceDiffEntry, DiffStatus } from "@cmux/shared/diff-types";
+import type { Id } from "@cmux/convex/dataModel";
+import type { TaskRunWithChildren } from "@/types/task";
+
+export interface LiveDiffPanelProps {
+  sandboxId: string | undefined;
+  isRunning: boolean;
+  taskRunId: Id<"taskRuns"> | undefined;
+  teamSlugOrId: string;
+  selectedRun: TaskRunWithChildren | null | undefined;
+  repoFullName: string | undefined;
+  baseBranch: string | undefined;
+  headBranch: string | undefined;
+}
+
+/**
+ * Panel that shows live git diff while sandbox is running,
+ * or falls back to committed diff when stopped.
+ */
+export function LiveDiffPanel({
+  sandboxId,
+  isRunning,
+  selectedRun,
+  repoFullName,
+  baseBranch,
+  headBranch,
+}: LiveDiffPanelProps) {
+  // Normalize branches for committed diff query
+  const normalizedBaseBranch = useMemo(
+    () => normalizeGitRef(baseBranch),
+    [baseBranch]
+  );
+  const normalizedHeadBranch = useMemo(
+    () => normalizeGitRef(headBranch),
+    [headBranch]
+  );
+
+  // Live diff from running sandbox
+  const liveDiffQuery = useLiveDiff({
+    sandboxId,
+    includeContent: true,
+    refetchInterval: isRunning ? 10_000 : false,
+    enabled: isRunning && Boolean(sandboxId),
+  });
+
+  // Committed diff fallback (when not running)
+  const committedDiffQuery = useTanstackQuery({
+    ...gitDiffQueryOptions({
+      repoFullName,
+      headRef: normalizedHeadBranch ?? "",
+      baseRef: normalizedBaseBranch ?? undefined,
+      includeContents: true,
+    }),
+    enabled:
+      !isRunning &&
+      Boolean(repoFullName?.trim()) &&
+      Boolean(normalizedHeadBranch?.trim()),
+  });
+
+  // Convert live diff result to ReplaceDiffEntry format
+  const liveDiffs = useMemo((): ReplaceDiffEntry[] => {
+    if (!liveDiffQuery.data?.files) return [];
+
+    return liveDiffQuery.data.files.map((file) => {
+      // Map live diff status to DiffStatus
+      let status: DiffStatus;
+      switch (file.status) {
+        case "added":
+        case "untracked":
+          status = "added";
+          break;
+        case "deleted":
+          status = "deleted";
+          break;
+        case "renamed":
+          status = "renamed";
+          break;
+        case "modified":
+        default:
+          status = "modified";
+          break;
+      }
+
+      return {
+        filePath: file.path,
+        status,
+        additions: file.insertions,
+        deletions: file.deletions,
+        isBinary: false,
+        // Content from live diff is raw unified diff stored in patch field
+        patch: liveDiffQuery.data?.diff,
+      };
+    });
+  }, [liveDiffQuery.data]);
+
+  // Determine which diffs to show
+  const diffs = isRunning ? liveDiffs : (committedDiffQuery.data ?? []);
+  const isLoading = isRunning
+    ? liveDiffQuery.isLoading
+    : committedDiffQuery.isLoading;
+  const hasError = isRunning
+    ? liveDiffQuery.isError
+    : committedDiffQuery.isError;
+  const errorMessage = isRunning
+    ? liveDiffQuery.error?.message
+    : committedDiffQuery.error?.message;
+
+  // No sandbox selected
+  if (!selectedRun) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+        Select a run to view live diffs
+      </div>
+    );
+  }
+
+  // Running but no sandbox ID yet
+  if (isRunning && !sandboxId) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+        Waiting for sandbox to start...
+      </div>
+    );
+  }
+
+  // Not running and no head branch
+  if (!isRunning && !normalizedHeadBranch) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+        No branch available for diff comparison
+      </div>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+        Failed to load diff{errorMessage ? `: ${errorMessage}` : ""}
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+        Loading {isRunning ? "live" : "committed"} diff...
+      </div>
+    );
+  }
+
+  if (diffs.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+        {isRunning ? "No uncommitted changes" : "No changes found"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full min-h-0 overflow-auto">
+      <NewGitDiffViewerWithSidebar diffs={diffs} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/apps/client/src/components/TaskPanelFactory.tsx
+++ b/apps/client/src/components/TaskPanelFactory.tsx
@@ -11,6 +11,8 @@ import {
   X,
   Maximize2,
   Minimize2,
+  GitPullRequest,
+  TestTube2,
 } from "lucide-react";
 import clsx from "clsx";
 import type { PanelType, PanelPosition } from "@/lib/panel-config";
@@ -25,6 +27,8 @@ import type { TaskRunTerminalPaneProps } from "./TaskRunTerminalPane";
 import type { TaskRunGitDiffPanelProps } from "./TaskRunGitDiffPanel";
 import type { TaskRunMemoryPanelProps } from "./TaskRunMemoryPanel";
 import type { TaskRunSummaryPanelProps } from "./TaskRunSummaryPanel";
+import type { LiveDiffPanelProps } from "./LiveDiffPanel";
+import type { TestResultsPanelProps } from "./TestResultsPanel";
 import { shouldUseServerIframePreflight } from "@/hooks/useIframePreflight";
 import { useVncClipboardBridge } from "@/hooks/useVncClipboardBridge";
 
@@ -192,12 +196,17 @@ interface PanelFactoryProps {
   TaskRunGitDiffPanel?: React.ComponentType<TaskRunGitDiffPanelProps>;
   TaskRunMemoryPanel?: React.ComponentType<TaskRunMemoryPanelProps>;
   TaskRunSummaryPanel?: React.ComponentType<TaskRunSummaryPanelProps>;
+  TaskRunLiveDiffPanel?: React.ComponentType<LiveDiffPanelProps>;
+  TaskRunTestResultsPanel?: React.ComponentType<TestResultsPanelProps>;
   // Constants
   TASK_RUN_IFRAME_ALLOW?: string;
   TASK_RUN_IFRAME_SANDBOX?: string;
   // Git diff panel props
   teamSlugOrId?: string;
   taskId?: Id<"tasks">;
+  // Live diff panel props
+  repoFullName?: string;
+  baseBranch?: string;
 }
 
 /**
@@ -732,6 +741,49 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
       );
     }
 
+    case "liveDiff": {
+      const { selectedRun, teamSlugOrId, taskId, TaskRunLiveDiffPanel, repoFullName, baseBranch } = props;
+      if (!TaskRunLiveDiffPanel || !teamSlugOrId || !taskId) return null;
+
+      const sandboxId = selectedRun?.vscode?.containerName;
+      const isRunning = selectedRun?.vscode?.status === "running";
+      const headBranch = selectedRun?.newBranch;
+
+      return panelWrapper(
+        <GitPullRequest className="size-3" aria-hidden />,
+        PANEL_LABELS.liveDiff,
+        <div className="relative flex-1 min-h-0 overflow-hidden">
+          <TaskRunLiveDiffPanel
+            key={selectedRun?._id}
+            sandboxId={sandboxId}
+            isRunning={isRunning}
+            taskRunId={selectedRun?._id}
+            teamSlugOrId={teamSlugOrId}
+            selectedRun={selectedRun}
+            repoFullName={repoFullName}
+            baseBranch={baseBranch}
+            headBranch={headBranch}
+          />
+        </div>
+      );
+    }
+
+    case "testResults": {
+      const { selectedRun, TaskRunTestResultsPanel } = props;
+      if (!TaskRunTestResultsPanel) return null;
+
+      return panelWrapper(
+        <TestTube2 className="size-3" aria-hidden />,
+        PANEL_LABELS.testResults,
+        <div className="relative flex-1 min-h-0 overflow-hidden">
+          <TaskRunTestResultsPanel
+            key={selectedRun?._id}
+            taskRunId={selectedRun?._id}
+          />
+        </div>
+      );
+    }
+
     case null:
       return null;
 
@@ -803,6 +855,27 @@ export const RenderPanel = React.memo(RenderPanelComponent, (prevProps, nextProp
       prevProps.task?.pullRequestDescription !== nextProps.task?.pullRequestDescription ||
       prevProps.selectedRun?._id !== nextProps.selectedRun?._id ||
       prevProps.selectedRun?.summary !== nextProps.selectedRun?.summary) {
+      return false;
+    }
+  }
+
+  // For liveDiff panel, check run state and branch changes
+  if (prevProps.type === "liveDiff") {
+    if (prevProps.selectedRun?._id !== nextProps.selectedRun?._id ||
+      prevProps.selectedRun?.vscode?.containerName !== nextProps.selectedRun?.vscode?.containerName ||
+      prevProps.selectedRun?.vscode?.status !== nextProps.selectedRun?.vscode?.status ||
+      prevProps.selectedRun?.newBranch !== nextProps.selectedRun?.newBranch ||
+      prevProps.teamSlugOrId !== nextProps.teamSlugOrId ||
+      prevProps.taskId !== nextProps.taskId ||
+      prevProps.repoFullName !== nextProps.repoFullName ||
+      prevProps.baseBranch !== nextProps.baseBranch) {
+      return false;
+    }
+  }
+
+  // For testResults panel, check selectedRun changes
+  if (prevProps.type === "testResults") {
+    if (prevProps.selectedRun?._id !== nextProps.selectedRun?._id) {
       return false;
     }
   }

--- a/apps/client/src/components/TestResultsPanel.tsx
+++ b/apps/client/src/components/TestResultsPanel.tsx
@@ -1,0 +1,238 @@
+import { useMemo } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@cmux/convex/api";
+import { CheckCircle2, XCircle, Clock, TestTube2, AlertCircle } from "lucide-react";
+import { parseTestOutput, looksLikeTestOutput, type ParsedTestResult } from "@/lib/parse-test-output";
+import type { Id } from "@cmux/convex/dataModel";
+import clsx from "clsx";
+
+export interface TestResultsPanelProps {
+  taskRunId: Id<"taskRuns"> | undefined;
+}
+
+interface TestResultCardProps {
+  result: ParsedTestResult;
+  timestamp: number;
+}
+
+function TestResultCard({ result, timestamp }: TestResultCardProps) {
+  const { summary, framework, duration, tests } = result;
+  const allPassed = summary.failed === 0;
+  const formattedTime = new Date(timestamp).toLocaleTimeString();
+
+  return (
+    <div
+      className={clsx(
+        "rounded-lg border p-3",
+        allPassed
+          ? "border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30"
+          : "border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/30"
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          {allPassed ? (
+            <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
+          ) : (
+            <XCircle className="size-4 text-red-600 dark:text-red-400" />
+          )}
+          <span
+            className={clsx(
+              "text-sm font-medium",
+              allPassed
+                ? "text-green-700 dark:text-green-300"
+                : "text-red-700 dark:text-red-300"
+            )}
+          >
+            {allPassed ? "All tests passed" : `${summary.failed} test${summary.failed > 1 ? "s" : ""} failed`}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+          <span className="capitalize">{framework}</span>
+          <span>{formattedTime}</span>
+        </div>
+      </div>
+
+      {/* Summary stats */}
+      <div className="flex items-center gap-4 text-xs">
+        <div className="flex items-center gap-1">
+          <CheckCircle2 className="size-3 text-green-600 dark:text-green-400" />
+          <span className="text-green-700 dark:text-green-300">
+            {summary.passed} passed
+          </span>
+        </div>
+        {summary.failed > 0 && (
+          <div className="flex items-center gap-1">
+            <XCircle className="size-3 text-red-600 dark:text-red-400" />
+            <span className="text-red-700 dark:text-red-300">
+              {summary.failed} failed
+            </span>
+          </div>
+        )}
+        {summary.skipped > 0 && (
+          <div className="flex items-center gap-1">
+            <AlertCircle className="size-3 text-yellow-600 dark:text-yellow-400" />
+            <span className="text-yellow-700 dark:text-yellow-300">
+              {summary.skipped} skipped
+            </span>
+          </div>
+        )}
+        {duration && (
+          <div className="flex items-center gap-1 text-neutral-500 dark:text-neutral-400">
+            <Clock className="size-3" />
+            <span>{duration >= 1000 ? `${(duration / 1000).toFixed(1)}s` : `${duration}ms`}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Individual test list (show failed tests if any) */}
+      {tests.length > 0 && summary.failed > 0 && (
+        <div className="mt-2 border-t border-red-200 dark:border-red-900 pt-2">
+          <p className="text-xs font-medium text-red-700 dark:text-red-300 mb-1">
+            Failed tests:
+          </p>
+          <ul className="space-y-0.5">
+            {tests
+              .filter((t) => t.status === "fail")
+              .slice(0, 5)
+              .map((test, i) => (
+                <li
+                  key={`${test.name}-${i}`}
+                  className="text-xs text-red-600 dark:text-red-400 font-mono truncate"
+                  title={test.name}
+                >
+                  {test.name}
+                </li>
+              ))}
+            {tests.filter((t) => t.status === "fail").length > 5 && (
+              <li className="text-xs text-red-500 dark:text-red-400">
+                ... and {tests.filter((t) => t.status === "fail").length - 5} more
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Panel that displays parsed test results from task run activity.
+ * Subscribes to taskRunActivity and filters for Bash tool results that look like test output.
+ */
+export function TestResultsPanel({ taskRunId }: TestResultsPanelProps) {
+  // Subscribe to activity for this task run
+  const activity = useQuery(
+    api.taskRunActivity.getByTaskRunAsc,
+    taskRunId ? { taskRunId, limit: 100 } : "skip"
+  );
+
+  // Parse test results from bash command outputs
+  const testResults = useMemo(() => {
+    if (!activity) return [];
+
+    const results: Array<{ result: ParsedTestResult; timestamp: number }> = [];
+
+    for (const event of activity) {
+      // Only look at tool_result events for Bash commands
+      if (event.type !== "tool_result") continue;
+      if (event.toolName !== "Bash") continue;
+
+      // Quick filter before full parse
+      const detail = event.detail ?? "";
+      if (!looksLikeTestOutput(detail)) continue;
+
+      // Attempt to parse
+      const parsed = parseTestOutput(detail);
+      if (parsed) {
+        results.push({
+          result: parsed,
+          timestamp: event.createdAt,
+        });
+      }
+    }
+
+    // Return most recent first
+    return results.reverse();
+  }, [activity]);
+
+  // No task run selected
+  if (!taskRunId) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+        Select a run to view test results
+      </div>
+    );
+  }
+
+  // Loading state
+  if (activity === undefined) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-neutral-500 dark:text-neutral-400">
+        Loading test results...
+      </div>
+    );
+  }
+
+  // No test results found
+  if (testResults.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center px-4 text-center gap-2">
+        <TestTube2 className="size-8 text-neutral-300 dark:text-neutral-600" />
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          No test results yet
+        </p>
+        <p className="text-xs text-neutral-400 dark:text-neutral-500 max-w-xs">
+          Test results will appear here when the agent runs tests (vitest, jest, go test, etc.)
+        </p>
+      </div>
+    );
+  }
+
+  // Summary of all results
+  const totalRuns = testResults.length;
+  const latestResult = testResults[0]?.result;
+  const allPassing = testResults.every((r) => r.result.summary.failed === 0);
+
+  return (
+    <div className="h-full overflow-auto">
+      {/* Summary header */}
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-neutral-200 bg-white px-3 py-2 dark:border-neutral-800 dark:bg-neutral-950">
+        <div className="flex items-center gap-2">
+          <TestTube2 className="size-4 text-neutral-500 dark:text-neutral-400" />
+          <span className="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+            Test Results
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {allPassing ? (
+            <span className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+              <CheckCircle2 className="size-3" />
+              All passing
+            </span>
+          ) : (
+            <span className="flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
+              <XCircle className="size-3" />
+              {latestResult?.summary.failed ?? 0} failing
+            </span>
+          )}
+          <span className="text-xs text-neutral-500 dark:text-neutral-400">
+            {totalRuns} run{totalRuns > 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Test result cards */}
+      <div className="space-y-2 p-3">
+        {testResults.map(({ result, timestamp }, index) => (
+          <TestResultCard
+            key={`${timestamp}-${index}`}
+            result={result}
+            timestamp={timestamp}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/lib/panel-config.ts
+++ b/apps/client/src/lib/panel-config.ts
@@ -1,7 +1,7 @@
 import type { LucideIcon } from "lucide-react";
-import { MessageSquare, Code2, TerminalSquare, Globe2, GitCompare, Brain, FileText } from "lucide-react";
+import { MessageSquare, Code2, TerminalSquare, Globe2, GitCompare, Brain, FileText, GitPullRequest, TestTube2 } from "lucide-react";
 
-export type PanelType = "chat" | "workspace" | "terminal" | "browser" | "gitDiff" | "memory" | "summary";
+export type PanelType = "chat" | "workspace" | "terminal" | "browser" | "gitDiff" | "memory" | "summary" | "liveDiff" | "testResults";
 
 /**
  * All available panel types. When adding a new panel:
@@ -11,7 +11,7 @@ export type PanelType = "chat" | "workspace" | "terminal" | "browser" | "gitDiff
  * 4. Add to PANEL_ICON_COMPONENTS
  * 5. Handle in TaskPanelFactory.tsx switch statement
  */
-export const ALL_PANEL_TYPES: PanelType[] = ["chat", "workspace", "terminal", "browser", "gitDiff", "memory", "summary"];
+export const ALL_PANEL_TYPES: PanelType[] = ["chat", "workspace", "terminal", "browser", "gitDiff", "memory", "summary", "liveDiff", "testResults"];
 
 export type LayoutMode =
   | "single-panel"    // Single full-width panel
@@ -51,7 +51,7 @@ export const DEFAULT_PANEL_CONFIG: PanelConfig = {
     "four-panel": { ...DEFAULT_LAYOUT_PANELS },
     "two-horizontal": { topLeft: "workspace", topRight: "browser", bottomLeft: null, bottomRight: null },
     "two-vertical": { topLeft: "chat", topRight: null, bottomLeft: "workspace", bottomRight: null },
-    "three-left": { topLeft: "workspace", topRight: "browser", bottomLeft: null, bottomRight: "gitDiff" },
+    "three-left": { topLeft: "chat", topRight: "liveDiff", bottomLeft: null, bottomRight: "workspace" },
     "three-right": { topLeft: "chat", topRight: null, bottomLeft: "terminal", bottomRight: "workspace" },
     "three-top": { topLeft: "workspace", topRight: null, bottomLeft: "chat", bottomRight: "terminal" },
     "three-bottom": { topLeft: "chat", topRight: "workspace", bottomLeft: null, bottomRight: "terminal" },
@@ -66,6 +66,8 @@ export const PANEL_LABELS: Record<PanelType, string> = {
   gitDiff: "Git Diff",
   memory: "Memory",
   summary: "Summary",
+  liveDiff: "Live Diff",
+  testResults: "Test Results",
 };
 
 /** @deprecated Use PANEL_ICON_COMPONENTS instead */
@@ -77,6 +79,8 @@ export const PANEL_ICONS: Record<PanelType, string> = {
   gitDiff: "GitCompare",
   memory: "Brain",
   summary: "FileText",
+  liveDiff: "GitPullRequest",
+  testResults: "TestTube2",
 };
 
 /**
@@ -91,6 +95,8 @@ export const PANEL_ICON_COMPONENTS: Record<PanelType, LucideIcon> = {
   gitDiff: GitCompare,
   memory: Brain,
   summary: FileText,
+  liveDiff: GitPullRequest,
+  testResults: TestTube2,
 };
 
 export const LAYOUT_LABELS: Record<LayoutMode, string> = {

--- a/apps/client/src/lib/parse-test-output.ts
+++ b/apps/client/src/lib/parse-test-output.ts
@@ -1,0 +1,262 @@
+/**
+ * Test output parsing utilities for vitest, jest, and go test formats.
+ */
+
+export type TestStatus = "pass" | "fail" | "skip" | "unknown";
+
+export interface ParsedTestResult {
+  framework: "vitest" | "jest" | "go" | "unknown";
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+  };
+  tests: ParsedTest[];
+  duration?: number;
+  raw: string;
+}
+
+export interface ParsedTest {
+  name: string;
+  status: TestStatus;
+  duration?: number;
+  file?: string;
+  error?: string;
+}
+
+/**
+ * Detects if output looks like test output and parses it.
+ * Returns null if not test output.
+ */
+export function parseTestOutput(output: string): ParsedTestResult | null {
+  if (!output || typeof output !== "string") {
+    return null;
+  }
+
+  // Try each parser in order
+  const vitestResult = parseVitestOutput(output);
+  if (vitestResult) return vitestResult;
+
+  const jestResult = parseJestOutput(output);
+  if (jestResult) return jestResult;
+
+  const goResult = parseGoTestOutput(output);
+  if (goResult) return goResult;
+
+  return null;
+}
+
+/**
+ * Parse vitest output format.
+ * Example: "Test Files  2 passed | 1 failed (3)" or "Tests  5 passed | 2 failed (7)"
+ */
+function parseVitestOutput(output: string): ParsedTestResult | null {
+  // Match vitest summary line
+  const summaryMatch = output.match(
+    /(?:Test Files|Tests)\s+(\d+)\s+passed(?:\s*\|\s*(\d+)\s+failed)?(?:\s*\|\s*(\d+)\s+skipped)?/i
+  );
+
+  if (!summaryMatch) {
+    // Also check for "x tests passed" format
+    const altMatch = output.match(/(\d+)\s+tests?\s+passed/i);
+    if (!altMatch) return null;
+
+    const passed = parseInt(altMatch[1], 10);
+    const failedMatch = output.match(/(\d+)\s+tests?\s+failed/i);
+    const failed = failedMatch ? parseInt(failedMatch[1], 10) : 0;
+
+    return {
+      framework: "vitest",
+      summary: {
+        total: passed + failed,
+        passed,
+        failed,
+        skipped: 0,
+      },
+      tests: [],
+      raw: output,
+    };
+  }
+
+  const passed = parseInt(summaryMatch[1], 10);
+  const failed = summaryMatch[2] ? parseInt(summaryMatch[2], 10) : 0;
+  const skipped = summaryMatch[3] ? parseInt(summaryMatch[3], 10) : 0;
+
+  // Parse individual test results
+  const tests: ParsedTest[] = [];
+  const testPattern = /([✓✗])\s+(.+?)(?:\s+\((\d+)ms\))?$/gm;
+  let match;
+  while ((match = testPattern.exec(output)) !== null) {
+    tests.push({
+      name: match[2].trim(),
+      status: match[1] === "✓" ? "pass" : "fail",
+      duration: match[3] ? parseInt(match[3], 10) : undefined,
+    });
+  }
+
+  // Parse duration
+  const durationMatch = output.match(/Duration\s+(\d+(?:\.\d+)?)\s*(s|ms)/i);
+  let duration: number | undefined;
+  if (durationMatch) {
+    const value = parseFloat(durationMatch[1]);
+    duration = durationMatch[2] === "s" ? value * 1000 : value;
+  }
+
+  return {
+    framework: "vitest",
+    summary: {
+      total: passed + failed + skipped,
+      passed,
+      failed,
+      skipped,
+    },
+    tests,
+    duration,
+    raw: output,
+  };
+}
+
+/**
+ * Parse jest output format.
+ * Example: "Test Suites: 2 passed, 1 failed, 3 total"
+ */
+function parseJestOutput(output: string): ParsedTestResult | null {
+  const suiteMatch = output.match(
+    /Test Suites:\s*(?:(\d+)\s+passed)?(?:,\s*)?(?:(\d+)\s+failed)?(?:,\s*)?(?:(\d+)\s+skipped)?(?:,\s*)?(\d+)\s+total/i
+  );
+
+  if (!suiteMatch) return null;
+
+  const passed = suiteMatch[1] ? parseInt(suiteMatch[1], 10) : 0;
+  const failed = suiteMatch[2] ? parseInt(suiteMatch[2], 10) : 0;
+  const skipped = suiteMatch[3] ? parseInt(suiteMatch[3], 10) : 0;
+  const total = parseInt(suiteMatch[4], 10);
+
+  // Parse individual test results
+  const tests: ParsedTest[] = [];
+  const passPattern = /✓\s+(.+?)(?:\s+\((\d+)\s*ms\))?$/gm;
+  const failPattern = /✕\s+(.+?)(?:\s+\((\d+)\s*ms\))?$/gm;
+
+  let match;
+  while ((match = passPattern.exec(output)) !== null) {
+    tests.push({
+      name: match[1].trim(),
+      status: "pass",
+      duration: match[2] ? parseInt(match[2], 10) : undefined,
+    });
+  }
+  while ((match = failPattern.exec(output)) !== null) {
+    tests.push({
+      name: match[1].trim(),
+      status: "fail",
+      duration: match[2] ? parseInt(match[2], 10) : undefined,
+    });
+  }
+
+  // Parse total duration
+  const durationMatch = output.match(/Time:\s*(\d+(?:\.\d+)?)\s*(s|ms)/i);
+  let duration: number | undefined;
+  if (durationMatch) {
+    const value = parseFloat(durationMatch[1]);
+    duration = durationMatch[2] === "s" ? value * 1000 : value;
+  }
+
+  return {
+    framework: "jest",
+    summary: {
+      total,
+      passed,
+      failed,
+      skipped,
+    },
+    tests,
+    duration,
+    raw: output,
+  };
+}
+
+/**
+ * Parse go test output format.
+ * Example: "--- PASS: TestFoo (0.00s)" or "PASS" / "FAIL"
+ */
+function parseGoTestOutput(output: string): ParsedTestResult | null {
+  // Check for go test markers
+  const hasGoTestOutput =
+    output.includes("--- PASS:") ||
+    output.includes("--- FAIL:") ||
+    output.includes("--- SKIP:") ||
+    /^(ok|FAIL)\s+\S+/m.test(output);
+
+  if (!hasGoTestOutput) return null;
+
+  const tests: ParsedTest[] = [];
+
+  // Parse individual test results
+  const testPattern = /---\s+(PASS|FAIL|SKIP):\s+(\S+)\s+\((\d+(?:\.\d+)?)s\)/g;
+  let match;
+  while ((match = testPattern.exec(output)) !== null) {
+    const statusMap: Record<string, TestStatus> = {
+      PASS: "pass",
+      FAIL: "fail",
+      SKIP: "skip",
+    };
+    tests.push({
+      name: match[2],
+      status: statusMap[match[1]] ?? "unknown",
+      duration: parseFloat(match[3]) * 1000,
+    });
+  }
+
+  const passed = tests.filter((t) => t.status === "pass").length;
+  const failed = tests.filter((t) => t.status === "fail").length;
+  const skipped = tests.filter((t) => t.status === "skip").length;
+
+  // Parse total duration from package summary
+  const durationMatch = output.match(
+    /(?:ok|FAIL)\s+\S+\s+(\d+(?:\.\d+)?)s/
+  );
+  let duration: number | undefined;
+  if (durationMatch) {
+    duration = parseFloat(durationMatch[1]) * 1000;
+  }
+
+  return {
+    framework: "go",
+    summary: {
+      total: tests.length,
+      passed,
+      failed,
+      skipped,
+    },
+    tests,
+    duration,
+    raw: output,
+  };
+}
+
+/**
+ * Quick check if a bash command output looks like it might contain test results.
+ * Used to filter activity before full parsing.
+ */
+export function looksLikeTestOutput(output: string): boolean {
+  if (!output || typeof output !== "string") return false;
+
+  const testIndicators = [
+    // vitest/jest
+    /test(?:s|ing)?/i,
+    /pass(?:ed|ing)?/i,
+    /fail(?:ed|ing)?/i,
+    /✓|✗|✕/,
+    /Test (?:Files|Suites)/i,
+    // go test
+    /---\s+(?:PASS|FAIL|SKIP):/,
+    /^(?:ok|FAIL)\s+\S+/m,
+    // bun test
+    /bun test/i,
+    // generic
+    /\d+\s+(?:passed|failed)/i,
+  ];
+
+  return testIndicators.some((pattern) => pattern.test(output));
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
@@ -2,6 +2,8 @@ import { TaskRunChatPane } from "@/components/TaskRunChatPane";
 import { TaskRunTerminalPane } from "@/components/TaskRunTerminalPane";
 import { TaskRunMemoryPanel } from "@/components/TaskRunMemoryPanel";
 import { TaskRunSummaryPanel } from "@/components/TaskRunSummaryPanel";
+import { LiveDiffPanel } from "@/components/LiveDiffPanel";
+import { TestResultsPanel } from "@/components/TestResultsPanel";
 import { FloatingPane } from "@/components/floating-pane";
 import { TaskDetailHeader } from "@/components/task-detail-header";
 import { AgentTeamPanel } from "@/components/dashboard/AgentTeamPanel";
@@ -932,6 +934,9 @@ function TaskDetailPage() {
     [effectiveActivePanelPosition, expandedPanel]
   );
 
+  // Get repo and branch info for live diff panel
+  const repoFullName = task?.projectFullName ?? undefined;
+
   const panelProps = useMemo(
     () => ({
       task: task ?? null,
@@ -964,11 +969,15 @@ function TaskDetailPage() {
       TaskRunGitDiffPanel,
       TaskRunMemoryPanel,
       TaskRunSummaryPanel,
+      TaskRunLiveDiffPanel: LiveDiffPanel,
+      TaskRunTestResultsPanel: TestResultsPanel,
       TASK_RUN_IFRAME_ALLOW,
       TASK_RUN_IFRAME_SANDBOX,
       onClose: handlePanelClose,
       teamSlugOrId,
       taskId,
+      repoFullName,
+      baseBranch,
     }),
     [
       task,
@@ -997,6 +1006,8 @@ function TaskDetailPage() {
       handlePanelClose,
       teamSlugOrId,
       taskId,
+      repoFullName,
+      baseBranch,
     ]
   );
 


### PR DESCRIPTION
## Summary

- Add Live Diff panel showing real-time uncommitted changes while sandbox runs
- Add Test Results panel that parses and displays test output from agent commands
- Update default layout to prioritize Activity stream and Live Diff
- Support vitest, jest, and go test output formats

## Test plan

- [ ] Start dev server with `./scripts/dev.sh`
- [ ] Create a task and start a run
- [ ] Verify Activity panel is now in the large left position (default layout)
- [ ] Verify Live Diff panel shows in top-right position
- [ ] While sandbox is running, verify Live Diff shows uncommitted changes
- [ ] Stop the sandbox, verify Live Diff falls back to committed diff view
- [ ] Run tests in the sandbox, verify Test Results panel parses the output
- [ ] Run `bun check` to ensure no type errors