### PR TITLE
fix(pve-lxc): wait for exec lane readiness after resume

### DIFF
--- a/packages/devsh/internal/pvelxc/exec.go
+++ b/packages/devsh/internal/pvelxc/exec.go
@@ -312,36 +312,6 @@ func (c *Client) ExecCommand(ctx context.Context, instanceID string, command str
 	return "", "", -1, fmt.Errorf("HTTP exec failed for container %d via candidates: %s", vmid, strings.Join(candidates, ", "))
 }
 
-// WaitForReady polls the exec lane until it becomes ready.
-// Returns the Instance when ready, or an error if timeout is exceeded.
-func (c *Client) WaitForReady(ctx context.Context, instanceID string, timeout time.Duration) (*Instance, error) {
-	pollInterval := 2 * time.Second
-	deadline := time.Now().Add(timeout)
-
-	for time.Now().Before(deadline) {
-		// Check context cancellation
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		// Try a simple echo command to test exec readiness
-		stdout, _, exitCode, err := c.ExecCommand(ctx, instanceID, "echo ready")
-		if err == nil && exitCode == 0 && strings.TrimSpace(stdout) == "ready" {
-			// Exec is ready, return the instance
-			return c.GetInstance(ctx, instanceID)
-		}
-
-		// Wait before next poll
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(pollInterval):
-		}
-	}
-
-	return nil, fmt.Errorf("container %s exec lane did not become ready within %v", instanceID, timeout)
-}
-
 func ExecHostFromPublicDomain(publicDomain string, port int, instanceID string) (string, error) {
 	if strings.TrimSpace(publicDomain) == "" {
 		return "", errors.New("publicDomain is required")

--- a/packages/pve-lxc-client/src/index.ts
+++ b/packages/pve-lxc-client/src/index.ts
@@ -152,36 +152,6 @@ export class PveLxcInstance {
   }
 
   /**
-   * Wait for the container's exec lane to become ready.
-   * Polls `echo ready` via exec until success or timeout.
-   * Use this after start/resume to ensure the exec daemon is available.
-   */
-  async waitForReady(options?: {
-    timeoutMs?: number;
-    pollIntervalMs?: number;
-  }): Promise<void> {
-    const timeoutMs = options?.timeoutMs ?? 60_000;
-    const pollIntervalMs = options?.pollIntervalMs ?? 2_000;
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < timeoutMs) {
-      try {
-        const result = await this.exec("echo ready", { timeoutMs: 10_000 });
-        if (result.exit_code === 0 && result.stdout.trim() === "ready") {
-          return;
-        }
-      } catch {
-        // Exec not ready yet, continue polling
-      }
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-    }
-
-    throw new Error(
-      `Container ${this.id} (vmid=${this.vmid}) exec lane did not become ready within ${timeoutMs}ms`
-    );
-  }
-
-  /**
    * Expose an HTTP service (uses public domain when available, falls back to FQDN)
    */
   async exposeHttpService(name: string, port: number): Promise<void> {


### PR DESCRIPTION
## Summary

- Add `waitForReady` method to PveLxcInstance that polls exec until ready
- Update all PVE-LXC resume paths to wait for exec lane before returning success
- This fixes the issue where `devsh exec` failed after `pause/resume` because the exec daemon wasn't ready yet

## Changes

- `packages/pve-lxc-client/src/index.ts`: Add `PveLxcInstance.waitForReady()` method
- `packages/devsh/internal/pvelxc/exec.go`: Add `Client.WaitForReady()` method in Go
- `apps/www/lib/routes/sandboxes-routes/lifecycle.route.ts`: Call waitForReady after PVE-LXC resume
- `apps/www/lib/routes/pve-lxc.resume.route.ts`: Call waitForReady after start
- `packages/devsh/internal/cli/resume.go`: Call WaitForReady for PVE-LXC provider

## Test plan

- [ ] `devsh start -p pve-lxc` creates a fresh sandbox
- [ ] `devsh exec <id> 'echo hello'` succeeds initially
- [ ] `devsh pause <id>` pauses the sandbox
- [ ] `devsh resume <id>` resumes and waits for exec readiness
- [ ] `devsh exec <id> 'echo resumed'` succeeds after resume

Closes #919