### PR TITLE
feat(convex): pass contextWindow to usage tracking

### DIFF
--- a/packages/convex/convex/anthropic_http.ts
+++ b/packages/convex/convex/anthropic_http.ts
@@ -16,6 +16,24 @@ import {
 
 const hardCodedApiKey = CMUX_ANTHROPIC_PROXY_PLACEHOLDER_API_KEY;
 
+// Context window sizes per model for usage tracking (Phase 5c)
+// These match the catalog values in packages/shared/src/providers/anthropic/catalog.ts
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "claude-opus-4-6": 1000000, // 1M context
+  "claude-opus-4-5-20251101": 200000,
+  "claude-sonnet-4-5-20250514": 200000,
+  "claude-sonnet-4-6": 200000,
+  "claude-haiku-4-5-20251001": 200000,
+};
+
+/**
+ * Get context window size for a model API ID.
+ * Returns undefined for unknown models.
+ */
+function getModelContextWindow(modelApiId: string): number | undefined {
+  return MODEL_CONTEXT_WINDOWS[modelApiId];
+}
+
 export const CLOUDFLARE_ANTHROPIC_BASE_URL =
   SHARED_CLOUDFLARE_ANTHROPIC_BASE_URL;
 
@@ -520,6 +538,7 @@ export const anthropicProxy = httpAction(async (ctx, req) => {
             id: workerAuth.payload.taskRunId as any,
             inputTokens,
             outputTokens,
+            contextWindow: getModelContextWindow(requestedModel),
           }).catch(() => {}); // Ignore errors to not block response
         }
       } else {
@@ -653,6 +672,7 @@ export const anthropicProxy = httpAction(async (ctx, req) => {
             id: workerAuth.payload.taskRunId as any,
             inputTokens,
             outputTokens,
+            contextWindow: getModelContextWindow(requestedModel),
           }).catch(() => {}); // Ignore errors to not block response
         }
       } else {


### PR DESCRIPTION
## Summary
- Add model context window mapping in anthropic_http.ts
- Pass contextWindow to updateContextUsage mutation for accurate % display
- Enables the 80% warning threshold in CostEstimationCard to work correctly

## Test plan
- [ ] Verify context usage percentage displays in dashboard for running tasks
- [ ] Confirm 80% threshold warning triggers at correct usage level