### PR TITLE
refactor: centralize skeleton imports (Q3 Phase 3)

### DIFF
--- a/apps/client/src/components/ActivityStream.tsx
+++ b/apps/client/src/components/ActivityStream.tsx
@@ -15,7 +15,7 @@ import {
   Download,
   Filter,
 } from "lucide-react";
-import { Skeleton } from "@/components/ui/skeleton";
+import { ActivityStreamSkeleton } from "@/components/dashboard/DashboardSkeletons";
 
 const ACTIVITY_TYPES = [
   "file_edit",
@@ -78,29 +78,6 @@ function formatTimestamp(timestamp: number): string {
 
 interface ActivityStreamProps {
   taskRunId: Id<"taskRuns">;
-}
-
-function LoadingSkeleton() {
-  return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-200 dark:border-neutral-800">
-        <Skeleton className="h-4 w-24" />
-        <Skeleton className="h-5 w-28" />
-      </div>
-      <div className="flex-1 p-3 space-y-3">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="flex items-start gap-2">
-            <Skeleton className="size-4 mt-0.5 shrink-0" />
-            <div className="flex-1 space-y-1">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-3 w-1/3" />
-            </div>
-            <Skeleton className="h-3 w-12 shrink-0" />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
 }
 
 export function ActivityStream({ taskRunId }: ActivityStreamProps) {
@@ -210,7 +187,7 @@ export function ActivityStream({ taskRunId }: ActivityStreamProps) {
 
   // Loading state
   if (!activities) {
-    return <LoadingSkeleton />;
+    return <ActivityStreamSkeleton />;
   }
 
   // Empty state (no activities at all)

--- a/apps/client/src/components/dashboard/DashboardSkeletons.tsx
+++ b/apps/client/src/components/dashboard/DashboardSkeletons.tsx
@@ -95,24 +95,27 @@ export function SessionTimelineSkeleton({ className }: { className?: string }) {
 }
 
 /**
- * Skeleton for ActivityStream - shows activity event list
+ * Skeleton for ActivityStream - shows activity event list with toolbar
  */
 export function ActivityStreamSkeleton({ className }: { className?: string }) {
   return (
-    <div className={cn("space-y-2", className)}>
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="flex items-start gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 p-3">
-          <Skeleton className="size-8 shrink-0 rounded-full" />
-          <div className="flex-1 space-y-2">
-            <div className="flex items-center justify-between">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-3 w-20" />
+    <div className={cn("flex h-full flex-col", className)}>
+      <div className="flex items-center justify-between border-b border-neutral-200 px-3 py-2 dark:border-neutral-800">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-5 w-28" />
+      </div>
+      <div className="flex-1 space-y-3 p-3">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-start gap-2">
+            <Skeleton className="mt-0.5 size-4 shrink-0" />
+            <div className="flex-1 space-y-1">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-3 w-1/3" />
             </div>
-            <Skeleton className="h-3 w-full max-w-md" />
-            <Skeleton className="h-3 w-3/4" />
+            <Skeleton className="h-3 w-12 shrink-0" />
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/client/src/components/dashboard/FileChangeHeatmap.tsx
+++ b/apps/client/src/components/dashboard/FileChangeHeatmap.tsx
@@ -3,7 +3,7 @@ import { useQuery as useConvexQuery } from "convex/react";
 import { FileCode, FolderOpen } from "lucide-react";
 import { memo, useMemo, useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { Skeleton } from "@/components/ui/skeleton";
+import { FileChangeHeatmapSkeleton } from "./DashboardSkeletons";
 
 const TIME_RANGES = [7, 14, 30] as const;
 type TimeRange = (typeof TIME_RANGES)[number];
@@ -239,28 +239,7 @@ function FileChangeHeatmapContent({ teamSlugOrId, days = 7 }: FileChangeHeatmapP
   };
 
   if (!result) {
-    return (
-      <div className="space-y-3">
-        {Array.from({ length: 3 }).map((_, groupIndex) => (
-          <div key={groupIndex} className="space-y-1">
-            <div className="flex items-center gap-2">
-              <Skeleton className="size-4" />
-              <Skeleton className="h-4 w-24" />
-            </div>
-            <div className="ml-6 space-y-1">
-              {Array.from({ length: 3 }).map((_, fileIndex) => (
-                <div key={fileIndex} className="flex items-center gap-2">
-                  <Skeleton className="size-3.5" />
-                  <Skeleton className="h-3 flex-1 max-w-32" />
-                  <Skeleton className="h-3 w-24" />
-                  <Skeleton className="h-3 w-10" />
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-    );
+    return <FileChangeHeatmapSkeleton className="border-0 p-0" />;
   }
 
   if (groups.length === 0) {

--- a/apps/client/src/components/dashboard/SessionActivityCard.tsx
+++ b/apps/client/src/components/dashboard/SessionActivityCard.tsx
@@ -3,7 +3,7 @@ import { useQuery as useConvexQuery } from "convex/react";
 import { GitCommit, GitPullRequest, FileCode, Plus, Minus, Clock } from "lucide-react";
 import { memo, useState } from "react";
 import { cn } from "@/lib/utils";
-import { Skeleton } from "@/components/ui/skeleton";
+import { SessionActivityCardSkeleton } from "./DashboardSkeletons";
 
 const TIME_RANGES = [7, 14, 30] as const;
 type TimeRange = (typeof TIME_RANGES)[number];
@@ -45,19 +45,7 @@ function SessionActivityCardContent({ teamSlugOrId, days = 7 }: SessionActivityC
   });
 
   if (!stats) {
-    return (
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-2">
-            <Skeleton className="size-4 rounded" />
-            <div className="flex flex-col gap-1">
-              <Skeleton className="h-6 w-12" />
-              <Skeleton className="h-3 w-16" />
-            </div>
-          </div>
-        ))}
-      </div>
-    );
+    return <SessionActivityCardSkeleton className="border-0 p-0" />;
   }
 
   if (stats.totalSessions === 0) {

--- a/apps/client/src/components/dashboard/SessionTimeline.tsx
+++ b/apps/client/src/components/dashboard/SessionTimeline.tsx
@@ -14,7 +14,7 @@ import {
 import { memo, useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { formatTime, formatShortDate, formatDuration } from "@/lib/time";
-import { Skeleton } from "@/components/ui/skeleton";
+import { SessionTimelineSkeleton } from "./DashboardSkeletons";
 
 interface SessionTimelineProps {
   teamSlugOrId: string;
@@ -268,27 +268,7 @@ function SessionTimelineContent({ teamSlugOrId, limit = 5 }: SessionTimelineProp
   }, [sessions]);
 
   if (!result) {
-    return (
-      <div className="space-y-4">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="rounded-lg border border-neutral-200 dark:border-neutral-700 p-3">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Skeleton className="size-4" />
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-3 w-16" />
-              </div>
-              <div className="flex items-center gap-3">
-                <Skeleton className="h-3 w-8" />
-                <Skeleton className="h-3 w-8" />
-                <Skeleton className="h-3 w-12" />
-                <Skeleton className="h-3 w-12" />
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
+    return <SessionTimelineSkeleton className="border-0 p-0" />;
   }
 
   if (sessions.length === 0) {


### PR DESCRIPTION
## Summary

- Replace inline skeleton definitions in dashboard components with imports from `DashboardSkeletons.tsx`
- Eliminates ~73 lines of duplicate skeleton code across 4 components
- Updates `ActivityStreamSkeleton` to match full-height layout with toolbar

## Files changed

**apps/client/src/components/dashboard/**
- `SessionActivityCard.tsx` - uses `SessionActivityCardSkeleton`
- `FileChangeHeatmap.tsx` - uses `FileChangeHeatmapSkeleton`
- `SessionTimeline.tsx` - uses `SessionTimelineSkeleton`
- `DashboardSkeletons.tsx` - updated `ActivityStreamSkeleton` layout

**apps/client/src/components/**
- `ActivityStream.tsx` - uses `ActivityStreamSkeleton` from DashboardSkeletons

## Test plan

- [x] `bun check` passes
- [ ] Visual verification: Dashboard skeleton states match component layout
- [ ] Dark mode appearance