### PR TITLE
feat(client): display token usage in CostEstimationCard

### DIFF
--- a/apps/client/src/components/dashboard/CostEstimationCard.tsx
+++ b/apps/client/src/components/dashboard/CostEstimationCard.tsx
@@ -3,7 +3,7 @@ import type { Id } from "@cmux/convex/dataModel";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { memo } from "react";
-import { AlertTriangle, Clock, Cpu, DollarSign, RefreshCw } from "lucide-react";
+import { AlertTriangle, Clock, Cpu, DollarSign, RefreshCw, Zap } from "lucide-react";
 
 type CostEstimationCardProps = {
   taskRunId: Id<"taskRuns">;
@@ -48,6 +48,16 @@ function formatDuration(ms: number): string {
     return `${minutes}m ${seconds % 60}s`;
   }
   return `${seconds}s`;
+}
+
+function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1)}K`;
+  }
+  return count.toString();
 }
 
 function CostEstimationCardSkeleton() {
@@ -165,6 +175,19 @@ export const CostEstimationCard = memo(function CostEstimationCard({
           <DollarSign className="size-3.5" />
           <span>Rate: {formatCost(costPerMinute)}/min</span>
         </div>
+        {taskRun.contextUsage && (
+          <div className="flex items-center gap-2">
+            <Zap className="size-3.5" />
+            <span>
+              Tokens: {formatTokenCount(taskRun.contextUsage.totalInputTokens)} in / {formatTokenCount(taskRun.contextUsage.totalOutputTokens)} out
+              {taskRun.contextUsage.usagePercent !== undefined && (
+                <span className="ml-1 text-neutral-400 dark:text-neutral-500">
+                  ({taskRun.contextUsage.usagePercent}% context)
+                </span>
+              )}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Disclaimer */}


### PR DESCRIPTION
## Summary
Adds token usage display to the CostEstimationCard component, completing the UI side of Phase 5c.

**Changes:**
- Show input/output token counts when available
- Display context window usage percentage
- Use compact formatting (e.g., "125K in / 8.2K out")

**Screenshot location:**
Token info appears in the Cost Estimation card alongside duration/model/rate.

## Test plan
- [x] `bun check` passes
- [ ] Manual test: verify token counts display for running/completed tasks