### PR TITLE
feat(shared): add E2B to provider capability contract

### DIFF
--- a/apps/www/components/preview/machine-preset-select.tsx
+++ b/apps/www/components/preview/machine-preset-select.tsx
@@ -128,6 +128,7 @@ const ALLOWED_PRESET_IDS_BY_PROVIDER: Record<
   morph: ["4vcpu_16gb_48gb", "8vcpu_32gb_48gb"],
   "pve-lxc": ["4vcpu_8gb_32gb", "6vcpu_8gb_40gb"],
   "pve-vm": [],
+  e2b: [], // E2B uses template-based presets
 };
 
 export function MachinePresetSelect({

--- a/apps/www/lib/routes/config.route.test.ts
+++ b/apps/www/lib/routes/config.route.test.ts
@@ -26,7 +26,7 @@ describe("configRouter", () => {
 
       if (res.response.status === 200 && res.data) {
         expect(res.data).toHaveProperty("provider");
-        expect(["morph", "pve-lxc", "pve-vm"]).toContain(res.data.provider);
+        expect(["morph", "pve-lxc", "pve-vm", "e2b"]).toContain(res.data.provider);
       }
     });
 

--- a/apps/www/lib/utils/sandbox-provider.ts
+++ b/apps/www/lib/utils/sandbox-provider.ts
@@ -99,7 +99,17 @@ export function getActiveSandboxProvider(): SandboxProviderConfig {
     };
   }
 
-  // Unknown/external provider (e.g. "e2b", "modal", "daytona") --
+  if (explicitProvider === "e2b") {
+    if (!env.E2B_API_KEY) {
+      throw new Error("SANDBOX_PROVIDER=e2b but E2B_API_KEY is not set.");
+    }
+    return {
+      provider: "e2b",
+      apiKey: env.E2B_API_KEY,
+    };
+  }
+
+  // Unknown/external provider (e.g. "modal", "daytona") --
   // the www sandbox provisioning layer only knows morph / pve-lxc / pve-vm,
   // so skip credential auto-detect and fall back to DEFAULT_SANDBOX_PROVIDER.
   // The raw SANDBOX_PROVIDER value is still available via env.SANDBOX_PROVIDER
@@ -116,6 +126,13 @@ export function getActiveSandboxProvider(): SandboxProviderConfig {
     return {
       provider: "morph",
       apiKey: env.MORPH_API_KEY,
+    };
+  }
+
+  if (env.E2B_API_KEY) {
+    return {
+      provider: "e2b",
+      apiKey: env.E2B_API_KEY,
     };
   }
 
@@ -147,15 +164,25 @@ export function isProxmoxAvailable(): boolean {
 }
 
 /**
+ * Check if E2B provider is available
+ */
+export function isE2bAvailable(): boolean {
+  return Boolean(env.E2B_API_KEY);
+}
+
+/**
  * Get a list of all available sandbox providers
  */
-export function getAvailableSandboxProviders(): Array<Extract<ConfigProvider, "morph" | "pve-lxc">> {
-  const providers: Array<Extract<ConfigProvider, "morph" | "pve-lxc">> = [];
+export function getAvailableSandboxProviders(): Array<Extract<ConfigProvider, "morph" | "pve-lxc" | "e2b">> {
+  const providers: Array<Extract<ConfigProvider, "morph" | "pve-lxc" | "e2b">> = [];
   if (isMorphAvailable()) {
     providers.push("morph");
   }
   if (isProxmoxAvailable()) {
     providers.push("pve-lxc");
+  }
+  if (isE2bAvailable()) {
+    providers.push("e2b");
   }
   return providers;
 }

--- a/apps/www/lib/utils/www-env.ts
+++ b/apps/www/lib/utils/www-env.ts
@@ -9,6 +9,7 @@ const getSandboxProviderSchema = () => {
   const provider = process.env.SANDBOX_PROVIDER;
   const isMorphRequired = !provider || provider === "morph";
   const isPveRequired = provider === "pve-lxc" || provider === "pve-vm";
+  const isE2bRequired = provider === "e2b";
 
   return {
     // Morph Cloud - required only if provider is "morph" or not specified
@@ -20,6 +21,10 @@ const getSandboxProviderSchema = () => {
       ? z.string().url()
       : z.string().url().optional(),
     PVE_API_TOKEN: isPveRequired
+      ? z.string().min(1)
+      : z.string().min(1).optional(),
+    // E2B Cloud - required only if provider is "e2b"
+    E2B_API_KEY: isE2bRequired
       ? z.string().min(1)
       : z.string().min(1).optional(),
   };
@@ -67,6 +72,8 @@ export const env = isTest ? (testEnv as unknown as ReturnType<typeof createEnv>)
     PVE_API_URL: sandboxProviderSchema.PVE_API_URL,
     PVE_API_TOKEN: sandboxProviderSchema.PVE_API_TOKEN,
     PVE_NODE: z.string().min(1).optional(),
+    // E2B Cloud - required if SANDBOX_PROVIDER is "e2b"
+    E2B_API_KEY: sandboxProviderSchema.E2B_API_KEY,
     // Public domain for PVE sandbox URLs via Cloudflare Tunnel (e.g., "example.com")
     // When set, generates URLs like https://port-{port}-{instanceId}.example.com
     PVE_PUBLIC_DOMAIN: z.string().min(1).optional(),

--- a/packages/convex/convex/environmentSnapshots.ts
+++ b/packages/convex/convex/environmentSnapshots.ts
@@ -44,6 +44,7 @@ export const create = authMutation({
       v.literal("pve-lxc"),
       v.literal("pve-vm"),
       v.literal("docker"),
+      v.literal("e2b"),
       v.literal("daytona"),
       v.literal("other")
     ),
@@ -210,6 +211,7 @@ export const findBySnapshotId = authQuery({
         v.literal("pve-lxc"),
         v.literal("pve-vm"),
         v.literal("docker"),
+        v.literal("e2b"),
         v.literal("daytona"),
         v.literal("other")
       )

--- a/packages/convex/convex/environments.ts
+++ b/packages/convex/convex/environments.ts
@@ -62,6 +62,7 @@ export const create = authMutation({
       v.literal("pve-lxc"),
       v.literal("pve-vm"),
       v.literal("docker"),
+      v.literal("e2b"),
       v.literal("daytona"),
       v.literal("other")
     ),

--- a/packages/shared/src/provider-types.test.ts
+++ b/packages/shared/src/provider-types.test.ts
@@ -70,14 +70,15 @@ describe("provider-types", () => {
   });
 
   describe("CONFIG_PROVIDERS", () => {
-    it("contains morph, pve-lxc, pve-vm", () => {
+    it("contains morph, pve-lxc, pve-vm, e2b", () => {
       expect(CONFIG_PROVIDERS).toContain("morph");
       expect(CONFIG_PROVIDERS).toContain("pve-lxc");
       expect(CONFIG_PROVIDERS).toContain("pve-vm");
+      expect(CONFIG_PROVIDERS).toContain("e2b");
     });
 
-    it("has exactly 3 providers", () => {
-      expect(CONFIG_PROVIDERS.length).toBe(3);
+    it("has exactly 4 providers", () => {
+      expect(CONFIG_PROVIDERS.length).toBe(4);
     });
 
     it("has no duplicates", () => {

--- a/packages/shared/src/provider-types.ts
+++ b/packages/shared/src/provider-types.ts
@@ -36,7 +36,7 @@ export const DEVBOX_PROVIDERS = [
 ] as const;
 
 /** Providers that support configuration via the sandbox config API */
-export const CONFIG_PROVIDERS = ["morph", "pve-lxc", "pve-vm"] as const;
+export const CONFIG_PROVIDERS = ["morph", "pve-lxc", "pve-vm", "e2b"] as const;
 
 /** A provider that can execute workspace containers at runtime */
 export type RuntimeProvider = (typeof RUNTIME_PROVIDERS)[number];

--- a/packages/shared/src/sandbox-presets.test.ts
+++ b/packages/shared/src/sandbox-presets.test.ts
@@ -15,6 +15,7 @@ describe("SANDBOX_PROVIDER_DISPLAY_NAMES", () => {
     expect(SANDBOX_PROVIDER_DISPLAY_NAMES.morph).toBe("Morph Cloud");
     expect(SANDBOX_PROVIDER_DISPLAY_NAMES["pve-lxc"]).toBe("Proxmox LXC");
     expect(SANDBOX_PROVIDER_DISPLAY_NAMES["pve-vm"]).toBe("Proxmox VM");
+    expect(SANDBOX_PROVIDER_DISPLAY_NAMES.e2b).toBe("E2B Cloud");
   });
 });
 
@@ -39,6 +40,15 @@ describe("SANDBOX_PROVIDER_CAPABILITIES", () => {
     expect(caps.supportsSnapshots).toBe(true);
     expect(caps.supportsNestedVirt).toBe(true);
     expect(caps.supportsGpu).toBe(true);
+  });
+
+  it("has capabilities for e2b provider", () => {
+    const caps = SANDBOX_PROVIDER_CAPABILITIES.e2b;
+    expect(caps.supportsHibernate).toBe(true);
+    expect(caps.supportsSnapshots).toBe(true);
+    expect(caps.supportsResize).toBe(false);
+    expect(caps.supportsNestedVirt).toBe(false);
+    expect(caps.supportsGpu).toBe(false);
   });
 });
 
@@ -160,5 +170,11 @@ describe("resolveSnapshotId", () => {
     await expect(
       resolveSnapshotId("snapshot_test", "pve-vm")
     ).rejects.toThrow("PVE VM provider not yet implemented");
+  });
+
+  it("throws for e2b provider (not implemented)", async () => {
+    await expect(
+      resolveSnapshotId("snapshot_test", "e2b")
+    ).rejects.toThrow("E2B snapshot resolution not yet implemented");
   });
 });

--- a/packages/shared/src/sandbox-presets.ts
+++ b/packages/shared/src/sandbox-presets.ts
@@ -29,6 +29,7 @@ export const SANDBOX_PROVIDER_DISPLAY_NAMES: Record<SandboxProviderType, string>
   morph: "Morph Cloud",
   "pve-lxc": "Proxmox LXC",
   "pve-vm": "Proxmox VM",
+  e2b: "E2B Cloud",
 };
 
 /**
@@ -72,6 +73,13 @@ export const SANDBOX_PROVIDER_CAPABILITIES: Record<SandboxProviderType, SandboxP
     supportsResize: true,
     supportsNestedVirt: true,
     supportsGpu: true,
+  },
+  e2b: {
+    supportsHibernate: true, // E2B betaPause() preserves RAM state
+    supportsSnapshots: true, // E2B supports snapshots
+    supportsResize: false,
+    supportsNestedVirt: false,
+    supportsGpu: false,
   },
 };
 
@@ -125,6 +133,7 @@ export const UI_VISIBLE_PRESET_IDS_BY_PROVIDER: Record<SandboxProviderType, read
   // Keep in sync with the latest pve-lxc snapshot manifest; disk size bumped to 40GB
   "pve-lxc": ["4vcpu_8gb_32gb", "6vcpu_8gb_40gb"],
   "pve-vm": [], // TODO: Add when PVE VM presets are defined
+  e2b: [], // E2B uses template-based presets, not resource-based
 };
 
 /**
@@ -134,6 +143,7 @@ export const UI_VISIBLE_PRESET_IDS = [
   ...UI_VISIBLE_PRESET_IDS_BY_PROVIDER.morph,
   ...UI_VISIBLE_PRESET_IDS_BY_PROVIDER["pve-lxc"],
   ...UI_VISIBLE_PRESET_IDS_BY_PROVIDER["pve-vm"],
+  ...UI_VISIBLE_PRESET_IDS_BY_PROVIDER.e2b,
 ] as const;
 
 /**
@@ -228,6 +238,11 @@ export async function resolveSnapshotId(
     case "pve-vm": {
       // TODO: Implement when PVE VM is added
       throw new Error("PVE VM provider not yet implemented");
+    }
+
+    case "e2b": {
+      // E2B uses template-based snapshots via E2B SDK
+      throw new Error("E2B snapshot resolution not yet implemented");
     }
 
     default: {

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -1661,7 +1661,7 @@ export type SandboxProviderCapabilities = {
 };
 
 export type SandboxConfig = {
-    provider: 'morph' | 'pve-lxc' | 'pve-vm';
+    provider: 'morph' | 'pve-lxc' | 'pve-vm' | 'e2b';
     providerDisplayName: string;
     presets: Array<SandboxPreset>;
     defaultPresetId: string;


### PR DESCRIPTION
## Summary
- Add "e2b" to `CONFIG_PROVIDERS` for config API support
- Add E2B capabilities: `supportsHibernate=true`, `supportsSnapshots=true`
- Add E2B auto-detection via `E2B_API_KEY` env var
- Add `E2B_API_KEY` to www-env schema with conditional validation
- Update Convex validators to include e2b in snapshot provider unions
- Add tests for E2B capability contract

## Test plan
- [x] `bun check` passes
- [x] `bun run test` passes for provider-types and sandbox-presets tests
- [ ] Manual: Set `E2B_API_KEY` and verify `/config/sandbox` returns E2B capabilities