### PR TITLE
feat(convex): tool suggestion learning from selections

### DIFF
--- a/apps/client/src/hooks/useToolSuggestions.ts
+++ b/apps/client/src/hooks/useToolSuggestions.ts
@@ -1,6 +1,6 @@
 import { api } from "@cmux/convex/api";
-import { useQuery } from "convex/react";
-import { useMemo } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { useCallback, useMemo } from "react";
 import { useDebouncedValue } from "./useDebouncedValue";
 
 /**
@@ -42,6 +42,76 @@ export function useToolSuggestions(prompt: string, options?: { debounceMs?: numb
     isLoading: shouldQuery ? suggestions === undefined : defaultTools === undefined,
     hasPromptSuggestions: shouldQuery && (suggestions?.length ?? 0) > 0,
   };
+}
+
+/**
+ * Hook for suggesting MCP tools with team-based learning.
+ *
+ * Uses team usage patterns to boost frequently-selected tools.
+ */
+export function useToolSuggestionsWithLearning(
+  prompt: string,
+  teamId: string | undefined,
+  options?: { debounceMs?: number; limit?: number }
+) {
+  const { debounceMs = 300, limit = 5 } = options ?? {};
+
+  const debouncedPrompt = useDebouncedValue(prompt, debounceMs);
+  const shouldQuery = debouncedPrompt.length >= 10;
+
+  // Use enhanced query with learning
+  const suggestions = useQuery(
+    api.mcpTools.suggestForPromptWithLearning,
+    shouldQuery ? { prompt: debouncedPrompt, teamId, limit } : "skip"
+  );
+
+  const defaultTools = useQuery(api.mcpTools.listDefaultEnabled);
+
+  const combinedTools = useMemo(() => {
+    if (!shouldQuery) {
+      return (defaultTools ?? []).map((t) => ({ ...t, usageCount: 0 }));
+    }
+
+    const suggestionNames = new Set((suggestions ?? []).map((t) => t.name));
+    const additionalDefaults = (defaultTools ?? [])
+      .filter((t) => !suggestionNames.has(t.name))
+      .map((t) => ({ ...t, usageCount: 0 }));
+
+    return [...(suggestions ?? []), ...additionalDefaults].slice(0, limit);
+  }, [suggestions, defaultTools, shouldQuery, limit]);
+
+  return {
+    suggestions: combinedTools,
+    isLoading: shouldQuery ? suggestions === undefined : defaultTools === undefined,
+    hasPromptSuggestions: shouldQuery && (suggestions?.length ?? 0) > 0,
+  };
+}
+
+/**
+ * Hook for tracking tool selection to enable learning.
+ */
+export function useToolSelectionTracker(teamId: string | undefined) {
+  const trackSelection = useMutation(api.mcpTools.trackToolSelection);
+
+  const track = useCallback(
+    async (toolName: string, prompt?: string) => {
+      if (!teamId) return;
+
+      // Extract keywords from prompt for learning
+      const promptKeywords = prompt
+        ? prompt
+            .toLowerCase()
+            .split(/\W+/)
+            .filter((w) => w.length > 3)
+            .slice(0, 10)
+        : undefined;
+
+      await trackSelection({ teamId, toolName, promptKeywords });
+    },
+    [teamId, trackSelection]
+  );
+
+  return { trackSelection: track };
 }
 
 /**

--- a/packages/convex/convex/mcpTools.ts
+++ b/packages/convex/convex/mcpTools.ts
@@ -272,6 +272,136 @@ export const setTeamToolPreference = mutation({
   },
 });
 
+// Track tool selection for learning (Phase 19 enhancement)
+export const trackToolSelection = mutation({
+  args: {
+    teamId: v.string(),
+    toolName: v.string(),
+    promptKeywords: v.optional(v.array(v.string())),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("toolUsageStats")
+      .withIndex("by_team_tool", (q) =>
+        q.eq("teamId", args.teamId).eq("toolName", args.toolName)
+      )
+      .first();
+
+    const now = Date.now();
+
+    if (existing) {
+      // Merge recent keywords (keep last 20 unique)
+      const existingKeywords = existing.recentPromptKeywords ?? [];
+      const newKeywords = args.promptKeywords ?? [];
+      const mergedKeywords = [
+        ...new Set([...newKeywords, ...existingKeywords]),
+      ].slice(0, 20);
+
+      await ctx.db.patch(existing._id, {
+        selectionCount: existing.selectionCount + 1,
+        lastSelectedAt: now,
+        recentPromptKeywords: mergedKeywords,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("toolUsageStats", {
+      teamId: args.teamId,
+      toolName: args.toolName,
+      selectionCount: 1,
+      lastSelectedAt: now,
+      recentPromptKeywords: args.promptKeywords,
+    });
+  },
+});
+
+// Get team's tool usage stats for boosting suggestions
+export const getTeamUsageStats = query({
+  args: { teamId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("toolUsageStats")
+      .withIndex("by_team", (q) => q.eq("teamId", args.teamId))
+      .collect();
+  },
+});
+
+// Enhanced suggestion with team usage learning
+export const suggestForPromptWithLearning = query({
+  args: {
+    prompt: v.string(),
+    teamId: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 5;
+    const allTools = await ctx.db.query("mcpTools").collect();
+
+    // Tokenize prompt
+    const promptTokens = new Set(
+      args.prompt
+        .toLowerCase()
+        .split(/\W+/)
+        .filter((w) => w.length > 2)
+    );
+
+    // Get team usage stats if teamId provided
+    const teamId = args.teamId;
+    const usageStats = teamId
+      ? await ctx.db
+          .query("toolUsageStats")
+          .withIndex("by_team", (q) => q.eq("teamId", teamId))
+          .collect()
+      : [];
+
+    const usageMap = new Map(usageStats.map((s) => [s.toolName, s]));
+
+    // Detect intent boosts
+    const categoryBoosts = detectIntentBoosts(args.prompt);
+
+    // Score tools with learning boost
+    const scoredTools = allTools.map((tool) => {
+      // Base keyword matching
+      const keywordMatches = tool.keywords.filter((kw) =>
+        promptTokens.has(kw.toLowerCase())
+      ).length;
+      const descriptionMatches = tool.description
+        .toLowerCase()
+        .split(/\W+/)
+        .filter((w) => promptTokens.has(w)).length;
+
+      let score = keywordMatches * 2 + descriptionMatches;
+
+      // Intent boost
+      const intentBoost = categoryBoosts[tool.category] ?? 0;
+      score += intentBoost;
+
+      // Learning boost based on team usage
+      const usage = usageMap.get(tool.name);
+      if (usage) {
+        // Logarithmic boost to prevent runaway scores
+        const usageBoost = Math.log2(usage.selectionCount + 1);
+        score += usageBoost;
+
+        // Extra boost if prompt matches learned keywords
+        const learnedKeywords = usage.recentPromptKeywords ?? [];
+        const learnedMatches = learnedKeywords.filter((kw) =>
+          promptTokens.has(kw.toLowerCase())
+        ).length;
+        score += learnedMatches * 0.5;
+      }
+
+      return { tool, score, usageCount: usage?.selectionCount ?? 0 };
+    });
+
+    return scoredTools
+      .filter((t) => t.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit)
+      .map((t) => ({ ...t.tool, usageCount: t.usageCount }));
+  },
+});
+
 // Seed initial tools (run once during setup)
 export const seedInitialTools = mutation({
   args: {},

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -2842,6 +2842,19 @@ const convexSchema = defineSchema({
   })
     .index("by_team", ["teamId"])
     .index("by_team_tool", ["teamId", "toolName"]),
+
+  // Tool usage tracking for learning from selections (Phase 19 enhancement)
+  toolUsageStats: defineTable({
+    teamId: v.string(),
+    toolName: v.string(),
+    selectionCount: v.number(), // Times tool was selected for a task
+    lastSelectedAt: v.number(),
+    // Optional: track prompt patterns that led to selection
+    recentPromptKeywords: v.optional(v.array(v.string())),
+  })
+    .index("by_team", ["teamId"])
+    .index("by_team_tool", ["teamId", "toolName"])
+    .index("by_selection_count", ["teamId", "selectionCount"]),
 });
 
 export default convexSchema;


### PR DESCRIPTION
## Summary
Phase 19 enhancement: learn from tool selections to improve suggestions.

This implements the "learning from selections" feature from PLAN.md Phase 19's FUTURE item.

## Changes

### Schema (`packages/convex/convex/schema.ts`)
- Add `toolUsageStats` table to track team tool selection patterns
  - `teamId`, `toolName`, `selectionCount`, `lastSelectedAt`
  - `recentPromptKeywords` - keywords from prompts that led to selection

### Backend (`packages/convex/convex/mcpTools.ts`)
- `trackToolSelection` mutation - record when a tool is selected for a task
- `getTeamUsageStats` query - retrieve team's tool usage patterns
- `suggestForPromptWithLearning` query - enhanced suggestions with:
  - Logarithmic boost based on selection count (prevents runaway scores)
  - Extra boost when prompt matches learned keywords

### Frontend (`apps/client/src/hooks/useToolSuggestions.ts`)
- `useToolSuggestionsWithLearning` hook - enhanced suggestions for teams
- `useToolSelectionTracker` hook - track selections from UI

## How It Works
1. When a user selects a tool for a task, `trackToolSelection` records:
   - Increments selection count for that tool
   - Stores keywords from the prompt that led to selection
2. Future suggestions use `suggestForPromptWithLearning` which:
   - Applies logarithmic boost: `log2(selectionCount + 1)`
   - Adds 0.5 per matching learned keyword
3. Teams that frequently use certain tools will see those ranked higher

## Test plan
- [x] `bun check` passes
- [ ] Manual: select tools for tasks, verify usage stats update
- [ ] Manual: verify frequently-used tools rank higher in suggestions