### PR TITLE
fix(convex): persist orchestration ids for heartbeat scans

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -283,6 +283,7 @@ export async function spawnAgent(
             newBranch,
             environmentId: options.environmentId,
             isOrchestrationHead: options.isOrchestrationHead,
+            orchestrationId: options.orchestrationOptions?.orchestrationId,
           }),
         );
       taskRunId = createdTaskRunId;

--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -880,6 +880,7 @@ async function handleOrchestrationSpawn(
           agentName: agent,
           environmentId,
           pullRequestTitle: prTitle,
+          orchestrationId,
         }),
       });
 
@@ -1027,6 +1028,7 @@ async function handleOrchestrationSpawn(
           newBranch: "",
           environmentId: environmentId as Id<"environments"> | undefined,
           isOrchestrationHead,
+          orchestrationId,
         }),
       );
 
@@ -1856,6 +1858,7 @@ Orchestration ID: ${orchestrationId}`;
           newBranch: "",
           environmentId: environmentId as Id<"environments"> | undefined,
           isOrchestrationHead: true,
+          orchestrationId,
         }),
       );
       const taskRunId = taskRunResult.taskRunId;

--- a/apps/server/src/utils/taskRunCreateArgs.test.ts
+++ b/apps/server/src/utils/taskRunCreateArgs.test.ts
@@ -33,6 +33,22 @@ describe("buildTaskRunCreateArgs", () => {
     expect(result.isOrchestrationHead).toBe(false);
   });
 
+  it("preserves orchestrationId when provided", () => {
+    const result = buildTaskRunCreateArgs({
+      teamSlugOrId: "team-1",
+      taskId: "task_123",
+      prompt: "orchestrated run",
+      isOrchestrationHead: true,
+      orchestrationId: "orch_123",
+    });
+
+    expect(result).toMatchObject({
+      taskId: "task_123",
+      isOrchestrationHead: true,
+      orchestrationId: "orch_123",
+    });
+  });
+
   it("omits undefined optional fields", () => {
     const result = buildTaskRunCreateArgs({
       teamSlugOrId: "team-1",

--- a/apps/server/src/utils/taskRunCreateArgs.ts
+++ b/apps/server/src/utils/taskRunCreateArgs.ts
@@ -9,6 +9,7 @@ type TaskRunCreateArgsInput<
   newBranch?: string;
   environmentId?: TEnvironmentId;
   isOrchestrationHead?: boolean;
+  orchestrationId?: string;
 };
 
 export function buildTaskRunCreateArgs<
@@ -34,6 +35,9 @@ export function buildTaskRunCreateArgs<
       : {}),
     ...(args.isOrchestrationHead !== undefined
       ? { isOrchestrationHead: args.isOrchestrationHead }
+      : {}),
+    ...(args.orchestrationId !== undefined
+      ? { orchestrationId: args.orchestrationId }
       : {}),
   };
 }

--- a/packages/convex/convex/orchestration_http.ts
+++ b/packages/convex/convex/orchestration_http.ts
@@ -78,6 +78,7 @@ const CreateTaskAndRunSchema = z.object({
   environmentId: z.string().optional(),
   pullRequestTitle: z.string().optional(),
   isOrchestrationHead: z.boolean().optional(), // Whether this is a head agent for orchestration
+  orchestrationId: z.string().optional(), // Grouping ID for orchestration head agents
 });
 
 type CreateTaskAndRunInput = z.infer<typeof CreateTaskAndRunSchema>;
@@ -172,6 +173,7 @@ export const createTaskAndRun = httpAction(async (ctx, req) => {
         newBranch: payload.newBranch,
         environmentId: payload.environmentId as Id<"environments"> | undefined,
         isOrchestrationHead: payload.isOrchestrationHead,
+        orchestrationId: payload.orchestrationId,
       }
     );
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -454,6 +454,11 @@ const convexSchema = defineSchema({
     .index("by_team_user_status_created", ["teamId", "userId", "status", "createdAt"])
     .index("by_pull_request_url", ["pullRequestUrl"])
     .index("by_orchestration_head_status", ["isOrchestrationHead", "orchestrationStatus"])
+    .index("by_orchestration_head_status_heartbeat", [
+      "isOrchestrationHead",
+      "orchestrationStatus",
+      "orchestrationHeartbeat",
+    ])
     .index("by_team_orchestration_head", ["teamId", "orchestrationId", "isOrchestrationHead"]),
 
   // Junction table linking taskRuns to pull requests by PR identity

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -542,6 +542,7 @@ export const createInternal = internalMutation({
     environmentId: v.optional(v.id("environments")),
     parentRunId: v.optional(v.id("taskRuns")), // Agent Teams (D4) - parent-child relationships
     isOrchestrationHead: v.optional(v.boolean()), // Whether this is a head agent for orchestration
+    orchestrationId: v.optional(v.string()), // Grouping ID for orchestration head agents
     // PR Comment → Agent: link back to source comment for result posting
     githubCommentId: v.optional(v.number()),
     githubCommentUrl: v.optional(v.string()),
@@ -580,6 +581,7 @@ export const createInternal = internalMutation({
       isLocalWorkspace: task.isLocalWorkspace,
       isCloudWorkspace: task.isCloudWorkspace,
       isOrchestrationHead: args.isOrchestrationHead,
+      orchestrationId: args.orchestrationId,
       githubCommentId: args.githubCommentId,
       githubCommentUrl: args.githubCommentUrl,
     });
@@ -631,6 +633,7 @@ export const create = authMutation({
     newBranch: v.optional(v.string()),
     environmentId: v.optional(v.id("environments")),
     isOrchestrationHead: v.optional(v.boolean()),
+    orchestrationId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = ctx.identity.subject;
@@ -668,6 +671,7 @@ export const create = authMutation({
       isLocalWorkspace: task.isLocalWorkspace,
       isCloudWorkspace: task.isCloudWorkspace,
       isOrchestrationHead: args.isOrchestrationHead,
+      orchestrationId: args.orchestrationId,
     });
 
     // Update task's lastActivityAt for sorting
@@ -3543,12 +3547,17 @@ export const checkStaleHeadAgents = internalMutation({
     const now = Date.now();
     const cutoff = now - HEAD_AGENT_HEARTBEAT_TIMEOUT_MS;
 
-    // Find running head agents with stale heartbeats
-    // Uses compound index to avoid full table scan (bandwidth optimization)
+    // Head runs only transition to orchestrationStatus="running" via
+    // updateOrchestrationHeartbeat, which writes orchestrationHeartbeat in the
+    // same mutation. Query the stale slice directly instead of collecting the
+    // entire running-head population each time the cron fires.
     const staleRuns = await ctx.db
       .query("taskRuns")
-      .withIndex("by_orchestration_head_status", (q) =>
-        q.eq("isOrchestrationHead", true).eq("orchestrationStatus", "running")
+      .withIndex("by_orchestration_head_status_heartbeat", (q) =>
+        q
+          .eq("isOrchestrationHead", true)
+          .eq("orchestrationStatus", "running")
+          .lt("orchestrationHeartbeat", cutoff)
       )
       .collect();
 


### PR DESCRIPTION
## Summary
- persist orchestration IDs on head task runs so the indexed `getByOrchestrationId` path can actually resolve live head runs
- add a heartbeat-aware `taskRuns` index and switch stale-head detection to query only the stale slice
- thread the optional orchestration ID through the server-side task-run creation helpers and add focused test coverage

## Testing
- bun run test src/utils/taskRunCreateArgs.test.ts
- pre-commit `bun check` (lint + typecheck)
