### PR TITLE
feat(client): swipe review UX polish - gestures, diff preview, comments

### DIFF
--- a/apps/client/src/components/swipe-review/file-review-card.tsx
+++ b/apps/client/src/components/swipe-review/file-review-card.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState, type PointerEvent } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -12,11 +12,21 @@ import { cn } from "@/lib/utils";
 
 type ReviewDecision = "pending" | "approved" | "changes_requested" | "skipped";
 
+interface HighlightedLine {
+  lineNumber: number;
+  content: string;
+  score: number;
+}
+
 interface FileReviewCardProps {
   filePath: string;
   decision: ReviewDecision;
   riskScore?: number;
   teamSlugOrId: string;
+  topHighlightedLines?: HighlightedLine[];
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  onSwipeDown?: () => void;
 }
 
 function getRiskLevel(score?: number): {
@@ -130,11 +140,21 @@ function getFileLanguage(ext: string): string {
   return langMap[ext.toLowerCase()] || ext.toUpperCase();
 }
 
+const SWIPE_THRESHOLD = 100; // pixels
+
 export function FileReviewCard({
   filePath,
   decision,
   riskScore,
+  topHighlightedLines,
+  onSwipeLeft,
+  onSwipeRight,
+  onSwipeDown,
 }: FileReviewCardProps) {
+  const [dragStartX, setDragStartX] = useState<number | null>(null);
+  const [dragStartY, setDragStartY] = useState<number | null>(null);
+  const [dragDelta, setDragDelta] = useState({ x: 0, y: 0 });
+
   const risk = useMemo(() => getRiskLevel(riskScore), [riskScore]);
   const ext = getFileExtension(filePath);
   const language = getFileLanguage(ext);
@@ -143,6 +163,58 @@ export function FileReviewCard({
     ? filePath.substring(0, filePath.lastIndexOf("/"))
     : "";
 
+  const handlePointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    setDragStartX(e.clientX);
+    setDragStartY(e.clientY);
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    if (dragStartX === null || dragStartY === null) return;
+    setDragDelta({
+      x: e.clientX - dragStartX,
+      y: e.clientY - dragStartY,
+    });
+  };
+
+  const handlePointerUp = () => {
+    const absX = Math.abs(dragDelta.x);
+    const absY = Math.abs(dragDelta.y);
+
+    // Determine dominant direction
+    if (absX > SWIPE_THRESHOLD && absX > absY) {
+      if (dragDelta.x > 0) {
+        onSwipeRight?.();
+      } else {
+        onSwipeLeft?.();
+      }
+    } else if (absY > SWIPE_THRESHOLD && absY > absX && dragDelta.y > 0) {
+      onSwipeDown?.();
+    }
+
+    setDragStartX(null);
+    setDragStartY(null);
+    setDragDelta({ x: 0, y: 0 });
+  };
+
+  const handlePointerCancel = () => {
+    setDragStartX(null);
+    setDragStartY(null);
+    setDragDelta({ x: 0, y: 0 });
+  };
+
+  // Visual feedback colors based on swipe direction
+  const getSwipeOverlay = () => {
+    const absX = Math.abs(dragDelta.x);
+    if (absX < 30) return null;
+
+    const opacity = Math.min((absX - 30) / 100, 0.3);
+    if (dragDelta.x > 0) {
+      return `rgba(34, 197, 94, ${opacity})`; // green for approve
+    }
+    return `rgba(239, 68, 68, ${opacity})`; // red for changes
+  };
+
   return (
     <div
       className={cn(
@@ -150,8 +222,19 @@ export function FileReviewCard({
         "bg-white dark:bg-neutral-900",
         "border-neutral-200 dark:border-neutral-700",
         decision === "approved" && "ring-2 ring-green-500",
-        decision === "changes_requested" && "ring-2 ring-red-500"
+        decision === "changes_requested" && "ring-2 ring-red-500",
+        "touch-none select-none cursor-grab",
+        dragStartX !== null && "cursor-grabbing"
       )}
+      style={{
+        transform: `translateX(${dragDelta.x}px) rotate(${dragDelta.x * 0.02}deg)`,
+        transition: dragStartX === null ? "transform 0.2s ease-out" : "none",
+        backgroundColor: getSwipeOverlay() ?? undefined,
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
     >
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-neutral-200 dark:border-neutral-800">
@@ -229,6 +312,37 @@ export function FileReviewCard({
             </span>
           )}
         </div>
+
+        {/* Diff preview - top highlighted lines */}
+        {topHighlightedLines && topHighlightedLines.length > 0 && (
+          <div className="mt-4 rounded-lg bg-neutral-950 p-3 font-mono text-xs overflow-hidden">
+            <div className="text-neutral-400 mb-2 text-[10px] uppercase tracking-wide">
+              Top changes to review
+            </div>
+            {topHighlightedLines.slice(0, 5).map((line) => (
+              <div
+                key={`${line.lineNumber}-${line.content.slice(0, 20)}`}
+                className="flex gap-3 py-0.5 hover:bg-neutral-800/50"
+              >
+                <span className="text-neutral-500 w-8 text-right shrink-0">
+                  {line.lineNumber}
+                </span>
+                <span
+                  className={cn(
+                    "flex-1 truncate",
+                    line.score >= 7
+                      ? "text-red-400"
+                      : line.score >= 5
+                        ? "text-orange-400"
+                        : "text-neutral-200"
+                  )}
+                >
+                  {line.content || " "}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Swipe hints */}

--- a/apps/client/src/components/swipe-review/swipe-review-ui.tsx
+++ b/apps/client/src/components/swipe-review/swipe-review-ui.tsx
@@ -14,6 +14,7 @@ import {
   AlertCircle,
   SkipForward,
   Zap,
+  MessageSquare,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -22,11 +23,18 @@ import { FileReviewCard } from "./file-review-card";
 
 type ReviewDecision = "pending" | "approved" | "changes_requested" | "skipped";
 
+interface HighlightedLine {
+  lineNumber: number;
+  content: string;
+  score: number;
+}
+
 interface FileWithDecision {
   path: string;
   decision: ReviewDecision;
   riskScore?: number;
   comment?: string;
+  topHighlightedLines?: HighlightedLine[];
 }
 
 interface SwipeReviewUIProps {
@@ -42,6 +50,8 @@ export function SwipeReviewUI({
 }: SwipeReviewUIProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isCreatingSession, setIsCreatingSession] = useState(false);
+  const [currentComment, setCurrentComment] = useState("");
+  const [showCommentInput, setShowCommentInput] = useState(false);
 
   // Fetch or create session
   const session = useQuery(
@@ -66,13 +76,46 @@ export function SwipeReviewUI({
 
     try {
       const heatmap = JSON.parse(session.heatmapData);
+
+      interface HeatmapLine {
+        lineNumber?: number;
+        line?: number;
+        content?: string;
+        text?: string;
+        score?: number;
+        riskScore?: number;
+      }
+
+      interface HeatmapFile {
+        path: string;
+        heatmap?: {
+          overallRiskScore?: number;
+          lines?: HeatmapLine[];
+          highlightedLines?: HeatmapLine[];
+        };
+      }
+
       const heatmapFiles =
-        heatmap.files?.map(
-          (f: { path: string; heatmap?: { overallRiskScore?: number } }) => ({
+        heatmap.files?.map((f: HeatmapFile) => {
+          // Extract top highlighted lines (sorted by score)
+          const lines: HeatmapLine[] =
+            f.heatmap?.lines || f.heatmap?.highlightedLines || [];
+          const topLines = lines
+            .map((l: HeatmapLine) => ({
+              lineNumber: l.lineNumber ?? l.line ?? 0,
+              content: l.content ?? l.text ?? "",
+              score: l.score ?? l.riskScore ?? 0,
+            }))
+            .filter((l) => l.lineNumber > 0 && l.score > 0)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, 5);
+
+          return {
             path: f.path,
             riskScore: f.heatmap?.overallRiskScore,
-          })
-        ) ?? [];
+            topHighlightedLines: topLines.length > 0 ? topLines : undefined,
+          };
+        }) ?? [];
 
       // Merge with existing decisions
       const decisionMap = new Map(
@@ -80,13 +123,18 @@ export function SwipeReviewUI({
       );
 
       return heatmapFiles.map(
-        (f: { path: string; riskScore?: number }): FileWithDecision => {
+        (f: {
+          path: string;
+          riskScore?: number;
+          topHighlightedLines?: HighlightedLine[];
+        }): FileWithDecision => {
           const existing = decisionMap.get(f.path);
           return {
             path: f.path,
             decision: existing?.decision ?? "pending",
             riskScore: f.riskScore,
             comment: existing?.comment,
+            topHighlightedLines: f.topHighlightedLines,
           };
         }
       );
@@ -142,7 +190,12 @@ export function SwipeReviewUI({
           filePath: currentFile.path,
           decision,
           riskScore: currentFile.riskScore,
+          comment: currentComment.trim() || undefined,
         });
+
+        // Clear comment input after submission
+        setCurrentComment("");
+        setShowCommentInput(false);
 
         // Auto-advance to next pending file
         const nextPendingIndex = files.findIndex(
@@ -165,6 +218,7 @@ export function SwipeReviewUI({
     [
       currentFile,
       currentIndex,
+      currentComment,
       files,
       initialSessionId,
       recordDecision,
@@ -362,7 +416,57 @@ export function SwipeReviewUI({
             decision={currentFile.decision}
             riskScore={currentFile.riskScore}
             teamSlugOrId={teamSlugOrId}
+            topHighlightedLines={currentFile.topHighlightedLines}
+            onSwipeLeft={() => handleDecision("changes_requested")}
+            onSwipeRight={() => handleDecision("approved")}
+            onSwipeDown={() => handleDecision("skipped")}
           />
+        )}
+      </div>
+
+      {/* Comment input */}
+      <div className="px-6 pb-2">
+        {showCommentInput ? (
+          <div className="max-w-2xl mx-auto">
+            <textarea
+              placeholder="Add a comment for this file (optional)"
+              value={currentComment}
+              onChange={(e) => setCurrentComment(e.target.value)}
+              className={cn(
+                "w-full p-3 text-sm rounded-lg border resize-none",
+                "border-neutral-200 dark:border-neutral-700",
+                "bg-white dark:bg-neutral-900",
+                "placeholder:text-neutral-400",
+                "focus:outline-none focus:ring-2 focus:ring-blue-500"
+              )}
+              rows={2}
+              autoFocus
+            />
+            <div className="flex justify-end mt-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setShowCommentInput(false);
+                  setCurrentComment("");
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex justify-center">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+              onClick={() => setShowCommentInput(true)}
+            >
+              <MessageSquare className="w-4 h-4 mr-1" />
+              Add comment
+            </Button>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Add touch/swipe gesture support for mobile UX (cards now actually respond to swipes)
- Add diff preview section showing top 5 highlighted lines from heatmap data
- Add optional comment input for file-level review comments

## Changes

### Touch Swipe Gestures (file-review-card.tsx)
- Pointer event handlers for touch/mouse drag detection
- 100px swipe threshold to trigger decision callbacks
- Card visually translates and rotates during drag
- Color overlay feedback: green tint for approve (right), red tint for changes (left)
- Swipe down triggers skip
- `touch-none` and `cursor-grab` CSS for proper mobile UX

### Diff Preview (file-review-card.tsx)
- New `topHighlightedLines` prop showing up to 5 high-risk lines
- Monospace code preview with line numbers
- Lines color-coded by risk score (red for 7+, orange for 5-6)
- Parsed from existing heatmap data in swipe-review-ui.tsx

### Comment Input (swipe-review-ui.tsx)
- Toggle button reveals textarea for optional file comments
- Comment passed to `recordDecision` mutation (backend already supports it)
- Comment clears after decision submission
- Keyboard shortcuts still work when not focused on textarea

## Test plan
- [x] `bun check` passes
- [ ] Manual: test swipe gestures on mobile/tablet or Chrome DevTools mobile emulation
- [ ] Manual: verify keyboard shortcuts (A/X/S/J/K/U) still work
- [ ] Manual: verify diff preview appears for files with heatmap line data
- [ ] Manual: verify comment persists through to GitHub PR review