### PR TITLE
fix(convex): add resume_tasks compat shim for shared backend

### DIFF
--- a/packages/convex/convex/resume_tasks.ts
+++ b/packages/convex/convex/resume_tasks.ts
@@ -1,0 +1,59 @@
+/**
+ * Compatibility shim for deprecated resume_tasks mutations.
+ *
+ * These stubs exist to suppress "Could not find public function" warnings
+ * when a remote workspace (connected to the same shared Convex dev backend)
+ * has clients still calling the old `resume_tasks:*` API surface.
+ *
+ * The current autopilot implementation uses HTTP actions at /api/autopilot/*
+ * and internal mutations in taskRuns.ts instead.
+ *
+ * These stubs are intentionally no-ops that return success to prevent
+ * error spam from stale clients. They should be removed once all clients
+ * have migrated to the HTTP-based autopilot API.
+ */
+
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+
+/**
+ * @deprecated Use POST /api/autopilot/heartbeat instead.
+ * This stub exists only for backward compatibility with stale clients.
+ */
+export const heartbeat = mutation({
+  args: {
+    taskRunId: v.optional(v.string()),
+  },
+  returns: v.object({
+    ok: v.boolean(),
+    message: v.optional(v.string()),
+  }),
+  handler: async (_ctx, _args) => {
+    // No-op stub - real implementation is in autopilot_http.ts
+    console.warn(
+      "[resume_tasks:heartbeat] Deprecated mutation called. Use POST /api/autopilot/heartbeat instead."
+    );
+    return { ok: true, message: "deprecated - use /api/autopilot/heartbeat" };
+  },
+});
+
+/**
+ * @deprecated Use the HTTP-based autopilot API instead.
+ * This stub exists only for backward compatibility with stale clients.
+ */
+export const claim = mutation({
+  args: {
+    taskRunId: v.optional(v.string()),
+  },
+  returns: v.object({
+    ok: v.boolean(),
+    message: v.optional(v.string()),
+  }),
+  handler: async (_ctx, _args) => {
+    // No-op stub - there is no direct equivalent in the new API
+    console.warn(
+      "[resume_tasks:claim] Deprecated mutation called. This functionality has been replaced."
+    );
+    return { ok: true, message: "deprecated - functionality replaced" };
+  },
+});


### PR DESCRIPTION
## Summary
- Add stub mutations for `resume_tasks:heartbeat` and `resume_tasks:claim` to suppress warning spam from stale clients
- These are no-ops that return success - the real autopilot implementation uses HTTP actions at `/api/autopilot/*`
- Fixes shared Convex dev backend isolation issue where remote workspace clients call deprecated API

## Context
The shared Convex dev backend at `https://api-kos4cos88kgkg4g0k0ww48c0.karldigi.dev` was emitting repeated warnings:
- `Could not find public function for 'resume_tasks:heartbeat'`
- `Could not find public function for 'resume_tasks:claim'`

This happens when another workspace deploys different Convex functions and stale clients still call the old API surface.

## Test plan
- [x] `bun check` passes
- [ ] Verify warnings stop after deploying to shared backend