### PR TITLE
feat(convex): extend activity events for lifecycle parity (Phase 4)

### DIFF
--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -699,8 +699,10 @@ const convexSchema = defineSchema({
   taskRunActivity: defineTable({
     taskRunId: v.id("taskRuns"),
     // Activity type: tool_call, file_edit, file_read, bash_command, test_run, git_commit, error,
-    // session_start, session_stop, context_warning, context_compacted, memory_loaded,
-    // user_prompt, subagent_start, subagent_stop, notification
+    // session_start, session_stop, session_resumed, context_warning, context_compacted,
+    // memory_loaded, memory_scope_changed, user_prompt, subagent_start, subagent_stop,
+    // notification, stop_requested, stop_blocked, stop_failed, tool_requested, tool_completed,
+    // approval_requested, approval_resolved (Phase 4 lifecycle parity)
     type: v.string(),
     toolName: v.optional(v.string()),
     summary: v.string(),
@@ -718,6 +720,18 @@ const convexSchema = defineSchema({
     previousBytes: v.optional(v.number()),
     newBytes: v.optional(v.number()),
     reductionPercent: v.optional(v.number()),
+    // Stop lifecycle fields (Phase 4 - stop_requested/blocked/failed events)
+    stopSource: v.optional(v.string()), // "user", "hook", "autopilot", "policy", "timeout", "error"
+    exitCode: v.optional(v.number()),
+    continuationPrompt: v.optional(v.string()),
+    // Approval fields (Phase 4 - approval_requested/resolved events)
+    approvalId: v.optional(v.string()),
+    resolution: v.optional(v.string()), // "allow", "allow_once", "allow_session", "deny", "deny_always", "timeout"
+    resolvedBy: v.optional(v.string()),
+    // Memory scope fields (Phase 4 - memory_scope_changed events)
+    scopeType: v.optional(v.string()), // "team", "repo", "user", "run"
+    scopeBytes: v.optional(v.number()),
+    scopeAction: v.optional(v.string()), // "injected", "updated", "cleared"
   })
     .index("by_task_run", ["taskRunId", "createdAt"])
     .index("by_team", ["teamId", "createdAt"]),

--- a/packages/convex/convex/taskRunActivity.ts
+++ b/packages/convex/convex/taskRunActivity.ts
@@ -6,6 +6,7 @@ import { internalMutation, query } from "./_generated/server";
  * Inserts a single agent activity event for real-time dashboard streaming.
  *
  * Extended to support canonical lifecycle events (context health, session lifecycle).
+ * Phase 4 adds: stop lifecycle, approval flow, memory scope events.
  */
 export const insert = internalMutation({
   args: {
@@ -26,6 +27,18 @@ export const insert = internalMutation({
     previousBytes: v.optional(v.number()),
     newBytes: v.optional(v.number()),
     reductionPercent: v.optional(v.number()),
+    // Stop lifecycle fields (Phase 4 - stop_requested/blocked/failed events)
+    stopSource: v.optional(v.string()),
+    exitCode: v.optional(v.number()),
+    continuationPrompt: v.optional(v.string()),
+    // Approval fields (Phase 4 - approval_requested/resolved events)
+    approvalId: v.optional(v.string()),
+    resolution: v.optional(v.string()),
+    resolvedBy: v.optional(v.string()),
+    // Memory scope fields (Phase 4 - memory_scope_changed events)
+    scopeType: v.optional(v.string()),
+    scopeBytes: v.optional(v.number()),
+    scopeAction: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.db.insert("taskRunActivity", {

--- a/packages/convex/convex/taskRunActivity_http.ts
+++ b/packages/convex/convex/taskRunActivity_http.ts
@@ -8,6 +8,8 @@ import { typedZid } from "@cmux/shared/utils/typed-zid";
 /**
  * Activity event types for dashboard timeline.
  * Extended to include canonical lifecycle events from agent-comm-events.ts.
+ *
+ * Phase 4 additions align with provider-lifecycle-adapter.ts for full parity.
  */
 const ACTIVITY_TYPES = [
   // Tool-use events (original)
@@ -23,11 +25,22 @@ const ACTIVITY_TYPES = [
   "session_start",
   "session_stop",
   "session_resumed",
+  // Stop lifecycle events (Phase 4 - lifecycle parity)
+  "stop_requested",
+  "stop_blocked",
+  "stop_failed",
   // Context health events (Phase 2)
   "context_warning",
   "context_compacted",
-  // Memory events (Phase 2)
+  // Memory events (Phase 2 + Phase 4)
   "memory_loaded",
+  "memory_scope_changed",
+  // Tool lifecycle events (Phase 4 - detailed tool tracking)
+  "tool_requested",
+  "tool_completed",
+  // Approval flow events (Phase 4 - runtime interruptions)
+  "approval_requested",
+  "approval_resolved",
   // Interaction events (Phase 2)
   "user_prompt",
   "subagent_start",
@@ -41,6 +54,9 @@ const ACTIVITY_TYPES = [
  * Base fields (required): taskRunId, type, summary
  * Tool fields (optional): toolName, detail, durationMs
  * Context health fields (optional): severity, warningType, currentUsage, maxCapacity, usagePercent
+ * Stop lifecycle fields (optional): stopSource, exitCode, continuationPrompt
+ * Approval fields (optional): approvalId, resolution, resolvedBy
+ * Memory scope fields (optional): scopeType, scopeBytes, scopeAction
  */
 const ActivityEventSchema = z.object({
   taskRunId: typedZid("taskRuns"),
@@ -61,6 +77,20 @@ const ActivityEventSchema = z.object({
   previousBytes: z.number().nonnegative().optional(),
   newBytes: z.number().nonnegative().optional(),
   reductionPercent: z.number().min(0).max(100).optional(),
+  // Stop lifecycle fields (Phase 4 - stop_requested/blocked/failed events)
+  stopSource: z.enum(["user", "hook", "autopilot", "policy", "timeout", "error"]).optional(),
+  exitCode: z.number().optional(),
+  continuationPrompt: z.string().max(2000).optional(),
+  // Approval fields (Phase 4 - approval_requested/resolved events)
+  approvalId: z.string().max(100).optional(),
+  resolution: z
+    .enum(["allow", "allow_once", "allow_session", "deny", "deny_always", "timeout"])
+    .optional(),
+  resolvedBy: z.string().max(100).optional(),
+  // Memory scope fields (Phase 4 - memory_scope_changed events)
+  scopeType: z.enum(["team", "repo", "user", "run"]).optional(),
+  scopeBytes: z.number().nonnegative().optional(),
+  scopeAction: z.enum(["injected", "updated", "cleared"]).optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Extends the taskRunActivity endpoint to support canonical lifecycle events from `provider-lifecycle-adapter.ts`, achieving lifecycle parity between what providers can emit and what the dashboard can receive.

### New Activity Event Types
- **Stop lifecycle**: `stop_requested`, `stop_blocked`, `stop_failed`
- **Tool lifecycle**: `tool_requested`, `tool_completed` 
- **Approval flow**: `approval_requested`, `approval_resolved`
- **Memory scope**: `memory_scope_changed`

### New Schema Fields
- `stopSource`, `exitCode`, `continuationPrompt` for stop events
- `approvalId`, `resolution`, `resolvedBy` for approval events  
- `scopeType`, `scopeBytes`, `scopeAction` for memory scope events

### Why
This aligns the activity endpoint with the canonical event spine in `agent-comm-events.ts`, enabling:
- Richer dashboard activity streams
- Better control-plane visibility for operators
- Foundation for runtime interruption and resume tracking

Part of the lifecycle parity work from [[cmux-agent-runtime-recommendation-2026-03-24]].

## Test plan
- [x] `bun check` passes
- [ ] Existing activity stream functionality unaffected (backwards compatible - all new fields optional)
- [ ] New event types can be posted via HTTP endpoint