### PR TITLE
feat(client): restore direct VncViewer for browser preview panels

### DIFF
--- a/apps/client/src/components/environment/EnvironmentSetupFlow.tsx
+++ b/apps/client/src/components/environment/EnvironmentSetupFlow.tsx
@@ -28,7 +28,10 @@ import {
   postApiSandboxesByIdEnvMutation,
   postApiSandboxesByIdRunScriptsMutation,
 } from "@cmux/www-openapi-client/react-query";
-import { resolveBrowserPreviewUrl } from "@/lib/toProxyWorkspaceUrl";
+import {
+  resolveBrowserPreviewUrl,
+  resolveBrowserPreviewWebsocketUrl,
+} from "@/lib/toProxyWorkspaceUrl";
 import { useMutation as useRQMutation, useQuery as useRQQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
@@ -128,6 +131,16 @@ export function EnvironmentSetupFlow({
   const browserHtmlUrl = useMemo(
     () =>
       resolveBrowserPreviewUrl({
+        vncUrl: vncUrlFromStatus,
+        workspaceUrl: vscodeUrl,
+      }) ?? undefined,
+    [vncUrlFromStatus, vscodeUrl]
+  );
+
+  // WebSocket URL for direct VncViewer connection (preferred over iframe)
+  const vncWebsocketUrl = useMemo(
+    () =>
+      resolveBrowserPreviewWebsocketUrl({
         vncUrl: vncUrlFromStatus,
         workspaceUrl: vscodeUrl,
       }) ?? undefined,
@@ -474,6 +487,7 @@ export function EnvironmentSetupFlow({
       exposedPorts={exposedPorts}
       vscodeUrl={vscodeUrl}
       browserHtmlUrl={browserHtmlUrl}
+      vncWebsocketUrl={vncWebsocketUrl}
       browserPersistKey={
         instanceId
           ? `env-workspace-config:browser:${instanceId}`

--- a/apps/client/src/components/environment/EnvironmentWorkspaceConfig.tsx
+++ b/apps/client/src/components/environment/EnvironmentWorkspaceConfig.tsx
@@ -14,6 +14,7 @@ import { PersistentWebView } from "@/components/persistent-webview";
 import { WorkspaceSetupPanel } from "@/components/WorkspaceSetupPanel";
 import { WorkspaceLoadingIndicator } from "@/components/workspace-loading-indicator";
 import { useVncClipboardBridge } from "@/hooks/useVncClipboardBridge";
+import { VncViewer } from "@cmux/shared/components/vnc-viewer";
 import {
   disableDragPointerEvents,
   restoreDragPointerEvents,
@@ -62,6 +63,8 @@ interface EnvironmentWorkspaceConfigProps {
   exposedPorts: string;
   vscodeUrl?: string;
   browserHtmlUrl?: string;
+  /** WebSocket URL for direct VncViewer connection (preferred over iframe) */
+  vncWebsocketUrl?: string;
   browserPersistKey: string;
   isSaving: boolean;
   errorMessage?: string | null;
@@ -99,6 +102,7 @@ export function EnvironmentWorkspaceConfig({
   exposedPorts,
   vscodeUrl,
   browserHtmlUrl,
+  vncWebsocketUrl,
   browserPersistKey,
   isSaving,
   errorMessage,
@@ -378,22 +382,26 @@ export function EnvironmentWorkspaceConfig({
     [vscodeUrl]
   );
 
+  // Use direct VncViewer when websocket URL is available
+  const useDirectVncViewer = Boolean(vncWebsocketUrl);
+
   const browserPlaceholder = useMemo(
     () =>
-      browserHtmlUrl
+      browserHtmlUrl || vncWebsocketUrl
         ? null
         : {
             title: "Waiting for browser",
             description: "We'll embed the browser session as soon as the environment exposes it.",
           },
-    [browserHtmlUrl]
+    [browserHtmlUrl, vncWebsocketUrl]
   );
 
-  const isVncBrowserPanel =
-    showBrowser && Boolean(browserHtmlUrl?.includes("/vnc.html"));
+  // Only use clipboard bridge for iframe fallback path (not direct VncViewer)
+  const isVncIframeFallback =
+    showBrowser && !useDirectVncViewer && Boolean(browserHtmlUrl?.includes("/vnc.html"));
   useVncClipboardBridge({
     persistKey: browserPersistKey,
-    enabled: isVncBrowserPanel,
+    enabled: isVncIframeFallback,
   });
 
   // Render scripts section
@@ -902,7 +910,19 @@ export function EnvironmentWorkspaceConfig({
         )}
 
         {/* Browser preview (shown for browser-setup step) */}
-        {showBrowser && browserHtmlUrl && (
+        {/* Prefer direct VncViewer when websocket URL is available */}
+        {showBrowser && useDirectVncViewer && vncWebsocketUrl && (
+          <VncViewer
+            url={vncWebsocketUrl}
+            autoConnect
+            scaleViewport
+            className="absolute inset-0"
+            loadingFallback={<WorkspaceLoadingIndicator variant="browser" status="loading" />}
+            errorFallback={<WorkspaceLoadingIndicator variant="browser" status="error" />}
+          />
+        )}
+        {/* Fallback to iframe when only HTML URL is available */}
+        {showBrowser && !useDirectVncViewer && browserHtmlUrl && (
           <PersistentWebView
             persistKey={browserPersistKey}
             src={browserHtmlUrl}

--- a/apps/client/src/lib/toProxyWorkspaceUrl.test.ts
+++ b/apps/client/src/lib/toProxyWorkspaceUrl.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveBrowserPreviewUrl,
+  resolveBrowserPreviewWebsocketUrl,
   toGenericVncUrl,
+  toGenericVncWebsocketUrl,
   toMorphVncUrl,
   toVncViewerUrl,
+  toVncWebsocketUrl,
 } from "./toProxyWorkspaceUrl";
 
 describe("toMorphVncUrl", () => {
@@ -63,5 +66,115 @@ describe("resolveBrowserPreviewUrl", () => {
     expect(result).toBe(
       "https://vnc-201.example.com/vnc.html?autoconnect=1&resize=scale",
     );
+  });
+});
+
+describe("toVncWebsocketUrl", () => {
+  it("converts https to wss with /websockify path", () => {
+    const result = toVncWebsocketUrl("https://vnc-201.example.com/");
+    expect(result).toBe("wss://vnc-201.example.com/websockify");
+  });
+
+  it("converts http to ws", () => {
+    const result = toVncWebsocketUrl("http://localhost:5900/");
+    expect(result).toBe("ws://localhost:5900/websockify");
+  });
+
+  it("strips query params and hash", () => {
+    const result = toVncWebsocketUrl(
+      "https://vnc.example.com/vnc.html?foo=bar#hash"
+    );
+    expect(result).toBe("wss://vnc.example.com/websockify");
+  });
+
+  it("returns null for empty input", () => {
+    expect(toVncWebsocketUrl("")).toBeNull();
+  });
+});
+
+describe("toGenericVncWebsocketUrl", () => {
+  it("converts Morph workspace URL to wss websocket URL", () => {
+    const result = toGenericVncWebsocketUrl(
+      "https://port-39378-morphvm-abc123.http.cloud.morph.so/"
+    );
+    expect(result).toBe(
+      "wss://port-39380-morphvm-abc123.http.cloud.morph.so/websockify"
+    );
+  });
+
+  it("converts PVE-LXC workspace URL to wss websocket URL", () => {
+    const result = toGenericVncWebsocketUrl(
+      "https://port-39378-pvelxc-1cc7473f.alphasolves.com/"
+    );
+    expect(result).toBe(
+      "wss://port-39380-pvelxc-1cc7473f.alphasolves.com/websockify"
+    );
+  });
+
+  it("returns null for non-port-based URLs", () => {
+    expect(toGenericVncWebsocketUrl("https://example.com/")).toBeNull();
+  });
+});
+
+describe("resolveBrowserPreviewWebsocketUrl", () => {
+  it("converts bare VNC host to wss websocket URL", () => {
+    const result = resolveBrowserPreviewWebsocketUrl({
+      vncUrl: "https://vnc-201.example.com/",
+    });
+    expect(result).toBe("wss://vnc-201.example.com/websockify");
+  });
+
+  it("rewrites /vnc.html to websocket on same host/path", () => {
+    const result = resolveBrowserPreviewWebsocketUrl({
+      vncUrl: "https://vnc.example.com/vnc.html?autoconnect=1",
+    });
+    expect(result).toBe("wss://vnc.example.com/websockify");
+  });
+
+  it("extracts ?path= param as websocket pathname", () => {
+    const result = resolveBrowserPreviewWebsocketUrl({
+      vncUrl: "https://vnc.example.com/vnc/vnc.html?path=vnc/websockify",
+    });
+    expect(result).toBe("wss://vnc.example.com/vnc/websockify");
+  });
+
+  it("handles subpath routing with ?path= preserving exact path", () => {
+    const result = resolveBrowserPreviewWebsocketUrl({
+      vncUrl: "https://proxy.example.com/?path=/sandbox/123/websockify",
+    });
+    expect(result).toBe("wss://proxy.example.com/sandbox/123/websockify");
+  });
+
+  it("falls back to Morph workspace derivation", () => {
+    const result = resolveBrowserPreviewWebsocketUrl({
+      workspaceUrl: "https://port-39378-morphvm-xyz789.http.cloud.morph.so/",
+    });
+    expect(result).toBe(
+      "wss://port-39380-morphvm-xyz789.http.cloud.morph.so/websockify"
+    );
+  });
+
+  it("falls back to PVE-LXC workspace derivation", () => {
+    const result = resolveBrowserPreviewWebsocketUrl({
+      workspaceUrl: "https://port-39378-pvelxc-abc123.alphasolves.com/",
+    });
+    expect(result).toBe(
+      "wss://port-39380-pvelxc-abc123.alphasolves.com/websockify"
+    );
+  });
+
+  it("prefers vncUrl over workspaceUrl", () => {
+    const result = resolveBrowserPreviewWebsocketUrl({
+      vncUrl: "https://vnc-direct.example.com/",
+      workspaceUrl: "https://port-39378-pvelxc-ignored.alphasolves.com/",
+    });
+    expect(result).toBe("wss://vnc-direct.example.com/websockify");
+  });
+
+  it("returns null when no URLs provided", () => {
+    expect(resolveBrowserPreviewWebsocketUrl({})).toBeNull();
+    expect(
+      resolveBrowserPreviewWebsocketUrl({ vncUrl: null, workspaceUrl: null })
+    ).toBeNull();
   });
 });

--- a/apps/client/src/lib/toProxyWorkspaceUrl.ts
+++ b/apps/client/src/lib/toProxyWorkspaceUrl.ts
@@ -273,6 +273,86 @@ export function resolveBrowserPreviewUrl(input: {
 }
 
 /**
+ * Resolve a VNC WebSocket URL for direct noVNC/RFB connection.
+ * This is the canonical client-side helper for browser preview transport resolution.
+ *
+ * Priority:
+ * 1. If vncUrl is provided:
+ *    - If it has ?path=..., extract that as the WebSocket pathname
+ *    - Otherwise convert to wss:// with /websockify pathname
+ * 2. Fall back to deriving WebSocket URL from workspaceUrl
+ *
+ * @returns wss:// URL for direct VNC connection, or null if unresolvable
+ */
+export function resolveBrowserPreviewWebsocketUrl(input: {
+  vncUrl?: string | null;
+  workspaceUrl?: string | null;
+}): string | null {
+  if (input.vncUrl) {
+    const wsUrl = toVncWebsocketUrlWithPath(input.vncUrl);
+    if (wsUrl) {
+      return wsUrl;
+    }
+  }
+
+  if (input.workspaceUrl) {
+    return toGenericVncWebsocketUrl(input.workspaceUrl);
+  }
+
+  return null;
+}
+
+/**
+ * Convert a VNC URL to WebSocket URL, handling ?path= query parameter if present.
+ * Some VNC providers route via ?path=vnc/websockify instead of direct /websockify.
+ */
+function toVncWebsocketUrlWithPath(vncBaseUrl: string): string | null {
+  if (!vncBaseUrl) {
+    return null;
+  }
+
+  try {
+    const url = new URL(vncBaseUrl);
+
+    // Check for ?path= query parameter (some providers use this for WebSocket routing)
+    const pathParam = url.searchParams.get("path");
+    if (pathParam) {
+      // Convert protocol and use the path param as pathname
+      url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+      url.pathname = pathParam.startsWith("/") ? pathParam : `/${pathParam}`;
+      url.search = "";
+      url.hash = "";
+      return url.toString();
+    }
+
+    // Check if URL ends in viewer HTML paths - extract base and convert
+    const normalizedPath = url.pathname.toLowerCase();
+    if (
+      normalizedPath.endsWith("/vnc.html") ||
+      normalizedPath.endsWith("/viewer.html")
+    ) {
+      // Replace the HTML viewer path with websockify on same base
+      const basePath = url.pathname.slice(0, url.pathname.lastIndexOf("/"));
+      url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+      url.pathname = basePath ? `${basePath}/websockify` : "/websockify";
+      url.search = "";
+      url.hash = "";
+      return url.toString();
+    }
+
+    // Standard conversion - just set /websockify
+    return toVncWebsocketUrl(vncBaseUrl);
+  } catch (error) {
+    console.debug(
+      "[toProxyWorkspaceUrl] Invalid VNC WebSocket URL with path:",
+      vncBaseUrl,
+      error
+    );
+    return null;
+  }
+}
+
+/**
  * Convert a direct VNC base URL to a WebSocket URL for noVNC/RFB connection.
  * Works with any VNC URL (PVE LXC, Morph, etc.) by converting protocol and setting /websockify path.
  *

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
@@ -9,7 +9,11 @@ import {
   TASK_RUN_IFRAME_ALLOW,
   TASK_RUN_IFRAME_SANDBOX,
 } from "@/lib/preloadTaskRunIframes";
-import { resolveBrowserPreviewUrl } from "@/lib/toProxyWorkspaceUrl";
+import {
+  resolveBrowserPreviewUrl,
+  resolveBrowserPreviewWebsocketUrl,
+} from "@/lib/toProxyWorkspaceUrl";
+import { VncViewer } from "@cmux/shared/components/vnc-viewer";
 import { convexQueryClient } from "@/contexts/convex/convex-query-client";
 import { api } from "@cmux/convex/api";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
@@ -61,16 +65,29 @@ function BrowserComponent() {
     [vscodeInfo?.vncUrl, rawBrowserUrl]
   );
 
+  // WebSocket URL for direct VncViewer connection (preferred over iframe)
+  const vncWebsocketUrl = useMemo(
+    () =>
+      resolveBrowserPreviewWebsocketUrl({
+        vncUrl: vscodeInfo?.vncUrl,
+        workspaceUrl: rawBrowserUrl,
+      }),
+    [vscodeInfo?.vncUrl, rawBrowserUrl]
+  );
+
+  // Use direct VncViewer when websocket URL is available
+  const useDirectVncViewer = Boolean(vncWebsocketUrl);
+
   const persistKey = useMemo(
     () => getTaskRunBrowserPersistKey(taskRunId),
     [taskRunId]
   );
 
-  // Enable clipboard bridge only for VNC panel (vnc.html URLs)
-  const isVncPanel = Boolean(browserUrl?.includes("/vnc.html"));
+  // Enable clipboard bridge only for iframe fallback path (not direct VncViewer)
+  const isVncIframeFallback = !useDirectVncViewer && Boolean(browserUrl?.includes("/vnc.html"));
   useVncClipboardBridge({
     persistKey,
-    enabled: isVncPanel,
+    enabled: isVncIframeFallback,
   });
 
   const hasBrowserView = Boolean(browserUrl);
@@ -131,7 +148,8 @@ function BrowserComponent() {
     []
   );
 
-  const isBrowserBusy = !hasBrowserView || browserStatus !== "loaded";
+  const hasBrowserConnection = Boolean(vncWebsocketUrl || browserUrl);
+  const isBrowserBusy = !hasBrowserConnection || browserStatus !== "loaded";
 
   return (
     <div className="flex flex-col grow bg-neutral-50 dark:bg-black">
@@ -140,7 +158,18 @@ function BrowserComponent() {
           className="flex flex-row grow min-h-0 relative"
           aria-busy={isBrowserBusy}
         >
-          {browserUrl ? (
+          {/* Prefer direct VncViewer when websocket URL is available */}
+          {useDirectVncViewer && vncWebsocketUrl ? (
+            <VncViewer
+              url={vncWebsocketUrl}
+              autoConnect
+              scaleViewport
+              className="grow flex"
+              loadingFallback={loadingFallback}
+              errorFallback={errorFallback}
+            />
+          ) : browserUrl ? (
+            /* Fallback to iframe when only HTML URL is available */
             <PersistentWebView
               key={persistKey}
               persistKey={persistKey}
@@ -171,13 +200,13 @@ function BrowserComponent() {
               }
             )}
           >
-            {showLoader ? (
+            {showLoader && !hasBrowserConnection ? (
               <WorkspaceLoadingIndicator variant="browser" status="loading" />
-            ) : (
+            ) : !hasBrowserConnection ? (
               <span className="text-sm text-neutral-500 dark:text-neutral-400 text-center px-4">
                 {overlayMessage}
               </span>
-            )}
+            ) : null}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `resolveBrowserPreviewWebsocketUrl` as the canonical helper for browser preview transport resolution
- Prefer direct VncViewer component over iframe-based noVNC HTML page
- Keep iframe fallback for compatibility when WebSocket URL cannot be resolved

## Key Changes

### New Function: `resolveBrowserPreviewWebsocketUrl`
Resolves VNC WebSocket URL for direct noVNC/RFB connection:
- Prefer explicit `vncUrl` if available
- If `vncUrl` has `?path=...`, extract that as WebSocket pathname
- If `vncUrl` ends in `/vnc.html` or `/viewer.html`, replace with `/websockify`
- Fall back to deriving WebSocket URL from `workspaceUrl`

### Updated Components
- **EnvironmentSetupFlow**: Computes `vncWebsocketUrl` alongside `browserHtmlUrl`
- **EnvironmentWorkspaceConfig**: Renders `VncViewer` when websocket URL available
- **Browser route**: Prefers `VncViewer` over `PersistentWebView` iframe

### Clipboard Handling
- `useVncClipboardBridge` only enabled for iframe fallback paths
- Direct VncViewer uses its own clipboard handling via ref methods

## Test Plan
- [x] `bun check`: PASS
- [x] New tests for WebSocket URL resolution (20 total in toProxyWorkspaceUrl.test.ts)
  - bare VNC host → wss://.../websockify
  - /vnc.html → same host/path rewritten to websocket
  - ?path=vnc/websockify → wss://.../vnc/websockify
  - Morph workspace fallback → derived websocket URL
  - PVE-LXC workspace fallback → derived websocket URL
- [x] All 461 client tests pass
- [ ] Manual: verify direct viewer works for environment setup browser panel
- [ ] Manual: verify direct viewer works for task browser panel
- [ ] Manual: verify iframe fallback still works when only browserHtmlUrl available