### PR TITLE
fix: add Vercel SPA fallback for client routes

### DIFF
--- a/apps/client/vercel.json
+++ b/apps/client/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a source-controlled `vercel.json` to the client app
- rewrite all non-file requests to `index.html` so TanStack Router can handle deep links like `/karldigi/dashboard`

## Why
Production currently serves the SPA shell at `/`, but direct requests to client routes return a Vercel `404 NOT_FOUND` before the app loads. This change matches Vercel's current SPA rewrite guidance for Vite deployments.