### PR TITLE
fix: preserve auth for dashboard provider status

### DIFF
--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -62,8 +62,8 @@ import { getGitHubOAuthToken } from "./utils/getGitHubToken";
 import { createDraftPr, fetchPrDetail } from "./utils/githubPr";
 import { getOctokit } from "./utils/octokit";
 import {
-  checkAllProvidersStatusWithAuthToken,
-  checkAllProvidersStatusWebModeWithAuthToken,
+  checkAllProvidersStatus,
+  checkAllProvidersStatusWebMode,
 } from "./utils/providerStatus";
 import { refreshGitHubData } from "./utils/refreshGitHubData";
 import { runWithAuth, runWithAuthToken } from "./utils/requestContext";
@@ -3842,14 +3842,11 @@ Please address the issue mentioned in the comment above.`;
     socket.on("check-provider-status", async (callback) => {
       try {
         // In web mode, only check API keys from Convex (no local files/keychains)
-        const status = env.NEXT_PUBLIC_WEB_MODE
-          ? await checkAllProvidersStatusWebModeWithAuthToken(
-              currentAuthToken,
-              { teamSlugOrId: safeTeam }
-            )
-          : await checkAllProvidersStatusWithAuthToken(currentAuthToken, {
-              teamSlugOrId: safeTeam,
-            });
+        const status = await runWithAuthToken(currentAuthToken, () =>
+          env.NEXT_PUBLIC_WEB_MODE
+            ? checkAllProvidersStatusWebMode({ teamSlugOrId: safeTeam })
+            : checkAllProvidersStatus({ teamSlugOrId: safeTeam })
+        );
         callback({ success: true, ...status });
       } catch (error) {
         serverLogger.error("Error checking provider status:", error);

--- a/apps/server/src/utils/providerStatus.test.ts
+++ b/apps/server/src/utils/providerStatus.test.ts
@@ -2,10 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   aggregateByVendor,
   checkAllProvidersStatusWebMode,
-  checkAllProvidersStatusWebModeWithAuthToken,
 } from "./providerStatus";
 import type { ProviderStatus } from "@cmux/shared";
-import { getAuthToken } from "./requestContext";
+import { getAuthToken, runWithAuthToken } from "./requestContext";
 
 const { queryMock } = vi.hoisted(() => ({
   queryMock: vi.fn(),
@@ -161,9 +160,9 @@ describe("checkAllProvidersStatusWebMode", () => {
       };
     });
 
-    await checkAllProvidersStatusWebModeWithAuthToken("socket-auth-token", {
-      teamSlugOrId: "test-team",
-    });
+    await runWithAuthToken("socket-auth-token", () =>
+      checkAllProvidersStatusWebMode({ teamSlugOrId: "test-team" })
+    );
 
     expect(authTokensSeen).toEqual(["socket-auth-token"]);
   });

--- a/apps/server/src/utils/providerStatus.ts
+++ b/apps/server/src/utils/providerStatus.ts
@@ -9,7 +9,6 @@ import { AGENT_CATALOG } from "@cmux/shared/agent-catalog";
 import { checkDockerStatus } from "@cmux/shared/providers/common/check-docker";
 import { isAuthFreeModel } from "@cmux/shared/providers/control-plane";
 import { getConvex } from "./convexClient.js";
-import { runWithAuthToken } from "./requestContext";
 
 export interface AggregatedProviderStatus {
   /** Vendor name: "anthropic", "openai", "google", etc. */
@@ -102,16 +101,6 @@ export async function checkAllProvidersStatus(
     providers: providerChecks,
     dockerStatus,
   };
-}
-
-export function checkAllProvidersStatusWithAuthToken(
-  authToken: string | null | undefined,
-  options: CheckAllProvidersStatusOptions = {}
-): Promise<{
-  providers: SharedProviderStatus[];
-  dockerStatus: DockerStatus;
-}> {
-  return runWithAuthToken(authToken, () => checkAllProvidersStatus(options));
 }
 
 /**
@@ -216,16 +205,4 @@ export async function checkAllProvidersStatusWebMode(options: {
     providers: providerChecks,
     dockerStatus,
   };
-}
-
-export function checkAllProvidersStatusWebModeWithAuthToken(
-  authToken: string | null | undefined,
-  options: { teamSlugOrId: string }
-): Promise<{
-  providers: SharedProviderStatus[];
-  dockerStatus: DockerStatus;
-}> {
-  return runWithAuthToken(authToken, () =>
-    checkAllProvidersStatusWebMode(options)
-  );
 }


### PR DESCRIPTION
## Summary
- preserve auth context for socket-driven dashboard provider status checks
- add auth-token helper wrappers for provider status queries
- cover the regression with a focused server test

## Verification
- pre-commit hook (`bun check`): pass
- `cd apps/server && bunx vitest run src/utils/providerStatus.test.ts`: pass
- reproduced in live dashboard: Codex marked `Setup required` while control-plane API reported OpenAI connected