### PR TITLE
feat: add event support matrix and provider coverage indicator

### DIFF
--- a/apps/client/src/components/ActivityStream.tsx
+++ b/apps/client/src/components/ActivityStream.tsx
@@ -1,5 +1,6 @@
 import { api } from "@cmux/convex/api";
 import type { Id } from "@cmux/convex/dataModel";
+import { isActivityTypeSupported } from "@cmux/shared/hook-registry";
 import { useQuery } from "convex/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { LucideIcon } from "lucide-react";
@@ -26,6 +27,7 @@ import {
   Bell,
   MessagesSquare,
   ServerCog,
+  Info,
 } from "lucide-react";
 import { ActivityStreamSkeleton } from "@/components/dashboard/DashboardSkeletons";
 import { formatDuration } from "@/lib/time";
@@ -554,9 +556,11 @@ function getActivitySearchText(activity: ActivityLike): string {
 
 interface ActivityStreamProps {
   taskRunId: Id<"taskRuns">;
+  /** Provider name for event coverage indicators (e.g., "claude", "codex") */
+  provider?: string;
 }
 
-export function ActivityStream({ taskRunId }: ActivityStreamProps) {
+export function ActivityStream({ taskRunId, provider }: ActivityStreamProps) {
   const activities = useQuery(api.taskRunActivity.getByTaskRunAsc, {
     taskRunId,
     limit: 200,
@@ -682,8 +686,21 @@ export function ActivityStream({ taskRunId }: ActivityStreamProps) {
 
   const hasActiveFilters = activeFilters.size > 0 || searchQuery.trim().length > 0;
 
+  // Check if provider has limited event coverage (not Claude)
+  const hasLimitedCoverage = provider && provider !== "claude";
+
   return (
     <div className="flex flex-col h-full">
+      {/* Limited coverage info banner */}
+      {hasLimitedCoverage && (
+        <div className="px-3 py-2 bg-blue-50 dark:bg-blue-950/30 border-b border-blue-200 dark:border-blue-900 flex items-center gap-2">
+          <Info className="h-4 w-4 text-blue-500 flex-shrink-0" />
+          <span className="text-xs text-blue-700 dark:text-blue-300">
+            Some event types are not available for {provider}. Grayed-out filters indicate unsupported events.
+          </span>
+        </div>
+      )}
+
       {/* Error banner */}
       {errorCount > 0 && (
         <div className="px-3 py-2 bg-red-50 dark:bg-red-950/40 border-b border-red-200 dark:border-red-900 flex items-center gap-2">
@@ -799,20 +816,32 @@ export function ActivityStream({ taskRunId }: ActivityStreamProps) {
                 const { icon: Icon, label } = getActivityConfig(type);
                 const isActive = activeFilters.has(type);
                 const count = activities.filter((a) => a.type === type).length;
-                if (count === 0) return null;
+                const isSupported = !provider || isActivityTypeSupported(type, provider);
+
+                // Show chip if there are events OR if provider doesn't support this type (to explain why it's missing)
+                if (count === 0 && isSupported) return null;
 
                 return (
                   <button
                     key={type}
-                    onClick={() => toggleFilter(type)}
+                    onClick={() => isSupported && toggleFilter(type)}
+                    disabled={!isSupported}
+                    title={
+                      isSupported
+                        ? undefined
+                        : `Not available for ${provider} provider`
+                    }
                     className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs transition-colors ${
-                      isActive
-                        ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
-                        : "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700"
+                      !isSupported
+                        ? "bg-neutral-50 text-neutral-400 dark:bg-neutral-900 dark:text-neutral-600 cursor-not-allowed opacity-60"
+                        : isActive
+                          ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                          : "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700"
                     }`}
                   >
                     <Icon className="h-3 w-3" />
-                    {label} ({count})
+                    {label} {count > 0 ? `(${count})` : ""}
+                    {!isSupported && <Info className="h-2.5 w-2.5 ml-0.5" />}
                   </button>
                 );
               })}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.activity.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.activity.tsx
@@ -152,7 +152,7 @@ function TaskRunActivity() {
         name="Activity Stream"
         fallback={<CompactErrorFallback name="Activity Stream" />}
       >
-        <ActivityStream taskRunId={taskRunId} />
+        <ActivityStream taskRunId={taskRunId} provider={selectedRun?.vscode?.provider} />
       </ErrorBoundary>
     </div>
   );

--- a/packages/shared/src/hook-registry.test.ts
+++ b/packages/shared/src/hook-registry.test.ts
@@ -6,6 +6,8 @@ import {
   getHooksForProvider,
   isHookCritical,
   getDispatchScript,
+  getEventSupportMatrix,
+  isActivityTypeSupported,
 } from "./hook-registry";
 
 describe("hook-registry", () => {
@@ -92,6 +94,74 @@ describe("hook-registry", () => {
     it("returns false for non-critical hooks", () => {
       expect(isHookCritical("session_start")).toBe(false);
       expect(isHookCritical("error")).toBe(false);
+    });
+  });
+
+  describe("getEventSupportMatrix", () => {
+    it("returns all events with provider coverage", () => {
+      const matrix = getEventSupportMatrix();
+
+      expect(matrix.length).toBe(HOOK_REGISTRY.length);
+      expect(matrix[0].providers.claude).toBeDefined();
+      expect(matrix[0].providers.codex).toBeDefined();
+    });
+
+    it("includes event metadata", () => {
+      const matrix = getEventSupportMatrix();
+      const sessionStart = matrix.find((e) => e.eventType === "session_start");
+
+      expect(sessionStart).toBeDefined();
+      expect(sessionStart?.description).toBeTruthy();
+      expect(sessionStart?.critical).toBe(false);
+    });
+
+    it("correctly reflects provider support", () => {
+      const matrix = getEventSupportMatrix();
+
+      // session_start is supported by all providers
+      const sessionStart = matrix.find((e) => e.eventType === "session_start");
+      expect(sessionStart?.providers.claude).toBe(true);
+      expect(sessionStart?.providers.codex).toBe(true);
+
+      // context_warning is Claude-only
+      const contextWarning = matrix.find(
+        (e) => e.eventType === "context_warning"
+      );
+      expect(contextWarning?.providers.claude).toBe(true);
+      expect(contextWarning?.providers.codex).toBe(false);
+    });
+  });
+
+  describe("isActivityTypeSupported", () => {
+    it("returns true for universal events", () => {
+      expect(isActivityTypeSupported("session_start", "claude")).toBe(true);
+      expect(isActivityTypeSupported("session_start", "codex")).toBe(true);
+      expect(isActivityTypeSupported("session_start", "gemini")).toBe(true);
+    });
+
+    it("returns false for Claude-only events on other providers", () => {
+      expect(isActivityTypeSupported("context_warning", "codex")).toBe(false);
+      expect(isActivityTypeSupported("approval_requested", "gemini")).toBe(
+        false
+      );
+      expect(isActivityTypeSupported("subagent_start", "codex")).toBe(false);
+    });
+
+    it("maps tool activity types to tool_call support", () => {
+      // Claude and Codex support tool_call
+      expect(isActivityTypeSupported("file_edit", "claude")).toBe(true);
+      expect(isActivityTypeSupported("file_edit", "codex")).toBe(true);
+
+      // Gemini does not support tool_call events
+      expect(isActivityTypeSupported("file_edit", "gemini")).toBe(false);
+      expect(isActivityTypeSupported("bash_command", "gemini")).toBe(false);
+    });
+
+    it("returns true for unmapped activity types", () => {
+      // thinking has no hook backing, should always be shown
+      expect(isActivityTypeSupported("thinking", "claude")).toBe(true);
+      expect(isActivityTypeSupported("thinking", "codex")).toBe(true);
+      expect(isActivityTypeSupported("thinking", "gemini")).toBe(true);
     });
   });
 

--- a/packages/shared/src/hook-registry.ts
+++ b/packages/shared/src/hook-registry.ts
@@ -29,6 +29,16 @@ export interface HookDefinition {
 }
 
 /**
+ * Event support matrix entry for documentation and UI display.
+ */
+export interface EventSupportMatrix {
+  eventType: LifecycleEventType;
+  description: string;
+  critical: boolean;
+  providers: Record<ProviderName, boolean>;
+}
+
+/**
  * Registry of all supported hooks with provider support matrix.
  */
 export const HOOK_REGISTRY: HookDefinition[] = [
@@ -200,6 +210,91 @@ export function getHooksForProvider(provider: ProviderName): HookDefinition[] {
 export function isHookCritical(type: LifecycleEventType): boolean {
   const def = getHookDefinition(type);
   return def?.critical ?? false;
+}
+
+/**
+ * All known provider names for matrix generation.
+ */
+const ALL_PROVIDERS: ProviderName[] = [
+  "claude",
+  "codex",
+  "gemini",
+  "amp",
+  "opencode",
+  "grok",
+  "qwen",
+  "cursor",
+];
+
+/**
+ * Get the full event support matrix for documentation and UI display.
+ * Returns all events with their provider support status.
+ */
+export function getEventSupportMatrix(): EventSupportMatrix[] {
+  return HOOK_REGISTRY.map((hook) => ({
+    eventType: hook.type,
+    description: hook.description,
+    critical: hook.critical,
+    providers: Object.fromEntries(
+      ALL_PROVIDERS.map((p) => [p, hook.providers.includes(p)])
+    ) as Record<ProviderName, boolean>,
+  }));
+}
+
+/**
+ * Check if an activity type is supported by a provider.
+ * Maps activity types to lifecycle event types for coverage checking.
+ */
+export function isActivityTypeSupported(
+  activityType: string,
+  provider: string
+): boolean {
+  // Map activity types to lifecycle event types
+  const activityToEventMap: Record<string, LifecycleEventType | null> = {
+    // Direct mappings
+    session_start: "session_start",
+    session_stop: "session_stop",
+    session_resumed: "session_resumed",
+    session_finished: "session_finished",
+    stop_requested: "stop_requested",
+    stop_blocked: "stop_blocked",
+    stop_failed: "stop_failed",
+    context_warning: "context_warning",
+    context_compacted: "context_compacted",
+    memory_loaded: "memory_loaded",
+    memory_scope_changed: "memory_scope_changed",
+    tool_requested: "tool_requested",
+    tool_completed: "tool_completed",
+    approval_requested: "approval_requested",
+    approval_resolved: "approval_resolved",
+    user_prompt: "user_prompt",
+    subagent_start: "subagent_start",
+    subagent_stop: "subagent_stop",
+    notification: "notification",
+    prompt_submitted: "prompt_submitted",
+    run_resumed: "run_resumed",
+    error: "error",
+    mcp_capabilities_negotiated: "mcp_capabilities_negotiated",
+    // Activity types that map to tool_call event
+    tool_call: "tool_call",
+    file_edit: "tool_call",
+    file_read: "tool_call",
+    bash_command: "tool_call",
+    test_run: "tool_call",
+    git_commit: "tool_call",
+    // Activity types with no hook backing (always shown)
+    thinking: null,
+  };
+
+  const eventType = activityToEventMap[activityType];
+
+  // If no mapping exists or it's null, assume it's always available
+  if (eventType === undefined || eventType === null) {
+    return true;
+  }
+
+  // Check if the provider supports this event type
+  return isHookSupported(eventType, provider as ProviderName);
 }
 
 // =============================================================================
@@ -692,7 +787,7 @@ exit 0
 // Phase 2 Hook Portability - Additional Script Builders
 // =============================================================================
 
-function buildSubagentStartScript(provider: ProviderName, logFile: string): string {
+function buildSubagentStartScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -723,7 +818,7 @@ exit 0
 `;
 }
 
-function buildSubagentStopScript(provider: ProviderName, logFile: string): string {
+function buildSubagentStopScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -756,7 +851,7 @@ exit 0
 `;
 }
 
-function buildNotificationScript(provider: ProviderName, logFile: string): string {
+function buildNotificationScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -787,7 +882,7 @@ exit 0
 `;
 }
 
-function buildTaskCreatedScript(provider: ProviderName, logFile: string): string {
+function buildTaskCreatedScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -820,7 +915,7 @@ exit 0
 `;
 }
 
-function buildUserPromptScript(provider: ProviderName, logFile: string): string {
+function buildUserPromptScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -855,7 +950,7 @@ exit 0
 `;
 }
 
-function buildPlanSyncScript(provider: ProviderName, logFile: string): string {
+function buildPlanSyncScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -904,7 +999,7 @@ exit 0
 `;
 }
 
-function buildSimplifyTrackScript(provider: ProviderName, logFile: string): string {
+function buildSimplifyTrackScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -955,7 +1050,7 @@ exit 0
 `;
 }
 
-function buildPrecompactScript(provider: ProviderName, logFile: string): string {
+function buildPrecompactScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -1014,7 +1109,7 @@ exit 0
 `;
 }
 
-function buildPostcompactScript(provider: ProviderName, logFile: string): string {
+function buildPostcompactScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 LOG_FILE="${logFile}"
@@ -1058,7 +1153,7 @@ exit 0
 `;
 }
 
-function buildSimplifyGateScript(provider: ProviderName, logFile: string): string {
+function buildSimplifyGateScript(_provider: ProviderName, logFile: string): string {
   return `#!/bin/bash
 set -eu
 


### PR DESCRIPTION
## Summary

- Add `getEventSupportMatrix()` to export hook registry as structured data for documentation
- Add `isActivityTypeSupported()` to check if activity types are supported by specific providers
- Update ActivityStream component to show provider coverage indicators
- Grayed-out filter chips with tooltip for unsupported event types
- Info banner for providers with limited event coverage (non-Claude)

## Changes

| File | Change |
|------|--------|
| `packages/shared/src/hook-registry.ts` | Add `getEventSupportMatrix()`, `isActivityTypeSupported()` utilities |
| `packages/shared/src/hook-registry.test.ts` | Add unit tests for new functions |
| `apps/client/src/components/ActivityStream.tsx` | Add provider prop, coverage indicators, info banner |
| `apps/client/src/routes/...activity.tsx` | Pass provider to ActivityStream |

## Test plan

- [x] Unit tests for `getEventSupportMatrix()` 
- [x] Unit tests for `isActivityTypeSupported()`
- [x] TypeScript type check passes
- [ ] Visual verification: Activity page for Codex run shows limited coverage banner
- [ ] Visual verification: Claude-only event filters grayed out for non-Claude providers