### PR TITLE
feat(client): simplify orchestration rules UX (Phase 3)

### DIFF
--- a/apps/client/src/components/settings/sections/OrchestrationRulesSection.tsx
+++ b/apps/client/src/components/settings/sections/OrchestrationRulesSection.tsx
@@ -17,14 +17,15 @@ interface OrchestrationRulesSectionProps {
   teamSlugOrId: string;
 }
 
-// Default tabs shown to all users
+// Default tab: Active rules only (simplified UX per Phase 3 rollout)
 const DEFAULT_TABS: { key: TabView; label: string }[] = [
   { key: "active", label: "Active" },
-  { key: "candidates", label: "Candidates" },
 ];
 
-// Advanced tab for skill candidates (hidden by default)
+// Advanced tabs: Candidates and Skill Candidates (hidden by default)
+// Reduces operator cognitive load for common path
 const ADVANCED_TABS: { key: TabView; label: string }[] = [
+  { key: "candidates", label: "Candidates" },
   { key: "skills", label: "Skill Candidates" },
 ];
 
@@ -100,7 +101,7 @@ export function OrchestrationRulesSection({ teamSlugOrId }: OrchestrationRulesSe
   return (
     <SettingSection
       title="Orchestration Rules"
-      description="Team-learned rules from previous orchestration runs. Active rules are injected into agent instructions at spawn time."
+      description="Rules injected into agent instructions at spawn time. Use Advanced to view auto-detected candidate rules."
       headerAction={
         <Button
           size="sm"
@@ -135,8 +136,8 @@ export function OrchestrationRulesSection({ teamSlugOrId }: OrchestrationRulesSe
             <button
               onClick={() => {
                 setShowAdvanced(!showAdvanced);
-                // Reset to default tab if hiding advanced and currently on skills
-                if (showAdvanced && activeTab === "skills") {
+                // Reset to default tab if hiding advanced and on an advanced-only tab
+                if (showAdvanced && (activeTab === "skills" || activeTab === "candidates")) {
                   setActiveTab("active");
                 }
               }}


### PR DESCRIPTION
## Summary

Simplifies the orchestration rules settings UI per Phase 3 of the platform simplification rollout.

**Before:** Default view shows Active + Candidates tabs
**After:** Default view shows only Active tab; Candidates moved to Advanced

## Changes

- Move Candidates tab from default to advanced mode
- Show only Active rules by default (reduces cognitive load)
- Update description to guide users to Advanced for candidate rules
- Reset to Active tab when hiding Advanced if on Candidates/Skills tab

## Motivation

From the simplification rollout plan:

> "Reduce the number of controls a normal operator must understand before launching a useful head agent... Keep storage model for now, but introduce a simpler operator-facing default."

Most operators only need to see and manage Active rules. Candidates and Skill Candidates are advanced features for power users.

## Test plan

- [x] `bun check` - PASSED
- [ ] Verify Active tab shows by default
- [ ] Verify clicking Advanced shows Candidates and Skill Candidates
- [ ] Verify hiding Advanced resets to Active if on Candidates tab