### PR TITLE
feat(dashboard): add orchestration event analytics

### DIFF
--- a/apps/client/src/components/orchestration/OrchestrationDashboard.tsx
+++ b/apps/client/src/components/orchestration/OrchestrationDashboard.tsx
@@ -6,6 +6,7 @@ import { OrchestrationTaskList } from "./OrchestrationTaskList";
 import { OrchestrationSpawnDialog } from "./OrchestrationSpawnDialog";
 import { OrchestrationDependencyGraph } from "./OrchestrationDependencyGraph";
 import { OrchestrationEventStream } from "./OrchestrationEventStream";
+import { OrchestrationEventAnalytics } from "./OrchestrationEventAnalytics";
 import { ProjectKanbanView } from "../projects/ProjectKanbanView";
 import { STATUS_CONFIG, type TaskStatus } from "./status-config";
 import type { Doc, Id } from "@cmux/convex/dataModel";
@@ -43,6 +44,18 @@ interface OrchestrationSummary {
   }>;
 }
 
+interface EventAnalytics {
+  totalEvents: number;
+  countsByType: Record<string, number>;
+  categories: {
+    taskLifecycle: number;
+    sessionLifecycle: number;
+    approvals: number;
+    contextHealth: number;
+  };
+  sinceTimestamp: number;
+}
+
 interface OrchestrationDashboardProps {
   teamSlugOrId: string;
   summary?: OrchestrationSummary;
@@ -51,6 +64,8 @@ interface OrchestrationDashboardProps {
   tasksLoading: boolean;
   statusFilter: string;
   orchestrationId?: string;
+  eventAnalytics?: EventAnalytics;
+  eventAnalyticsLoading?: boolean;
 }
 
 export function OrchestrationDashboard({
@@ -61,6 +76,8 @@ export function OrchestrationDashboard({
   tasksLoading,
   statusFilter,
   orchestrationId,
+  eventAnalytics,
+  eventAnalyticsLoading,
 }: OrchestrationDashboardProps) {
   const navigate = useNavigate();
   const [spawnDialogOpen, setSpawnDialogOpen] = useState(false);
@@ -180,6 +197,12 @@ export function OrchestrationDashboard({
             loading={summaryLoading}
             onFilterChange={handleStatusFilterChange}
             activeFilter={statusFilter}
+          />
+
+          {/* Event Analytics */}
+          <OrchestrationEventAnalytics
+            analytics={eventAnalytics}
+            loading={eventAnalyticsLoading ?? false}
           />
 
           {/* Event Stream (when orchestrationId provided) */}

--- a/apps/client/src/components/orchestration/OrchestrationEventAnalytics.tsx
+++ b/apps/client/src/components/orchestration/OrchestrationEventAnalytics.tsx
@@ -1,0 +1,127 @@
+import { Activity, Zap, ShieldCheck, AlertTriangle } from "lucide-react";
+import clsx from "clsx";
+
+interface EventAnalytics {
+  totalEvents: number;
+  countsByType: Record<string, number>;
+  categories: {
+    taskLifecycle: number;
+    sessionLifecycle: number;
+    approvals: number;
+    contextHealth: number;
+  };
+  sinceTimestamp: number;
+}
+
+interface OrchestrationEventAnalyticsProps {
+  analytics?: EventAnalytics;
+  loading: boolean;
+}
+
+const CATEGORY_CARDS = [
+  {
+    key: "taskLifecycle",
+    label: "Task Events",
+    icon: Zap,
+    color: "text-blue-500",
+    bgColor: "bg-blue-50 dark:bg-blue-900/20",
+  },
+  {
+    key: "sessionLifecycle",
+    label: "Session Events",
+    icon: Activity,
+    color: "text-purple-500",
+    bgColor: "bg-purple-50 dark:bg-purple-900/20",
+  },
+  {
+    key: "approvals",
+    label: "Approvals",
+    icon: ShieldCheck,
+    color: "text-amber-500",
+    bgColor: "bg-amber-50 dark:bg-amber-900/20",
+  },
+  {
+    key: "contextHealth",
+    label: "Context Health",
+    icon: AlertTriangle,
+    color: "text-red-500",
+    bgColor: "bg-red-50 dark:bg-red-900/20",
+  },
+] as const;
+
+export function OrchestrationEventAnalytics({
+  analytics,
+  loading,
+}: OrchestrationEventAnalyticsProps) {
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="mb-3 h-5 w-32 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700" />
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {CATEGORY_CARDS.map((card) => (
+            <div
+              key={card.key}
+              className="animate-pulse rounded-md bg-neutral-100 p-3 dark:bg-neutral-800"
+            >
+              <div className="mb-2 h-4 w-16 rounded bg-neutral-200 dark:bg-neutral-700" />
+              <div className="h-6 w-10 rounded bg-neutral-200 dark:bg-neutral-700" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!analytics) {
+    return null;
+  }
+
+  const timeRangeLabel = getTimeRangeLabel(analytics.sinceTimestamp);
+
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+          Event Analytics
+        </h3>
+        <span className="text-xs text-neutral-500 dark:text-neutral-400">
+          {timeRangeLabel} · {analytics.totalEvents} total
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {CATEGORY_CARDS.map((card) => {
+          const count =
+            analytics.categories[
+              card.key as keyof typeof analytics.categories
+            ] ?? 0;
+          const Icon = card.icon;
+
+          return (
+            <div
+              key={card.key}
+              className={clsx("rounded-md p-3", card.bgColor)}
+            >
+              <div className="flex items-center gap-1.5">
+                <Icon className={clsx("size-3.5", card.color)} />
+                <span className="text-xs font-medium text-neutral-600 dark:text-neutral-400">
+                  {card.label}
+                </span>
+              </div>
+              <div className="mt-1 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                {count}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function getTimeRangeLabel(sinceTimestamp: number): string {
+  const hours = Math.round((Date.now() - sinceTimestamp) / (1000 * 60 * 60));
+  if (hours <= 1) return "Last hour";
+  if (hours <= 24) return `Last ${hours}h`;
+  const days = Math.round(hours / 24);
+  return `Last ${days}d`;
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.orchestration.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.orchestration.tsx
@@ -34,6 +34,13 @@ function OrchestrationPage() {
     })
   );
 
+  // Fetch event analytics (last 24 hours)
+  const { data: eventAnalytics, isLoading: eventAnalyticsLoading } = useQuery(
+    convexQuery(api.orchestrationEvents.getEventAnalytics, {
+      teamSlugOrId,
+    })
+  );
+
   return (
     <FloatingPane header={<TitleBar title="Orchestration" />}>
       <OrchestrationDashboard
@@ -43,6 +50,8 @@ function OrchestrationPage() {
         tasks={tasks}
         tasksLoading={tasksLoading}
         statusFilter={status ?? "all"}
+        eventAnalytics={eventAnalytics}
+        eventAnalyticsLoading={eventAnalyticsLoading}
       />
     </FloatingPane>
   );

--- a/packages/convex/convex/orchestrationEvents.ts
+++ b/packages/convex/convex/orchestrationEvents.ts
@@ -308,6 +308,70 @@ export const getByOrchestrationInternal = internalQuery({
 });
 
 /**
+ * Get event analytics for a team (authenticated).
+ * Returns counts by event type for dashboard metrics.
+ */
+export const getEventAnalytics = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    sinceTimestamp: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await getTeamId(ctx, args.teamSlugOrId);
+    // Default to last 24 hours if no timestamp provided
+    const since = args.sinceTimestamp ?? Date.now() - 24 * 60 * 60 * 1000;
+
+    const events = await ctx.db
+      .query("orchestrationEvents")
+      .withIndex("by_team", (q) => q.eq("teamId", teamId))
+      .order("desc")
+      .take(1000);
+
+    // Filter by timestamp and count by type
+    const filteredEvents = events.filter((e) => e.createdAt >= since);
+    const countsByType: Record<string, number> = {};
+    for (const event of filteredEvents) {
+      countsByType[event.eventType] = (countsByType[event.eventType] ?? 0) + 1;
+    }
+
+    // Group by category for dashboard display
+    const taskLifecycle =
+      (countsByType["task_spawn_requested"] ?? 0) +
+      (countsByType["task_started"] ?? 0) +
+      (countsByType["task_status_changed"] ?? 0) +
+      (countsByType["task_completed"] ?? 0);
+
+    const sessionLifecycle =
+      (countsByType["session_started"] ?? 0) +
+      (countsByType["session_resumed"] ?? 0) +
+      (countsByType["session_finished"] ?? 0) +
+      (countsByType["session_stop_requested"] ?? 0) +
+      (countsByType["session_stop_blocked"] ?? 0) +
+      (countsByType["session_stop_failed"] ?? 0);
+
+    const approvals =
+      (countsByType["approval_required"] ?? 0) +
+      (countsByType["approval_resolved"] ?? 0);
+
+    const contextHealth =
+      (countsByType["context_warning"] ?? 0) +
+      (countsByType["context_compacted"] ?? 0);
+
+    return {
+      totalEvents: filteredEvents.length,
+      countsByType,
+      categories: {
+        taskLifecycle,
+        sessionLifecycle,
+        approvals,
+        contextHealth,
+      },
+      sinceTimestamp: since,
+    };
+  },
+});
+
+/**
  * Check if an event already exists (for deduplication).
  */
 export const eventExists = internalQuery({


### PR DESCRIPTION
## Summary

- Add `getEventAnalytics` query to count events by type and category
- Add `OrchestrationEventAnalytics` component showing metrics for:
  - Task lifecycle events (spawn, start, complete)
  - Session lifecycle events (start, resume, finish, stop)
  - Approval events (required, resolved)
  - Context health events (warning, compacted)
- Display analytics on orchestration dashboard below summary cards

This implements the "Event Analytics" item from the orchestration roadmap notes.

## Test plan

- [x] `bun check` passes
- [ ] View orchestration dashboard shows event analytics section
- [ ] Analytics load with correct counts from last 24 hours