### PR TITLE
feat(client): restore direct VNC viewer in TaskPanelFactory

### DIFF
--- a/apps/client/src/components/TaskPanelFactory.tsx
+++ b/apps/client/src/components/TaskPanelFactory.tsx
@@ -31,6 +31,7 @@ import type { LiveDiffPanelProps } from "./LiveDiffPanel";
 import type { TestResultsPanelProps } from "./TestResultsPanel";
 import { shouldUseServerIframePreflight } from "@/hooks/useIframePreflight";
 import { useVncClipboardBridge } from "@/hooks/useVncClipboardBridge";
+import { VncViewer } from "@cmux/shared/components/vnc-viewer";
 
 const PANEL_DRAG_START_EVENT = "cmux:panel-drag-start";
 const PANEL_DRAG_END_EVENT = "cmux:panel-drag-end";
@@ -177,6 +178,8 @@ interface PanelFactoryProps {
   rawWorkspaceUrl?: string | null;
   // Browser panel props
   browserUrl?: string | null;
+  /** VNC WebSocket URL for direct noVNC/RFB connection (preferred over browserUrl iframe) */
+  vncWebsocketUrl?: string | null;
   browserPersistKey?: string | null;
   browserStatus?: PersistentIframeStatus;
   setBrowserStatus?: (status: PersistentIframeStatus) => void;
@@ -212,9 +215,12 @@ interface PanelFactoryProps {
 /**
  * Browser panel content wrapper that includes VNC clipboard bridge.
  * This is a separate component so we can use hooks (useVncClipboardBridge).
+ * Prefers direct VncViewer when vncWebsocketUrl is available, falls back to iframe.
  */
 interface BrowserPanelContentProps {
   browserUrl: string;
+  /** VNC WebSocket URL for direct noVNC/RFB connection (preferred over iframe) */
+  vncWebsocketUrl?: string | null;
   browserPersistKey: string;
   isExpanded: boolean;
   isAnyPanelExpanded: boolean;
@@ -230,6 +236,7 @@ interface BrowserPanelContentProps {
 
 function BrowserPanelContent({
   browserUrl,
+  vncWebsocketUrl,
   browserPersistKey,
   isExpanded,
   isAnyPanelExpanded,
@@ -242,40 +249,57 @@ function BrowserPanelContent({
   TASK_RUN_IFRAME_ALLOW,
   TASK_RUN_IFRAME_SANDBOX,
 }: BrowserPanelContentProps): ReactNode {
-  // Enable clipboard bridge for VNC panel (vnc.html URLs)
-  const isVncPanel = browserUrl.includes("/vnc.html");
+  // Prefer direct VncViewer when websocket URL is available
+  const useDirectVncViewer = Boolean(vncWebsocketUrl);
+
+  // Enable clipboard bridge only for VNC iframe fallback (not direct VncViewer)
+  const isVncIframeFallback = !useDirectVncViewer && browserUrl.includes("/vnc.html");
   useVncClipboardBridge({
     persistKey: browserPersistKey,
-    enabled: isVncPanel,
+    enabled: isVncIframeFallback,
   });
+
+  const loadingFallback = (
+    <WorkspaceLoadingIndicator variant="browser" status="loading" />
+  );
+  const errorFallback = (
+    <WorkspaceLoadingIndicator variant="browser" status="error" />
+  );
 
   return (
     <div className={clsx("relative flex-1", isExpanded && "h-full")} aria-busy={isBrowserBusy}>
-      <PersistentWebView
-        key={browserPersistKey}
-        persistKey={browserPersistKey}
-        src={browserUrl}
-        className="flex h-full"
-        iframeClassName={clsx("select-none")}
-        persistentWrapperClassName={isExpanded ? "z-[var(--z-maximized-iframe)]" : undefined}
-        allow={TASK_RUN_IFRAME_ALLOW}
-        sandbox={TASK_RUN_IFRAME_SANDBOX}
-        retainOnUnmount
-        onStatusChange={setBrowserStatus}
-        fallback={
-          <WorkspaceLoadingIndicator variant="browser" status="loading" />
-        }
-        fallbackClassName="bg-neutral-50 dark:bg-black"
-        errorFallback={
-          <WorkspaceLoadingIndicator variant="browser" status="error" />
-        }
-        errorFallbackClassName="bg-neutral-50/95 dark:bg-black/95"
-        loadTimeoutMs={45_000}
-        isExpanded={isExpanded}
-        isAnyPanelExpanded={isAnyPanelExpanded}
-        isFocusEligible={isActivePanel}
-        onActivate={handleActivate}
-      />
+      {useDirectVncViewer && vncWebsocketUrl ? (
+        <VncViewer
+          url={vncWebsocketUrl}
+          autoConnect
+          scaleViewport
+          className="flex h-full"
+          loadingFallback={loadingFallback}
+          errorFallback={errorFallback}
+        />
+      ) : (
+        <PersistentWebView
+          key={browserPersistKey}
+          persistKey={browserPersistKey}
+          src={browserUrl}
+          className="flex h-full"
+          iframeClassName={clsx("select-none")}
+          persistentWrapperClassName={isExpanded ? "z-[var(--z-maximized-iframe)]" : undefined}
+          allow={TASK_RUN_IFRAME_ALLOW}
+          sandbox={TASK_RUN_IFRAME_SANDBOX}
+          retainOnUnmount
+          onStatusChange={setBrowserStatus}
+          fallback={loadingFallback}
+          fallbackClassName="bg-neutral-50 dark:bg-black"
+          errorFallback={errorFallback}
+          errorFallbackClassName="bg-neutral-50/95 dark:bg-black/95"
+          loadTimeoutMs={45_000}
+          isExpanded={isExpanded}
+          isAnyPanelExpanded={isAnyPanelExpanded}
+          isFocusEligible={isActivePanel}
+          onActivate={handleActivate}
+        />
+      )}
     </div>
   );
 }
@@ -632,6 +656,7 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
     case "browser": {
       const {
         browserUrl,
+        vncWebsocketUrl,
         browserPersistKey,
         setBrowserStatus,
         browserPlaceholder,
@@ -656,6 +681,7 @@ const RenderPanelComponent = (props: PanelFactoryProps): ReactNode => {
         browserUrl && browserPersistKey ? (
           <BrowserPanelContent
             browserUrl={browserUrl}
+            vncWebsocketUrl={vncWebsocketUrl}
             browserPersistKey={browserPersistKey}
             isExpanded={isExpanded}
             isAnyPanelExpanded={isAnyPanelExpanded}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/persistent-webview-keys";
 import {
   resolveBrowserPreviewUrl,
+  resolveBrowserPreviewWebsocketUrl,
   toMorphXtermBaseUrl,
 } from "@/lib/toProxyWorkspaceUrl";
 import { getWorkspaceUrl } from "@/lib/workspace-url";
@@ -725,6 +726,15 @@ function TaskDetailPage() {
       }),
     [rawBrowserUrl, selectedRun?.vscode?.vncUrl]
   );
+  // WebSocket URL for direct VncViewer connection (preferred over iframe)
+  const vncWebsocketUrl = useMemo(
+    () =>
+      resolveBrowserPreviewWebsocketUrl({
+        vncUrl: selectedRun?.vscode?.vncUrl,
+        workspaceUrl: rawBrowserUrl,
+      }),
+    [rawBrowserUrl, selectedRun?.vscode?.vncUrl]
+  );
   const browserPersistKey = selectedRunId
     ? getTaskRunBrowserPersistKey(selectedRunId)
     : null;
@@ -955,6 +965,7 @@ function TaskDetailPage() {
       workspacePlaceholder,
       rawWorkspaceUrl,
       browserUrl,
+      vncWebsocketUrl,
       browserPersistKey,
       browserStatus,
       setBrowserStatus: handleBrowserStatusChange,
@@ -996,6 +1007,7 @@ function TaskDetailPage() {
       workspacePlaceholder,
       rawWorkspaceUrl,
       browserUrl,
+      vncWebsocketUrl,
       browserPersistKey,
       browserStatus,
       handleBrowserStatusChange,


### PR DESCRIPTION
## Summary
- Add `vncWebsocketUrl` prop support to TaskPanelFactory browser panel
- Prefer direct VncViewer component when WebSocket URL is available (lower latency, no iframe sandboxing)
- Fall back to iframe-based noVNC viewer when only HTML URL is available
- Disable clipboard bridge for direct VncViewer path (not needed since it handles clipboard natively)

## Changes
**apps/client/src/components/TaskPanelFactory.tsx**
- Import VncViewer from shared components
- Add `vncWebsocketUrl` optional prop to `PanelFactoryProps` and `BrowserPanelContentProps`
- Update `BrowserPanelContent` to render VncViewer when `vncWebsocketUrl` is present
- Only enable clipboard bridge for iframe fallback path

**apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.index.tsx**
- Import `resolveBrowserPreviewWebsocketUrl` utility
- Derive `vncWebsocketUrl` using same inputs as `browserUrl`
- Pass `vncWebsocketUrl` in panelProps

## Context
This aligns the TaskPanelFactory browser panel with the dedicated browser route (`run/$runId/browser.tsx`) which already had direct VncViewer support. The environment setup flow also uses direct VncViewer.

## Test plan
- [ ] Verify browser panel renders VncViewer for Morph sandboxes
- [ ] Verify browser panel renders VncViewer for PVE-LXC sandboxes  
- [ ] Verify iframe fallback works when WebSocket URL unavailable
- [ ] Type checks pass (`bun check`)