### PR TITLE
feat(convex): P2 runtime interruptions generalization

### DIFF
--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -117,6 +117,7 @@ import type * as pveLxcInstances from "../pveLxcInstances.js";
 import type * as pve_lxc_actions from "../pve_lxc_actions.js";
 import type * as resultAggregation from "../resultAggregation.js";
 import type * as resume_tasks from "../resume_tasks.js";
+import type * as runtimeInterruptions_http from "../runtimeInterruptions_http.js";
 import type * as sandboxInstanceMaintenance from "../sandboxInstanceMaintenance.js";
 import type * as sandboxInstances from "../sandboxInstances.js";
 import type * as scheduledTasks from "../scheduledTasks.js";
@@ -271,6 +272,7 @@ declare const fullApi: ApiFromModules<{
   pve_lxc_actions: typeof pve_lxc_actions;
   resultAggregation: typeof resultAggregation;
   resume_tasks: typeof resume_tasks;
+  runtimeInterruptions_http: typeof runtimeInterruptions_http;
   sandboxInstanceMaintenance: typeof sandboxInstanceMaintenance;
   sandboxInstances: typeof sandboxInstances;
   scheduledTasks: typeof scheduledTasks;

--- a/packages/convex/convex/http.ts
+++ b/packages/convex/convex/http.ts
@@ -98,6 +98,11 @@ import {
   getApproval,
   resolveApproval,
 } from "./approvalBroker_http";
+import {
+  reportInterruption,
+  resolveInterruption,
+  getInterruptionState,
+} from "./runtimeInterruptions_http";
 
 const http = httpRouter();
 
@@ -592,6 +597,25 @@ http.route({
   pathPrefix: "/api/approvals/",
   method: "POST",
   handler: resolveApproval,
+});
+
+// P2: Runtime interruptions API
+http.route({
+  path: "/api/runtime/interrupt",
+  method: "POST",
+  handler: reportInterruption,
+});
+
+http.route({
+  path: "/api/runtime/resume",
+  method: "POST",
+  handler: resolveInterruption,
+});
+
+http.route({
+  path: "/api/runtime/interruption-state",
+  method: "GET",
+  handler: getInterruptionState,
 });
 
 export default http;

--- a/packages/convex/convex/runtimeInterruptions_http.ts
+++ b/packages/convex/convex/runtimeInterruptions_http.ts
@@ -1,0 +1,254 @@
+/**
+ * Runtime Interruptions HTTP API
+ *
+ * P2: Generalized runtime interruptions for agents to report pause, checkpoint,
+ * handoff, and other blocking states with provider session binding and
+ * checkpoint references for replay-safe resume.
+ *
+ * This extends the approval model to support:
+ * - Typed interruption categories (not just approvals)
+ * - Provider session binding (Codex thread_id, Claude session, etc.)
+ * - Checkpoint references for LangGraph-style durable execution
+ * - Resume ancestry tracking
+ */
+
+import { z } from "zod";
+import { jsonResponse } from "../_shared/http-utils";
+import { internal } from "./_generated/api";
+import { httpAction } from "./_generated/server";
+import { getWorkerAuth } from "./users/utils/getWorkerAuth";
+import { typedZid } from "@cmux/shared/utils/typed-zid";
+
+/**
+ * Interruption types for the generalized runtime model.
+ */
+const INTERRUPTION_TYPES = [
+  "approval_pending",
+  "paused_by_operator",
+  "sandbox_paused",
+  "context_overflow",
+  "rate_limited",
+  "timed_out",
+  // P2: Extended types
+  "checkpoint_pending",
+  "handoff_pending",
+  "user_input_required",
+] as const;
+
+/**
+ * Schema for reporting a runtime interruption.
+ */
+const ReportInterruptionSchema = z.object({
+  taskRunId: typedZid("taskRuns"),
+  status: z.enum(INTERRUPTION_TYPES),
+  reason: z.string().max(1000).optional(),
+  // Expiry for auto-resume or timeout
+  expiresInMs: z.number().positive().optional(),
+  // Provider-specific resume token
+  resumeToken: z.string().max(10_000).optional(),
+  // P2: Provider session binding
+  providerSessionId: z.string().max(500).optional(),
+  resumeTargetId: z.string().max(500).optional(),
+  // P2: Checkpoint reference
+  checkpointRef: z.string().max(2000).optional(),
+  checkpointGeneration: z.number().nonnegative().optional(),
+  // Link to approval request if this is approval-based
+  approvalRequestId: z.string().max(100).optional(),
+});
+
+/**
+ * Schema for resolving (resuming from) an interruption.
+ */
+const ResolveInterruptionSchema = z.object({
+  taskRunId: typedZid("taskRuns"),
+  resolvedBy: z.string().max(200).optional(),
+});
+
+/**
+ * POST /api/runtime/interrupt
+ *
+ * Report a runtime interruption. Called by agents when they enter a blocking
+ * state that requires operator action or external resolution.
+ */
+export const reportInterruption = httpAction(async (ctx, req) => {
+  const auth = await getWorkerAuth(req, {
+    loggerPrefix: "[runtimeInterruptions]",
+  });
+  if (!auth) {
+    return jsonResponse({ code: 401, message: "Unauthorized" }, 401);
+  }
+
+  const contentType = req.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return jsonResponse(
+      { code: 415, message: "Content-Type must be application/json" },
+      415
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ code: 400, message: "Invalid JSON body" }, 400);
+  }
+
+  const parsed = ReportInterruptionSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonResponse(
+      { code: 400, message: "Validation failed", details: parsed.error.flatten() },
+      400
+    );
+  }
+
+  const { taskRunId, status, reason, expiresInMs, ...rest } = parsed.data;
+
+  // Verify the caller owns this task run
+  if (auth.payload.taskRunId !== taskRunId) {
+    return jsonResponse({ code: 403, message: "Forbidden" }, 403);
+  }
+
+  try {
+    await ctx.runMutation(internal.taskRuns.setInterruptionState, {
+      taskRunId,
+      status,
+      reason,
+      expiresAt: expiresInMs ? Date.now() + expiresInMs : undefined,
+      resumeToken: rest.resumeToken,
+      providerSessionId: rest.providerSessionId,
+      resumeTargetId: rest.resumeTargetId,
+      checkpointRef: rest.checkpointRef,
+      checkpointGeneration: rest.checkpointGeneration,
+      approvalRequestId: rest.approvalRequestId,
+    });
+
+    return jsonResponse({
+      ok: true,
+      taskRunId,
+      status,
+      message: `Interruption reported: ${status}`,
+    });
+  } catch (error) {
+    console.error("[runtimeInterruptions] Failed to report interruption:", error);
+    return jsonResponse(
+      { code: 500, message: "Failed to report interruption" },
+      500
+    );
+  }
+});
+
+/**
+ * POST /api/runtime/resume
+ *
+ * Resolve a runtime interruption. Called when an operator or system
+ * action clears the blocking state.
+ */
+export const resolveInterruption = httpAction(async (ctx, req) => {
+  const auth = await getWorkerAuth(req, {
+    loggerPrefix: "[runtimeInterruptions]",
+  });
+  if (!auth) {
+    return jsonResponse({ code: 401, message: "Unauthorized" }, 401);
+  }
+
+  const contentType = req.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return jsonResponse(
+      { code: 415, message: "Content-Type must be application/json" },
+      415
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ code: 400, message: "Invalid JSON body" }, 400);
+  }
+
+  const parsed = ResolveInterruptionSchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonResponse(
+      { code: 400, message: "Validation failed", details: parsed.error.flatten() },
+      400
+    );
+  }
+
+  const { taskRunId, resolvedBy } = parsed.data;
+
+  // Verify the caller owns this task run
+  if (auth.payload.taskRunId !== taskRunId) {
+    return jsonResponse({ code: 403, message: "Forbidden" }, 403);
+  }
+
+  try {
+    await ctx.runMutation(internal.taskRuns.resolveInterruption, {
+      taskRunId,
+      resolvedBy,
+    });
+
+    return jsonResponse({
+      ok: true,
+      taskRunId,
+      message: "Interruption resolved",
+    });
+  } catch (error) {
+    console.error("[runtimeInterruptions] Failed to resolve interruption:", error);
+    return jsonResponse(
+      { code: 500, message: "Failed to resolve interruption" },
+      500
+    );
+  }
+});
+
+/**
+ * GET /api/runtime/interruption-state?taskRunId=...
+ *
+ * Query the current interruption state for a task run.
+ * Useful for agents to check if they should resume or wait.
+ */
+export const getInterruptionState = httpAction(async (ctx, req) => {
+  const auth = await getWorkerAuth(req, {
+    loggerPrefix: "[runtimeInterruptions]",
+  });
+  if (!auth) {
+    return jsonResponse({ code: 401, message: "Unauthorized" }, 401);
+  }
+
+  const url = new URL(req.url);
+  const taskRunIdRaw = url.searchParams.get("taskRunId");
+
+  if (!taskRunIdRaw) {
+    return jsonResponse(
+      { code: 400, message: "Missing taskRunId query parameter" },
+      400
+    );
+  }
+
+  const taskRunId = typedZid("taskRuns").safeParse(taskRunIdRaw);
+  if (!taskRunId.success) {
+    return jsonResponse(
+      { code: 400, message: "Invalid taskRunId format" },
+      400
+    );
+  }
+
+  // Verify the caller owns this task run
+  if (auth.payload.taskRunId !== taskRunId.data) {
+    return jsonResponse({ code: 403, message: "Forbidden" }, 403);
+  }
+
+  try {
+    const state = await ctx.runQuery(internal.taskRuns.isInterrupted, {
+      taskRunId: taskRunId.data,
+    });
+
+    return jsonResponse(state);
+  } catch (error) {
+    console.error("[runtimeInterruptions] Failed to get interruption state:", error);
+    return jsonResponse(
+      { code: 500, message: "Failed to get interruption state" },
+      500
+    );
+  }
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -406,9 +406,9 @@ const convexSchema = defineSchema({
         lastUpdated: v.number(), // Timestamp of last update
       })
     ),
-    // Interruption state (Phase 7: Unified pause/approval model)
+    // Interruption state (Phase 7: Unified pause/approval model, P2: Runtime interruptions)
     // Tracks when an agent is blocked and why, enabling unified handling of
-    // approvals, operator pauses, and sandbox pauses across all providers
+    // approvals, operator pauses, sandbox pauses, and checkpoint-based resume
     interruptionState: v.optional(
       v.object({
         status: v.union(
@@ -418,7 +418,11 @@ const convexSchema = defineSchema({
           v.literal("sandbox_paused"), // Underlying sandbox is paused
           v.literal("context_overflow"), // Context window exceeded
           v.literal("rate_limited"), // Provider rate limit hit
-          v.literal("timed_out") // Approval or action timed out
+          v.literal("timed_out"), // Approval or action timed out
+          // P2: Extended interruption types for generalized runtime model
+          v.literal("checkpoint_pending"), // Waiting for checkpoint save to complete
+          v.literal("handoff_pending"), // Waiting for handoff to another agent
+          v.literal("user_input_required") // Waiting for user elicitation response
         ),
         reason: v.optional(v.string()), // Human-readable explanation
         approvalRequestId: v.optional(v.string()), // Link to approvalRequests.requestId
@@ -427,6 +431,12 @@ const convexSchema = defineSchema({
         resumeToken: v.optional(v.string()), // Provider-specific resume state
         resolvedAt: v.optional(v.number()), // When interruption was resolved
         resolvedBy: v.optional(v.string()), // User ID who resolved
+        // P2: Provider session binding for resume ancestry
+        providerSessionId: v.optional(v.string()), // Provider's session/thread ID (e.g., Codex thread_id)
+        resumeTargetId: v.optional(v.string()), // Target for SendMessage resume (agent or session ID)
+        // P2: Checkpoint reference for replay-safe resume
+        checkpointRef: v.optional(v.string()), // Reference to checkpoint state (LangGraph-style)
+        checkpointGeneration: v.optional(v.number()), // Monotonic counter for checkpoint ordering
       })
     ),
   })

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -910,7 +910,7 @@ export const updateStatus = internalMutation({
   },
 });
 
-// Interruption state validator - matches schema definition
+// Interruption state validator - matches schema definition (P2: Runtime interruptions)
 const interruptionStatusValidator = v.union(
   v.literal("none"),
   v.literal("approval_pending"),
@@ -918,12 +918,19 @@ const interruptionStatusValidator = v.union(
   v.literal("sandbox_paused"),
   v.literal("context_overflow"),
   v.literal("rate_limited"),
-  v.literal("timed_out")
+  v.literal("timed_out"),
+  // P2: Extended interruption types for generalized runtime model
+  v.literal("checkpoint_pending"),
+  v.literal("handoff_pending"),
+  v.literal("user_input_required")
 );
 
 /**
  * Set interruption state on a task run.
- * Used when an agent is blocked (approval needed, sandbox paused, etc.)
+ * Used when an agent is blocked (approval needed, sandbox paused, checkpoint, handoff, etc.)
+ *
+ * P2: Extended to support provider session binding and checkpoint references for
+ * replay-safe resume and explicit resume ancestry.
  */
 export const setInterruptionState = internalMutation({
   args: {
@@ -933,6 +940,12 @@ export const setInterruptionState = internalMutation({
     approvalRequestId: v.optional(v.string()),
     expiresAt: v.optional(v.number()),
     resumeToken: v.optional(v.string()),
+    // P2: Provider session binding for resume ancestry
+    providerSessionId: v.optional(v.string()),
+    resumeTargetId: v.optional(v.string()),
+    // P2: Checkpoint reference for replay-safe resume
+    checkpointRef: v.optional(v.string()),
+    checkpointGeneration: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const run = await ctx.db.get(args.taskRunId);
@@ -941,15 +954,25 @@ export const setInterruptionState = internalMutation({
     }
 
     const now = Date.now();
+
+    // Build interruption state with P2 fields
+    const interruptionState: NonNullable<typeof run.interruptionState> = {
+      status: args.status,
+      reason: args.reason,
+      approvalRequestId: args.approvalRequestId,
+      blockedAt: now,
+      expiresAt: args.expiresAt,
+      resumeToken: args.resumeToken,
+      // P2: Include provider session binding if provided
+      providerSessionId: args.providerSessionId,
+      resumeTargetId: args.resumeTargetId,
+      // P2: Include checkpoint reference if provided
+      checkpointRef: args.checkpointRef,
+      checkpointGeneration: args.checkpointGeneration,
+    };
+
     await ctx.db.patch(args.taskRunId, {
-      interruptionState: {
-        status: args.status,
-        reason: args.reason,
-        approvalRequestId: args.approvalRequestId,
-        blockedAt: now,
-        expiresAt: args.expiresAt,
-        resumeToken: args.resumeToken,
-      },
+      interruptionState,
       updatedAt: now,
     });
 
@@ -1018,7 +1041,7 @@ export const resolveInterruption = internalMutation({
 });
 
 /**
- * Query to check if a task run is currently interrupted.
+ * Query to check if a task run is currently interrupted (internal).
  */
 export const isInterrupted = internalQuery({
   args: {
@@ -1042,9 +1065,96 @@ export const isInterrupted = internalQuery({
       blockedAt: state.blockedAt,
       expiresAt: state.expiresAt,
       approvalRequestId: state.approvalRequestId,
+      // P2: Include provider session and checkpoint info
+      providerSessionId: state.providerSessionId,
+      resumeTargetId: state.resumeTargetId,
+      checkpointRef: state.checkpointRef,
+      checkpointGeneration: state.checkpointGeneration,
     };
   },
 });
+
+/**
+ * P2: Public query to get full interruption state for UI visibility.
+ * Returns the complete interruption state including provider session binding
+ * and checkpoint references for operator-facing dashboards.
+ */
+export const getInterruptionState = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    taskRunId: v.id("taskRuns"),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+
+    const run = await ctx.db.get(args.taskRunId);
+    if (!run || run.teamId !== teamId) {
+      return null;
+    }
+
+    const state = run.interruptionState;
+    if (!state || state.status === "none") {
+      return {
+        interrupted: false,
+        status: "none" as const,
+        taskRunId: args.taskRunId,
+        agentName: run.agentName,
+      };
+    }
+
+    return {
+      interrupted: true,
+      taskRunId: args.taskRunId,
+      agentName: run.agentName,
+      // Core interruption fields
+      status: state.status,
+      reason: state.reason,
+      blockedAt: state.blockedAt,
+      expiresAt: state.expiresAt,
+      resolvedAt: state.resolvedAt,
+      resolvedBy: state.resolvedBy,
+      // Approval link
+      approvalRequestId: state.approvalRequestId,
+      // P2: Provider session binding
+      providerSessionId: state.providerSessionId,
+      resumeTargetId: state.resumeTargetId,
+      resumeToken: state.resumeToken,
+      // P2: Checkpoint reference
+      checkpointRef: state.checkpointRef,
+      checkpointGeneration: state.checkpointGeneration,
+      // Computed: is resumable?
+      canResume: canResumeFromInterruption(state),
+    };
+  },
+});
+
+/**
+ * P2: Determine if an interruption can be resumed.
+ * Used by UI to show/hide resume buttons appropriately.
+ */
+function canResumeFromInterruption(state: {
+  status: string;
+  resumeToken?: string;
+  providerSessionId?: string;
+  checkpointRef?: string;
+}): boolean {
+  // Cannot resume if already resolved
+  if (state.status === "none") return false;
+
+  // Approval-based interruptions require resolution through approval flow
+  if (state.status === "approval_pending") return false;
+
+  // Checkpoint-based resume requires a checkpoint reference
+  if (state.status === "checkpoint_pending") {
+    return !!state.checkpointRef;
+  }
+
+  // Handoff requires a target
+  if (state.status === "handoff_pending") return false;
+
+  // Other interruptions can be resumed if we have session or token
+  return !!(state.resumeToken || state.providerSessionId);
+}
 
 export const getRunDiffContext = authQuery({
   args: {

--- a/packages/shared/src/provider-lifecycle-adapter.ts
+++ b/packages/shared/src/provider-lifecycle-adapter.ts
@@ -853,3 +853,138 @@ export function buildExtendedLifecycleHooks(
 
   return result;
 }
+
+// =============================================================================
+// P2: Runtime Interruption Payload Builders
+// =============================================================================
+
+/**
+ * P2: Interruption status types for the generalized runtime model.
+ */
+export type InterruptionStatusType =
+  | "none"
+  | "approval_pending"
+  | "paused_by_operator"
+  | "sandbox_paused"
+  | "context_overflow"
+  | "rate_limited"
+  | "timed_out"
+  | "checkpoint_pending"
+  | "handoff_pending"
+  | "user_input_required";
+
+/**
+ * P2: Payload for reporting a runtime interruption.
+ */
+export interface RuntimeInterruptionPayload {
+  taskRunId: string;
+  status: InterruptionStatusType;
+  reason?: string;
+  expiresInMs?: number;
+  resumeToken?: string;
+  // Provider session binding
+  providerSessionId?: string;
+  resumeTargetId?: string;
+  // Checkpoint reference
+  checkpointRef?: string;
+  checkpointGeneration?: number;
+  // Link to approval if applicable
+  approvalRequestId?: string;
+}
+
+/**
+ * P2: Build a runtime interruption payload (TypeScript).
+ * Use when agents need to report blocking states to the control plane.
+ */
+export function buildRuntimeInterruptionPayload(
+  taskRunId: string,
+  status: InterruptionStatusType,
+  options?: {
+    reason?: string;
+    expiresInMs?: number;
+    resumeToken?: string;
+    providerSessionId?: string;
+    resumeTargetId?: string;
+    checkpointRef?: string;
+    checkpointGeneration?: number;
+    approvalRequestId?: string;
+  }
+): RuntimeInterruptionPayload {
+  return {
+    taskRunId,
+    status,
+    reason: options?.reason,
+    expiresInMs: options?.expiresInMs,
+    resumeToken: options?.resumeToken,
+    providerSessionId: options?.providerSessionId,
+    resumeTargetId: options?.resumeTargetId,
+    checkpointRef: options?.checkpointRef,
+    checkpointGeneration: options?.checkpointGeneration,
+    approvalRequestId: options?.approvalRequestId,
+  };
+}
+
+/**
+ * P2: Generate shell curl command for reporting runtime interruptions.
+ */
+export function shellCurlInterruptionPost(
+  status: InterruptionStatusType,
+  options?: {
+    background?: boolean;
+    logFile?: string;
+    reasonExpr?: string;
+  }
+): string {
+  const background = options?.background !== false;
+  const logFile = options?.logFile ?? '"\${LOG_FILE}"';
+  const reasonArg = options?.reasonExpr
+    ? `--arg reason ${options.reasonExpr}`
+    : '--arg reason ""';
+
+  const jqPayload = `'{taskRunId: $trid, status: "${status}", reason: $reason}'`;
+
+  const curlCmd = `curl -s -X POST "\${CMUX_CALLBACK_URL}/api/runtime/interrupt" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "$(jq -n --arg trid "\${CMUX_TASK_RUN_ID:-}" ${reasonArg} ${jqPayload})" \\
+    >> ${logFile} 2>&1 || true`;
+
+  if (background) {
+    return `(
+  ${curlCmd}
+) &`;
+  }
+  return curlCmd;
+}
+
+/**
+ * P2: Build interruption hook script for checkpoint-based pauses.
+ * Called when an agent wants to save a checkpoint and pause.
+ */
+export function buildCheckpointInterruptionHook(
+  ctx: LifecycleAdapterContext,
+  options?: HookScriptOptions
+): string {
+  const preamble = buildHookPreamble(ctx);
+
+  return `${preamble}
+CHECKPOINT_REF="\${1:-}"
+REASON="\${2:-Checkpoint saved}"
+${options?.prolog ?? ""}
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ]; then
+  exit 0
+fi
+# Report checkpoint interruption
+curl -s -X POST "\${CMUX_CALLBACK_URL}/api/runtime/interrupt" \\
+  -H "Content-Type: application/json" \\
+  -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+  -d "$(jq -n \\
+    --arg trid "\${CMUX_TASK_RUN_ID:-}" \\
+    --arg cpref "$CHECKPOINT_REF" \\
+    --arg reason "$REASON" \\
+    '{taskRunId: $trid, status: "checkpoint_pending", reason: $reason, checkpointRef: $cpref}')" \\
+  >> "\${LOG_FILE}" 2>&1 || true
+${options?.epilog ?? ""}
+exit 0
+`;
+}


### PR DESCRIPTION
## Summary

Extends the approval-based interruption model to a generalized runtime interruption system for P2 of the cmux agent runtime recommendation.

- **Extended interruption types**: `checkpoint_pending`, `handoff_pending`, `user_input_required` (in addition to existing approval/pause/timeout types)
- **Provider session binding**: `providerSessionId` and `resumeTargetId` for resume ancestry tracking (e.g., Codex thread_id, Claude session)
- **Checkpoint references**: `checkpointRef` and `checkpointGeneration` for LangGraph-style replay-safe resume
- **HTTP API**: `/api/runtime/interrupt`, `/api/runtime/resume`, `/api/runtime/interruption-state` endpoints for agent reporting
- **Public query**: `getInterruptionState` for UI visibility with `canResume` computed field
- **Shell helpers**: `buildRuntimeInterruptionPayload` and `shellCurlInterruptionPost` for agent hooks

## Context

This implements P2 from the [cmux agent runtime recommendation](5️⃣-Projects/GitHub/cmux/cmux-agent-runtime-recommendation-2026-03-24.md):

> Generalize approvals into runtime interruptions: cmux already has durable approvals. The next step is to turn that into a broader interruption model.

The new fields enable:
- Codex `thread_id` and Claude session binding for explicit resume ancestry
- Checkpoint-based pause/resume following LangGraph patterns
- Handoff coordination between agents
- User elicitation blocking states

## Test plan

- [x] `bun check` passes
- [ ] Deploy to staging and verify schema migration
- [ ] Test `/api/runtime/interrupt` with sample payload
- [ ] Test `getInterruptionState` query from UI