### PR TITLE
fix(www): accept task-run JWT on orchestration sync

### DIFF
--- a/apps/www/lib/routes/orchestrate/sync.route.test.ts
+++ b/apps/www/lib/routes/orchestrate/sync.route.test.ts
@@ -1,0 +1,209 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { orchestrateSyncRouter } from "./sync.route";
+
+const {
+  getAccessTokenFromRequest,
+  getConvex,
+  getConvexAdmin,
+  extractTaskRunJwtFromRequest,
+  verifyTaskRunJwt,
+} = vi.hoisted(() => ({
+  getAccessTokenFromRequest: vi.fn(),
+  getConvex: vi.fn(),
+  getConvexAdmin: vi.fn(),
+  extractTaskRunJwtFromRequest: vi.fn(),
+  verifyTaskRunJwt: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/auth", () => ({
+  getAccessTokenFromRequest,
+}));
+
+vi.mock("@/lib/utils/get-convex", () => ({
+  getConvex,
+  getConvexAdmin,
+}));
+
+vi.mock("@/lib/utils/jwt-task-run", () => ({
+  extractTaskRunJwtFromRequest,
+  verifyTaskRunJwt,
+}));
+
+describe("orchestrateSyncRouter POST /sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts verified task-run JWT auth for heartbeat updates", async () => {
+    getAccessTokenFromRequest.mockResolvedValue(null);
+    extractTaskRunJwtFromRequest.mockReturnValue(null);
+    verifyTaskRunJwt.mockResolvedValue({
+      taskRunId: "ns7_task_run_123",
+      teamId: "team_123",
+      userId: "user_123",
+    });
+
+    const adminMutation = vi.fn(async () => ({ ok: true }));
+    const adminQuery = vi.fn(async () => []);
+    getConvexAdmin.mockReturnValue({
+      mutation: adminMutation,
+      query: adminQuery,
+    });
+
+    const app = new OpenAPIHono();
+    app.route("/", orchestrateSyncRouter);
+
+    const response = await app.request(
+      "/v1/cmux/orchestration/orch_123/sync",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-task-run-jwt",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          orchestrationId: "orch_123",
+          headAgentStatus: "running",
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(adminMutation).toHaveBeenCalledTimes(1);
+    expect(adminMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        teamId: "team_123",
+        id: "ns7_task_run_123",
+        orchestrationId: "orch_123",
+        status: "running",
+      })
+    );
+  });
+
+  it("accepts verified task-run JWT auth for pull sync", async () => {
+    getAccessTokenFromRequest.mockResolvedValue(null);
+    extractTaskRunJwtFromRequest.mockReturnValue(null);
+    verifyTaskRunJwt.mockResolvedValue({
+      taskRunId: "ns7_task_run_123",
+      teamId: "team_123",
+      userId: "user_123",
+    });
+
+    const adminQuery = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          _id: "task_server_123",
+          prompt: "Investigate stale head",
+          assignedAgentName: "codex/gpt-5.4",
+          status: "running",
+          taskRunId: "ns7_worker_123",
+          dependencies: [],
+          priority: 1,
+          result: undefined,
+          errorMessage: undefined,
+          _creationTime: 1710000000000,
+          startedAt: 1710000005000,
+          completedAt: undefined,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          messageId: "msg_123",
+          senderName: "head-agent",
+          recipientName: "*",
+          messageType: "status",
+          content: "still running",
+          timestamp: "2026-03-26T10:00:00.000Z",
+          read: false,
+        },
+      ])
+      .mockResolvedValueOnce({
+        depth: 1,
+        capacity: 20,
+        hasPendingInputs: true,
+        oldestInputAt: 1710000010000,
+      });
+    getConvexAdmin.mockReturnValue({
+      mutation: vi.fn(),
+      query: adminQuery,
+    });
+
+    const app = new OpenAPIHono();
+    app.route("/", orchestrateSyncRouter);
+
+    const response = await app.request(
+      "/v1/cmux/orchestration/orch_123/sync",
+      {
+        method: "GET",
+        headers: {
+          authorization: "Bearer test-task-run-jwt",
+          "content-type": "application/json",
+        },
+      }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      tasks: [
+        {
+          id: "task_server_123",
+          prompt: "Investigate stale head",
+          agentName: "codex/gpt-5.4",
+          status: "running",
+        },
+      ],
+      messages: [
+        {
+          id: "msg_123",
+          from: "head-agent",
+          to: "*",
+          type: "status",
+          message: "still running",
+        },
+      ],
+      aggregatedStatus: {
+        total: 1,
+        completed: 0,
+        running: 1,
+        failed: 0,
+        pending: 0,
+      },
+      turnState: {
+        turnNumber: 0,
+        awaitingOperatorInput: true,
+        pendingInputs: 1,
+        queueCapacity: 20,
+      },
+    });
+  });
+
+  it("rejects invalid JWT bearer auth", async () => {
+    getAccessTokenFromRequest.mockResolvedValue(null);
+    extractTaskRunJwtFromRequest.mockReturnValue(null);
+    verifyTaskRunJwt.mockResolvedValue(null);
+
+    const app = new OpenAPIHono();
+    app.route("/", orchestrateSyncRouter);
+
+    const response = await app.request(
+      "/v1/cmux/orchestration/orch_123/sync",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer invalid-task-run-jwt",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          orchestrationId: "orch_123",
+          headAgentStatus: "running",
+        }),
+      }
+    );
+
+    expect(response.status).toBe(401);
+    expect(getConvexAdmin).not.toHaveBeenCalled();
+  });
+});

--- a/apps/www/lib/routes/orchestrate/sync.route.ts
+++ b/apps/www/lib/routes/orchestrate/sync.route.ts
@@ -7,13 +7,88 @@
  */
 
 import { getAccessTokenFromRequest } from "@/lib/utils/auth";
-import { getConvex } from "@/lib/utils/get-convex";
-import { api } from "@cmux/convex/api";
+import { getConvex, getConvexAdmin } from "@/lib/utils/get-convex";
+import {
+  extractTaskRunJwtFromRequest,
+  verifyTaskRunJwt,
+  type TaskRunJwtPayload,
+} from "@/lib/utils/jwt-task-run";
+import { api, internal } from "@cmux/convex/api";
 import type { Id } from "@cmux/convex/dataModel";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { extractTeamFromJwt, extractTaskRunIdFromJwt } from "./_helpers";
 
 export const orchestrateSyncRouter = new OpenAPIHono();
+
+type SyncAuthContext = {
+  accessToken?: string;
+  teamSlugOrId: string;
+  jwtPayload?: TaskRunJwtPayload;
+};
+
+type SyncTaskRecord = {
+  _id: string;
+  prompt: string;
+  assignedAgentName?: string | null;
+  status: string;
+  taskRunId?: string | null;
+  dependencies?: string[];
+  priority?: number;
+  result?: string | null;
+  errorMessage?: string | null;
+  _creationTime: number;
+  startedAt?: number;
+  completedAt?: number;
+  metadata?: unknown;
+};
+
+type InternalSyncMessageRecord = {
+  messageId: string;
+  senderName: string;
+  recipientName?: string | null;
+  messageType?: string | null;
+  content: string;
+  timestamp: string;
+  read?: boolean;
+};
+
+async function resolveSyncAuthContext(
+  request: Request
+): Promise<
+  | SyncAuthContext
+  | {
+      error: string;
+      status: 401;
+    }
+> {
+  const accessToken = await getAccessTokenFromRequest(request);
+  if (accessToken) {
+    const teamSlugOrId = new URL(request.url).searchParams.get("teamSlugOrId");
+    if (!teamSlugOrId) {
+      return { error: "Unauthorized - no team context", status: 401 };
+    }
+    return { accessToken, teamSlugOrId };
+  }
+
+  const authHeader = request.headers.get("Authorization");
+  const bearerToken = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : null;
+  const jwtToken = extractTaskRunJwtFromRequest(request) ?? bearerToken;
+
+  if (!jwtToken) {
+    return { error: "Unauthorized - no team context", status: 401 };
+  }
+
+  const jwtPayload = await verifyTaskRunJwt(jwtToken);
+  if (!jwtPayload) {
+    return { error: "Unauthorized - invalid JWT signature", status: 401 };
+  }
+
+  return {
+    teamSlugOrId: jwtPayload.teamId,
+    jwtPayload,
+  };
+}
 
 // ============================================================================
 // Schemas
@@ -137,44 +212,45 @@ orchestrateSyncRouter.openapi(
     },
   }),
   async (c) => {
-    const authHeader = c.req.header("Authorization");
-    const accessToken = await getAccessTokenFromRequest(c.req.raw);
-
-    let teamSlugOrId: string | undefined;
-    let taskRunId: string | undefined;
-
-    if (!accessToken && authHeader?.startsWith("Bearer ")) {
-      teamSlugOrId = extractTeamFromJwt(authHeader);
-      taskRunId = extractTaskRunIdFromJwt(authHeader);
-      if (!teamSlugOrId) {
-        return c.text("Invalid JWT", 401);
-      }
-    } else if (accessToken) {
-      const queryParams = c.req.query();
-      teamSlugOrId = queryParams.teamSlugOrId;
+    const auth = await resolveSyncAuthContext(c.req.raw);
+    if ("error" in auth) {
+      return c.text(auth.error, auth.status);
     }
 
-    if (!teamSlugOrId) {
-      return c.text("Unauthorized - no team context", 401);
-    }
+    const convex = auth.accessToken
+      ? getConvex({ accessToken: auth.accessToken })
+      : null;
+    const adminClient = !auth.accessToken ? getConvexAdmin() : null;
 
-    const { orchestrationId } = c.req.valid("param");
+    if (!auth.accessToken && !adminClient) {
+      return c.text("Server configuration error", 500);
+    }
 
     try {
-      if (!accessToken) {
-        return c.text("Unauthorized - OAuth token required", 401);
-      }
-      const convex = getConvex({ accessToken });
+      const { orchestrationId } = c.req.valid("param");
 
-      const allTasks = await convex.query(api.orchestrationQueries.listTasksByTeam, {
-        teamSlugOrId,
-        limit: 100,
-      });
-
-      const tasks = allTasks.filter((t) => {
-        const meta = t.metadata as { orchestrationId?: string } | undefined;
-        return meta?.orchestrationId === orchestrationId;
-      });
+      const tasks = (
+        adminClient && auth.jwtPayload
+          ? await adminClient.query(
+              internal.orchestrationQueries.getOrchestrationStateInternal,
+              {
+                teamId: auth.jwtPayload.teamId,
+                orchestrationId,
+                taskRunId: undefined,
+              }
+            )
+          : await convex!
+              .query(api.orchestrationQueries.listTasksByTeam, {
+                teamSlugOrId: auth.teamSlugOrId,
+                limit: 100,
+              })
+              .then((allTasks) =>
+                allTasks.filter((t) => {
+                  const meta = t.metadata as { orchestrationId?: string } | undefined;
+                  return meta?.orchestrationId === orchestrationId;
+                })
+              )
+      ) as SyncTaskRecord[];
 
       if (tasks.length === 0) {
         return c.text("Orchestration not found", 404);
@@ -190,9 +266,26 @@ orchestrateSyncRouter.openapi(
         read?: boolean;
       }> = [];
 
-      if (taskRunId) {
-        const rawMessages = await convex.query(api.orchestrate.getMessages, {
-          taskRunId: taskRunId as Id<"taskRuns">,
+      if (auth.jwtPayload?.taskRunId && adminClient) {
+        const rawMessages = (await adminClient.query(
+          internal.orchestrationQueries.getMessagesForTaskRunInternal,
+          {
+            taskRunId: auth.jwtPayload.taskRunId as Id<"taskRuns">,
+            includeRead: false,
+          }
+        )) as InternalSyncMessageRecord[];
+        messages = rawMessages.map((m) => ({
+          id: m.messageId,
+          from: m.senderName,
+          to: m.recipientName || "*",
+          type: m.messageType as "handoff" | "request" | "status" | undefined,
+          message: m.content,
+          timestamp: m.timestamp,
+          read: m.read,
+        }));
+      } else if (auth.jwtPayload?.taskRunId) {
+        const rawMessages = await convex!.query(api.orchestrate.getMessages, {
+          taskRunId: auth.jwtPayload.taskRunId as Id<"taskRuns">,
           includeRead: false,
         });
         messages = rawMessages.map((m) => ({
@@ -238,10 +331,19 @@ orchestrateSyncRouter.openapi(
       } | undefined;
 
       try {
-        const queueStatus = await convex.query(api.operatorInputQueue.getQueueStatus, {
-          teamSlugOrId,
-          orchestrationId,
-        });
+        const queueStatus =
+          adminClient && auth.jwtPayload
+            ? await adminClient.query(
+                internal.operatorInputQueue.getQueueStatusInternal,
+                {
+                  teamId: auth.jwtPayload.teamId,
+                  orchestrationId,
+                }
+              )
+            : await convex!.query(api.operatorInputQueue.getQueueStatus, {
+                teamSlugOrId: auth.teamSlugOrId,
+                orchestrationId,
+              });
         // Turn number could be tracked in orchestration metadata; for now use 0
         // and let agents track their own turn count locally
         turnState = {
@@ -308,27 +410,18 @@ orchestrateSyncRouter.openapi(
     },
   }),
   async (c) => {
-    const authHeader = c.req.header("Authorization");
-    const accessToken = await getAccessTokenFromRequest(c.req.raw);
-
-    let teamSlugOrId: string | undefined;
-
-    if (!accessToken && authHeader?.startsWith("Bearer ")) {
-      teamSlugOrId = extractTeamFromJwt(authHeader);
-      if (!teamSlugOrId) {
-        return c.text("Invalid JWT", 401);
-      }
-    } else if (accessToken) {
-      const queryParams = c.req.query();
-      teamSlugOrId = queryParams.teamSlugOrId;
+    const auth = await resolveSyncAuthContext(c.req.raw);
+    if ("error" in auth) {
+      return c.text(auth.error, auth.status);
     }
 
-    if (!teamSlugOrId) {
-      return c.text("Unauthorized - no team context", 401);
-    }
+    const convex = auth.accessToken
+      ? getConvex({ accessToken: auth.accessToken })
+      : null;
+    const adminClient = !auth.accessToken ? getConvexAdmin() : null;
 
-    if (!accessToken) {
-      return c.text("Unauthorized - OAuth token required", 401);
+    if (!auth.accessToken && !adminClient) {
+      return c.text("Server configuration error", 500);
     }
 
     const { orchestrationId } = c.req.valid("param");
@@ -339,19 +432,29 @@ orchestrateSyncRouter.openapi(
     }
 
     try {
-      const convex = getConvex({ accessToken });
       let tasksUpdated = 0;
 
       if (body.tasks && body.tasks.length > 0) {
-        const allTasks = await convex.query(api.orchestrationQueries.listTasksByTeam, {
-          teamSlugOrId,
-          limit: 100,
-        });
-
-        const orchTasks = allTasks.filter((t) => {
-          const meta = t.metadata as { orchestrationId?: string; localTaskId?: string } | undefined;
-          return meta?.orchestrationId === orchestrationId;
-        });
+        const orchTasks = (
+          adminClient && auth.jwtPayload
+            ? await adminClient.query(
+                internal.orchestrationQueries.getOrchestrationStateInternal,
+                {
+                  teamId: auth.jwtPayload.teamId,
+                  orchestrationId,
+                  taskRunId: undefined,
+                }
+              )
+            : await convex!.query(api.orchestrationQueries.listTasksByTeam, {
+                teamSlugOrId: auth.teamSlugOrId,
+                limit: 100,
+              }).then((allTasks) =>
+                allTasks.filter((t) => {
+                  const meta = t.metadata as { orchestrationId?: string; localTaskId?: string } | undefined;
+                  return meta?.orchestrationId === orchestrationId;
+                })
+              )
+        ) as SyncTaskRecord[];
 
         for (const pushTask of body.tasks) {
           const serverTask = orchTasks.find((t) => {
@@ -361,16 +464,36 @@ orchestrateSyncRouter.openapi(
 
           if (serverTask) {
             if (pushTask.status === "completed") {
-              await convex.mutation(api.orchestrationQueries.completeTask, {
-                taskId: serverTask._id as Id<"orchestrationTasks">,
-                result: pushTask.result,
-              });
+              if (adminClient) {
+                await adminClient.mutation(
+                  internal.orchestrationQueries.completeTaskInternal,
+                  {
+                    taskId: serverTask._id as Id<"orchestrationTasks">,
+                    result: pushTask.result,
+                  }
+                );
+              } else {
+                await convex!.mutation(api.orchestrationQueries.completeTask, {
+                  taskId: serverTask._id as Id<"orchestrationTasks">,
+                  result: pushTask.result,
+                });
+              }
               tasksUpdated++;
             } else if (pushTask.status === "failed") {
-              await convex.mutation(api.orchestrationQueries.failTask, {
-                taskId: serverTask._id as Id<"orchestrationTasks">,
-                errorMessage: pushTask.errorMessage ?? "Task failed",
-              });
+              if (adminClient) {
+                await adminClient.mutation(
+                  internal.orchestrationQueries.failTaskInternal,
+                  {
+                    taskId: serverTask._id as Id<"orchestrationTasks">,
+                    errorMessage: pushTask.errorMessage ?? "Task failed",
+                  }
+                );
+              } else {
+                await convex!.mutation(api.orchestrationQueries.failTask, {
+                  taskId: serverTask._id as Id<"orchestrationTasks">,
+                  errorMessage: pushTask.errorMessage ?? "Task failed",
+                });
+              }
               tasksUpdated++;
             }
           }
@@ -380,28 +503,47 @@ orchestrateSyncRouter.openapi(
       let heartbeatUpdated = false;
       if (body.headAgentStatus) {
         try {
-          const headAgentRun = await convex.query(api.taskRuns.getByOrchestrationId, {
-            orchestrationId,
-            teamSlugOrId,
-          });
-
-          if (headAgentRun) {
-            await convex.mutation(api.taskRuns.updateOrchestrationHeartbeat, {
-              teamSlugOrId,
-              id: headAgentRun._id as Id<"taskRuns">,
-              status: body.headAgentStatus,
-            });
+          if (adminClient && auth.jwtPayload) {
+            await adminClient.mutation(
+              internal.taskRuns.updateOrchestrationHeartbeatInternal,
+              {
+                teamId: auth.jwtPayload.teamId,
+                id: auth.jwtPayload.taskRunId as Id<"taskRuns">,
+                orchestrationId,
+                status: body.headAgentStatus,
+              }
+            );
             console.log(`[orchestrate] Head agent heartbeat updated: ${body.headAgentStatus}`, {
               orchestrationId,
-              taskRunId: headAgentRun._id,
+              taskRunId: auth.jwtPayload.taskRunId,
+              userId: auth.jwtPayload.userId,
               message: body.message,
             });
             heartbeatUpdated = true;
           } else {
-            console.log(`[orchestrate] Head agent status update (no matching task run): ${body.headAgentStatus}`, {
+            const headAgentRun = await convex!.query(api.taskRuns.getByOrchestrationId, {
               orchestrationId,
-              message: body.message,
+              teamSlugOrId: auth.teamSlugOrId,
             });
+
+            if (headAgentRun) {
+              await convex!.mutation(api.taskRuns.updateOrchestrationHeartbeat, {
+                teamSlugOrId: auth.teamSlugOrId,
+                id: headAgentRun._id as Id<"taskRuns">,
+                status: body.headAgentStatus,
+              });
+              console.log(`[orchestrate] Head agent heartbeat updated: ${body.headAgentStatus}`, {
+                orchestrationId,
+                taskRunId: headAgentRun._id,
+                message: body.message,
+              });
+              heartbeatUpdated = true;
+            } else {
+              console.log(`[orchestrate] Head agent status update (no matching task run): ${body.headAgentStatus}`, {
+                orchestrationId,
+                message: body.message,
+              });
+            }
           }
         } catch (err) {
           console.error("[orchestrate] Failed to update head agent heartbeat:", err);

--- a/packages/convex/convex/operatorInputQueue.ts
+++ b/packages/convex/convex/operatorInputQueue.ts
@@ -88,6 +88,49 @@ export const getQueueStatus = authQuery({
 });
 
 /**
+ * Get queue status for an orchestration without Stack auth.
+ * Used by server-side JWT-authenticated routes in apps/www.
+ */
+export const getQueueStatusInternal = internalQuery({
+  args: {
+    teamId: v.string(),
+    orchestrationId: v.string(),
+    queueCapacity: v.optional(v.number()),
+  },
+  returns: v.object({
+    depth: v.number(),
+    capacity: v.number(),
+    hasPendingInputs: v.boolean(),
+    oldestInputAt: v.optional(v.number()),
+  }),
+  handler: async (ctx, args) => {
+    const capacity = Math.max(
+      MIN_QUEUE_CAPACITY,
+      Math.min(args.queueCapacity ?? DEFAULT_QUEUE_CAPACITY, MAX_QUEUE_CAPACITY)
+    );
+
+    const pendingInputs = await ctx.db
+      .query("operatorInputQueue")
+      .withIndex("by_orchestration_pending", (q) =>
+        q.eq("orchestrationId", args.orchestrationId).eq("processedAt", undefined)
+      )
+      .collect();
+
+    const teamInputs = pendingInputs.filter((i) => i.teamId === args.teamId);
+
+    return {
+      depth: teamInputs.length,
+      capacity,
+      hasPendingInputs: teamInputs.length > 0,
+      oldestInputAt:
+        teamInputs.length > 0
+          ? Math.min(...teamInputs.map((i) => i.queuedAt))
+          : undefined,
+    };
+  },
+});
+
+/**
  * Get pending inputs for an orchestration (internal use).
  * Returns inputs sorted by priority then queue time.
  */

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -3504,6 +3504,55 @@ export const updateOrchestrationHeartbeat = authMutation({
 });
 
 /**
+ * Update orchestration head agent heartbeat without Stack auth.
+ * Used by server-side JWT-authenticated routes in apps/www.
+ */
+export const updateOrchestrationHeartbeatInternal = internalMutation({
+  args: {
+    teamId: v.string(),
+    id: v.id("taskRuns"),
+    orchestrationId: v.optional(v.string()),
+    status: v.optional(
+      v.union(
+        v.literal("running"),
+        v.literal("completed"),
+        v.literal("failed")
+      )
+    ),
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.id);
+    if (!doc) {
+      throw new Error("Task run not found");
+    }
+    if (doc.teamId !== args.teamId) {
+      throw new Error("Task run not found or unauthorized");
+    }
+    if (
+      args.orchestrationId &&
+      doc.orchestrationId &&
+      doc.orchestrationId !== args.orchestrationId
+    ) {
+      throw new Error("Task run orchestrationId mismatch");
+    }
+
+    const now = Date.now();
+    const patch: Record<string, unknown> = {
+      orchestrationHeartbeat: now,
+      updatedAt: now,
+    };
+
+    if (args.status) {
+      patch.orchestrationStatus = args.status;
+    }
+
+    await ctx.db.patch(args.id, patch);
+
+    return { ok: true, heartbeat: now, status: args.status };
+  },
+});
+
+/**
  * Get task run by orchestration ID (for head agent lookup).
  */
 export const getByOrchestrationId = authQuery({


### PR DESCRIPTION
## Summary
- accept verified task-run JWT auth on both orchestration sync GET and POST routes in `apps/www`
- use internal/admin Convex helpers on the JWT path so head-agent heartbeats do not require Stack OAuth and do not re-query by orchestration id
- add focused tests for JWT-authenticated sync pull and push behavior

## Testing
- set -a; source /root/workspace/.env; set +a; bunx convex codegen --typecheck=disable
- bun run test lib/routes/orchestrate/sync.route.test.ts
- bun run typecheck (apps/www)
- bun run typecheck (packages/convex)
- pre-commit `bun check` during git commit
