### PR TITLE
feat(taskRuns): add context usage tracking (Phase 5c)

### DIFF
--- a/dev-docs/spikes/q4-context-optimization.md
+++ b/dev-docs/spikes/q4-context-optimization.md
@@ -50,10 +50,12 @@ When context nears limit, trigger compact/summarize:
 - [x] Show context capacity in agent selector
 - [x] Add tooltip with model capabilities
 
-### Phase 5c: Pre-Compact (Future)
-- [ ] Monitor context usage
-- [ ] Implement summarization triggers
-- [ ] Add user preferences
+### Phase 5c: Context Usage Tracking (Partial)
+- [x] Track cumulative token usage per task run
+- [x] Store contextUsage in taskRuns table
+- [x] Wire anthropic_http to update usage on each request
+- [ ] Implement summarization triggers (future)
+- [ ] Add user preferences (future)
 
 ## Status
 
@@ -62,4 +64,4 @@ When context nears limit, trigger compact/summarize:
   - Gemini/Grok: d4d7f7d53
   - Qwen/AMP: b10fb56b8
 - [x] Phase 5b: Display - Agent selector shows context info (18eda22a7)
-- [ ] Phase 5c: Pre-Compact (future)
+- [x] Phase 5c: Context usage tracking (partial)

--- a/packages/convex/convex/anthropic_http.ts
+++ b/packages/convex/convex/anthropic_http.ts
@@ -503,14 +503,25 @@ export const anthropicProxy = httpAction(async (ctx, req) => {
       // Track non-streaming responses with token usage
       if (!isStreaming) {
         const responseData = await response.clone().json().catch(() => null);
+        const inputTokens = responseData?.usage?.input_tokens;
+        const outputTokens = responseData?.usage?.output_tokens;
         trackEvent(requestedModel, false, response.status, {
-          inputTokens: responseData?.usage?.input_tokens,
-          outputTokens: responseData?.usage?.output_tokens,
+          inputTokens,
+          outputTokens,
           cacheCreationInputTokens: responseData?.usage?.cache_creation_input_tokens,
           cacheReadInputTokens: responseData?.usage?.cache_read_input_tokens,
           errorType: response.ok ? undefined : responseData?.error?.type,
         });
         await drainPosthogEvents();
+
+        // Update context usage in Convex (Phase 5c) - fire and forget
+        if (inputTokens && outputTokens && workerAuth?.payload.taskRunId) {
+          ctx.runMutation(internal.taskRuns.updateContextUsage, {
+            id: workerAuth.payload.taskRunId as any,
+            inputTokens,
+            outputTokens,
+          }).catch(() => {}); // Ignore errors to not block response
+        }
       } else {
         // For streaming, track without token usage (not available until stream ends)
         trackEvent(requestedModel, true, response.status);
@@ -625,14 +636,25 @@ export const anthropicProxy = httpAction(async (ctx, req) => {
       // Track non-streaming responses with token usage
       if (!isStreaming) {
         const responseData = await response.clone().json().catch(() => null);
+        const inputTokens = responseData?.usage?.input_tokens;
+        const outputTokens = responseData?.usage?.output_tokens;
         trackEvent(requestedModel, false, response.status, {
-          inputTokens: responseData?.usage?.input_tokens,
-          outputTokens: responseData?.usage?.output_tokens,
+          inputTokens,
+          outputTokens,
           cacheCreationInputTokens: responseData?.usage?.cache_creation_input_tokens,
           cacheReadInputTokens: responseData?.usage?.cache_read_input_tokens,
           errorType: response.ok ? undefined : responseData?.error?.type,
         });
         await drainPosthogEvents();
+
+        // Update context usage in Convex (Phase 5c) - fire and forget
+        if (inputTokens && outputTokens && workerAuth?.payload.taskRunId) {
+          ctx.runMutation(internal.taskRuns.updateContextUsage, {
+            id: workerAuth.payload.taskRunId as any,
+            inputTokens,
+            outputTokens,
+          }).catch(() => {}); // Ignore errors to not block response
+        }
       } else {
         // For streaming, track without token usage (not available until stream ends)
         trackEvent(requestedModel, true, response.status);

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -396,6 +396,16 @@ const convexSchema = defineSchema({
       )
     ),
     operatorVerificationError: v.optional(v.string()),
+    // Context usage tracking (Phase 5c)
+    contextUsage: v.optional(
+      v.object({
+        totalInputTokens: v.number(), // Cumulative input tokens
+        totalOutputTokens: v.number(), // Cumulative output tokens
+        contextWindow: v.optional(v.number()), // Model's context window size
+        usagePercent: v.optional(v.number()), // Current usage as percentage of context window
+        lastUpdated: v.number(), // Timestamp of last update
+      })
+    ),
   })
     .index("by_task", ["taskId", "createdAt"])
     .index("by_parent", ["parentRunId"])

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -3224,6 +3224,61 @@ export const initializeAutopilot = authMutation({
 });
 
 /**
+ * Update context usage tracking for a task run (Phase 5c).
+ * Called from anthropic_http when token usage is available.
+ */
+export const updateContextUsage = internalMutation({
+  args: {
+    id: v.id("taskRuns"),
+    inputTokens: v.number(),
+    outputTokens: v.number(),
+    contextWindow: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.id);
+    if (!doc) {
+      return null;
+    }
+
+    const existing = doc.contextUsage;
+    const totalInputTokens = (existing?.totalInputTokens ?? 0) + args.inputTokens;
+    const totalOutputTokens = (existing?.totalOutputTokens ?? 0) + args.outputTokens;
+    const contextWindow = args.contextWindow ?? existing?.contextWindow;
+
+    // Calculate usage percentage if we have context window size
+    // Note: input tokens contribute to context, output tokens are generated
+    const usagePercent = contextWindow
+      ? Math.round((totalInputTokens / contextWindow) * 100)
+      : undefined;
+
+    await ctx.db.patch(args.id, {
+      contextUsage: {
+        totalInputTokens,
+        totalOutputTokens,
+        contextWindow,
+        usagePercent,
+        lastUpdated: Date.now(),
+      },
+    });
+
+    return { totalInputTokens, totalOutputTokens, usagePercent };
+  },
+});
+
+/**
+ * Get context usage for a task run (Phase 5c).
+ */
+export const getContextUsage = internalQuery({
+  args: {
+    id: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.id);
+    return doc?.contextUsage ?? null;
+  },
+});
+
+/**
  * Get autopilot info for resume.
  * Returns thread-id and config for resuming an autopilot session.
  */


### PR DESCRIPTION
## Summary
Phase 5c partial implementation - tracks cumulative token usage per task run.

**Changes:**
- Add `contextUsage` field to taskRuns schema
- Add `updateContextUsage` internal mutation
- Wire `anthropic_http` to update usage on each non-streaming request

**Schema:**
```typescript
contextUsage: {
  totalInputTokens: number;
  totalOutputTokens: number;
  contextWindow?: number;
  usagePercent?: number;
  lastUpdated: number;
}
```

This enables future features like:
- Context usage display in UI
- Auto-summarization at 80% threshold
- Pre-compact hooks

## Test plan
- [x] `bun check` passes
- [x] Schema validates
- [ ] Manual test: verify token counts accumulate during task runs