### PR TITLE
feat(shared): add approval risk classifier for graduated command approval

### DIFF
--- a/packages/shared/src/approval-risk-classifier.test.ts
+++ b/packages/shared/src/approval-risk-classifier.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyRisk,
+  getRiskLevel,
+  isAutoApprovable,
+  requiresExplicitApproval,
+  type RiskClassificationInput,
+} from "./approval-risk-classifier";
+
+describe("approval-risk-classifier", () => {
+  describe("classifyRisk", () => {
+    describe("high-risk patterns", () => {
+      it("classifies git force push as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git push --force origin main",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("Force push");
+      });
+
+      it("classifies git push -f as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git push -f origin feature",
+        });
+        expect(result.level).toBe("high");
+      });
+
+      it("classifies git reset --hard as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git reset --hard HEAD~1",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("Hard reset");
+      });
+
+      it("classifies rm -rf as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "rm -rf ./node_modules",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("Recursive delete");
+      });
+
+      it("classifies gh pr create as high risk for task sandboxes", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "gh pr create --title 'Test'",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("PR lifecycle");
+      });
+
+      it("classifies gh pr merge as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "gh pr merge 123 --squash",
+        });
+        expect(result.level).toBe("high");
+      });
+
+      it("classifies devsh start as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "devsh start -p pve-lxc",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("Sandbox lifecycle");
+      });
+
+      it("classifies cloudrouter delete as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "cloudrouter delete sandbox-123",
+        });
+        expect(result.level).toBe("high");
+      });
+
+      it("classifies sudo commands as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "sudo apt-get install something",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("Elevated privileges");
+      });
+
+      it("classifies DROP TABLE as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "psql -c 'DROP TABLE users;'",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("DROP");
+      });
+
+      it("classifies gh workflow run as high risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "gh workflow run 'Build' --ref main",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("Workflow triggers");
+      });
+    });
+
+    describe("low-risk patterns", () => {
+      it("classifies cat as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "cat README.md",
+        });
+        expect(result.level).toBe("low");
+        expect(result.reason).toContain("Read-only");
+      });
+
+      it("classifies ls as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "ls -la",
+        });
+        expect(result.level).toBe("low");
+        expect(result.reason).toContain("Directory listing");
+      });
+
+      it("classifies git status as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git status",
+        });
+        expect(result.level).toBe("low");
+        expect(result.reason).toContain("Git read");
+      });
+
+      it("classifies git log as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git log --oneline -10",
+        });
+        expect(result.level).toBe("low");
+      });
+
+      it("classifies git diff as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git diff HEAD~1",
+        });
+        expect(result.level).toBe("low");
+      });
+
+      it("classifies gh pr list as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "gh pr list --state open",
+        });
+        expect(result.level).toBe("low");
+        expect(result.reason).toContain("GitHub read");
+      });
+
+      it("classifies grep as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "grep -r 'TODO' src/",
+        });
+        expect(result.level).toBe("low");
+        expect(result.reason).toContain("Search");
+      });
+
+      it("classifies npm list as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "npm list --depth=0",
+        });
+        expect(result.level).toBe("low");
+        expect(result.reason).toContain("Package read");
+      });
+    });
+
+    describe("medium-risk patterns (default)", () => {
+      it("classifies git commit as medium risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git commit -m 'feat: add feature'",
+        });
+        expect(result.level).toBe("medium");
+      });
+
+      it("classifies git push (non-force) as medium risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git push origin feature-branch",
+        });
+        expect(result.level).toBe("medium");
+      });
+
+      it("classifies npm install as medium risk", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "npm install lodash",
+        });
+        expect(result.level).toBe("medium");
+      });
+    });
+
+    describe("tool-level classification", () => {
+      it("classifies Read tool as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Read",
+          input: "/path/to/file.ts",
+        });
+        expect(result.level).toBe("low");
+        expect(result.reason).toContain("read-only");
+      });
+
+      it("classifies Glob tool as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Glob",
+          input: "**/*.ts",
+        });
+        expect(result.level).toBe("low");
+      });
+
+      it("classifies Grep tool as low risk", () => {
+        const result = classifyRisk({
+          toolName: "Grep",
+          input: "pattern",
+        });
+        expect(result.level).toBe("low");
+      });
+
+      it("classifies Write tool as medium risk", () => {
+        const result = classifyRisk({
+          toolName: "Write",
+          input: "/path/to/file.ts",
+        });
+        expect(result.level).toBe("medium");
+        expect(result.reason).toContain("File modification");
+      });
+
+      it("classifies Edit tool as medium risk", () => {
+        const result = classifyRisk({
+          toolName: "Edit",
+          input: "old_string -> new_string",
+        });
+        expect(result.level).toBe("medium");
+      });
+
+      it("classifies WebFetch as high risk", () => {
+        const result = classifyRisk({
+          toolName: "WebFetch",
+          input: "https://example.com",
+        });
+        expect(result.level).toBe("high");
+        expect(result.reason).toContain("external network");
+      });
+    });
+
+    describe("head agent behavior", () => {
+      it("allows head agents to use gh pr create", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "gh pr create --title 'Test'",
+          isHeadAgent: true,
+        });
+        expect(result.level).toBe("medium");
+        expect(result.reason).toContain("Head agent");
+      });
+
+      it("allows head agents to use devsh commands", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "devsh start -p pve-lxc",
+          isHeadAgent: true,
+        });
+        expect(result.level).toBe("medium");
+      });
+
+      it("still flags truly destructive ops for head agents", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "git push --force origin main",
+          isHeadAgent: true,
+        });
+        expect(result.level).toBe("high");
+      });
+
+      it("still flags rm -rf for head agents", () => {
+        const result = classifyRisk({
+          toolName: "Bash",
+          input: "rm -rf /",
+          isHeadAgent: true,
+        });
+        expect(result.level).toBe("high");
+      });
+    });
+  });
+
+  describe("getRiskLevel", () => {
+    it("returns just the level string", () => {
+      expect(getRiskLevel({ toolName: "Bash", input: "ls -la" })).toBe("low");
+      expect(getRiskLevel({ toolName: "Bash", input: "git commit -m 'test'" })).toBe("medium");
+      expect(getRiskLevel({ toolName: "Bash", input: "rm -rf /" })).toBe("high");
+    });
+  });
+
+  describe("isAutoApprovable", () => {
+    it("returns true for low-risk operations", () => {
+      expect(isAutoApprovable({ toolName: "Bash", input: "cat README.md" })).toBe(true);
+      expect(isAutoApprovable({ toolName: "Read", input: "/path/file" })).toBe(true);
+    });
+
+    it("returns false for medium and high-risk operations", () => {
+      expect(isAutoApprovable({ toolName: "Bash", input: "git commit -m 'test'" })).toBe(false);
+      expect(isAutoApprovable({ toolName: "Bash", input: "rm -rf /" })).toBe(false);
+    });
+  });
+
+  describe("requiresExplicitApproval", () => {
+    it("returns true for high-risk operations", () => {
+      expect(requiresExplicitApproval({ toolName: "Bash", input: "rm -rf /" })).toBe(true);
+      expect(requiresExplicitApproval({ toolName: "Bash", input: "git push --force" })).toBe(true);
+    });
+
+    it("returns false for low and medium-risk operations", () => {
+      expect(requiresExplicitApproval({ toolName: "Bash", input: "cat README.md" })).toBe(false);
+      expect(requiresExplicitApproval({ toolName: "Bash", input: "git commit -m 'test'" })).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/approval-risk-classifier.ts
+++ b/packages/shared/src/approval-risk-classifier.ts
@@ -1,0 +1,289 @@
+/**
+ * Approval Risk Classifier
+ *
+ * Classifies tool/command risk levels for the approval broker.
+ * Replaces hardcoded "medium" risk levels with real classification.
+ *
+ * Based on patterns from:
+ * - IronClaw's graduated command approval (commit b58b421)
+ * - cmux existing deny rules and approval broker schema
+ *
+ * Risk levels:
+ * - low: Safe, read-only, or well-scoped operations
+ * - medium: Standard write operations with reversible effects
+ * - high: Destructive, irreversible, or security-sensitive operations
+ */
+
+/**
+ * Risk level for approval requests.
+ */
+export type RiskLevel = "low" | "medium" | "high";
+
+/**
+ * Tool/command context for risk classification.
+ */
+export interface RiskClassificationInput {
+  /** Tool name (e.g., "Bash", "Write", "Edit") */
+  toolName: string;
+  /** Tool input/command content */
+  input: string;
+  /** Optional: agent name for context */
+  agentName?: string;
+  /** Optional: whether this is a head agent (more permissive) */
+  isHeadAgent?: boolean;
+}
+
+/**
+ * Result of risk classification.
+ */
+export interface RiskClassificationResult {
+  /** Classified risk level */
+  level: RiskLevel;
+  /** Reason for the classification */
+  reason: string;
+  /** Matched pattern if any */
+  matchedPattern?: string;
+}
+
+// =============================================================================
+// Pattern Definitions
+// =============================================================================
+
+/**
+ * High-risk patterns - destructive, irreversible, or security-sensitive.
+ * These require explicit human approval.
+ */
+const HIGH_RISK_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  // Git destructive operations
+  { pattern: /git\s+push\s+(-f|--force)/, reason: "Force push can destroy remote history" },
+  { pattern: /git\s+push\s+--force-with-lease/, reason: "Force push with lease can still overwrite" },
+  { pattern: /git\s+reset\s+--hard/, reason: "Hard reset discards uncommitted changes" },
+  { pattern: /git\s+clean\s+-[fd]/, reason: "Clean removes untracked files permanently" },
+  { pattern: /git\s+checkout\s+--\s+\./, reason: "Checkout discards all local changes" },
+  { pattern: /git\s+stash\s+drop/, reason: "Stash drop permanently deletes stashed changes" },
+
+  // File system destructive operations
+  { pattern: /rm\s+(-rf?|--recursive)/, reason: "Recursive delete can remove entire directories" },
+  { pattern: /rm\s+-[^r]*f/, reason: "Force delete bypasses confirmation" },
+  { pattern: />\s*\/dev\/null/, reason: "Redirecting to /dev/null discards output" },
+  { pattern: /truncate\s/, reason: "Truncate can destroy file contents" },
+  { pattern: /dd\s+.*of=/, reason: "dd can overwrite disk data" },
+
+  // System/security operations
+  { pattern: /chmod\s+[0-7]*[0-7][0-7][0-7]/, reason: "Permission changes can affect security" },
+  { pattern: /chown\s/, reason: "Ownership changes can affect security" },
+  { pattern: /sudo\s/, reason: "Elevated privileges bypass normal protections" },
+  { pattern: /su\s+-/, reason: "User switching can access privileged contexts" },
+
+  // Network/external operations
+  { pattern: /curl\s+.*-X\s*(POST|PUT|DELETE|PATCH)/, reason: "Mutating HTTP request to external service" },
+  { pattern: /wget\s+.*--post/, reason: "POST request to external service" },
+
+  // PR/merge operations (cmux manages these)
+  { pattern: /gh\s+pr\s+(create|merge|close)/, reason: "PR lifecycle managed by cmux" },
+  { pattern: /gh\s+issue\s+close/, reason: "Issue closing should be deliberate" },
+
+  // Sandbox/infrastructure operations
+  { pattern: /devsh\s+(start|delete|pause|resume)/, reason: "Sandbox lifecycle managed by cmux" },
+  { pattern: /cloudrouter\s+(start|delete|stop)/, reason: "Sandbox lifecycle managed by cmux" },
+  { pattern: /gh\s+workflow\s+run/, reason: "Workflow triggers affect all sandboxes" },
+
+  // Database operations
+  { pattern: /DROP\s+(TABLE|DATABASE|INDEX)/i, reason: "DROP operations are destructive" },
+  { pattern: /TRUNCATE\s+TABLE/i, reason: "TRUNCATE removes all data" },
+  { pattern: /DELETE\s+FROM\s+\w+\s*(;|$)/i, reason: "DELETE without WHERE affects all rows" },
+
+  // Package/dependency operations
+  { pattern: /npm\s+unpublish/, reason: "Unpublish removes packages from registry" },
+  { pattern: /pip\s+uninstall/, reason: "Uninstall removes dependencies" },
+];
+
+/**
+ * Low-risk patterns - read-only or well-scoped safe operations.
+ */
+const LOW_RISK_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  // Read operations
+  { pattern: /^(cat|head|tail|less|more)\s/, reason: "Read-only file viewing" },
+  { pattern: /^ls\s/, reason: "Directory listing" },
+  { pattern: /^pwd$/, reason: "Print working directory" },
+  { pattern: /^echo\s/, reason: "Echo output" },
+  { pattern: /^(grep|rg|ag)\s/, reason: "Search operation" },
+  { pattern: /^find\s.*-print/, reason: "Find without modification" },
+  { pattern: /^wc\s/, reason: "Word/line count" },
+  { pattern: /^file\s/, reason: "File type detection" },
+  { pattern: /^stat\s/, reason: "File statistics" },
+  { pattern: /^du\s/, reason: "Disk usage" },
+  { pattern: /^df\s/, reason: "Filesystem info" },
+
+  // Git read operations
+  { pattern: /^git\s+(status|log|diff|show|branch|tag)(\s|$)/, reason: "Git read operation" },
+  { pattern: /^git\s+ls-files/, reason: "Git list files" },
+  { pattern: /^git\s+rev-parse/, reason: "Git reference parsing" },
+
+  // GitHub read operations
+  { pattern: /^gh\s+(pr|issue)\s+(list|view|status)/, reason: "GitHub read operation" },
+  { pattern: /^gh\s+repo\s+view/, reason: "GitHub repo view" },
+  { pattern: /^gh\s+api\s+.*--method\s*GET/, reason: "GitHub API GET request" },
+
+  // Node/package read operations
+  { pattern: /^(npm|yarn|pnpm|bun)\s+(list|ls|outdated|audit)/, reason: "Package read operation" },
+  { pattern: /^node\s+-e\s+['"].*console\.log/, reason: "Node evaluation for output" },
+
+  // Safe tools
+  { pattern: /^(which|whereis|type)\s/, reason: "Command location lookup" },
+  { pattern: /^env$/, reason: "Environment listing" },
+  { pattern: /^date$/, reason: "Date display" },
+  { pattern: /^whoami$/, reason: "User identification" },
+];
+
+/**
+ * Low-risk tool names that are generally safe.
+ */
+const LOW_RISK_TOOLS = new Set([
+  "Read",
+  "Glob",
+  "Grep",
+  "LS",
+  "ListDir",
+  "Search",
+  "Find",
+]);
+
+/**
+ * High-risk tool names that always require approval.
+ */
+const HIGH_RISK_TOOLS = new Set([
+  "WebFetch", // External network requests
+  "WebSearch", // External search
+]);
+
+// =============================================================================
+// Classification Functions
+// =============================================================================
+
+/**
+ * Classify the risk level of a tool/command.
+ *
+ * @param input - Tool name and input to classify
+ * @returns Classification result with level, reason, and optional pattern
+ *
+ * @example
+ * ```ts
+ * const result = classifyRisk({
+ *   toolName: "Bash",
+ *   input: "git push --force origin main",
+ * });
+ * // { level: "high", reason: "Force push can destroy remote history", matchedPattern: "git push --force" }
+ * ```
+ */
+export function classifyRisk(input: RiskClassificationInput): RiskClassificationResult {
+  const { toolName, input: commandInput, isHeadAgent } = input;
+
+  // Head agents get more permissive treatment for sandbox management
+  if (isHeadAgent) {
+    // Still flag truly destructive operations
+    const headAgentHighRisk = HIGH_RISK_PATTERNS.filter(p =>
+      !p.reason.includes("managed by cmux") // Allow cmux-managed operations for head agents
+    );
+
+    for (const { pattern, reason } of headAgentHighRisk) {
+      if (pattern.test(commandInput)) {
+        return {
+          level: "high",
+          reason,
+          matchedPattern: pattern.source,
+        };
+      }
+    }
+
+    // Head agents default to medium for most operations
+    return {
+      level: "medium",
+      reason: "Head agent operation (elevated trust)",
+    };
+  }
+
+  // Check tool-level classification first
+  if (LOW_RISK_TOOLS.has(toolName)) {
+    return {
+      level: "low",
+      reason: `${toolName} is a read-only tool`,
+    };
+  }
+
+  if (HIGH_RISK_TOOLS.has(toolName)) {
+    return {
+      level: "high",
+      reason: `${toolName} involves external network access`,
+    };
+  }
+
+  // For Bash and similar, check command patterns
+  if (toolName === "Bash" || toolName === "Shell" || toolName === "Execute") {
+    // Check high-risk patterns first
+    for (const { pattern, reason } of HIGH_RISK_PATTERNS) {
+      if (pattern.test(commandInput)) {
+        return {
+          level: "high",
+          reason,
+          matchedPattern: pattern.source,
+        };
+      }
+    }
+
+    // Check low-risk patterns
+    for (const { pattern, reason } of LOW_RISK_PATTERNS) {
+      if (pattern.test(commandInput)) {
+        return {
+          level: "low",
+          reason,
+          matchedPattern: pattern.source,
+        };
+      }
+    }
+  }
+
+  // Write/Edit tools are medium by default
+  if (toolName === "Write" || toolName === "Edit" || toolName === "NotebookEdit") {
+    return {
+      level: "medium",
+      reason: "File modification operation",
+    };
+  }
+
+  // Default to medium for unknown patterns
+  return {
+    level: "medium",
+    reason: "Standard operation (no specific risk pattern matched)",
+  };
+}
+
+/**
+ * Convenience function to get just the risk level string.
+ *
+ * @param input - Tool name and input to classify
+ * @returns Risk level string
+ */
+export function getRiskLevel(input: RiskClassificationInput): RiskLevel {
+  return classifyRisk(input).level;
+}
+
+/**
+ * Check if an operation should be auto-approved (low risk).
+ *
+ * @param input - Tool name and input to classify
+ * @returns True if the operation is low-risk and can be auto-approved
+ */
+export function isAutoApprovable(input: RiskClassificationInput): boolean {
+  return classifyRisk(input).level === "low";
+}
+
+/**
+ * Check if an operation requires explicit human approval (high risk).
+ *
+ * @param input - Tool name and input to classify
+ * @returns True if the operation is high-risk and requires human approval
+ */
+export function requiresExplicitApproval(input: RiskClassificationInput): boolean {
+  return classifyRisk(input).level === "high";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -45,6 +45,7 @@ export * from "./mcp-form";
 export * from "./mcp-preview";
 export * from "./agent-comm-events";
 export * from "./a2a-protocol";
+export * from "./approval-risk-classifier";
 export * from "./timezone-constants";
 // Note: useNetwork hook is NOT exported here to avoid SSR issues.
 // Import directly from "@cmux/shared/hooks/use-network" in client components.


### PR DESCRIPTION
## Summary
- Add `classifyRisk()` to replace hardcoded `riskLevel: "medium"` in permission hooks
- Classify commands into low/medium/high based on destructive patterns
- Based on IronClaw's graduated command approval pattern (commit b58b421)

## Risk Classification

| Level | Examples | Behavior |
|-------|----------|----------|
| **High** | `git push --force`, `rm -rf`, `sudo`, `DROP TABLE`, `gh pr create/merge`, `devsh start/delete` | Requires explicit human approval |
| **Medium** | `git commit`, `git push`, `npm install`, file writes | Standard approval flow |
| **Low** | `cat`, `ls`, `git status`, `grep`, Read/Glob tools | Can be auto-approved |

## Head Agent Behavior
- Head agents (cloud workspaces) get elevated trust for cmux-managed operations
- PR lifecycle and sandbox commands are medium-risk for head agents
- Truly destructive ops (force push, rm -rf) still require approval

## Test plan
- [x] `bun check` passes
- [x] 34 test cases covering all risk patterns
- [ ] Integration: Update anthropic permission hook to use classifier