### PR TITLE
chore: surface CMUX_SERVER_URL and WWW_INTERNAL_URL in env configs

### DIFF
--- a/.env.coolify.example
+++ b/.env.coolify.example
@@ -35,6 +35,15 @@ NEXT_PUBLIC_WWW_ORIGIN=https://www.cmux.sh
 NEXT_PUBLIC_CLIENT_ORIGIN=https://app.cmux.sh
 # NEXT_PUBLIC_SERVER_ORIGIN=https://server.cmux.sh
 
+# ── Internal Service URLs (REQUIRED for Docker Compose inter-service calls) ──
+# Server URL for agent-to-server API calls (e.g., spawn_agent MCP tool).
+# Use Docker service name for inter-container communication.
+CMUX_SERVER_URL=http://cmux-server:9776
+
+# Internal URL for server→www API calls within the Docker network.
+# Bypasses Cloudflare tunnel to avoid 524 timeout on long-running requests.
+WWW_INTERNAL_URL=http://cmux-www:9779
+
 # ── CORS (REQUIRED for server) ────────────────────────────────────────────────
 # Comma-separated list of allowed origins for WebSocket connections
 CMUX_ALLOWED_SOCKET_ORIGINS=https://app.cmux.sh,https://www.cmux.sh

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,16 @@ BASE_APP_URL=
 NEXT_PUBLIC_WWW_ORIGIN=
 # NEXT_PUBLIC_SERVER_ORIGIN=
 
+# ── Internal Service URLs (Coolify/Docker Compose) ───────────────────────────
+# Server URL for agent-to-server API calls (e.g., spawn_agent MCP tool).
+# In Coolify: http://cmux-server:9776 or your server's internal hostname.
+# CMUX_SERVER_URL=http://localhost:9776
+
+# Internal URL for server→www API calls on the same machine.
+# Bypasses Cloudflare tunnel to avoid 524 timeout on long-running requests.
+# In Coolify: http://cmux-www:9779 or your www service's internal hostname.
+# WWW_INTERNAL_URL=http://localhost:9779
+
 # ── GitHub App ───────────────────────────────────────────────────────────────
 CMUX_GITHUB_APP_ID=
 CMUX_GITHUB_APP_PRIVATE_KEY=

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -109,6 +109,9 @@ services:
       - CMUX_ALLOWED_SOCKET_ORIGINS=${CMUX_ALLOWED_SOCKET_ORIGINS}
       # Origins
       - NEXT_PUBLIC_WWW_ORIGIN=${NEXT_PUBLIC_WWW_ORIGIN:-}
+      # Internal service URLs for inter-container communication
+      - CMUX_SERVER_URL=${CMUX_SERVER_URL:-http://cmux-server:9776}
+      - WWW_INTERNAL_URL=${WWW_INTERNAL_URL:-http://cmux-www:9779}
       # Mode
       - NEXT_PUBLIC_WEB_MODE=${NEXT_PUBLIC_WEB_MODE:-true}
       - DEFAULT_SANDBOX_TIMEZONE=${DEFAULT_SANDBOX_TIMEZONE:-Asia/Hong_Kong}


### PR DESCRIPTION
## Summary
Document and configure internal service URLs for Coolify/Docker Compose deployment:

- `CMUX_SERVER_URL`: Agent-to-server API calls (e.g., spawn_agent MCP tool)
- `WWW_INTERNAL_URL`: Server→www API calls bypassing Cloudflare tunnel (avoids 524 timeout)

## Changes
- `.env.example`: Add commented examples with explanations
- `.env.coolify.example`: Add as required vars with Docker service names
- `docker-compose.coolify.yml`: Add to cmux-server environment with sensible defaults

## Context
These variables already exist in `apps/server/src/utils/server-env.ts` but weren't documented in env templates. This surfaces them for Coolify deployment per the strategy in `2026-03-22-vercel-preview-coolify-release-strategy.md`.

## Test plan
- [x] `bun check` passes
- [ ] Verify Coolify deployment picks up env vars