### PR TITLE
feat(convex): emit context_warning events when usage exceeds thresholds

### DIFF
--- a/packages/convex/convex/anthropic_http.ts
+++ b/packages/convex/convex/anthropic_http.ts
@@ -539,6 +539,7 @@ export const anthropicProxy = httpAction(async (ctx, req) => {
             inputTokens,
             outputTokens,
             contextWindow: getModelContextWindow(requestedModel),
+            provider: "anthropic",
           }).catch(() => {}); // Ignore errors to not block response
         }
       } else {
@@ -673,6 +674,7 @@ export const anthropicProxy = httpAction(async (ctx, req) => {
             inputTokens,
             outputTokens,
             contextWindow: getModelContextWindow(requestedModel),
+            provider: "anthropic",
           }).catch(() => {}); // Ignore errors to not block response
         }
       } else {

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -3227,12 +3227,17 @@ export const initializeAutopilot = authMutation({
  * Update context usage tracking for a task run (Phase 5c).
  * Called from anthropic_http when token usage is available.
  */
+// Context warning thresholds
+const CONTEXT_WARNING_THRESHOLD = 80; // Emit warning at 80%
+const CONTEXT_CRITICAL_THRESHOLD = 95; // Emit critical at 95%
+
 export const updateContextUsage = internalMutation({
   args: {
     id: v.id("taskRuns"),
     inputTokens: v.number(),
     outputTokens: v.number(),
     contextWindow: v.optional(v.number()),
+    provider: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const doc = await ctx.db.get(args.id);
@@ -3251,6 +3256,8 @@ export const updateContextUsage = internalMutation({
       ? Math.round((totalInputTokens / contextWindow) * 100)
       : undefined;
 
+    const previousUsagePercent = existing?.usagePercent;
+
     await ctx.db.patch(args.id, {
       contextUsage: {
         totalInputTokens,
@@ -3260,6 +3267,41 @@ export const updateContextUsage = internalMutation({
         lastUpdated: Date.now(),
       },
     });
+
+    // Emit context_warning event when crossing thresholds
+    if (usagePercent !== undefined && contextWindow) {
+      const crossedWarning = previousUsagePercent !== undefined
+        ? previousUsagePercent < CONTEXT_WARNING_THRESHOLD && usagePercent >= CONTEXT_WARNING_THRESHOLD
+        : usagePercent >= CONTEXT_WARNING_THRESHOLD;
+      const crossedCritical = previousUsagePercent !== undefined
+        ? previousUsagePercent < CONTEXT_CRITICAL_THRESHOLD && usagePercent >= CONTEXT_CRITICAL_THRESHOLD
+        : usagePercent >= CONTEXT_CRITICAL_THRESHOLD;
+
+      if (crossedWarning || crossedCritical) {
+        const severity = crossedCritical ? "critical" : "warning";
+        const timestamp = Date.now().toString(36);
+        const random = Math.random().toString(36).substring(2, 10);
+        const eventId = `evt_${timestamp}_${random}`;
+
+        // Log the context warning event
+        await ctx.runMutation(internal.orchestrationEvents.logEventInternal, {
+          teamId: doc.teamId,
+          eventId,
+          orchestrationId: doc.orchestrationId ?? args.id,
+          eventType: "context_warning",
+          taskRunId: args.id,
+          payload: {
+            provider: args.provider ?? doc.agentName ?? "unknown",
+            severity,
+            warningType: "capacity",
+            summary: `Context window at ${usagePercent}% capacity (${totalInputTokens.toLocaleString()} / ${contextWindow.toLocaleString()} tokens)`,
+            currentUsage: totalInputTokens,
+            maxCapacity: contextWindow,
+            usagePercent,
+          },
+        });
+      }
+    }
 
     return { totalInputTokens, totalOutputTokens, usagePercent };
   },


### PR DESCRIPTION
## Summary
- Emit `context_warning` orchestration events when context usage crosses 80% (warning) or 95% (critical) thresholds
- Events are stored in `orchestrationEvents` table for dashboard visibility
- Includes severity, usage stats, and human-readable summary

## Event Payload
```typescript
{
  provider: "anthropic",
  severity: "warning" | "critical",
  warningType: "capacity",
  summary: "Context window at 85% capacity (850,000 / 1,000,000 tokens)",
  currentUsage: 850000,
  maxCapacity: 1000000,
  usagePercent: 85
}
```

## Threshold Behavior
- Events only fire when **crossing** the threshold (not on every update)
- 80% → warning severity
- 95% → critical severity

## Part of
Phase 4: Provider-neutral lifecycle events (step 3 of design doc)

## Test plan
- [x] `bun check` passes
- [ ] CI passes