### PR TITLE
fix: preserve Ralph home hook fallback for Codex

### DIFF
--- a/.codex/hooks/cmux-stop-dispatch.sh
+++ b/.codex/hooks/cmux-stop-dispatch.sh
@@ -26,8 +26,26 @@ route_to_workspace_hook() {
   local hook_path="${workspace_root}/${relative_hook_path}"
 
   if [[ ! -f "$hook_path" ]]; then
-    emit_allow
-    return 0
+    return 1
+  fi
+
+  printf '%s' "$HOOK_INPUT" | bash "$hook_path"
+}
+
+route_to_home_hook() {
+  local hook_name="$1"
+  local codex_home=""
+  local hook_path=""
+
+  if [[ -n "${CODEX_HOME:-}" ]]; then
+    codex_home="$CODEX_HOME"
+  else
+    codex_home="$HOME/.codex"
+  fi
+
+  hook_path="${codex_home}/hooks/${hook_name}"
+  if [[ ! -f "$hook_path" ]]; then
+    return 1
   fi
 
   printf '%s' "$HOOK_INPUT" | bash "$hook_path"
@@ -39,12 +57,24 @@ WORKSPACE_ROOT="$(resolve_workspace_root "$HOOK_CWD")"
 RALPH_STATE_FILE="${WORKSPACE_ROOT}/.codex/ralph-loop-state.json"
 
 if [[ -f "$RALPH_STATE_FILE" ]]; then
-  route_to_workspace_hook "$WORKSPACE_ROOT" ".codex/hooks/ralph-loop-stop.sh"
+  if route_to_workspace_hook "$WORKSPACE_ROOT" ".codex/hooks/ralph-loop-stop.sh"; then
+    exit 0
+  fi
+
+  if route_to_home_hook "ralph-loop-stop.sh"; then
+    exit 0
+  fi
+
+  emit_allow
   exit 0
 fi
 
 if [[ "${CMUX_AUTOPILOT_ENABLED:-0}" = "1" ]] || [[ "${CMUX_CODEX_HOOKS_ENABLED:-0}" = "1" ]]; then
-  route_to_workspace_hook "$WORKSPACE_ROOT" ".codex/hooks/autopilot-stop.sh"
+  if route_to_workspace_hook "$WORKSPACE_ROOT" ".codex/hooks/autopilot-stop.sh"; then
+    exit 0
+  fi
+
+  emit_allow
   exit 0
 fi
 

--- a/.codex/hooks/test-autopilot-stop.sh
+++ b/.codex/hooks/test-autopilot-stop.sh
@@ -7,11 +7,13 @@ unset CMUX_AUTOPILOT_DELAY CMUX_AUTOPILOT_IDLE_THRESHOLD CMUX_AUTOPILOT_MAX_TURN
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOOK="$SCRIPT_DIR/autopilot-stop.sh"
-HOOKS_TEMPLATE="$PROJECT_DIR/.codex/autopilot-hooks.json"
+HOME_HOOK_INSTALLER="$PROJECT_DIR/scripts/install-codex-home-hooks.sh"
 TEST_SESSION="codex-hook-test-$$"
 STOP_FILE="/tmp/codex-test-stop-${TEST_SESSION}"
 FAKE_BIN_DIR="/tmp/codex-hook-bin-${TEST_SESSION}"
 FAKE_SLEEP_LOG="/tmp/codex-hook-sleep-${TEST_SESSION}.log"
+HOME_HOOK_TEST_DIR="/tmp/codex-hook-home-${TEST_SESSION}"
+HOME_HOOKS_FILE="${HOME_HOOK_TEST_DIR}/.codex/hooks.json"
 PASS=0
 FAIL=0
 CONDITIONAL_WAIT_TEXT="Only if you are blocked on external work and are about to poll status"
@@ -28,6 +30,7 @@ cleanup() {
   rm -f "/tmp/codex-autopilot-wrapup-${TEST_SESSION}"
   rm -f "$FAKE_SLEEP_LOG"
   rm -rf "$FAKE_BIN_DIR"
+  rm -rf "$HOME_HOOK_TEST_DIR"
 }
 trap cleanup EXIT
 
@@ -133,9 +136,12 @@ run_hidden_sleep_monitoring_hook() {
 
 echo "=== Codex autopilot hook smoke test ==="
 
+mkdir -p "$HOME_HOOK_TEST_DIR"
+bash "$HOME_HOOK_INSTALLER" --home "$HOME_HOOK_TEST_DIR" >/dev/null
+
 assert "Codex Stop hook timeout allows hidden monitoring sleeps" jq -e '
   .hooks.Stop[0].hooks[0].timeout >= 75
-' "$HOOKS_TEMPLATE"
+' "$HOME_HOOKS_FILE"
 
 cleanup
 touch "$STOP_FILE"

--- a/.codex/hooks/test-cmux-stop-dispatch.sh
+++ b/.codex/hooks/test-cmux-stop-dispatch.sh
@@ -42,8 +42,9 @@ make_stop_payload() {
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+HOME_DIR="$TMP_DIR/home"
 WORKSPACE="$TMP_DIR/workspace"
-mkdir -p "$WORKSPACE/.codex/hooks"
+mkdir -p "$WORKSPACE/.codex/hooks" "$HOME_DIR/.codex/hooks"
 
 cp "$RALPH_STOP_SCRIPT" "$WORKSPACE/.codex/hooks/ralph-loop-stop.sh"
 
@@ -54,7 +55,7 @@ jq -nc '{decision: "block", reason: "autopilot continuation"}'
 EOF
 chmod +x "$WORKSPACE/.codex/hooks/autopilot-stop.sh"
 
-NO_STATE_OUTPUT="$(cd "$WORKSPACE" && printf '%s' "$(make_stop_payload "$WORKSPACE" "")" | bash "$DISPATCH_SCRIPT")"
+NO_STATE_OUTPUT="$(cd "$WORKSPACE" && printf '%s' "$(make_stop_payload "$WORKSPACE" "")" | env -u CMUX_AUTOPILOT_ENABLED -u CMUX_CODEX_HOOKS_ENABLED bash "$DISPATCH_SCRIPT")"
 assert_eq "$(jq -c . <<<"$NO_STATE_OUTPUT")" "{}" "dispatcher should emit an empty JSON object when Ralph and autopilot are inactive"
 
 cat >"$WORKSPACE/.codex/ralph-loop-state.json" <<'EOF'
@@ -71,13 +72,41 @@ cat >"$WORKSPACE/.codex/ralph-loop-state.json" <<'EOF'
 }
 EOF
 
-FIRST_OUTPUT="$(cd "$TMP_DIR" && printf '%s' "$(make_stop_payload "$WORKSPACE" "draft one")" | bash "$DISPATCH_SCRIPT")"
+FIRST_OUTPUT="$(cd "$TMP_DIR" && printf '%s' "$(make_stop_payload "$WORKSPACE" "draft one")" | env -u CMUX_AUTOPILOT_ENABLED -u CMUX_CODEX_HOOKS_ENABLED bash "$DISPATCH_SCRIPT")"
 assert_eq "$(jq -r '.decision' <<<"$FIRST_OUTPUT")" "block" "dispatcher should route Ralph state to the Ralph stop hook"
 assert_eq "$(jq -r '.iteration' "$WORKSPACE/.codex/ralph-loop-state.json")" "1" "dispatcher should preserve Ralph iteration updates"
 
-COMPLETION_OUTPUT="$(printf '%s' "$(make_stop_payload "$WORKSPACE" "<promise>DONE</promise>")" | bash "$DISPATCH_SCRIPT")"
+COMPLETION_OUTPUT="$(printf '%s' "$(make_stop_payload "$WORKSPACE" "<promise>DONE</promise>")" | env -u CMUX_AUTOPILOT_ENABLED -u CMUX_CODEX_HOOKS_ENABLED bash "$DISPATCH_SCRIPT")"
 assert_eq "$(jq -r '.systemMessage | contains("completion signal detected")' <<<"$COMPLETION_OUTPUT")" "true" "dispatcher should allow when Ralph emits the completion signal"
 assert_eq "$([[ -f "$WORKSPACE/.codex/ralph-loop-state.json" ]] && echo yes || echo no)" "no" "dispatcher should let Ralph clean up state after completion"
+
+rm -f "$WORKSPACE/.codex/hooks/ralph-loop-stop.sh"
+cat >"$HOME_DIR/.codex/hooks/ralph-loop-stop.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+jq -nc '{decision: "block", reason: "home ralph continuation"}'
+EOF
+chmod +x "$HOME_DIR/.codex/hooks/ralph-loop-stop.sh"
+
+cat >"$WORKSPACE/.codex/ralph-loop-state.json" <<'EOF'
+{
+  "active": true,
+  "prompt": "Fallback to home Ralph hook",
+  "iteration": 0,
+  "max_iterations": 2,
+  "completion_promise": "DONE",
+  "completion_signal": "<promise>DONE</promise>",
+  "created_at": "2026-03-23T00:00:00Z",
+  "updated_at": "2026-03-23T00:00:00Z",
+  "state_version": 1
+}
+EOF
+
+HOME_FALLBACK_OUTPUT="$(printf '%s' "$(make_stop_payload "$WORKSPACE" "draft one")" | HOME="$HOME_DIR" env -u CMUX_AUTOPILOT_ENABLED -u CMUX_CODEX_HOOKS_ENABLED bash "$DISPATCH_SCRIPT")"
+assert_eq "$(jq -r '.decision' <<<"$HOME_FALLBACK_OUTPUT")" "block" "dispatcher should fall back to the home Ralph hook when the workspace hook is absent"
+assert_eq "$(jq -r '.reason' <<<"$HOME_FALLBACK_OUTPUT")" "home ralph continuation" "dispatcher should preserve the home Ralph hook output"
+rm -f "$WORKSPACE/.codex/ralph-loop-state.json"
+cp "$RALPH_STOP_SCRIPT" "$WORKSPACE/.codex/hooks/ralph-loop-stop.sh"
 
 AUTOPILOT_OUTPUT="$(printf '%s' "$(make_stop_payload "$WORKSPACE" "")" | CMUX_AUTOPILOT_ENABLED=1 bash "$DISPATCH_SCRIPT")"
 assert_eq "$(jq -r '.decision' <<<"$AUTOPILOT_OUTPUT")" "block" "dispatcher should route autopilot-enabled sessions to the autopilot hook"
@@ -97,9 +126,9 @@ cat >"$WORKSPACE/.codex/ralph-loop-state.json" <<'EOF'
 }
 EOF
 
-MAX_FIRST_OUTPUT="$(printf '%s' "$(make_stop_payload "$WORKSPACE" "draft")" | bash "$DISPATCH_SCRIPT")"
+MAX_FIRST_OUTPUT="$(printf '%s' "$(make_stop_payload "$WORKSPACE" "draft")" | env -u CMUX_AUTOPILOT_ENABLED -u CMUX_CODEX_HOOKS_ENABLED bash "$DISPATCH_SCRIPT")"
 assert_eq "$(jq -r '.decision' <<<"$MAX_FIRST_OUTPUT")" "block" "dispatcher should allow Ralph to consume the first max-iteration turn"
-MAX_SECOND_OUTPUT="$(printf '%s' "$(make_stop_payload "$WORKSPACE" "still working")" | bash "$DISPATCH_SCRIPT")"
+MAX_SECOND_OUTPUT="$(printf '%s' "$(make_stop_payload "$WORKSPACE" "still working")" | env -u CMUX_AUTOPILOT_ENABLED -u CMUX_CODEX_HOOKS_ENABLED bash "$DISPATCH_SCRIPT")"
 assert_eq "$(jq -r '.systemMessage | contains("max iteration limit")' <<<"$MAX_SECOND_OUTPUT")" "true" "dispatcher should allow once Ralph reaches its max iteration limit"
 assert_eq "$([[ -f "$WORKSPACE/.codex/ralph-loop-state.json" ]] && echo yes || echo no)" "no" "dispatcher should let Ralph clean up state after max-iteration exit"
 


### PR DESCRIPTION
## Summary
- prefer workspace Ralph Stop hooks, then fall back to the home-installed Ralph hook before autopilot routing
- keep the dispatcher permissive when neither Ralph nor autopilot hooks are present
- update Codex hook smoke tests to validate the current home-hook installer flow and home Ralph fallback

## Testing
- bash .codex/hooks/test-cmux-stop-dispatch.sh
- bash .codex/hooks/test-autopilot-stop.sh
- bash scripts/test-codex-home-hooks-install.sh
- bash scripts/test-agent-autopilot.sh