### PR TITLE
feat: hook portability phase 2 - migrate Claude hooks to thin stubs

### DIFF
--- a/apps/www/lib/routes/hooks.dispatch.route.ts
+++ b/apps/www/lib/routes/hooks.dispatch.route.ts
@@ -104,6 +104,17 @@ hooksDispatchRouter.openapi(
       "approval_requested",
       "approval_resolved",
       "mcp_capabilities_negotiated",
+      // Phase 2 Hook Portability additions
+      "subagent_start",
+      "subagent_stop",
+      "notification",
+      "task_created",
+      "user_prompt",
+      "plan_sync",
+      "simplify_track",
+      "precompact",
+      "postcompact",
+      "simplify_gate",
     ];
     if (!validEvents.includes(event as LifecycleEventType)) {
       return c.text(`Invalid event type: ${event}`, 400);

--- a/packages/shared/src/hook-registry.ts
+++ b/packages/shared/src/hook-registry.ts
@@ -104,6 +104,69 @@ export const HOOK_REGISTRY: HookDefinition[] = [
     critical: false,
     description: "Stop requested by operator",
   },
+  // P3 Simple hooks - Phase 2 additions
+  {
+    type: "subagent_start",
+    providers: ["claude"],
+    critical: false,
+    description: "Sub-agent spawned via Agent tool",
+  },
+  {
+    type: "subagent_stop",
+    providers: ["claude"],
+    critical: false,
+    description: "Sub-agent completed",
+  },
+  {
+    type: "notification",
+    providers: ["claude"],
+    critical: false,
+    description: "Agent needs user attention (permission prompt, idle)",
+  },
+  {
+    type: "task_created",
+    providers: ["claude"],
+    critical: false,
+    description: "Task created via TaskCreate tool",
+  },
+  {
+    type: "user_prompt",
+    providers: ["claude"],
+    critical: false,
+    description: "User prompt submitted before processing",
+  },
+  // P2 Medium hooks
+  {
+    type: "plan_sync",
+    providers: ["claude"],
+    critical: false,
+    description: "Plan synced to GitHub Projects on ExitPlanMode",
+  },
+  {
+    type: "simplify_track",
+    providers: ["claude"],
+    critical: false,
+    description: "Marks /simplify completion for pre-merge gate",
+  },
+  // P1 Critical hooks
+  {
+    type: "precompact",
+    providers: ["claude"],
+    critical: true,
+    description: "Pre-compaction memory sync (must return {continue: true})",
+  },
+  {
+    type: "postcompact",
+    providers: ["claude"],
+    critical: false,
+    description: "Post-compaction context re-injection",
+  },
+  {
+    type: "simplify_gate",
+    providers: ["claude"],
+    critical: true,
+    description: "Blocks stop if /simplify required but not run",
+  },
 ];
 
 /**
@@ -191,6 +254,37 @@ export function getDispatchScript(
     case "stop_requested":
       return buildStopRequestedScript(provider, logFile);
 
+    // Phase 2 Hook Portability additions
+    case "subagent_start":
+      return buildSubagentStartScript(provider, logFile);
+
+    case "subagent_stop":
+      return buildSubagentStopScript(provider, logFile);
+
+    case "notification":
+      return buildNotificationScript(provider, logFile);
+
+    case "task_created":
+      return buildTaskCreatedScript(provider, logFile);
+
+    case "user_prompt":
+      return buildUserPromptScript(provider, logFile);
+
+    case "plan_sync":
+      return buildPlanSyncScript(provider, logFile);
+
+    case "simplify_track":
+      return buildSimplifyTrackScript(provider, logFile);
+
+    case "precompact":
+      return buildPrecompactScript(provider, logFile);
+
+    case "postcompact":
+      return buildPostcompactScript(provider, logFile);
+
+    case "simplify_gate":
+      return buildSimplifyGateScript(provider, logFile);
+
     default:
       return null;
   }
@@ -227,24 +321,49 @@ function buildSessionStopScript(provider: ProviderName, logFile: string): string
 set -eu
 LOG_FILE="${logFile}"
 
-# Sync memory files (best-effort)
-/root/lifecycle/memory/sync.sh >> "\${LOG_FILE}" 2>&1 || true
+echo "[CMUX Stop Hook] Script started at \$(date)" >> "\$LOG_FILE"
+echo "[CMUX Stop Hook] CMUX_TASK_RUN_ID=\${CMUX_TASK_RUN_ID:-}" >> "\$LOG_FILE"
 
-# Post session completion activity event (non-blocking)
-if [ -n "\${CMUX_TASK_RUN_JWT:-}" ] && [ -n "\${CMUX_CALLBACK_URL:-}" ]; then
+# Sync memory files (best-effort)
+/root/lifecycle/memory/sync.sh >> "\$LOG_FILE" 2>&1 || true
+
+# Post session completion callbacks (non-blocking)
+if [ -n "\${CMUX_TASK_RUN_JWT:-}" ] && [ -n "\${CMUX_CALLBACK_URL:-}" ] && [ -n "\${CMUX_TASK_RUN_ID:-}" ]; then
   (
+    # Call crown/complete for status updates
+    curl -s -X POST "\${CMUX_CALLBACK_URL}/api/crown/complete" \\
+      -H "Content-Type: application/json" \\
+      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+      -d "{\\"taskRunId\\": \\"\${CMUX_TASK_RUN_ID}\\", \\"exitCode\\": 0}" \\
+      >> "\$LOG_FILE" 2>&1 || true
+
+    # Call notifications endpoint for user notification
+    curl -s -X POST "\${CMUX_CALLBACK_URL}/api/notifications/agent-stopped" \\
+      -H "Content-Type: application/json" \\
+      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+      -d "{\\"taskRunId\\": \\"\${CMUX_TASK_RUN_ID}\\"}" \\
+      >> "\$LOG_FILE" 2>&1 || true
+
+    # Post "agent stopped" activity event for dashboard timeline
     curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
       -H "Content-Type: application/json" \\
       -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-      -d "$(jq -n --arg trid "\${CMUX_TASK_RUN_ID:-}" \\
-           '{taskRunId: $trid, type: "session_stop", toolName: "${provider}", summary: "Session completed"}')" \\
-      >> "\${LOG_FILE}" 2>&1 || true
+      -d "$(jq -n --arg trid "\${CMUX_TASK_RUN_ID}" \\
+           '{taskRunId: \$trid, type: "session_stop", toolName: "${provider}", summary: "Session completed"}')" \\
+      >> "\$LOG_FILE" 2>&1 || true
+
+    echo "[CMUX Stop Hook] API calls completed at \$(date)" >> "\$LOG_FILE"
   ) &
 fi
 
-# Create completion marker
+# Create completion marker for task run
+if [ -n "\${CMUX_TASK_RUN_ID:-}" ]; then
+  touch "/root/lifecycle/${provider}-complete-\${CMUX_TASK_RUN_ID}"
+fi
+
+# Create generic completion marker
 touch /root/lifecycle/done.txt
-echo "[CMUX] ${provider} session complete" >> "\${LOG_FILE}"
+echo "[CMUX] ${provider} session complete" >> "\$LOG_FILE"
 `;
 }
 
@@ -299,6 +418,34 @@ exit 0
 }
 
 function buildErrorScript(provider: ProviderName, logFile: string): string {
+  // For Claude, we receive error events via stdin
+  if (provider === "claude") {
+    return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+EVENT=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+ERROR_MSG=\$(echo "\$EVENT" | jq -r '.error // "Agent stopped due to an error"' | head -c 300)
+
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg summary "Error: \$ERROR_MSG" \\
+      '{taskRunId: \$trid, type: "error", summary: \$summary}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+exit 0
+`;
+  }
+
+  // Default pattern for other providers (error message as argument)
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -324,6 +471,59 @@ exit 0
 }
 
 function buildToolCallScript(provider: ProviderName, logFile: string): string {
+  // For Claude, we receive tool_use events via stdin and need to parse them
+  // For Codex, we receive env vars TOOL_NAME and SUMMARY
+  if (provider === "claude") {
+    return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+EVENT=\$(cat)
+TOOL_NAME=\$(echo "\$EVENT" | jq -r '.tool_use.name // "unknown"')
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+# Map tool names to activity types
+case "\$TOOL_NAME" in
+  Edit|Write|NotebookEdit) TYPE="file_edit" ;;
+  Read)                     TYPE="file_read" ;;
+  Bash)                     TYPE="bash_command" ;;
+  Grep|Glob)                TYPE="file_read" ;;
+  Agent)                    TYPE="tool_call" ;;
+  *)                        TYPE="tool_call" ;;
+esac
+
+# Build human-readable summary from tool input
+case "\$TOOL_NAME" in
+  Edit)  SUMMARY="Edit \$(echo "\$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
+  Read)  SUMMARY="Read \$(echo "\$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
+  Write) SUMMARY="Write \$(echo "\$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
+  Bash)  SUMMARY="Run: \$(echo "\$EVENT" | jq -r '.tool_use.input.command // ""' | head -c 80)" ;;
+  Grep)  SUMMARY="Search: \$(echo "\$EVENT" | jq -r '.tool_use.input.pattern // ""' | head -c 60)" ;;
+  Glob)  SUMMARY="Find: \$(echo "\$EVENT" | jq -r '.tool_use.input.pattern // ""' | head -c 60)" ;;
+  Agent) SUMMARY="Agent: \$(echo "\$EVENT" | jq -r '.tool_use.input.description // ""' | head -c 60)" ;;
+  *)     SUMMARY="\$TOOL_NAME" ;;
+esac
+
+# Non-blocking POST
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg type "\$TYPE" \\
+      --arg tool "\$TOOL_NAME" \\
+      --arg summary "\$SUMMARY" \\
+      '{taskRunId: \$trid, type: \$type, toolName: \$tool, summary: \$summary}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+exit 0
+`;
+  }
+
+  // Default pattern for other providers (Codex uses env vars)
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -485,5 +685,434 @@ fi
     >> "\${LOG_FILE}" 2>&1 || true
 ) &
 exit 0
+`;
+}
+
+// =============================================================================
+// Phase 2 Hook Portability - Additional Script Builders
+// =============================================================================
+
+function buildSubagentStartScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+REQUEST=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+AGENT_ID=\$(echo "\$REQUEST" | jq -r '.agent_id // "unknown"')
+AGENT_TYPE=\$(echo "\$REQUEST" | jq -r '.agent_type // "unknown"')
+
+echo "[subagent-start] Agent \$AGENT_ID (\$AGENT_TYPE) spawned" >> "\$LOG_FILE" 2>&1
+
+# Post activity event to dashboard (background, don't block)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg agentId "\$AGENT_ID" \\
+      --arg agentType "\$AGENT_TYPE" \\
+      '{taskRunId: \$trid, type: "subagent_start", toolName: "Agent", summary: ("Spawned " + \$agentType + " subagent: " + \$agentId)}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+exit 0
+`;
+}
+
+function buildSubagentStopScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+REQUEST=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+AGENT_ID=\$(echo "\$REQUEST" | jq -r '.agent_id // "unknown"')
+AGENT_TYPE=\$(echo "\$REQUEST" | jq -r '.agent_type // "unknown"')
+LAST_MESSAGE=\$(echo "\$REQUEST" | jq -r '.last_assistant_message // ""' | head -c 200)
+
+echo "[subagent-stop] Agent \$AGENT_ID (\$AGENT_TYPE) completed" >> "\$LOG_FILE" 2>&1
+
+# Post activity event to dashboard (background, don't block)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg agentId "\$AGENT_ID" \\
+      --arg agentType "\$AGENT_TYPE" \\
+      --arg summary "\$LAST_MESSAGE" \\
+      '{taskRunId: \$trid, type: "subagent_stop", toolName: "Agent", summary: (\$agentType + " subagent completed: " + (\$summary | if length > 100 then (.[0:100] + "...") else . end))}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+exit 0
+`;
+}
+
+function buildNotificationScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+REQUEST=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+NOTIFICATION_TYPE=\$(echo "\$REQUEST" | jq -r '.notification_type // "unknown"')
+MESSAGE=\$(echo "\$REQUEST" | jq -r '.message // ""' | head -c 200)
+
+echo "[notification] Type: \$NOTIFICATION_TYPE - \$MESSAGE" >> "\$LOG_FILE" 2>&1
+
+# Post activity event to dashboard (background, don't block)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg notifType "\$NOTIFICATION_TYPE" \\
+      --arg msg "\$MESSAGE" \\
+      '{taskRunId: \$trid, type: "notification", summary: (\$notifType + ": " + (\$msg | if length > 100 then (.[0:100] + "...") else . end))}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+exit 0
+`;
+}
+
+function buildTaskCreatedScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+REQUEST=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+TASK_ID=\$(echo "\$REQUEST" | jq -r '.task_id // "unknown"')
+TASK_SUBJECT=\$(echo "\$REQUEST" | jq -r '.subject // ""' | head -c 100)
+TASK_STATUS=\$(echo "\$REQUEST" | jq -r '.status // "pending"')
+
+echo "[task-created] Task \$TASK_ID created: \$TASK_SUBJECT" >> "\$LOG_FILE" 2>&1
+
+# Post activity event to dashboard (background, don't block)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg taskId "\$TASK_ID" \\
+      --arg subject "\$TASK_SUBJECT" \\
+      --arg status "\$TASK_STATUS" \\
+      '{taskRunId: \$trid, type: "task_created", toolName: "TaskCreate", summary: ("Created task: " + (\$subject | if length > 60 then (.[0:60] + "...") else . end))}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+exit 0
+`;
+}
+
+function buildUserPromptScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+REQUEST=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+PROMPT=\$(echo "\$REQUEST" | jq -r '.prompt // ""' | head -c 200)
+SESSION_ID=\$(echo "\$REQUEST" | jq -r '.session_id // ""')
+
+# Only log non-empty prompts
+if [ -z "\$PROMPT" ]; then
+  exit 0
+fi
+
+echo "[user-prompt] Session \$SESSION_ID: \$PROMPT" >> "\$LOG_FILE" 2>&1
+
+# Post activity event to dashboard (background, don't block prompt processing)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg prompt "\$PROMPT" \\
+      '{taskRunId: \$trid, type: "user_prompt", summary: ("User: " + (\$prompt | if length > 100 then (.[0:100] + "...") else . end))}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+exit 0
+`;
+}
+
+function buildPlanSyncScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+INPUT=\$(cat)
+
+echo "[CMUX Plan Hook] Script started at \$(date)" >> "\$LOG_FILE"
+echo "[CMUX Plan Hook] Input: \$INPUT" >> "\$LOG_FILE"
+
+# Only sync if we have the required env vars and a linked project
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ]; then
+  echo "[CMUX Plan Hook] Missing env vars, skipping sync" >> "\$LOG_FILE"
+  exit 0
+fi
+
+# Extract plan file path from tool_input (if available)
+# ExitPlanMode doesn't pass the plan file path directly, so we look for plan files
+PLAN_DIR="/root/.claude/plans"
+if [ ! -d "\$PLAN_DIR" ]; then
+  echo "[CMUX Plan Hook] No plans directory found" >> "\$LOG_FILE"
+  exit 0
+fi
+
+# Find the most recently modified plan file
+PLAN_FILE=\$(ls -t "\$PLAN_DIR"/*.md 2>/dev/null | head -1)
+if [ -z "\$PLAN_FILE" ] || [ ! -f "\$PLAN_FILE" ]; then
+  echo "[CMUX Plan Hook] No plan files found" >> "\$LOG_FILE"
+  exit 0
+fi
+
+echo "[CMUX Plan Hook] Found plan file: \$PLAN_FILE" >> "\$LOG_FILE"
+
+# Read plan content
+PLAN_CONTENT=\$(cat "\$PLAN_FILE" | head -c 50000)  # Limit to 50KB
+
+# Send to plan sync endpoint (best-effort, non-blocking)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/integrations/github-projects/plan-sync" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n --arg content "\$PLAN_CONTENT" --arg file "\$PLAN_FILE" '{planContent: \$content, planFile: \$file}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+  echo "[CMUX Plan Hook] Sync request sent" >> "\$LOG_FILE"
+) &
+
+exit 0
+`;
+}
+
+function buildSimplifyTrackScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+REQUEST=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+# Extract skill name from tool input
+SKILL_NAME=\$(echo "\$REQUEST" | jq -r '.tool_input.skill // .tool_use.input.skill // empty')
+
+echo "[simplify-track] Skill used: \$SKILL_NAME" >> "\$LOG_FILE" 2>&1
+
+# Check if this is the simplify skill (with or without arguments)
+if [[ "\$SKILL_NAME" == "simplify" ]] || [[ "\$SKILL_NAME" == "simplify "* ]]; then
+  echo "[simplify-track] /simplify detected, marking as passed..." >> "\$LOG_FILE" 2>&1
+
+  # Extract mode from arguments if present (--quick, --staged-only, or default to "full")
+  MODE="full"
+  if [[ "\$SKILL_NAME" == *"--quick"* ]]; then
+    MODE="quick"
+  elif [[ "\$SKILL_NAME" == *"--staged-only"* ]]; then
+    MODE="staged-only"
+  fi
+
+  # Call the mark-passed endpoint
+  (
+    RESPONSE=\$(curl -s -X POST "\${CMUX_CALLBACK_URL}/api/v1/cmux/orchestration/simplify/mark-passed" \\
+      -H "Content-Type: application/json" \\
+      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+      -d "{\\"mode\\": \\"\$MODE\\"}" 2>&1)
+    echo "[simplify-track] API response: \$RESPONSE" >> "\$LOG_FILE" 2>&1
+
+    # Also post activity event
+    curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+      -H "Content-Type: application/json" \\
+      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+      -d "\$(jq -n \\
+        --arg trid "\${CMUX_TASK_RUN_ID}" \\
+        --arg mode "\$MODE" \\
+        '{taskRunId: \$trid, type: "simplify_passed", summary: ("/simplify (" + \$mode + ") completed")}')" \\
+      >> "\$LOG_FILE" 2>&1 || true
+  ) &
+fi
+
+exit 0
+`;
+}
+
+function buildPrecompactScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+REQUEST=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  # No cmux context - allow compaction to proceed
+  echo '{"continue": true}'
+  exit 0
+fi
+
+TRIGGER=\$(echo "\$REQUEST" | jq -r '.trigger // "auto"')
+SESSION_ID=\$(echo "\$REQUEST" | jq -r '.session_id // empty')
+
+echo "[precompact-hook] Trigger: \$TRIGGER, Session: \$SESSION_ID" >> "\$LOG_FILE" 2>&1
+
+# Sync memory to Convex before compaction (background, don't block)
+(
+  # Read current memory state
+  MEMORY_CONTENT=""
+  if [ -f "/root/lifecycle/memory/knowledge/MEMORY.md" ]; then
+    MEMORY_CONTENT=\$(cat /root/lifecycle/memory/knowledge/MEMORY.md | head -c 50000 | base64 -w 0)
+  fi
+
+  TASKS_CONTENT=""
+  if [ -f "/root/lifecycle/memory/TASKS.json" ]; then
+    TASKS_CONTENT=\$(cat /root/lifecycle/memory/TASKS.json | head -c 20000 | base64 -w 0)
+  fi
+
+  # Post to memory sync endpoint
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/memory/sync" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg trigger "\$TRIGGER" \\
+      --arg memory "\$MEMORY_CONTENT" \\
+      --arg tasks "\$TASKS_CONTENT" \\
+      '{taskRunId: \$trid, trigger: \$trigger, memoryBase64: \$memory, tasksBase64: \$tasks}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+
+  # Also post a context_warning activity event
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg trigger "\$TRIGGER" \\
+      '{taskRunId: \$trid, type: "context_warning", summary: ("Context compaction triggered: " + \$trigger)}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+
+# Allow compaction to proceed
+echo '{"continue": true}'
+exit 0
+`;
+}
+
+function buildPostcompactScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+LOG_FILE="${logFile}"
+REQUEST=\$(cat)
+
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+TRIGGER=\$(echo "\$REQUEST" | jq -r '.trigger // "auto"')
+SUMMARY=\$(echo "\$REQUEST" | jq -r '.summary // ""' | head -c 300)
+
+echo "[postcompact] Trigger: \$TRIGGER, Summary length: \${#SUMMARY}" >> "\$LOG_FILE" 2>&1
+
+# Post activity event to dashboard (background)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID}" \\
+      --arg trigger "\$TRIGGER" \\
+      '{taskRunId: \$trid, type: "context_compacted", summary: ("Context compacted (" + \$trigger + ")")}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+
+# Re-inject critical task context after compaction
+# This ensures agent remembers its core mission even after context is summarized
+TASK_CONTEXT=""
+if [ -f "/root/lifecycle/memory/knowledge/MEMORY.md" ]; then
+  # Extract P0 (Core) entries - most critical to preserve
+  TASK_CONTEXT=\$(grep -A 50 "## P0 Core" /root/lifecycle/memory/knowledge/MEMORY.md 2>/dev/null | head -20 || true)
+fi
+
+if [ -n "\$TASK_CONTEXT" ]; then
+  echo "Critical context from MEMORY.md (P0 Core):"
+  echo "\$TASK_CONTEXT"
+fi
+
+exit 0
+`;
+}
+
+function buildSimplifyGateScript(provider: ProviderName, logFile: string): string {
+  return `#!/bin/bash
+set -eu
+
+LOG_FILE="${logFile}"
+echo "[simplify-gate] Checking simplify requirement at \$(date)" >> "\$LOG_FILE"
+
+# Skip if requirement not enabled
+if [ "\${CMUX_REQUIRE_SIMPLIFY:-0}" != "1" ]; then
+  echo "[simplify-gate] Requirement not enabled, allowing stop" >> "\$LOG_FILE"
+  exit 0
+fi
+
+# Skip if missing env vars
+if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ]; then
+  echo "[simplify-gate] Missing env vars, allowing stop" >> "\$LOG_FILE"
+  exit 0
+fi
+
+# Check simplify status from API
+RESPONSE=\$(curl -s "\${CMUX_CALLBACK_URL}/api/v1/cmux/orchestration/simplify/status" \\
+  -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" 2>&1)
+
+echo "[simplify-gate] API response: \$RESPONSE" >> "\$LOG_FILE"
+
+# Parse response
+REQUIRED=\$(echo "\$RESPONSE" | jq -r '.required // false')
+PASSED=\$(echo "\$RESPONSE" | jq -r '.passed // false')
+SKIPPED_REASON=\$(echo "\$RESPONSE" | jq -r '.skippedReason // empty')
+
+echo "[simplify-gate] Required: \$REQUIRED, Passed: \$PASSED, Skipped: \$SKIPPED_REASON" >> "\$LOG_FILE"
+
+# If not required or already passed/skipped, allow stop
+if [ "\$REQUIRED" != "true" ] || [ "\$PASSED" == "true" ] || [ -n "\$SKIPPED_REASON" ]; then
+  echo "[simplify-gate] Requirement satisfied, allowing stop" >> "\$LOG_FILE"
+  exit 0
+fi
+
+# Block the stop - /simplify is required but hasn't been run
+echo "[simplify-gate] BLOCKING: /simplify required but not run" >> "\$LOG_FILE"
+
+# Emit stop_blocked event to dashboard (background, non-blocking)
+(
+  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
+    -H "Content-Type: application/json" \\
+    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
+    -d "\$(jq -n \\
+      --arg trid "\${CMUX_TASK_RUN_ID:-}" \\
+      '{taskRunId: \$trid, type: "stop_blocked", toolName: "claude", summary: "Stop blocked: /simplify required but not run", blockedBy: "simplify_gate"}')" \\
+    >> "\$LOG_FILE" 2>&1 || true
+) &
+
+echo "BLOCKED: Your team requires /simplify to run before task completion." >&2
+echo "Please run /simplify (or /simplify --quick) before stopping." >&2
+echo "To skip this requirement, ask your team admin to disable it in settings." >&2
+exit 2
 `;
 }

--- a/packages/shared/src/provider-lifecycle-adapter.ts
+++ b/packages/shared/src/provider-lifecycle-adapter.ts
@@ -97,7 +97,18 @@ export type LifecycleEventType =
   | "approval_requested"
   | "approval_resolved"
   // MCP runtime (P5 Lifecycle Parity)
-  | "mcp_capabilities_negotiated";
+  | "mcp_capabilities_negotiated"
+  // Phase 2 Hook Portability additions
+  | "subagent_start"
+  | "subagent_stop"
+  | "notification"
+  | "task_created"
+  | "user_prompt"
+  | "plan_sync"
+  | "simplify_track"
+  | "precompact"
+  | "postcompact"
+  | "simplify_gate";
 
 /**
  * Context for building lifecycle hooks.
@@ -399,7 +410,15 @@ export type CanonicalActivityType =
   | "approval_requested"
   | "approval_resolved"
   // Notifications
-  | "notification";
+  | "notification"
+  // Phase 2 Hook Portability additions
+  | "task_created"
+  | "plan_sync"
+  | "simplify_track"
+  | "simplify_passed"
+  | "precompact"
+  | "postcompact"
+  | "simplify_gate";
 
 /**
  * Context warning subtypes for canonical events.

--- a/packages/shared/src/providers/anthropic/environment.test.ts
+++ b/packages/shared/src/providers/anthropic/environment.test.ts
@@ -358,4 +358,121 @@ describe("getClaudeEnvironment", () => {
       }),
     ).rejects.toThrow(/does not support effort selection/);
   });
+
+  describe("thin hook stubs (Phase 2 Hook Portability)", () => {
+    it("generates thin stub hooks that contain /api/hooks/dispatch URL", async () => {
+      const result = await getClaudeEnvironment(BASE_CONTEXT);
+
+      // Check several hooks that should be thin stubs
+      const thinStubHooks = [
+        "/root/lifecycle/claude/subagent-start-hook.sh",
+        "/root/lifecycle/claude/subagent-stop-hook.sh",
+        "/root/lifecycle/claude/user-prompt-hook.sh",
+        "/root/lifecycle/claude/notification-hook.sh",
+        "/root/lifecycle/claude/task-created-hook.sh",
+        "/root/lifecycle/claude/postcompact-hook.sh",
+        "/root/lifecycle/claude/plan-hook.sh",
+        "/root/lifecycle/claude/simplify-track-hook.sh",
+        "/root/lifecycle/claude/activity-hook.sh",
+        "/root/lifecycle/claude/error-hook.sh",
+      ];
+
+      for (const hookPath of thinStubHooks) {
+        const hookFile = result.files.find(
+          (f) => f.destinationPath === hookPath,
+        );
+        expect(hookFile, `Hook ${hookPath} should exist`).toBeDefined();
+
+        const script = Buffer.from(
+          hookFile!.contentBase64,
+          "base64",
+        ).toString("utf-8");
+
+        // Thin stubs should reference the dispatch endpoint
+        expect(
+          script,
+          `Hook ${hookPath} should contain dispatch URL`,
+        ).toContain("/api/hooks/dispatch");
+
+        // Thin stubs should have cache handling
+        expect(
+          script,
+          `Hook ${hookPath} should have cache file`,
+        ).toContain("CACHE_FILE=");
+      }
+    });
+
+    it("generates critical hooks with fallback functions", async () => {
+      const result = await getClaudeEnvironment(BASE_CONTEXT);
+
+      // Critical hooks that need fallback
+      const criticalHooks = [
+        {
+          path: "/root/lifecycle/claude/stop-hook.sh",
+          mustContain: ["run_fallback()", "done.txt"],
+        },
+        {
+          path: "/root/lifecycle/claude/precompact-hook.sh",
+          mustContain: ["run_fallback()", '{"continue": true}'],
+        },
+        {
+          path: "/root/lifecycle/claude/simplify-gate-hook.sh",
+          mustContain: ["run_fallback()"],
+        },
+      ];
+
+      for (const { path, mustContain } of criticalHooks) {
+        const hookFile = result.files.find((f) => f.destinationPath === path);
+        expect(hookFile, `Critical hook ${path} should exist`).toBeDefined();
+
+        const script = Buffer.from(
+          hookFile!.contentBase64,
+          "base64",
+        ).toString("utf-8");
+
+        for (const content of mustContain) {
+          expect(
+            script,
+            `Critical hook ${path} should contain "${content}"`,
+          ).toContain(content);
+        }
+      }
+    });
+
+    it("stop hook fallback includes memory sync and completion marker", async () => {
+      const result = await getClaudeEnvironment(BASE_CONTEXT);
+
+      const stopHook = result.files.find(
+        (f) => f.destinationPath === "/root/lifecycle/claude/stop-hook.sh",
+      );
+      expect(stopHook).toBeDefined();
+
+      const script = Buffer.from(stopHook!.contentBase64, "base64").toString(
+        "utf-8",
+      );
+
+      // Fallback should include memory sync
+      expect(script).toContain("memory/sync.sh");
+
+      // Fallback should create completion marker
+      expect(script).toContain("done.txt");
+    });
+
+    it("precompact hook fallback returns continue:true", async () => {
+      const result = await getClaudeEnvironment(BASE_CONTEXT);
+
+      const precompactHook = result.files.find(
+        (f) => f.destinationPath === "/root/lifecycle/claude/precompact-hook.sh",
+      );
+      expect(precompactHook).toBeDefined();
+
+      const script = Buffer.from(
+        precompactHook!.contentBase64,
+        "base64",
+      ).toString("utf-8");
+
+      // Fallback should output JSON to allow compaction
+      expect(script).toContain('{"continue": true}');
+    });
+  });
 });

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -14,6 +14,7 @@ import {
 } from "../../agent-memory-protocol";
 import { buildClaudeMdContent } from "../../agent-instruction-pack";
 import { buildMergedClaudeConfig } from "../../mcp-preview";
+import { buildThinHookStubFile } from "../../provider-lifecycle-adapter";
 
 export const CLAUDE_KEY_ENV_VARS_TO_UNSET = [
   "ANTHROPIC_API_KEY",
@@ -212,215 +213,67 @@ export async function getClaudeEnvironment(
     "rm -f /root/lifecycle/claude-complete-* 2>/dev/null || true",
   );
 
-  // Create the stop hook script in /root/lifecycle (outside git repo)
-  const stopHookScript = `#!/bin/bash
-# Claude Code stop hook for cmux task completion detection
-# This script is called when Claude Code finishes responding
-
+  // Stop hook script - thin stub with comprehensive fallback for critical operations
+  // P0 Critical: must sync memory and create completion markers even if server unreachable
+  const stopHookFallback = `#!/bin/bash
+set -eu
 LOG_FILE="/root/lifecycle/claude-hook.log"
+echo "[CMUX Stop Hook Fallback] Running at \$(date)" >> "\$LOG_FILE"
 
-echo "[CMUX Stop Hook] Script started at $(date)" >> "$LOG_FILE"
-echo "[CMUX Stop Hook] CMUX_TASK_RUN_ID=\${CMUX_TASK_RUN_ID}" >> "$LOG_FILE"
-echo "[CMUX Stop Hook] CMUX_CALLBACK_URL=\${CMUX_CALLBACK_URL}" >> "$LOG_FILE"
+# Sync memory files (best-effort)
+/root/lifecycle/memory/sync.sh >> "\$LOG_FILE" 2>&1 || true
 
-if [ -n "\${CMUX_TASK_RUN_JWT}" ] && [ -n "\${CMUX_TASK_RUN_ID}" ] && [ -n "\${CMUX_CALLBACK_URL}" ]; then
-  (
-    # Sync memory files to Convex (best-effort, before completion callbacks)
-    echo "[CMUX Stop Hook] Syncing memory files..." >> "$LOG_FILE"
-    /root/lifecycle/memory/sync.sh >> "$LOG_FILE" 2>&1 || true
-
-    # Call crown/complete for status updates
-    echo "[CMUX Stop Hook] Calling crown/complete..." >> "$LOG_FILE"
-    curl -s -X POST "\${CMUX_CALLBACK_URL}/api/crown/complete" \\
-      -H "Content-Type: application/json" \\
-      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-      -d "{\\"taskRunId\\": \\"\${CMUX_TASK_RUN_ID}\\", \\"exitCode\\": 0}" \\
-      >> "$LOG_FILE" 2>&1
-    echo "" >> "$LOG_FILE"
-
-    # Call notifications endpoint for user notification
-    echo "[CMUX Stop Hook] Calling notifications/agent-stopped..." >> "$LOG_FILE"
-    curl -s -X POST "\${CMUX_CALLBACK_URL}/api/notifications/agent-stopped" \\
-      -H "Content-Type: application/json" \\
-      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-      -d "{\\"taskRunId\\": \\"\${CMUX_TASK_RUN_ID}\\"}" \\
-      >> "$LOG_FILE" 2>&1
-    echo "" >> "$LOG_FILE"
-    # Post "agent stopped" activity event for dashboard timeline
-    curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-      -H "Content-Type: application/json" \\
-      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-      -d "{\\"taskRunId\\": \\"\${CMUX_TASK_RUN_ID}\\", \\"type\\": \\"tool_call\\", \\"toolName\\": \\"Stop\\", \\"summary\\": \\"Agent stopped\\"}" \\
-      >> "$LOG_FILE" 2>&1 || true
-
-    echo "[CMUX Stop Hook] API calls completed at $(date)" >> "$LOG_FILE"
-  ) &
-else
-  echo "[CMUX Stop Hook] Missing required env vars, skipping API calls" >> "$LOG_FILE"
+# Create completion marker for task run
+if [ -n "\${CMUX_TASK_RUN_ID:-}" ]; then
+  touch "/root/lifecycle/claude-complete-\${CMUX_TASK_RUN_ID}"
 fi
 
-# Write completion marker for backward compatibility
-if [ -n "\${CMUX_TASK_RUN_ID}" ]; then
-  COMPLETE_MARKER="/root/lifecycle/claude-complete-\${CMUX_TASK_RUN_ID}"
-  echo "[CMUX Stop Hook] Creating completion marker at \${COMPLETE_MARKER}" >> "$LOG_FILE"
-  mkdir -p "$(dirname "$COMPLETE_MARKER")"
-  touch "$COMPLETE_MARKER"
-fi
+# Create generic completion marker
+touch /root/lifecycle/done.txt
 
-# Also log to stderr for visibility
-echo "[CMUX Stop Hook] Task completed for task run ID: \${CMUX_TASK_RUN_ID:-unknown}" >&2
-
-# Always allow Claude to stop (don't block)
+echo "[CMUX Stop Hook Fallback] Completed" >> "\$LOG_FILE"
 exit 0`;
 
   // Add stop hook script to files array (like Codex does) to ensure it's created before git init
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/stop-hook.sh`,
-    contentBase64: Buffer.from(stopHookScript).toString("base64"),
-    mode: "755",
-  });
+  files.push(
+    buildThinHookStubFile(
+      "session_stop",
+      "claude",
+      `${claudeLifecycleDir}/stop-hook.sh`,
+      Buffer.from.bind(Buffer),
+      { fallbackScript: stopHookFallback },
+    ),
+  );
 
-  // Plan hook script - captures ExitPlanMode and syncs to GitHub Projects
-  // Receives JSON on stdin with tool_input containing plan file path
-  const planHookScript = `#!/bin/bash
-# Claude Code plan hook - syncs plans to GitHub Projects
-# This script is called when ExitPlanMode tool is used
+  // Plan hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "plan_sync",
+      "claude",
+      `${claudeLifecycleDir}/plan-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
 
-LOG_FILE="/root/lifecycle/claude-hook.log"
-INPUT=$(cat)
+  // Activity hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "tool_call",
+      "claude",
+      `${claudeLifecycleDir}/activity-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
 
-echo "[CMUX Plan Hook] Script started at $(date)" >> "$LOG_FILE"
-echo "[CMUX Plan Hook] Input: $INPUT" >> "$LOG_FILE"
-
-# Only sync if we have the required env vars and a linked project
-if [ -z "\${CMUX_TASK_RUN_JWT}" ] || [ -z "\${CMUX_CALLBACK_URL}" ]; then
-  echo "[CMUX Plan Hook] Missing env vars, skipping sync" >> "$LOG_FILE"
-  exit 0
-fi
-
-# Extract plan file path from tool_input (if available)
-# ExitPlanMode doesn't pass the plan file path directly, so we look for plan files
-PLAN_DIR="/root/.claude/plans"
-if [ ! -d "$PLAN_DIR" ]; then
-  echo "[CMUX Plan Hook] No plans directory found" >> "$LOG_FILE"
-  exit 0
-fi
-
-# Find the most recently modified plan file
-PLAN_FILE=$(ls -t "$PLAN_DIR"/*.md 2>/dev/null | head -1)
-if [ -z "$PLAN_FILE" ] || [ ! -f "$PLAN_FILE" ]; then
-  echo "[CMUX Plan Hook] No plan files found" >> "$LOG_FILE"
-  exit 0
-fi
-
-echo "[CMUX Plan Hook] Found plan file: $PLAN_FILE" >> "$LOG_FILE"
-
-# Read plan content
-PLAN_CONTENT=$(cat "$PLAN_FILE" | head -c 50000)  # Limit to 50KB
-
-# Send to plan sync endpoint (best-effort, non-blocking)
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/integrations/github-projects/plan-sync" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n --arg content "$PLAN_CONTENT" --arg file "$PLAN_FILE" '{planContent: $content, planFile: $file}')" \\
-    >> "$LOG_FILE" 2>&1 || true
-  echo "[CMUX Plan Hook] Sync request sent" >> "$LOG_FILE"
-) &
-
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/plan-hook.sh`,
-    contentBase64: Buffer.from(planHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // Activity hook script - reports agent tool-use events to cmux dashboard
-  const activityHookScript = `#!/bin/bash
-# Claude Code activity hook - posts tool-use events for real-time dashboard
-# Runs after every matched tool call. Non-blocking (background POST).
-set -eu
-EVENT=$(cat)
-TOOL_NAME=$(echo "$EVENT" | jq -r '.tool_use.name // "unknown"')
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-# Map tool names to activity types
-case "$TOOL_NAME" in
-  Edit|Write|NotebookEdit) TYPE="file_edit" ;;
-  Read)                     TYPE="file_read" ;;
-  Bash)                     TYPE="bash_command" ;;
-  Grep|Glob)                TYPE="file_read" ;;
-  Agent)                    TYPE="tool_call" ;;
-  *)                        TYPE="tool_call" ;;
-esac
-
-# Build human-readable summary from tool input
-case "$TOOL_NAME" in
-  Edit)  SUMMARY="Edit $(echo "$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
-  Read)  SUMMARY="Read $(echo "$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
-  Write) SUMMARY="Write $(echo "$EVENT" | jq -r '.tool_use.input.file_path // ""' | sed 's|.*/||')" ;;
-  Bash)  SUMMARY="Run: $(echo "$EVENT" | jq -r '.tool_use.input.command // ""' | head -c 80)" ;;
-  Grep)  SUMMARY="Search: $(echo "$EVENT" | jq -r '.tool_use.input.pattern // ""' | head -c 60)" ;;
-  Glob)  SUMMARY="Find: $(echo "$EVENT" | jq -r '.tool_use.input.pattern // ""' | head -c 60)" ;;
-  Agent) SUMMARY="Agent: $(echo "$EVENT" | jq -r '.tool_use.input.description // ""' | head -c 60)" ;;
-  *)     SUMMARY="$TOOL_NAME" ;;
-esac
-
-# Non-blocking POST
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg type "$TYPE" \\
-      --arg tool "$TOOL_NAME" \\
-      --arg summary "$SUMMARY" \\
-      '{taskRunId: $trid, type: $type, toolName: $tool, summary: $summary}')" \\
-    >> /root/lifecycle/activity-hook.log 2>&1 || true
-) &
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/activity-hook.sh`,
-    contentBase64: Buffer.from(activityHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // Error hook script - reports StopFailure events (API errors, rate limits) to dashboard
-  const errorHookScript = `#!/bin/bash
-# Claude Code error hook - surfaces agent failures in cmux dashboard
-# Fires on StopFailure: rate limit, auth failure, API error, etc.
-set -eu
-EVENT=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-ERROR_MSG=$(echo "$EVENT" | jq -r '.error // "Agent stopped due to an error"' | head -c 300)
-
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg summary "Error: $ERROR_MSG" \\
-      '{taskRunId: $trid, type: "error", summary: $summary}')" \\
-    >> /root/lifecycle/activity-hook.log 2>&1 || true
-) &
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/error-hook.sh`,
-    contentBase64: Buffer.from(errorHookScript).toString("base64"),
-    mode: "755",
-  });
+  // Error hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "error",
+      "claude",
+      `${claudeLifecycleDir}/error-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
 
   // Permission hook script - bridges Claude permission requests to cmux approval broker
   // This enables human-in-the-loop approval via the cmux dashboard
@@ -583,435 +436,108 @@ exit 0`;
     mode: "755",
   });
 
-  // PreCompact hook script - syncs memory to Convex before context compression
-  // This ensures memory state is persisted before the context window gets summarized
-  const preCompactHookScript = `#!/bin/bash
-# Claude Code pre-compact hook - syncs memory before context compression
-# Fires on PreCompact: before context window gets compressed/summarized
+  // PreCompact hook script - thin stub with fallback that allows compaction
+  // Critical: must return {"continue": true} even if server unreachable
+  const precompactFallback = `#!/bin/bash
 set -eu
-REQUEST=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  # No cmux context - allow compaction to proceed
-  echo '{"continue": true}'
-  exit 0
-fi
-
-TRIGGER=$(echo "$REQUEST" | jq -r '.trigger // "auto"')
-SESSION_ID=$(echo "$REQUEST" | jq -r '.session_id // empty')
-
-echo "[precompact-hook] Trigger: $TRIGGER, Session: $SESSION_ID" >> /root/lifecycle/precompact-hook.log 2>&1
-
-# Sync memory to Convex before compaction (background, don't block)
-(
-  # Read current memory state
-  MEMORY_CONTENT=""
-  if [ -f "/root/lifecycle/memory/knowledge/MEMORY.md" ]; then
-    MEMORY_CONTENT=$(cat /root/lifecycle/memory/knowledge/MEMORY.md | head -c 50000 | base64 -w 0)
-  fi
-
-  TASKS_CONTENT=""
-  if [ -f "/root/lifecycle/memory/TASKS.json" ]; then
-    TASKS_CONTENT=$(cat /root/lifecycle/memory/TASKS.json | head -c 20000 | base64 -w 0)
-  fi
-
-  # Post to memory sync endpoint
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/memory/sync" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg trigger "$TRIGGER" \\
-      --arg memory "$MEMORY_CONTENT" \\
-      --arg tasks "$TASKS_CONTENT" \\
-      '{taskRunId: $trid, trigger: $trigger, memoryBase64: $memory, tasksBase64: $tasks}')" \\
-    >> /root/lifecycle/precompact-hook.log 2>&1 || true
-
-  # Also post a context_warning activity event
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg trigger "$TRIGGER" \\
-      '{taskRunId: $trid, type: "context_warning", summary: ("Context compaction triggered: " + $trigger)}')" \\
-    >> /root/lifecycle/precompact-hook.log 2>&1 || true
-) &
-
-# Allow compaction to proceed
+# Fallback: allow compaction to proceed
 echo '{"continue": true}'
 exit 0`;
+  files.push(
+    buildThinHookStubFile(
+      "precompact",
+      "claude",
+      `${claudeLifecycleDir}/precompact-hook.sh`,
+      Buffer.from.bind(Buffer),
+      { fallbackScript: precompactFallback },
+    ),
+  );
 
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/precompact-hook.sh`,
-    contentBase64: Buffer.from(preCompactHookScript).toString("base64"),
-    mode: "755",
-  });
+  // SubagentStart hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "subagent_start",
+      "claude",
+      `${claudeLifecycleDir}/subagent-start-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
 
-  // SubagentStart hook script - tracks when Claude spawns sub-agents
-  const subagentStartHookScript = `#!/bin/bash
-# Claude Code subagent-start hook - tracks sub-agent spawning in cmux dashboard
-# Fires on SubagentStart: when a subagent is spawned via Agent tool
+  // SubagentStop hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "subagent_stop",
+      "claude",
+      `${claudeLifecycleDir}/subagent-stop-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
+
+  // UserPromptSubmit hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "user_prompt",
+      "claude",
+      `${claudeLifecycleDir}/user-prompt-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
+
+  // Notification hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "notification",
+      "claude",
+      `${claudeLifecycleDir}/notification-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
+
+  // PostCompact hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "postcompact",
+      "claude",
+      `${claudeLifecycleDir}/postcompact-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
+
+  // Simplify skill tracking hook - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "simplify_track",
+      "claude",
+      `${claudeLifecycleDir}/simplify-track-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
+
+  // Simplify gate hook - thin stub with fallback that allows stop on server failure
+  // Critical: should not block stop if server is unreachable
+  const simplifyGateFallback = `#!/bin/bash
 set -eu
-REQUEST=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-AGENT_ID=$(echo "$REQUEST" | jq -r '.agent_id // "unknown"')
-AGENT_TYPE=$(echo "$REQUEST" | jq -r '.agent_type // "unknown"')
-
-echo "[subagent-start] Agent $AGENT_ID ($AGENT_TYPE) spawned" >> /root/lifecycle/subagent-hook.log 2>&1
-
-# Post activity event to dashboard (background, don't block)
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg agentId "$AGENT_ID" \\
-      --arg agentType "$AGENT_TYPE" \\
-      '{taskRunId: $trid, type: "subagent_start", toolName: "Agent", summary: ("Spawned " + $agentType + " subagent: " + $agentId)}')" \\
-    >> /root/lifecycle/subagent-hook.log 2>&1 || true
-) &
+# Fallback: allow stop to proceed (fail open)
 exit 0`;
+  files.push(
+    buildThinHookStubFile(
+      "simplify_gate",
+      "claude",
+      `${claudeLifecycleDir}/simplify-gate-hook.sh`,
+      Buffer.from.bind(Buffer),
+      { fallbackScript: simplifyGateFallback },
+    ),
+  );
 
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/subagent-start-hook.sh`,
-    contentBase64: Buffer.from(subagentStartHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // SubagentStop hook script - tracks when Claude sub-agents complete
-  const subagentStopHookScript = `#!/bin/bash
-# Claude Code subagent-stop hook - tracks sub-agent completion in cmux dashboard
-# Fires on SubagentStop: when a subagent finishes responding
-set -eu
-REQUEST=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-AGENT_ID=$(echo "$REQUEST" | jq -r '.agent_id // "unknown"')
-AGENT_TYPE=$(echo "$REQUEST" | jq -r '.agent_type // "unknown"')
-LAST_MESSAGE=$(echo "$REQUEST" | jq -r '.last_assistant_message // ""' | head -c 200)
-
-echo "[subagent-stop] Agent $AGENT_ID ($AGENT_TYPE) completed" >> /root/lifecycle/subagent-hook.log 2>&1
-
-# Post activity event to dashboard (background, don't block)
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg agentId "$AGENT_ID" \\
-      --arg agentType "$AGENT_TYPE" \\
-      --arg summary "$LAST_MESSAGE" \\
-      '{taskRunId: $trid, type: "subagent_stop", toolName: "Agent", summary: ($agentType + " subagent completed: " + ($summary | if length > 100 then (.[0:100] + "...") else . end))}')" \\
-    >> /root/lifecycle/subagent-hook.log 2>&1 || true
-) &
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/subagent-stop-hook.sh`,
-    contentBase64: Buffer.from(subagentStopHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // UserPromptSubmit hook script - tracks when user submits prompts
-  // Useful for session activity monitoring and interaction tracking
-  const userPromptSubmitHookScript = `#!/bin/bash
-# Claude Code user-prompt-submit hook - tracks user prompt submissions
-# Fires on UserPromptSubmit: when user submits a prompt, before Claude processes it
-set -eu
-REQUEST=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-PROMPT=$(echo "$REQUEST" | jq -r '.prompt // ""' | head -c 200)
-SESSION_ID=$(echo "$REQUEST" | jq -r '.session_id // ""')
-
-# Only log non-empty prompts
-if [ -z "$PROMPT" ]; then
-  exit 0
-fi
-
-echo "[user-prompt] Session $SESSION_ID: $PROMPT" >> /root/lifecycle/prompt-hook.log 2>&1
-
-# Post activity event to dashboard (background, don't block prompt processing)
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg prompt "$PROMPT" \\
-      '{taskRunId: $trid, type: "user_prompt", summary: ("User: " + ($prompt | if length > 100 then (.[0:100] + "...") else . end))}')" \\
-    >> /root/lifecycle/prompt-hook.log 2>&1 || true
-) &
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/user-prompt-hook.sh`,
-    contentBase64: Buffer.from(userPromptSubmitHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // Notification hook script - fires when Claude needs user attention
-  // Useful for surfacing permission prompts and idle states to dashboard
-  const notificationHookScript = `#!/bin/bash
-# Claude Code notification hook - surfaces attention requests to dashboard
-# Fires on Notification: when Claude needs user attention (permission prompt, idle, etc.)
-set -eu
-REQUEST=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-NOTIFICATION_TYPE=$(echo "$REQUEST" | jq -r '.notification_type // "unknown"')
-MESSAGE=$(echo "$REQUEST" | jq -r '.message // ""' | head -c 200)
-
-echo "[notification] Type: $NOTIFICATION_TYPE - $MESSAGE" >> /root/lifecycle/notification-hook.log 2>&1
-
-# Post activity event to dashboard (background, don't block)
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg notifType "$NOTIFICATION_TYPE" \\
-      --arg msg "$MESSAGE" \\
-      '{taskRunId: $trid, type: "notification", summary: ($notifType + ": " + ($msg | if length > 100 then (.[0:100] + "...") else . end))}')" \\
-    >> /root/lifecycle/notification-hook.log 2>&1 || true
-) &
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/notification-hook.sh`,
-    contentBase64: Buffer.from(notificationHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // PostCompact hook script - fires after context compression completes
-  // Can re-inject critical context and log compaction events
-  const postCompactHookScript = `#!/bin/bash
-# Claude Code post-compact hook - fires after context compression
-# Useful for re-injecting critical context and logging compaction events
-set -eu
-REQUEST=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-TRIGGER=$(echo "$REQUEST" | jq -r '.trigger // "auto"')
-SUMMARY=$(echo "$REQUEST" | jq -r '.summary // ""' | head -c 300)
-
-echo "[postcompact] Trigger: $TRIGGER, Summary length: \${#SUMMARY}" >> /root/lifecycle/postcompact-hook.log 2>&1
-
-# Post activity event to dashboard (background)
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg trigger "$TRIGGER" \\
-      '{taskRunId: $trid, type: "context_compacted", summary: ("Context compacted (" + $trigger + ")")}')" \\
-    >> /root/lifecycle/postcompact-hook.log 2>&1 || true
-) &
-
-# Re-inject critical task context after compaction
-# This ensures agent remembers its core mission even after context is summarized
-TASK_CONTEXT=""
-if [ -f "/root/lifecycle/memory/knowledge/MEMORY.md" ]; then
-  # Extract P0 (Core) entries - most critical to preserve
-  TASK_CONTEXT=$(grep -A 50 "## P0 Core" /root/lifecycle/memory/knowledge/MEMORY.md 2>/dev/null | head -20 || true)
-fi
-
-if [ -n "$TASK_CONTEXT" ]; then
-  echo "Critical context from MEMORY.md (P0 Core):"
-  echo "$TASK_CONTEXT"
-fi
-
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/postcompact-hook.sh`,
-    contentBase64: Buffer.from(postCompactHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // Simplify skill tracking hook - detects when /simplify is used
-  // Marks the task run as having passed /simplify when the skill completes
-  const simplifyTrackHookScript = `#!/bin/bash
-# Claude Code /simplify tracking hook - marks task run when simplify skill completes
-# Fires on PostToolUse for Skill tool, checks if it's /simplify
-set -eu
-REQUEST=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-# Extract skill name from tool input
-SKILL_NAME=$(echo "$REQUEST" | jq -r '.tool_input.skill // .tool_use.input.skill // empty')
-
-echo "[simplify-track] Skill used: $SKILL_NAME" >> /root/lifecycle/simplify-hook.log 2>&1
-
-# Check if this is the simplify skill (with or without arguments)
-if [[ "$SKILL_NAME" == "simplify" ]] || [[ "$SKILL_NAME" == "simplify "* ]]; then
-  echo "[simplify-track] /simplify detected, marking as passed..." >> /root/lifecycle/simplify-hook.log 2>&1
-
-  # Extract mode from arguments if present (--quick, --staged-only, or default to "full")
-  MODE="full"
-  if [[ "$SKILL_NAME" == *"--quick"* ]]; then
-    MODE="quick"
-  elif [[ "$SKILL_NAME" == *"--staged-only"* ]]; then
-    MODE="staged-only"
-  fi
-
-  # Call the mark-passed endpoint
-  (
-    RESPONSE=$(curl -s -X POST "\${CMUX_CALLBACK_URL}/api/v1/cmux/orchestration/simplify/mark-passed" \\
-      -H "Content-Type: application/json" \\
-      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-      -d "{\\"mode\\": \\"$MODE\\"}" 2>&1)
-    echo "[simplify-track] API response: $RESPONSE" >> /root/lifecycle/simplify-hook.log 2>&1
-
-    # Also post activity event
-    curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-      -H "Content-Type: application/json" \\
-      -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-      -d "$(jq -n \\
-        --arg trid "\${CMUX_TASK_RUN_ID}" \\
-        --arg mode "$MODE" \\
-        '{taskRunId: $trid, type: "simplify_passed", summary: ("/simplify (" + $mode + ") completed")}')" \\
-      >> /root/lifecycle/simplify-hook.log 2>&1 || true
-  ) &
-fi
-
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/simplify-track-hook.sh`,
-    contentBase64: Buffer.from(simplifyTrackHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // Simplify gate hook - blocks agent stop if /simplify required but not passed
-  // Only runs when CMUX_REQUIRE_SIMPLIFY=1 is set
-  const simplifyGateHookScript = `#!/bin/bash
-# Claude Code /simplify gate hook - enforces pre-merge requirement
-# Exit code 2 = block agent from stopping, stderr = message to user
-set -eu
-
-LOG_FILE="/root/lifecycle/simplify-gate.log"
-echo "[simplify-gate] Checking simplify requirement at $(date)" >> "$LOG_FILE"
-
-# Skip if requirement not enabled
-if [ "\${CMUX_REQUIRE_SIMPLIFY:-0}" != "1" ]; then
-  echo "[simplify-gate] Requirement not enabled, allowing stop" >> "$LOG_FILE"
-  exit 0
-fi
-
-# Skip if missing env vars
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ]; then
-  echo "[simplify-gate] Missing env vars, allowing stop" >> "$LOG_FILE"
-  exit 0
-fi
-
-# Check simplify status from API
-RESPONSE=$(curl -s "\${CMUX_CALLBACK_URL}/api/v1/cmux/orchestration/simplify/status" \\
-  -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" 2>&1)
-
-echo "[simplify-gate] API response: $RESPONSE" >> "$LOG_FILE"
-
-# Parse response
-REQUIRED=$(echo "$RESPONSE" | jq -r '.required // false')
-PASSED=$(echo "$RESPONSE" | jq -r '.passed // false')
-SKIPPED_REASON=$(echo "$RESPONSE" | jq -r '.skippedReason // empty')
-
-echo "[simplify-gate] Required: $REQUIRED, Passed: $PASSED, Skipped: $SKIPPED_REASON" >> "$LOG_FILE"
-
-# If not required or already passed/skipped, allow stop
-if [ "$REQUIRED" != "true" ] || [ "$PASSED" == "true" ] || [ -n "$SKIPPED_REASON" ]; then
-  echo "[simplify-gate] Requirement satisfied, allowing stop" >> "$LOG_FILE"
-  exit 0
-fi
-
-# Block the stop - /simplify is required but hasn't been run
-echo "[simplify-gate] BLOCKING: /simplify required but not run" >> "$LOG_FILE"
-
-# Emit stop_blocked event to dashboard (background, non-blocking)
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID:-}" \\
-      '{taskRunId: $trid, type: "stop_blocked", toolName: "claude", summary: "Stop blocked: /simplify required but not run", blockedBy: "simplify_gate"}')" \\
-    >> "$LOG_FILE" 2>&1 || true
-) &
-
-echo "BLOCKED: Your team requires /simplify to run before task completion." >&2
-echo "Please run /simplify (or /simplify --quick) before stopping." >&2
-echo "To skip this requirement, ask your team admin to disable it in settings." >&2
-exit 2`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/simplify-gate-hook.sh`,
-    contentBase64: Buffer.from(simplifyGateHookScript).toString("base64"),
-    mode: "755",
-  });
-
-  // TaskCreated hook script - tracks when tasks are created via TaskCreate tool
-  // Useful for dashboard activity tracking and task registry sync
-  // See: https://code.claude.com/docs/en/changelog (v2.1.84)
-  const taskCreatedHookScript = `#!/bin/bash
-# Claude Code task-created hook - tracks task creation in cmux dashboard
-# Fires on TaskCreated: when a task is created via TaskCreate tool
-set -eu
-REQUEST=$(cat)
-
-if [ -z "\${CMUX_TASK_RUN_JWT:-}" ] || [ -z "\${CMUX_CALLBACK_URL:-}" ] || [ -z "\${CMUX_TASK_RUN_ID:-}" ]; then
-  exit 0
-fi
-
-TASK_ID=$(echo "$REQUEST" | jq -r '.task_id // "unknown"')
-TASK_SUBJECT=$(echo "$REQUEST" | jq -r '.subject // ""' | head -c 100)
-TASK_STATUS=$(echo "$REQUEST" | jq -r '.status // "pending"')
-
-echo "[task-created] Task $TASK_ID created: $TASK_SUBJECT" >> /root/lifecycle/task-hook.log 2>&1
-
-# Post activity event to dashboard (background, don't block)
-(
-  curl -s -X POST "\${CMUX_CALLBACK_URL}/api/task-run/activity" \\
-    -H "Content-Type: application/json" \\
-    -H "x-cmux-token: \${CMUX_TASK_RUN_JWT}" \\
-    -d "$(jq -n \\
-      --arg trid "\${CMUX_TASK_RUN_ID}" \\
-      --arg taskId "$TASK_ID" \\
-      --arg subject "$TASK_SUBJECT" \\
-      --arg status "$TASK_STATUS" \\
-      '{taskRunId: $trid, type: "task_created", toolName: "TaskCreate", summary: ("Created task: " + ($subject | if length > 60 then (.[0:60] + "...") else . end))}')" \\
-    >> /root/lifecycle/task-hook.log 2>&1 || true
-) &
-exit 0`;
-
-  files.push({
-    destinationPath: `${claudeLifecycleDir}/task-created-hook.sh`,
-    contentBase64: Buffer.from(taskCreatedHookScript).toString("base64"),
-    mode: "755",
-  });
+  // TaskCreated hook script - thin stub that fetches dispatch logic from server
+  files.push(
+    buildThinHookStubFile(
+      "task_created",
+      "claude",
+      `${claudeLifecycleDir}/task-created-hook.sh`,
+      Buffer.from.bind(Buffer),
+    ),
+  );
 
   // Check if user has provided an OAuth token (preferred) or API key
   const hasOAuthToken =


### PR DESCRIPTION
## Summary

Implements fetch-on-invoke pattern for Claude Code hooks by replacing inline shell scripts with thin stubs that fetch dispatch logic from the `/api/hooks/dispatch` endpoint (PR #943).

**Key changes:**
- Added 10 new event types to hook registry: `subagent_start`, `subagent_stop`, `notification`, `task_created`, `user_prompt`, `plan_sync`, `simplify_track`, `precompact`, `postcompact`, `simplify_gate`
- Migrated 12 Claude inline hooks to thin stubs using `buildThinHookStubFile()`
- Critical hooks include inline fallbacks for reliability when server is unreachable
- Added unit tests verifying thin stubs contain dispatch URL and fallbacks

**Critical hook fallbacks:**
- `stop-hook.sh`: memory sync + completion markers
- `precompact-hook.sh`: returns `{"continue": true}`
- `simplify-gate-hook.sh`: allows stop to proceed (fail open)

**Deferred:** Codex hooks remain inline due to complex workspace resolution and multi-hook routing logic that doesn't fit the thin stub pattern.

## Test plan

- [x] Type check passes (`bun run typecheck`)
- [x] Unit tests pass for thin stub generation
- [x] Tests verify dispatch URL in thin stubs
- [x] Tests verify fallback functions in critical hooks
- [ ] Manual validation: spawn sandbox and verify hooks fetch from dispatch endpoint
- [ ] Manual validation: verify fallback executes when `CMUX_CALLBACK_URL` is unset