### PR TITLE
feat(client): add resume ancestry UI for session binding visibility

### DIFF
--- a/apps/client/src/components/dashboard/SessionBindingCard.tsx
+++ b/apps/client/src/components/dashboard/SessionBindingCard.tsx
@@ -1,0 +1,194 @@
+import { api } from "@cmux/convex/api";
+import type { Id } from "@cmux/convex/dataModel";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Activity,
+  Clock,
+  Link2,
+  MessageSquare,
+  RotateCcw,
+  Terminal,
+  User,
+  Zap,
+} from "lucide-react";
+import clsx from "clsx";
+
+interface SessionBindingCardProps {
+  teamSlugOrId: string;
+  taskRunId: Id<"taskRuns">;
+}
+
+/**
+ * Displays provider session binding and resume ancestry info.
+ * Shows whether the run has a bound provider session and if it's a resumed session.
+ */
+export function SessionBindingCard({
+  teamSlugOrId,
+  taskRunId,
+}: SessionBindingCardProps) {
+  const { data: ancestry, isLoading } = useQuery({
+    ...convexQuery(api.providerSessions.getResumeAncestry, {
+      teamSlugOrId,
+      taskRunId,
+    }),
+    enabled: Boolean(teamSlugOrId && taskRunId),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="flex items-center gap-2">
+          <div className="size-4 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700" />
+          <div className="h-4 w-32 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!ancestry?.hasBoundSession) {
+    return (
+      <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="flex items-center gap-2 text-neutral-500 dark:text-neutral-400">
+          <Link2 className="size-4" />
+          <span className="text-sm">No session binding</span>
+        </div>
+        <p className="mt-1 text-xs text-neutral-400 dark:text-neutral-500">
+          Session bindings enable resume across retries
+        </p>
+      </div>
+    );
+  }
+
+  const providerIcon = getProviderIcon(ancestry.provider);
+  const statusColor = getStatusColor(ancestry.status);
+
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {providerIcon}
+          <span className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+            {ancestry.provider ? capitalizeFirst(ancestry.provider) : "Unknown"} Session
+          </span>
+          {ancestry.isResumedSession && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+              <RotateCcw className="size-3" />
+              Resumed
+            </span>
+          )}
+        </div>
+        <span
+          className={clsx(
+            "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+            statusColor
+          )}
+        >
+          <Zap className="size-3" />
+          {ancestry.status}
+        </span>
+      </div>
+
+      {/* Details */}
+      <div className="mt-3 grid grid-cols-2 gap-3 text-xs">
+        {/* Mode */}
+        <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+          <User className="size-3.5" />
+          <span>Mode:</span>
+          <span className="font-medium text-neutral-800 dark:text-neutral-200">
+            {ancestry.mode ?? "unknown"}
+          </span>
+        </div>
+
+        {/* Reply channel */}
+        {ancestry.replyChannel && (
+          <div className="flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+            <MessageSquare className="size-3.5" />
+            <span>Channel:</span>
+            <span className="font-medium text-neutral-800 dark:text-neutral-200">
+              {ancestry.replyChannel}
+            </span>
+          </div>
+        )}
+
+        {/* Session ID */}
+        {ancestry.providerSessionId && (
+          <div className="col-span-2 flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+            <Terminal className="size-3.5" />
+            <span>Session:</span>
+            <code className="rounded bg-neutral-100 px-1.5 py-0.5 font-mono text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+              {truncateId(ancestry.providerSessionId)}
+            </code>
+          </div>
+        )}
+
+        {/* Thread ID (Codex) */}
+        {ancestry.providerThreadId && (
+          <div className="col-span-2 flex items-center gap-2 text-neutral-600 dark:text-neutral-400">
+            <Activity className="size-3.5" />
+            <span>Thread:</span>
+            <code className="rounded bg-neutral-100 px-1.5 py-0.5 font-mono text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+              {truncateId(ancestry.providerThreadId)}
+            </code>
+          </div>
+        )}
+
+        {/* Timestamps */}
+        {ancestry.createdAt && (
+          <div className="flex items-center gap-2 text-neutral-500 dark:text-neutral-400">
+            <Clock className="size-3.5" />
+            <span>Bound:</span>
+            <span>{new Date(ancestry.createdAt).toLocaleString()}</span>
+          </div>
+        )}
+
+        {ancestry.lastActiveAt && (
+          <div className="flex items-center gap-2 text-neutral-500 dark:text-neutral-400">
+            <Clock className="size-3.5" />
+            <span>Active:</span>
+            <span>{new Date(ancestry.lastActiveAt).toLocaleString()}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function getProviderIcon(provider: string | null) {
+  const className = "size-4 text-neutral-600 dark:text-neutral-400";
+  switch (provider) {
+    case "claude":
+      return <span className={clsx(className, "font-bold text-orange-600")}>C</span>;
+    case "codex":
+      return <span className={clsx(className, "font-bold text-green-600")}>X</span>;
+    case "gemini":
+      return <span className={clsx(className, "font-bold text-blue-600")}>G</span>;
+    default:
+      return <Terminal className={className} />;
+  }
+}
+
+function getStatusColor(status: string | null) {
+  switch (status) {
+    case "active":
+      return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400";
+    case "suspended":
+      return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400";
+    case "expired":
+      return "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400";
+    case "terminated":
+      return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+    default:
+      return "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400";
+  }
+}
+
+function capitalizeFirst(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function truncateId(id: string, maxLen = 24): string {
+  if (id.length <= maxLen) return id;
+  return `${id.slice(0, 12)}...${id.slice(-8)}`;
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.activity.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.activity.tsx
@@ -11,6 +11,7 @@ import { CompactErrorFallback, ErrorBoundary } from "@/components/ErrorBoundary"
 import { LiveDiffStats } from "@/components/LiveDiffStats";
 import { CostEstimationCard } from "@/components/dashboard/CostEstimationCard";
 import { ResourceUsageCard } from "@/components/dashboard/ResourceUsageCard";
+import { SessionBindingCard } from "@/components/dashboard/SessionBindingCard";
 import { convexQueryClient } from "@/contexts/convex/convex-query-client";
 
 const paramsSchema = z.object({
@@ -87,7 +88,7 @@ function TaskRunActivity() {
 
       {showMetrics && (
         <div className="px-4 pb-4">
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             <ErrorBoundary
               key={`${resetKey}-resource-usage`}
               name="Resource Usage"
@@ -101,6 +102,13 @@ function TaskRunActivity() {
               fallback={<CompactErrorFallback name="Cost Estimation" />}
             >
               <CostEstimationCard taskRunId={taskRunId} teamSlugOrId={teamSlugOrId} />
+            </ErrorBoundary>
+            <ErrorBoundary
+              key={`${resetKey}-session-binding`}
+              name="Session Binding"
+              fallback={<CompactErrorFallback name="Session Binding" />}
+            >
+              <SessionBindingCard taskRunId={taskRunId} teamSlugOrId={teamSlugOrId} />
             </ErrorBoundary>
           </div>
         </div>

--- a/packages/convex/convex/providerSessions.ts
+++ b/packages/convex/convex/providerSessions.ts
@@ -232,6 +232,93 @@ export const getByTaskRun = authQuery({
 });
 
 /**
+ * Resume ancestry summary for UI display.
+ * Returns session binding info with ancestry context:
+ * - Whether this run has a bound provider session
+ * - Whether it's a resumed session (has prior activity)
+ * - Provider-specific resume identifiers
+ */
+export interface ResumeAncestry {
+  /** Whether a session binding exists */
+  hasBoundSession: boolean;
+  /** Provider name (claude, codex, etc.) */
+  provider: string | null;
+  /** Agent mode (head, worker, reviewer) */
+  mode: string | null;
+  /** Provider-specific session ID (Claude) */
+  providerSessionId: string | null;
+  /** Provider-specific thread ID (Codex) */
+  providerThreadId: string | null;
+  /** Session status */
+  status: "active" | "suspended" | "expired" | "terminated" | null;
+  /** When session was created */
+  createdAt: number | null;
+  /** When session was last active */
+  lastActiveAt: number | null;
+  /** Whether this appears to be a resumed session */
+  isResumedSession: boolean;
+  /** Reply channel preference */
+  replyChannel: "mailbox" | "sse" | "pty" | "ui" | null;
+}
+
+export const getResumeAncestry = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    taskRunId: v.id("taskRuns"),
+  },
+  handler: async (ctx, args): Promise<ResumeAncestry> => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    // Get binding for this task run
+    const binding = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task_run", (q) => q.eq("taskRunId", args.taskRunId))
+      .first();
+
+    if (!binding || binding.teamId !== teamId) {
+      return {
+        hasBoundSession: false,
+        provider: null,
+        mode: null,
+        providerSessionId: null,
+        providerThreadId: null,
+        status: null,
+        createdAt: null,
+        lastActiveAt: null,
+        isResumedSession: false,
+        replyChannel: null,
+      };
+    }
+
+    // Check if this is a resumed session by looking at task-level bindings
+    // A session is considered "resumed" if the task had a prior binding before this run
+    const taskBinding = await ctx.db
+      .query("providerSessionBindings")
+      .withIndex("by_task", (q) => q.eq("taskId", binding.taskId))
+      .first();
+
+    const isResumedSession =
+      taskBinding !== null &&
+      taskBinding.createdAt !== null &&
+      binding.createdAt !== null &&
+      taskBinding.createdAt < binding.createdAt;
+
+    return {
+      hasBoundSession: true,
+      provider: binding.provider,
+      mode: binding.mode,
+      providerSessionId: binding.providerSessionId ?? null,
+      providerThreadId: binding.providerThreadId ?? null,
+      status: binding.status,
+      createdAt: binding.createdAt ?? null,
+      lastActiveAt: binding.lastActiveAt ?? null,
+      isResumedSession,
+      replyChannel: binding.replyChannel ?? null,
+    };
+  },
+});
+
+/**
  * Get all session bindings for an orchestration.
  */
 export const getByOrchestration = authQuery({


### PR DESCRIPTION
## Summary
- Add `getResumeAncestry` Convex query returning session binding with ancestry context
- Add `SessionBindingCard` component showing provider session info (session ID, thread ID, status, mode)
- Display "Resumed" badge when session continues from prior run
- Integrate into Activity view under Resource Metrics panel

## Context
This completes item 3 "Resume ancestry" from the [weekly research report 2026-03-24](5️⃣-Projects/GitHub/cmux/research-weekly-2026-03-24.md):
> The missing step is to promote that state into Convex-backed runtime state so resume ancestry, active provider session binding, and run ownership survive beyond local lifecycle files.

## Test plan
- [ ] Navigate to a task run Activity tab
- [ ] Expand "Show Resource & Cost Metrics"
- [ ] Verify Session Binding card appears with provider info
- [ ] For resumed runs, verify "Resumed" badge displays