### PR TITLE
fix(git-diff): improve deleted branch error handling and add timeout

### DIFF
--- a/apps/client/src/queries/git-diff.ts
+++ b/apps/client/src/queries/git-diff.ts
@@ -48,7 +48,16 @@ export function gitDiffQueryOptions({
     ],
     queryFn: async () => {
       const socket = await waitForConnectedSocket();
+      const TIMEOUT_MS = 60_000; // 60 second timeout for large repos
       return await new Promise<ReplaceDiffEntry[]>((resolve, reject) => {
+        let didRespond = false;
+        const timeout = setTimeout(() => {
+          if (!didRespond) {
+            didRespond = true;
+            reject(new Error("Git diff request timed out. The repository may be large or the server is busy."));
+          }
+        }, TIMEOUT_MS);
+
         socket.emit(
           "git-diff",
           {
@@ -65,15 +74,22 @@ export function gitDiffQueryOptions({
           },
           (
             resp:
-              | { ok: true; diffs: ReplaceDiffEntry[] }
-              | { ok: false; error: string; diffs?: [] }
+              | { ok: true; diffs: ReplaceDiffEntry[]; branchDeleted?: boolean }
+              | { ok: false; error: string; diffs?: []; branchDeleted?: boolean }
           ) => {
+            if (didRespond) return;
+            didRespond = true;
+            clearTimeout(timeout);
+
             if (resp.ok) {
               resolve(resp.diffs);
             } else {
-              reject(
-                new Error(resp.error || "Failed to load repository diffs")
-              );
+              // Provide more specific error messages
+              let errorMessage = resp.error || "Failed to load repository diffs";
+              if (resp.branchDeleted) {
+                errorMessage = `Branch '${canonicalHeadRef}' was not found. It may have been deleted after the PR was merged.`;
+              }
+              reject(new Error(errorMessage));
             }
           }
         );

--- a/apps/server/native/core/src/diff/refs.rs
+++ b/apps/server/native/core/src/diff/refs.rs
@@ -272,7 +272,10 @@ pub fn diff_refs(opts: GitDiffOptions) -> Result<Vec<DiffEntry>> {
                             _d_head.as_millis(),
                             cwd,
                         );
-                        return Ok(Vec::new());
+                        return Err(anyhow::anyhow!(
+                            "Branch '{}' not found. It may have been deleted after the PR was merged.",
+                            head_ref
+                        ));
                     }
                 } else {
                     let _d_head = t_head.elapsed();
@@ -283,7 +286,10 @@ pub fn diff_refs(opts: GitDiffOptions) -> Result<Vec<DiffEntry>> {
                         _d_head.as_millis(),
                         cwd,
                     );
-                    return Ok(Vec::new());
+                    return Err(anyhow::anyhow!(
+                        "Branch '{}' not found. It may have been deleted after the PR was merged.",
+                        head_ref
+                    ));
                 }
             } else {
                 let _d_head = t_head.elapsed();
@@ -294,7 +300,10 @@ pub fn diff_refs(opts: GitDiffOptions) -> Result<Vec<DiffEntry>> {
                     _d_head.as_millis(),
                     cwd,
                 );
-                return Ok(Vec::new());
+                return Err(anyhow::anyhow!(
+                    "Branch '{}' not found. It may have been deleted after the PR was merged.",
+                    head_ref
+                ));
             }
         }
     };


### PR DESCRIPTION
## Summary
- Native Rust (`refs.rs`): Return error instead of empty `Vec::new()` when branch not found after fetch attempts
- Client (`git-diff.ts`): Add 60-second timeout to prevent indefinite socket hang
- Client: Better error messages for deleted branch scenarios (shows "Branch 'X' not found. It may have been deleted after the PR was merged.")

## Test plan
- [ ] Verify git diff panel shows meaningful error for merged PRs with deleted branches
- [ ] Verify large repo diffs timeout gracefully after 60s instead of hanging
- [ ] Verify normal diff operations still work correctly

## Notes
Native module requires rebuild with `cargo build --release` for production deployment.