### PR TITLE
feat(convex): add unified interruption state model for task runs

### DIFF
--- a/packages/convex/convex/approvalBroker.ts
+++ b/packages/convex/convex/approvalBroker.ts
@@ -17,6 +17,7 @@
 
 import { v } from "convex/values";
 import { getTeamId } from "../_shared/team";
+import { internal } from "./_generated/api";
 import { internalMutation, internalQuery } from "./_generated/server";
 import { authMutation, authQuery } from "./users/utils";
 import {
@@ -152,6 +153,17 @@ export const createRequest = authMutation({
       createdAt: now,
     });
 
+    // Set interruption state on the task run to enable unified pause/approval handling
+    if (args.taskRunId) {
+      await ctx.runMutation(internal.taskRuns.setInterruptionState, {
+        taskRunId: args.taskRunId,
+        status: "approval_pending",
+        reason: args.action,
+        approvalRequestId: requestId,
+        expiresAt: args.expiresInMs ? now + args.expiresInMs : undefined,
+      });
+    }
+
     return { requestId, docId: requestDoc };
   },
 });
@@ -226,6 +238,14 @@ export const resolveRequest = authMutation({
       payload: event,
       createdAt: now,
     });
+
+    // Resolve interruption state on the task run
+    if (request.taskRunId) {
+      await ctx.runMutation(internal.taskRuns.resolveInterruption, {
+        taskRunId: request.taskRunId,
+        resolvedBy: userId,
+      });
+    }
 
     return { success: true, status };
   },
@@ -599,6 +619,17 @@ export const createRequestInternal = internalMutation({
       createdAt: now,
     });
 
+    // Set interruption state on the task run to enable unified pause/approval handling
+    if (args.taskRunId) {
+      await ctx.runMutation(internal.taskRuns.setInterruptionState, {
+        taskRunId: args.taskRunId,
+        status: "approval_pending",
+        reason: args.action,
+        approvalRequestId: requestId,
+        expiresAt: args.expiresInMs ? now + args.expiresInMs : undefined,
+      });
+    }
+
     return { requestId, docId: requestDoc };
   },
 });
@@ -665,6 +696,14 @@ export const resolveRequestInternal = internalMutation({
       payload: event,
       createdAt: now,
     });
+
+    // Resolve interruption state on the task run
+    if (request.taskRunId) {
+      await ctx.runMutation(internal.taskRuns.resolveInterruption, {
+        taskRunId: request.taskRunId,
+        resolvedBy: args.resolvedBy ?? "system",
+      });
+    }
 
     return { success: true, status };
   },

--- a/packages/convex/convex/feedEvents.ts
+++ b/packages/convex/convex/feedEvents.ts
@@ -9,6 +9,8 @@ export const list = query({
       v.union(
         v.literal("task_completed"),
         v.literal("task_failed"),
+        v.literal("task_interrupted"),
+        v.literal("task_resumed"),
         v.literal("pr_merged"),
         v.literal("pr_opened"),
         v.literal("pr_closed"),

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -406,6 +406,29 @@ const convexSchema = defineSchema({
         lastUpdated: v.number(), // Timestamp of last update
       })
     ),
+    // Interruption state (Phase 7: Unified pause/approval model)
+    // Tracks when an agent is blocked and why, enabling unified handling of
+    // approvals, operator pauses, and sandbox pauses across all providers
+    interruptionState: v.optional(
+      v.object({
+        status: v.union(
+          v.literal("none"), // Not interrupted
+          v.literal("approval_pending"), // Waiting for approval (linked to approvalRequests)
+          v.literal("paused_by_operator"), // Operator requested pause
+          v.literal("sandbox_paused"), // Underlying sandbox is paused
+          v.literal("context_overflow"), // Context window exceeded
+          v.literal("rate_limited"), // Provider rate limit hit
+          v.literal("timed_out") // Approval or action timed out
+        ),
+        reason: v.optional(v.string()), // Human-readable explanation
+        approvalRequestId: v.optional(v.string()), // Link to approvalRequests.requestId
+        blockedAt: v.number(), // When interruption started
+        expiresAt: v.optional(v.number()), // Auto-resume or expire time
+        resumeToken: v.optional(v.string()), // Provider-specific resume state
+        resolvedAt: v.optional(v.number()), // When interruption was resolved
+        resolvedBy: v.optional(v.string()), // User ID who resolved
+      })
+    ),
   })
     .index("by_task", ["taskId", "createdAt"])
     .index("by_parent", ["parentRunId"])
@@ -2296,6 +2319,8 @@ const convexSchema = defineSchema({
     eventType: v.union(
       v.literal("task_completed"),
       v.literal("task_failed"),
+      v.literal("task_interrupted"),
+      v.literal("task_resumed"),
       v.literal("pr_merged"),
       v.literal("pr_opened"),
       v.literal("pr_closed"),

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -910,6 +910,142 @@ export const updateStatus = internalMutation({
   },
 });
 
+// Interruption state validator - matches schema definition
+const interruptionStatusValidator = v.union(
+  v.literal("none"),
+  v.literal("approval_pending"),
+  v.literal("paused_by_operator"),
+  v.literal("sandbox_paused"),
+  v.literal("context_overflow"),
+  v.literal("rate_limited"),
+  v.literal("timed_out")
+);
+
+/**
+ * Set interruption state on a task run.
+ * Used when an agent is blocked (approval needed, sandbox paused, etc.)
+ */
+export const setInterruptionState = internalMutation({
+  args: {
+    taskRunId: v.id("taskRuns"),
+    status: interruptionStatusValidator,
+    reason: v.optional(v.string()),
+    approvalRequestId: v.optional(v.string()),
+    expiresAt: v.optional(v.number()),
+    resumeToken: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get(args.taskRunId);
+    if (!run) {
+      throw new Error("Task run not found");
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(args.taskRunId, {
+      interruptionState: {
+        status: args.status,
+        reason: args.reason,
+        approvalRequestId: args.approvalRequestId,
+        blockedAt: now,
+        expiresAt: args.expiresAt,
+        resumeToken: args.resumeToken,
+      },
+      updatedAt: now,
+    });
+
+    // Create feed event for interruption
+    const task = await ctx.db.get(run.taskId);
+    const reasonText = args.reason ? `: ${args.reason}` : "";
+    // Note: eventType validated in feedEvents.ts and schema.ts, types regenerate at dev time
+    await ctx.runMutation(internal.feedEvents.create, {
+      teamId: run.teamId,
+      userId: run.userId,
+      eventType: "task_interrupted" as "approval_required",
+      title: `Agent paused (${args.status})${reasonText}`,
+      description: args.reason,
+      taskId: run.taskId,
+      taskRunId: args.taskRunId,
+      agentName: run.agentName,
+      repoFullName: task?.projectFullName,
+    });
+  },
+});
+
+/**
+ * Resolve an interruption (approval granted, resume from pause, etc.)
+ */
+export const resolveInterruption = internalMutation({
+  args: {
+    taskRunId: v.id("taskRuns"),
+    resolvedBy: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get(args.taskRunId);
+    if (!run) {
+      throw new Error("Task run not found");
+    }
+
+    if (!run.interruptionState || run.interruptionState.status === "none") {
+      // Already resolved or never interrupted
+      return;
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(args.taskRunId, {
+      interruptionState: {
+        ...run.interruptionState,
+        status: "none",
+        resolvedAt: now,
+        resolvedBy: args.resolvedBy,
+      },
+      updatedAt: now,
+    });
+
+    // Create feed event for resolution
+    const task = await ctx.db.get(run.taskId);
+    // Note: eventType validated in feedEvents.ts and schema.ts, types regenerate at dev time
+    await ctx.runMutation(internal.feedEvents.create, {
+      teamId: run.teamId,
+      userId: run.userId,
+      eventType: "task_resumed" as "approval_resolved",
+      title: `Agent resumed${args.resolvedBy ? ` by ${args.resolvedBy}` : ""}`,
+      taskId: run.taskId,
+      taskRunId: args.taskRunId,
+      agentName: run.agentName,
+      repoFullName: task?.projectFullName,
+    });
+  },
+});
+
+/**
+ * Query to check if a task run is currently interrupted.
+ */
+export const isInterrupted = internalQuery({
+  args: {
+    taskRunId: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get(args.taskRunId);
+    if (!run) {
+      return { interrupted: false, status: "none" as const };
+    }
+
+    const state = run.interruptionState;
+    if (!state || state.status === "none") {
+      return { interrupted: false, status: "none" as const };
+    }
+
+    return {
+      interrupted: true,
+      status: state.status,
+      reason: state.reason,
+      blockedAt: state.blockedAt,
+      expiresAt: state.expiresAt,
+      approvalRequestId: state.approvalRequestId,
+    };
+  },
+});
+
 export const getRunDiffContext = authQuery({
   args: {
     teamSlugOrId: v.string(),


### PR DESCRIPTION
## Summary

Implements Priority 2 from research: first-class interruption/resume state as a unified runtime object.

- Add `interruptionState` field to `taskRuns` schema with statuses: `approval_pending`, `paused_by_operator`, `sandbox_paused`, `context_overflow`, `rate_limited`, `timed_out`, `none`
- Add `setInterruptionState` and `resolveInterruption` mutations for lifecycle management
- Add `isInterrupted` query for status checks
- Add `task_interrupted` and `task_resumed` feed event types
- Wire approval broker to automatically set/resolve interruption state when approvals are created/resolved

## Motivation

From the [research-weekly-2026-03-24](research notes), Priority 2 recommends:

> "cmux should stop treating approvals and pauses as scattered hook events. Create one durable interruption model."

This enables unified handling of approvals, operator pauses, and sandbox pauses across all providers (Claude, Codex, LangGraph, OpenAI Agents) through one control object instead of separate subsystems.

## Test plan

- [ ] Run `bun check` - PASSED
- [ ] Verify schema change compiles
- [ ] Verify approval broker integration works (create approval → interruption state set, resolve approval → interruption state resolved)
- [ ] Types will regenerate when dev server starts