### PR TITLE
ci: harden bun install in tests and release PR workflows

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -61,9 +61,26 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Install dependencies (bun)
+      - name: Install dependencies (skip Electron download, retry on transient failure)
         if: steps.release_changes.outputs.proceed == 'true'
-        run: bun install --frozen-lockfile
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+        run: |
+          set -euo pipefail
+
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "bun install failed after $attempt attempts" >&2
+              exit 1
+            fi
+
+            echo "bun install failed on attempt $attempt, retrying in 15 seconds..." >&2
+            sleep 15
+          done
 
       - name: Configure git user
         if: steps.release_changes.outputs.proceed == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,8 +49,25 @@ jobs:
         with:
           workspaces: apps/server/native/core
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Install dependencies (skip Electron download, retry on transient failure)
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+        run: |
+          set -euo pipefail
+
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "bun install failed after $attempt attempts" >&2
+              exit 1
+            fi
+
+            echo "bun install failed on attempt $attempt, retrying in 15 seconds..." >&2
+            sleep 15
+          done
 
       - name: Build native-core addon
         run: bun run build


### PR DESCRIPTION
## Summary
- skip Electron binary download during bun install in the required test workflow and the daily release PR workflow
- retry bun install up to 3 times with a 15 second backoff for transient registry/CDN failures
- clarify the install step name in GitHub Actions logs

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); YAML.load_file(".github/workflows/release-pr.yml"); puts "YAML OK"'
- ELECTRON_SKIP_BINARY_DOWNLOAD=1 bun install --frozen-lockfile
- pre-commit hook via git commit (bun check passed)