### PR TITLE
feat(events): add P1/P5 lifecycle event types for schema convergence

### DIFF
--- a/packages/convex/convex/orchestrationEvents.ts
+++ b/packages/convex/convex/orchestrationEvents.ts
@@ -46,7 +46,13 @@ const eventTypeValidator = v.union(
   v.literal("memory_pruned"), // Legacy alias for memory_updated with action=archive
   // Context health events (Phase 4)
   v.literal("context_warning"),
-  v.literal("context_compacted")
+  v.literal("context_compacted"),
+  // Prompt/Turn tracking events (P1 Lifecycle Parity)
+  v.literal("prompt_submitted"),
+  v.literal("session_finished"),
+  v.literal("run_resumed"),
+  // MCP runtime events (P5 Lifecycle Parity)
+  v.literal("mcp_capabilities_negotiated")
 );
 
 // =============================================================================

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -2087,7 +2087,13 @@ const convexSchema = defineSchema({
       // Operator input queue events
       v.literal("operator_input_queued"),
       v.literal("operator_input_drained"),
-      v.literal("queue_full_rejected")
+      v.literal("queue_full_rejected"),
+      // Prompt/Turn tracking events (P1 Lifecycle Parity)
+      v.literal("prompt_submitted"),
+      v.literal("session_finished"),
+      v.literal("run_resumed"),
+      // MCP runtime events (P5 Lifecycle Parity)
+      v.literal("mcp_capabilities_negotiated")
     ),
     teamId: v.string(),
     taskId: v.optional(v.string()), // Related orchestration task ID

--- a/packages/convex/convex/taskRunActivity_http.ts
+++ b/packages/convex/convex/taskRunActivity_http.ts
@@ -25,6 +25,7 @@ const ACTIVITY_TYPES = [
   "session_start",
   "session_stop",
   "session_resumed",
+  "session_finished", // P1: Clean session exit (distinct from error)
   // Stop lifecycle events (Phase 4 - lifecycle parity)
   "stop_requested",
   "stop_blocked",
@@ -46,6 +47,11 @@ const ACTIVITY_TYPES = [
   "subagent_start",
   "subagent_stop",
   "notification",
+  // Prompt/Turn tracking events (P1 Lifecycle Parity)
+  "prompt_submitted", // P1: Track prompts/turns submitted to agent
+  "run_resumed", // P1: Resume from checkpoint/session
+  // MCP runtime events (P5 Lifecycle Parity)
+  "mcp_capabilities_negotiated", // P5: MCP server capability negotiation
 ] as const;
 
 /**
@@ -91,6 +97,33 @@ const ActivityEventSchema = z.object({
   scopeType: z.enum(["team", "repo", "user", "run"]).optional(),
   scopeBytes: z.number().nonnegative().optional(),
   scopeAction: z.enum(["injected", "updated", "cleared"]).optional(),
+  // Prompt/Turn tracking fields (P1 Lifecycle Parity - prompt_submitted/session_finished/run_resumed)
+  promptSource: z.enum(["user", "operator", "hook", "queue", "handoff"]).optional(),
+  turnNumber: z.number().nonnegative().optional(),
+  promptLength: z.number().nonnegative().optional(),
+  turnCount: z.number().nonnegative().optional(),
+  providerSessionId: z.string().max(200).optional(),
+  // Resume fields (P1 - run_resumed events)
+  resumeReason: z.enum(["checkpoint", "reconnect", "handoff", "retry", "manual"]).optional(),
+  previousTaskRunId: z.string().max(100).optional(),
+  previousSessionId: z.string().max(200).optional(),
+  checkpointRef: z.string().max(200).optional(),
+  // MCP runtime fields (P5 Lifecycle Parity - mcp_capabilities_negotiated)
+  serverName: z.string().max(100).optional(),
+  serverId: z.string().max(100).optional(),
+  protocolVersion: z.string().max(20).optional(),
+  transport: z.enum(["stdio", "http", "sse", "websocket"]).optional(),
+  mcpCapabilities: z.object({
+    tools: z.boolean().optional(),
+    resources: z.boolean().optional(),
+    prompts: z.boolean().optional(),
+    tasks: z.boolean().optional(),
+    logging: z.boolean().optional(),
+    completions: z.boolean().optional(),
+  }).optional(),
+  toolCount: z.number().nonnegative().optional(),
+  resourceCount: z.number().nonnegative().optional(),
+  mcpSessionId: z.string().max(200).optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Add P1 lifecycle events (`prompt_submitted`, `session_finished`, `run_resumed`) and P5 event (`mcp_capabilities_negotiated`) to activity endpoint schema
- Add matching event types to orchestrationEvents validator for consistent persistence
- Add P1/P5 event literals to schema.ts orchestrationEvents table definition

This enables lifecycle parity between the provider-lifecycle-adapter payloads (merged in #862) and the Convex storage layer.

## Test plan

- [x] `bun check` passes
- [ ] Verify activity events with new types can be posted via HTTP endpoint
- [ ] Verify orchestration events with new types can be logged via mutations