### PR TITLE
Fix task stop to tear down sandboxes before archive

### DIFF
--- a/packages/convex/convex/cmux_http.ts
+++ b/packages/convex/convex/cmux_http.ts
@@ -251,6 +251,24 @@ async function recordProviderStopActivity(
   }
 }
 
+function toTaskRunStopState(
+  run: Pick<Doc<"taskRuns">, "_id" | "status" | "vscode" | "networking">
+) {
+  return {
+    _id: String(run._id),
+    status: run.status,
+    vscode: run.vscode
+      ? {
+          provider: run.vscode.provider,
+          containerName: run.vscode.containerName,
+          status: run.vscode.status,
+          stoppedAt: run.vscode.stoppedAt,
+        }
+      : undefined,
+    networking: run.networking,
+  };
+}
+
 /**
  * Get the provider instance ID for a devbox ID
  */
@@ -2890,29 +2908,18 @@ async function handleStopTask(
       teamId,
       userId,
     });
+    const stopRuns = runs.map(toTaskRunStopState);
     const runsById = new Map(runs.map((run) => [String(run._id), run]));
-    const stopTargets = collectTaskStopTargets(
-      runs.map((run) => ({
-        _id: String(run._id),
-        status: run.status,
-        vscode: run.vscode
-          ? {
-              provider: run.vscode.provider,
-              containerName: run.vscode.containerName,
-              status: run.vscode.status,
-              stoppedAt: run.vscode.stoppedAt,
-            }
-          : undefined,
-        networking: run.networking,
-      }))
-    );
+    const stopRunsById = new Map(stopRuns.map((run) => [run._id, run]));
+    const stopTargets = collectTaskStopTargets(stopRuns);
 
     const stopFailures: string[] = [];
 
     for (const target of stopTargets) {
       const stoppedAt = Date.now();
       const run = runsById.get(target.runId);
-      if (!run) {
+      const stopRun = stopRunsById.get(target.runId);
+      if (!run || !stopRun) {
         continue;
       }
 
@@ -2959,22 +2966,7 @@ async function handleStopTask(
         });
       }
 
-      const patch = buildStoppedTaskRunMetadataPatch(
-        {
-          _id: String(run._id),
-          status: run.status,
-          vscode: run.vscode
-            ? {
-                provider: run.vscode.provider,
-                containerName: run.vscode.containerName,
-                status: run.vscode.status,
-                stoppedAt: run.vscode.stoppedAt,
-              }
-            : undefined,
-          networking: run.networking,
-        },
-        stoppedAt
-      );
+      const patch = buildStoppedTaskRunMetadataPatch(stopRun, stoppedAt);
 
       if (patch) {
         await ctx.runMutation(internal.taskRuns.updateVSCodeMetadataInternal, {
@@ -2990,14 +2982,19 @@ async function handleStopTask(
       return jsonResponse({ code: 500, message }, 500);
     }
 
-    for (const run of runs) {
-      if (!shouldMarkTaskRunStopped({ _id: String(run._id), status: run.status })) {
+    for (const run of stopRuns) {
+      if (!shouldMarkTaskRunStopped(run)) {
+        continue;
+      }
+
+      const taskRun = runsById.get(run._id);
+      if (!taskRun) {
         continue;
       }
 
       await ctx.runMutation(api.taskRuns.failByTeamMember, {
         teamSlugOrId,
-        id: run._id,
+        id: taskRun._id,
         errorMessage: "Task stopped by user",
         exitCode: 130,
       });

--- a/packages/convex/convex/taskStopHelpers.test.ts
+++ b/packages/convex/convex/taskStopHelpers.test.ts
@@ -63,8 +63,6 @@ describe("taskStopHelpers", () => {
   it("builds a stopped metadata patch that preserves networking ports", () => {
     const patch = buildStoppedTaskRunMetadataPatch(
       {
-        _id: "run_1",
-        status: "running",
         vscode: {
           provider: "pve-lxc",
           containerName: "cr_123",
@@ -100,25 +98,21 @@ describe("taskStopHelpers", () => {
   it("marks only pending and running task runs as user-stopped", () => {
     expect(
       shouldMarkTaskRunStopped({
-        _id: "run_pending",
         status: "pending",
       })
     ).toBe(true);
     expect(
       shouldMarkTaskRunStopped({
-        _id: "run_running",
         status: "running",
       })
     ).toBe(true);
     expect(
       shouldMarkTaskRunStopped({
-        _id: "run_completed",
         status: "completed",
       })
     ).toBe(false);
     expect(
       shouldMarkTaskRunStopped({
-        _id: "run_failed",
         status: "failed",
       })
     ).toBe(false);

--- a/packages/convex/convex/taskStopHelpers.ts
+++ b/packages/convex/convex/taskStopHelpers.ts
@@ -25,6 +25,9 @@ type TaskRunStopLike = {
   }>;
 };
 
+type TaskRunStopStatusLike = Pick<TaskRunStopLike, "status">;
+type TaskRunStopMetadataLike = Pick<TaskRunStopLike, "vscode" | "networking">;
+
 export type TaskStopTarget = {
   runId: string;
   instanceId: string;
@@ -34,12 +37,7 @@ export type TaskStopTarget = {
 export function isStoppableTaskProvider(
   provider: string | undefined
 ): provider is StoppableTaskProvider {
-  return (
-    provider === "e2b" ||
-    provider === "modal" ||
-    provider === "morph" ||
-    provider === "pve-lxc"
-  );
+  return provider === "e2b" || provider === "morph" || provider === "pve-lxc";
 }
 
 export function collectTaskStopTargets(
@@ -55,12 +53,12 @@ export function collectTaskStopTargets(
   });
 }
 
-export function shouldMarkTaskRunStopped(run: TaskRunStopLike): boolean {
+export function shouldMarkTaskRunStopped(run: TaskRunStopStatusLike): boolean {
   return run.status === "pending" || run.status === "running";
 }
 
 export function buildStoppedTaskRunMetadataPatch(
-  run: TaskRunStopLike,
+  run: TaskRunStopMetadataLike,
   stoppedAt: number
 ): {
   vscode: {


### PR DESCRIPTION
## Summary
- make `POST /api/v1/cmux/tasks/{id}/stop` actually stop task sandboxes before archiving the task
- stop tracked Morph, E2B, and PVE-LXC sandboxes by provider instance ID and mark their devbox records as `stopped`
- patch task run VS Code metadata to `stopped` and mark pending/running runs as user-stopped before archiving
- treat already-missing sandbox instances as idempotent cleanup instead of surfacing false failures
- add focused helper tests for task-stop target selection, metadata patching, and ignorable stop errors

## Testing
- `cd packages/convex && bunx vitest run convex/taskStopHelpers.test.ts`
- `cd packages/convex && bunx vitest run convex/cmux_http.test.ts`
- `cd packages/convex && bun run typecheck`
- pre-commit `bun check`

## Notes
- this follows the separate bug discovered after merging #895: `devsh task stop` previously archived the task but could leave the sandbox running
- local Docker-backed task runs are still outside this Convex-side stop path; this PR fixes the cloud-backed task sandboxes used by the urgent PVE-LXC flow
