### PR TITLE
feat(convex,mcp): add context health summary endpoint and MCP tool

### DIFF
--- a/packages/convex/convex/autopilot_http.ts
+++ b/packages/convex/convex/autopilot_http.ts
@@ -10,6 +10,7 @@
  * - POST /api/autopilot/status - Update autopilot status
  * - POST /api/autopilot/session-event - Log session lifecycle events
  * - GET /api/autopilot/info - Get autopilot info for resume
+ * - GET /api/autopilot/context-health - Get context health summary
  */
 
 import { verifyTaskRunToken } from "../../shared/src/convex-safe";
@@ -323,6 +324,34 @@ export const autopilotInfo = httpAction(async (ctx, req) => {
   } catch (error) {
     console.error("[autopilot_http] Failed to get autopilot info", error);
     const message = error instanceof Error ? error.message : "Failed to get autopilot info";
+    return jsonResponse({ code: 500, message }, 500);
+  }
+});
+
+/**
+ * GET /api/autopilot/context-health
+ *
+ * Get context health summary for a task run.
+ * Returns aggregated context usage and warning state.
+ */
+export const autopilotContextHealth = httpAction(async (ctx, req) => {
+  const authResult = await authenticateRequest(req);
+  if (authResult instanceof Response) return authResult;
+  const { taskRunId } = authResult;
+
+  try {
+    const summary = await ctx.runQuery(internal.taskRuns.getContextHealthSummary, {
+      id: taskRunId as Id<"taskRuns">,
+    });
+
+    if (!summary) {
+      return jsonResponse({ code: 404, message: "Task run not found" }, 404);
+    }
+
+    return jsonResponse(summary);
+  } catch (error) {
+    console.error("[autopilot_http] Failed to get context health", error);
+    const message = error instanceof Error ? error.message : "Failed to get context health";
     return jsonResponse({ code: 500, message }, 500);
   }
 });

--- a/packages/convex/convex/http.ts
+++ b/packages/convex/convex/http.ts
@@ -87,6 +87,7 @@ import {
   autopilotStatus,
   autopilotSessionEvent,
   autopilotInfo,
+  autopilotContextHealth,
 } from "./autopilot_http";
 import {
   recordStart as sessionActivityRecordStart,
@@ -542,6 +543,12 @@ http.route({
   path: "/api/autopilot/info",
   method: "GET",
   handler: autopilotInfo,
+});
+
+http.route({
+  path: "/api/autopilot/context-health",
+  method: "GET",
+  handler: autopilotContextHealth,
 });
 
 // =============================================================================

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -3321,6 +3321,77 @@ export const getContextUsage = internalQuery({
 });
 
 /**
+ * Get context health summary for a task run (Phase 4).
+ * Aggregates context usage and recent warning events into a compact summary.
+ */
+export const getContextHealthSummary = internalQuery({
+  args: {
+    id: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.id);
+    if (!doc) {
+      return null;
+    }
+
+    const contextUsage = doc.contextUsage;
+    const orchestrationId = doc.orchestrationId ?? args.id;
+
+    // Get recent context_warning events for this task run
+    const recentWarnings = await ctx.db
+      .query("orchestrationEvents")
+      .withIndex("by_orchestration_type", (q) =>
+        q.eq("orchestrationId", orchestrationId).eq("eventType", "context_warning")
+      )
+      .order("desc")
+      .take(5);
+
+    // Determine latest severity from warnings
+    let latestWarningSeverity: "info" | "warning" | "critical" | null = null;
+    const warningReasons: string[] = [];
+
+    for (const event of recentWarnings) {
+      const payload = event.payload as { severity?: string; summary?: string } | undefined;
+      if (payload?.severity) {
+        if (!latestWarningSeverity || payload.severity === "critical") {
+          latestWarningSeverity = payload.severity as "info" | "warning" | "critical";
+        }
+      }
+      if (payload?.summary && !warningReasons.includes(payload.summary)) {
+        warningReasons.push(payload.summary);
+      }
+    }
+
+    // Get recent context_compacted events
+    const recentCompactions = await ctx.db
+      .query("orchestrationEvents")
+      .withIndex("by_orchestration_type", (q) =>
+        q.eq("orchestrationId", orchestrationId).eq("eventType", "context_compacted")
+      )
+      .order("desc")
+      .take(3);
+
+    return {
+      taskRunId: args.id,
+      provider: doc.agentName ?? "unknown",
+      // Context usage stats
+      totalInputTokens: contextUsage?.totalInputTokens ?? 0,
+      totalOutputTokens: contextUsage?.totalOutputTokens ?? 0,
+      contextWindow: contextUsage?.contextWindow,
+      usagePercent: contextUsage?.usagePercent,
+      // Warning state
+      latestWarningSeverity,
+      topWarningReasons: warningReasons.slice(0, 3),
+      warningCount: recentWarnings.length,
+      // Compaction state
+      recentCompactionCount: recentCompactions.length,
+      // Timestamps
+      lastUpdatedAt: contextUsage?.lastUpdated ?? doc.updatedAt,
+    };
+  },
+});
+
+/**
  * Get autopilot info for resume.
  * Returns thread-id and config for resuming an autopilot session.
  */

--- a/packages/devsh-memory-mcp/src/index.ts
+++ b/packages/devsh-memory-mcp/src/index.ts
@@ -828,6 +828,16 @@ export function createMemoryMcpServer(config?: Partial<MemoryMcpConfig>) {
         },
       },
       {
+        name: "get_context_health",
+        description:
+          "Get context health summary for the current task run. Returns context window usage, warning state, and recent compaction events. " +
+          "Use this to monitor context pressure and decide when to summarize or archive context.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {},
+        },
+      },
+      {
         name: "bind_provider_session",
         description:
           "Bind a provider-specific session ID to the current task. Use to enable session resume on task retry. " +
@@ -2390,6 +2400,96 @@ export function createMemoryMcpServer(config?: Partial<MemoryMcpConfig>) {
             content: [{
               type: "text",
               text: `Error getting orchestration summary: ${errorMsg}`,
+            }],
+          };
+        }
+      }
+
+      case "get_context_health": {
+        const jwt = process.env.CMUX_TASK_RUN_JWT;
+        const callbackUrl = process.env.CMUX_CALLBACK_URL;
+
+        if (!jwt) {
+          return {
+            content: [{
+              type: "text",
+              text: "CMUX_TASK_RUN_JWT environment variable not set. This tool requires JWT authentication.",
+            }],
+          };
+        }
+
+        if (!callbackUrl) {
+          return {
+            content: [{
+              type: "text",
+              text: "CMUX_CALLBACK_URL environment variable not set.",
+            }],
+          };
+        }
+
+        try {
+          const url = `${callbackUrl}/api/autopilot/context-health`;
+          const response = await fetch(url, {
+            method: "GET",
+            headers: {
+              Authorization: `Bearer ${jwt}`,
+            },
+          });
+
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => ({})) as { message?: string };
+            return {
+              content: [{
+                type: "text",
+                text: `Error getting context health: ${response.status} ${errorData.message ?? response.statusText}`,
+              }],
+            };
+          }
+
+          const data = await response.json() as {
+            taskRunId: string;
+            provider: string;
+            totalInputTokens: number;
+            totalOutputTokens: number;
+            contextWindow?: number;
+            usagePercent?: number;
+            latestWarningSeverity: string | null;
+            topWarningReasons: string[];
+            warningCount: number;
+            recentCompactionCount: number;
+            lastUpdatedAt: number;
+          };
+
+          // Format a human-readable summary
+          const usageStr = data.contextWindow
+            ? `${data.totalInputTokens.toLocaleString()} / ${data.contextWindow.toLocaleString()} tokens (${data.usagePercent ?? 0}%)`
+            : `${data.totalInputTokens.toLocaleString()} input tokens`;
+
+          const warningStr = data.latestWarningSeverity
+            ? `${data.latestWarningSeverity.toUpperCase()} - ${data.topWarningReasons[0] ?? "No details"}`
+            : "None";
+
+          const summary = [
+            `Provider: ${data.provider}`,
+            `Context Usage: ${usageStr}`,
+            `Output Tokens: ${data.totalOutputTokens.toLocaleString()}`,
+            `Warning State: ${warningStr}`,
+            `Warning Count: ${data.warningCount}`,
+            `Compaction Count: ${data.recentCompactionCount}`,
+          ].join("\n");
+
+          return {
+            content: [{
+              type: "text",
+              text: `Context Health Summary:\n${summary}\n\nRaw Data:\n${JSON.stringify(data, null, 2)}`,
+            }],
+          };
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{
+              type: "text",
+              text: `Error getting context health: ${errorMsg}`,
             }],
           };
         }


### PR DESCRIPTION
## Summary
- Add `getContextHealthSummary` Convex query for aggregating context usage and warning state
- Add `GET /api/autopilot/context-health` HTTP endpoint
- Add `get_context_health` MCP tool for agents to self-monitor context pressure

## Context Health Summary Fields
```typescript
{
  taskRunId: string;
  provider: string;
  totalInputTokens: number;
  totalOutputTokens: number;
  contextWindow?: number;
  usagePercent?: number;
  latestWarningSeverity: "info" | "warning" | "critical" | null;
  topWarningReasons: string[];
  warningCount: number;
  recentCompactionCount: number;
  lastUpdatedAt: number;
}
```

## MCP Tool Output
```
Context Health Summary:
Provider: anthropic
Context Usage: 850,000 / 1,000,000 tokens (85%)
Output Tokens: 45,000
Warning State: WARNING - Context window at 85% capacity
Warning Count: 1
Compaction Count: 0
```

## Part of
Phase 4: Provider-neutral lifecycle events (step 4 of design doc)

## Test plan
- [x] `bun check` passes
- [ ] CI passes