### PR TITLE
feat(shared): add Grok CLI activity stream integration

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -107,3 +107,10 @@ All 11 Claude Code v2.1.78 hooks integrated:
 - [x] Session completion hook with activity event
 - [x] Error hook for error surfacing
 - [x] Startup command to fire session start
+
+### Phase 15: Grok Activity Stream Integration — IN PROGRESS
+- [x] Session start hook with activity event
+- [x] Session completion hook with activity event
+- [x] Error hook for error surfacing
+- [x] Startup command to fire session start
+- [ ] PR merge

--- a/packages/shared/src/providers/grok/environment.ts
+++ b/packages/shared/src/providers/grok/environment.ts
@@ -29,7 +29,92 @@ async function makeGrokEnvironment(
   const startupCommands: string[] = [];
 
   startupCommands.push("mkdir -p ~/.grok");
+  startupCommands.push("mkdir -p /root/lifecycle/grok");
   startupCommands.push("rm -f /tmp/grok-telemetry-*.log 2>/dev/null || true");
+
+  // Session start hook - posts activity event when Grok session begins
+  const sessionStartHook = `#!/bin/bash
+set -eu
+LOG_FILE="/root/lifecycle/grok-hook.log"
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ]; then
+  exit 0
+fi
+# Post session start activity event (non-blocking)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "$(jq -n --arg trid "\${CMUX_TASK_RUN_ID:-}" \\
+         '{taskRunId: $trid, type: "session_start", toolName: "grok", summary: "Session started"}')" \\
+    >> "\${LOG_FILE}" 2>&1 || true
+) &
+exit 0
+`;
+  files.push({
+    destinationPath: "/root/lifecycle/grok/session-start-hook.sh",
+    contentBase64: Buffer.from(sessionStartHook).toString("base64"),
+    mode: "755",
+  });
+
+  // Session completion hook - posts activity event when Grok session ends
+  const sessionCompleteHook = `#!/bin/bash
+set -eu
+LOG_FILE="/root/lifecycle/grok-hook.log"
+MARKER_DIR="/root/lifecycle"
+GENERIC_MARKER="\${MARKER_DIR}/done.txt"
+
+# Post session completion activity event (non-blocking)
+if [ -n "\${CMUX_TASK_RUN_JWT:-}" ] && [ -n "\${CMUX_CALLBACK_URL:-}" ]; then
+  (
+    curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+      -H "Content-Type: application/json" \\
+      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+      -d "$(jq -n --arg trid "\${CMUX_TASK_RUN_ID:-}" \\
+           '{taskRunId: $trid, type: "session_stop", toolName: "grok", summary: "Session completed"}')" \\
+      >> "\${LOG_FILE}" 2>&1 || true
+  ) &
+fi
+
+# Sync memory files (best-effort)
+/root/lifecycle/memory/sync.sh >> "\${LOG_FILE}" 2>&1 || true
+
+# Create completion marker
+touch "\${GENERIC_MARKER}"
+echo "[CMUX] Grok session complete" >> "\${LOG_FILE}"
+`;
+  files.push({
+    destinationPath: "/root/lifecycle/grok/session-complete-hook.sh",
+    contentBase64: Buffer.from(sessionCompleteHook).toString("base64"),
+    mode: "755",
+  });
+
+  // Error hook - surfaces errors to dashboard
+  const errorHook = `#!/bin/bash
+set -eu
+LOG_FILE="/root/lifecycle/grok-hook.log"
+ERROR_MSG="\${1:-Unknown error}"
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ]; then
+  exit 0
+fi
+# Post error activity event (non-blocking)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "$(jq -n --arg trid "\${CMUX_TASK_RUN_ID:-}" --arg msg "$ERROR_MSG" \\
+         '{taskRunId: $trid, type: "error", toolName: "grok", summary: $msg}')" \\
+    >> "\${LOG_FILE}" 2>&1 || true
+) &
+exit 0
+`;
+  files.push({
+    destinationPath: "/root/lifecycle/grok/error-hook.sh",
+    contentBase64: Buffer.from(errorHook).toString("base64"),
+    mode: "755",
+  });
+
+  // Fire session start hook on sandbox initialization
+  startupCommands.push("/root/lifecycle/grok/session-start-hook.sh &");
 
   type GrokSettings = {
     selectedAuthType?: string;


### PR DESCRIPTION
## Summary
- Add session lifecycle hooks for real-time dashboard visibility
- Session start hook fired on sandbox initialization
- Session completion hook with memory sync
- Error hook for failure surfacing

## Test plan
- [ ] Verify session_start event posts when Grok sandbox initializes
- [ ] Verify session_stop event posts on session completion
- [ ] Verify error events surface to activity stream