### PR TITLE
feat: add task-class model routing for automatic cost-optimized agent selection

### DIFF
--- a/apps/client/src/components/dashboard/DashboardInputControls.tsx
+++ b/apps/client/src/components/dashboard/DashboardInputControls.tsx
@@ -27,6 +27,11 @@ import { api } from "@cmux/convex/api";
 import type { ProviderStatusResponse } from "@cmux/shared";
 import type { SelectedAgentSelection } from "@cmux/shared/agent-selection-core";
 import { type AgentVendor } from "@cmux/shared/agent-catalog";
+import {
+  type TaskClass,
+  TASK_CLASS_MAPPINGS,
+  getTaskClassMapping,
+} from "@cmux/shared";
 import { parseGithubRepoUrl } from "@cmux/shared";
 import { useUser } from "@stackframe/react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -81,6 +86,9 @@ interface DashboardInputControlsProps {
   /** Ralph Mode: keep working until explicit completion signal */
   isRalphMode?: boolean;
   onRalphModeToggle?: () => void;
+  /** Task class for automatic model routing */
+  selectedTaskClass?: TaskClass | null;
+  onTaskClassChange?: (taskClass: TaskClass | null) => void;
 }
 
 // Type for models from Convex
@@ -264,6 +272,8 @@ export const DashboardInputControls = memo(function DashboardInputControls({
   convexModels,
   isRalphMode = false,
   onRalphModeToggle,
+  selectedTaskClass = null,
+  onTaskClassChange,
 }: DashboardInputControlsProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -320,6 +330,49 @@ export const DashboardInputControls = memo(function DashboardInputControls({
       new Map((convexModels ?? []).map((model) => [model.name, model])),
     [convexModels],
   );
+
+  // Task class options for automatic model routing
+  const taskClassOptions = useMemo<SelectOptionObject[]>(() => {
+    return TASK_CLASS_MAPPINGS.map((mapping) => ({
+      value: mapping.taskClass,
+      label: mapping.displayName,
+      description: mapping.description,
+    }));
+  }, []);
+
+  // Handle task class change - auto-populate agent based on mapping
+  const handleTaskClassChange = useCallback(
+    (values: string[]) => {
+      const taskClass = values[0] as TaskClass | undefined;
+      onTaskClassChange?.(taskClass ?? null);
+
+      if (taskClass && convexModels) {
+        const mapping = getTaskClassMapping(taskClass);
+        if (mapping) {
+          // Find first available model from the mapping
+          const availableModelNames = new Set(convexModels.map((m) => m.name));
+          const defaultModel = mapping.defaultModels.find((m) =>
+            availableModelNames.has(m)
+          );
+          const escalationModel = mapping.escalationModels.find((m) =>
+            availableModelNames.has(m)
+          );
+          const selectedModel = defaultModel ?? escalationModel;
+
+          if (selectedModel) {
+            onAgentSelectionsChange([
+              {
+                agentName: selectedModel,
+                selectedVariant: mapping.defaultVariant,
+              },
+            ]);
+          }
+        }
+      }
+    },
+    [convexModels, onAgentSelectionsChange, onTaskClassChange]
+  );
+
   const agentOptions = useMemo<AgentOption[]>(() => {
     const baseModels: Array<{
       name: string;
@@ -1176,6 +1229,39 @@ export const DashboardInputControls = memo(function DashboardInputControls({
                 </div>
               </TooltipTrigger>
               <TooltipContent>Branch this task starts from</TooltipContent>
+            </Tooltip>
+          </div>
+        )}
+
+        {/* Task Class Selector - auto-routes to recommended models */}
+        {onTaskClassChange && (
+          <div data-onboarding="task-class-picker">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <SearchableSelect
+                    options={taskClassOptions}
+                    value={selectedTaskClass ? [selectedTaskClass] : []}
+                    onChange={handleTaskClassChange}
+                    placeholder="Work type"
+                    singleSelect={true}
+                    className="rounded-2xl min-w-[130px]"
+                    classNames={{
+                      popover: "w-[240px]",
+                    }}
+                    showSearch={false}
+                    leftIcon={
+                      <SlidersHorizontal className="w-4 h-4 text-neutral-500 dark:text-neutral-400" />
+                    }
+                  />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-64">
+                <p className="font-medium">Task-Class Routing</p>
+                <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                  Select work type to auto-pick the best model for cost/capability
+                </p>
+              </TooltipContent>
             </Tooltip>
           </div>
         )}

--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -44,6 +44,8 @@ import { env } from "./utils/server-env";
 import { getResponseErrorMessage } from "./utils/httpError";
 import { buildTaskRunCreateArgs } from "./utils/taskRunCreateArgs";
 
+import type { TaskClass } from "@cmux/shared";
+
 interface StartTaskRequest {
   // Required fields
   taskId: string;
@@ -85,6 +87,8 @@ interface StartTaskRequest {
   // Cloud workspace and orchestration head flags
   isCloudWorkspace?: boolean;
   isOrchestrationHead?: boolean;
+  // Task-class model routing
+  taskClass?: TaskClass;
 }
 
 interface StartTaskResponse {

--- a/apps/server/src/utils/taskRunCreateArgs.ts
+++ b/apps/server/src/utils/taskRunCreateArgs.ts
@@ -1,3 +1,5 @@
+import type { TaskClass, AgentSelectionSource } from "@cmux/shared";
+
 type TaskRunCreateArgsInput<
   TTaskId extends string = string,
   TEnvironmentId extends string | undefined = string | undefined,
@@ -7,6 +9,8 @@ type TaskRunCreateArgsInput<
   prompt: string;
   agentName?: string;
   selectedVariant?: string;
+  taskClass?: TaskClass;
+  agentSelectionSource?: AgentSelectionSource;
   newBranch?: string;
   environmentId?: TEnvironmentId;
   isOrchestrationHead?: boolean;
@@ -32,6 +36,10 @@ export function buildTaskRunCreateArgs<
     ...(args.agentName !== undefined ? { agentName: args.agentName } : {}),
     ...(args.selectedVariant !== undefined
       ? { selectedVariant: args.selectedVariant }
+      : {}),
+    ...(args.taskClass !== undefined ? { taskClass: args.taskClass } : {}),
+    ...(args.agentSelectionSource !== undefined
+      ? { agentSelectionSource: args.agentSelectionSource }
       : {}),
     ...(args.newBranch !== undefined ? { newBranch: args.newBranch } : {}),
     ...(args.environmentId !== undefined

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -207,6 +207,23 @@ const convexSchema = defineSchema({
     prompt: v.string(), // The prompt that will be passed to claude
     agentName: v.optional(v.string()), // Name of the agent that ran this task (e.g., "claude/sonnet-4")
     selectedVariant: v.optional(v.string()), // Optional effort/reasoning selection for this run
+    taskClass: v.optional(
+      v.union(
+        v.literal("routine"),
+        v.literal("deep-coding"),
+        v.literal("review"),
+        v.literal("eval"),
+        v.literal("architecture"),
+        v.literal("large-context")
+      )
+    ), // Task class for automatic model selection
+    agentSelectionSource: v.optional(
+      v.union(
+        v.literal("explicit"),
+        v.literal("task-class-default"),
+        v.literal("system-default")
+      )
+    ), // How the agent was selected
     summary: v.optional(v.string()), // Markdown summary of the run
     status: v.union(
       v.literal("pending"),
@@ -482,7 +499,8 @@ const convexSchema = defineSchema({
       "orchestrationStatus",
       "orchestrationHeartbeat",
     ])
-    .index("by_team_orchestration_head", ["teamId", "orchestrationId", "isOrchestrationHead"]),
+    .index("by_team_orchestration_head", ["teamId", "orchestrationId", "isOrchestrationHead"])
+    .index("by_task_class", ["taskClass", "createdAt"]),
 
   // Junction table linking taskRuns to pull requests by PR identity
   // Enables efficient lookup of taskRuns when a PR webhook fires

--- a/packages/convex/convex/taskRuns.ts
+++ b/packages/convex/convex/taskRuns.ts
@@ -608,6 +608,23 @@ export const createInternal = internalMutation({
     prompt: v.string(),
     agentName: v.optional(v.string()),
     selectedVariant: v.optional(v.string()),
+    taskClass: v.optional(
+      v.union(
+        v.literal("routine"),
+        v.literal("deep-coding"),
+        v.literal("review"),
+        v.literal("eval"),
+        v.literal("architecture"),
+        v.literal("large-context")
+      )
+    ),
+    agentSelectionSource: v.optional(
+      v.union(
+        v.literal("explicit"),
+        v.literal("task-class-default"),
+        v.literal("system-default")
+      )
+    ),
     newBranch: v.optional(v.string()),
     environmentId: v.optional(v.id("environments")),
     parentRunId: v.optional(v.id("taskRuns")), // Agent Teams (D4) - parent-child relationships
@@ -642,6 +659,8 @@ export const createInternal = internalMutation({
       prompt: args.prompt,
       agentName: args.agentName,
       selectedVariant: args.selectedVariant,
+      taskClass: args.taskClass,
+      agentSelectionSource: args.agentSelectionSource,
       newBranch: args.newBranch,
       status: "pending",
       createdAt: now,
@@ -714,6 +733,23 @@ export const create = authMutation({
     prompt: v.string(),
     agentName: v.optional(v.string()),
     selectedVariant: v.optional(v.string()),
+    taskClass: v.optional(
+      v.union(
+        v.literal("routine"),
+        v.literal("deep-coding"),
+        v.literal("review"),
+        v.literal("eval"),
+        v.literal("architecture"),
+        v.literal("large-context")
+      )
+    ),
+    agentSelectionSource: v.optional(
+      v.union(
+        v.literal("explicit"),
+        v.literal("task-class-default"),
+        v.literal("system-default")
+      )
+    ),
     newBranch: v.optional(v.string()),
     environmentId: v.optional(v.id("environments")),
     isOrchestrationHead: v.optional(v.boolean()),
@@ -746,6 +782,8 @@ export const create = authMutation({
       prompt: args.prompt,
       agentName: args.agentName,
       selectedVariant: args.selectedVariant,
+      taskClass: args.taskClass,
+      agentSelectionSource: args.agentSelectionSource,
       newBranch: args.newBranch,
       status: "pending",
       createdAt: now,

--- a/packages/shared/src/agent-selection-core.ts
+++ b/packages/shared/src/agent-selection-core.ts
@@ -119,6 +119,8 @@ export interface SelectedAgentSelection {
   selectedVariant?: string;
 }
 
+import type { AgentSelectionSource, TaskClass } from "./task-class-routing";
+
 export interface NormalizedAgentSelection {
   requestedAgentName: string;
   assignedAgentName: string;
@@ -126,12 +128,18 @@ export interface NormalizedAgentSelection {
   catalogEntry?: AgentCatalogEntry;
   variants: ModelVariant[];
   defaultVariant?: string;
+  /** Task class used for model selection (if applicable) */
+  taskClass?: TaskClass;
+  /** How the agent was selected */
+  selectionSource: AgentSelectionSource;
 }
 
 export function normalizeAgentSelection(options: {
   agentName: string;
   selectedVariant?: string | null;
   applyDefaultVariant?: boolean;
+  taskClass?: TaskClass;
+  selectionSource?: AgentSelectionSource;
 }): NormalizedAgentSelection {
   const requestedAgentName = options.agentName.trim();
   if (!requestedAgentName) {
@@ -155,5 +163,7 @@ export function normalizeAgentSelection(options: {
     catalogEntry,
     variants: getDeclaredVariants(catalogEntry),
     defaultVariant: catalogEntry?.defaultVariant,
+    taskClass: options.taskClass,
+    selectionSource: options.selectionSource ?? "explicit",
   };
 }

--- a/packages/shared/src/agent-selection.ts
+++ b/packages/shared/src/agent-selection.ts
@@ -9,6 +9,11 @@ import {
   type CodexReasoningEffort,
 } from "./providers/openai/configs";
 import { createOpencodeFreeDynamicConfig } from "./providers/opencode/configs";
+import {
+  resolveModelForTaskClass,
+  type AgentSelectionSource,
+  type TaskClass,
+} from "./task-class-routing";
 
 function resolveAgentConfig(
   agentName: string,
@@ -45,15 +50,80 @@ export interface ResolvedAgentSelection {
   catalogEntry?: NormalizedAgentSelection["catalogEntry"];
   variants: NormalizedAgentSelection["variants"];
   defaultVariant?: NormalizedAgentSelection["defaultVariant"];
+  taskClass?: NormalizedAgentSelection["taskClass"];
+  selectionSource: NormalizedAgentSelection["selectionSource"];
   agentConfig: AgentConfig;
 }
 
-export function resolveAgentSelection(options: {
-  agentName: string;
+/** Default model for system-default selection */
+const SYSTEM_DEFAULT_AGENT = "claude/sonnet-4.5";
+
+export interface ResolveAgentSelectionOptions {
+  /** Explicit agent name (takes precedence over taskClass) */
+  agentName?: string;
+  /** Explicit variant selection */
   selectedVariant?: string | null;
+  /** Whether to apply catalog default variant */
   applyDefaultVariant?: boolean;
-}): ResolvedAgentSelection {
-  const normalized = normalizeAgentSelection(options);
+  /** Task class for automatic model selection */
+  taskClass?: TaskClass;
+  /** Available models for task-class routing (required when using taskClass without agentName) */
+  availableModels?: string[];
+}
+
+/**
+ * Resolve agent selection with support for task-class routing.
+ *
+ * Resolution priority:
+ * 1. Explicit agentName (if provided) → selectionSource: "explicit"
+ * 2. TaskClass routing (if taskClass + availableModels provided) → selectionSource: "task-class-default"
+ * 3. System default → selectionSource: "system-default"
+ */
+export function resolveAgentSelection(
+  options: ResolveAgentSelectionOptions
+): ResolvedAgentSelection {
+  let effectiveAgentName: string;
+  let effectiveVariant: string | null | undefined = options.selectedVariant;
+  let taskClass: TaskClass | undefined = options.taskClass;
+  let selectionSource: AgentSelectionSource;
+
+  // Priority 1: Explicit agent name
+  if (options.agentName) {
+    effectiveAgentName = options.agentName;
+    selectionSource = "explicit";
+  }
+  // Priority 2: Task-class routing
+  else if (options.taskClass && options.availableModels) {
+    const resolved = resolveModelForTaskClass(
+      options.taskClass,
+      options.availableModels
+    );
+    if (resolved) {
+      effectiveAgentName = resolved.agentName;
+      // Use task-class variant if no explicit variant provided
+      if (effectiveVariant === undefined) {
+        effectiveVariant = resolved.selectedVariant;
+      }
+      selectionSource = "task-class-default";
+    } else {
+      // Task-class routing failed, fall back to system default
+      effectiveAgentName = SYSTEM_DEFAULT_AGENT;
+      selectionSource = "system-default";
+    }
+  }
+  // Priority 3: System default
+  else {
+    effectiveAgentName = options.agentName ?? SYSTEM_DEFAULT_AGENT;
+    selectionSource = options.agentName ? "explicit" : "system-default";
+  }
+
+  const normalized = normalizeAgentSelection({
+    agentName: effectiveAgentName,
+    selectedVariant: effectiveVariant,
+    applyDefaultVariant: options.applyDefaultVariant,
+    taskClass,
+    selectionSource,
+  });
 
   return {
     requestedAgentName: normalized.requestedAgentName,
@@ -62,9 +132,11 @@ export function resolveAgentSelection(options: {
     catalogEntry: normalized.catalogEntry,
     variants: normalized.variants,
     defaultVariant: normalized.defaultVariant,
+    taskClass: normalized.taskClass,
+    selectionSource: normalized.selectionSource,
     agentConfig: resolveAgentConfig(
       normalized.assignedAgentName,
-      normalized.selectedVariant,
+      normalized.selectedVariant
     ),
   };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -48,6 +48,15 @@ export * from "./agent-comm-events";
 export * from "./a2a-protocol";
 export * from "./approval-risk-classifier";
 export * from "./timezone-constants";
+export * from "./task-class-routing";
+export * from "./agent-selection";
+// agent-selection-core exports SelectedAgentSelection which conflicts with socket-schemas
+// Only export what's needed from agent-selection-core, not the duplicate type
+export {
+  normalizeAgentSelection,
+  type NormalizedAgentSelection,
+} from "./agent-selection-core";
+export * from "./agent-catalog";
 // Note: useNetwork hook is NOT exported here to avoid SSR issues.
 // Import directly from "@cmux/shared/hooks/use-network" in client components.
 // Note: Environment component utilities are NOT exported here.

--- a/packages/shared/src/task-class-routing.test.ts
+++ b/packages/shared/src/task-class-routing.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import {
+  TASK_CLASSES,
+  TASK_CLASS_MAPPINGS,
+  getTaskClassMapping,
+  getAllTaskClassMappings,
+  isValidTaskClass,
+  resolveModelForTaskClass,
+  getRecommendedTaskClassForModel,
+  type TaskClass,
+} from "./task-class-routing";
+
+describe("task-class-routing", () => {
+  describe("TASK_CLASSES", () => {
+    it("should have all expected task classes", () => {
+      expect(TASK_CLASSES).toContain("routine");
+      expect(TASK_CLASSES).toContain("deep-coding");
+      expect(TASK_CLASSES).toContain("review");
+      expect(TASK_CLASSES).toContain("eval");
+      expect(TASK_CLASSES).toContain("architecture");
+      expect(TASK_CLASSES).toContain("large-context");
+      expect(TASK_CLASSES).toHaveLength(6);
+    });
+  });
+
+  describe("TASK_CLASS_MAPPINGS", () => {
+    it("should have a mapping for each task class", () => {
+      expect(TASK_CLASS_MAPPINGS).toHaveLength(6);
+      for (const taskClass of TASK_CLASSES) {
+        const mapping = TASK_CLASS_MAPPINGS.find(
+          (m) => m.taskClass === taskClass
+        );
+        expect(mapping).toBeDefined();
+        expect(mapping?.displayName).toBeTruthy();
+        expect(mapping?.description).toBeTruthy();
+        expect(mapping?.defaultModels).toBeInstanceOf(Array);
+        expect(mapping?.escalationModels).toBeInstanceOf(Array);
+      }
+    });
+
+    it("should have at least one default model per mapping", () => {
+      for (const mapping of TASK_CLASS_MAPPINGS) {
+        expect(mapping.defaultModels.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("getTaskClassMapping", () => {
+    it("should return mapping for valid task class", () => {
+      const mapping = getTaskClassMapping("routine");
+      expect(mapping).toBeDefined();
+      expect(mapping?.taskClass).toBe("routine");
+      expect(mapping?.displayName).toBe("Routine");
+    });
+
+    it("should return undefined for invalid task class", () => {
+      // @ts-expect-error - testing invalid input
+      const mapping = getTaskClassMapping("invalid");
+      expect(mapping).toBeUndefined();
+    });
+  });
+
+  describe("getAllTaskClassMappings", () => {
+    it("should return all mappings", () => {
+      const mappings = getAllTaskClassMappings();
+      expect(mappings).toEqual(TASK_CLASS_MAPPINGS);
+      expect(mappings).toHaveLength(6);
+    });
+  });
+
+  describe("isValidTaskClass", () => {
+    it("should return true for valid task classes", () => {
+      expect(isValidTaskClass("routine")).toBe(true);
+      expect(isValidTaskClass("deep-coding")).toBe(true);
+      expect(isValidTaskClass("architecture")).toBe(true);
+    });
+
+    it("should return false for invalid task classes", () => {
+      expect(isValidTaskClass("invalid")).toBe(false);
+      expect(isValidTaskClass("")).toBe(false);
+      expect(isValidTaskClass("ROUTINE")).toBe(false);
+    });
+  });
+
+  describe("resolveModelForTaskClass", () => {
+    it("should return first available default model", () => {
+      const result = resolveModelForTaskClass("routine", [
+        "claude/sonnet-4.5",
+        "codex/gpt-5.4-mini",
+      ]);
+      expect(result).not.toBeNull();
+      expect(result?.agentName).toBe("codex/gpt-5.4-mini");
+      expect(result?.wasEscalated).toBe(false);
+    });
+
+    it("should use escalation model when defaults unavailable", () => {
+      const result = resolveModelForTaskClass("routine", [
+        "claude/opus-4.5", // This is an escalation model for routine
+      ]);
+      expect(result).not.toBeNull();
+      expect(result?.agentName).toBe("claude/opus-4.5");
+      expect(result?.wasEscalated).toBe(true);
+    });
+
+    it("should return null when no models available", () => {
+      const result = resolveModelForTaskClass("routine", []);
+      expect(result).toBeNull();
+    });
+
+    it("should return null when only unrelated models available", () => {
+      const result = resolveModelForTaskClass("routine", [
+        "some/unknown-model",
+        "another/model",
+      ]);
+      expect(result).toBeNull();
+    });
+
+    it("should apply default variant from mapping", () => {
+      const result = resolveModelForTaskClass("architecture", [
+        "claude/opus-4.6",
+      ]);
+      expect(result).not.toBeNull();
+      expect(result?.agentName).toBe("claude/opus-4.6");
+      expect(result?.selectedVariant).toBe("max");
+    });
+
+    it("should prefer first default model over later ones", () => {
+      // routine's first default is codex/gpt-5.4-mini
+      const result = resolveModelForTaskClass("routine", [
+        "claude/sonnet-4.5", // second default
+        "codex/gpt-5.4-mini", // first default
+      ]);
+      expect(result?.agentName).toBe("codex/gpt-5.4-mini");
+    });
+
+    it("should handle large-context class with Gemini", () => {
+      const result = resolveModelForTaskClass("large-context", [
+        "gemini/2.5-pro",
+      ]);
+      expect(result).not.toBeNull();
+      expect(result?.agentName).toBe("gemini/2.5-pro");
+    });
+
+    it("should handle eval class with flash models", () => {
+      const result = resolveModelForTaskClass("eval", [
+        "gemini/2.5-flash",
+        "claude/haiku-4.5",
+      ]);
+      expect(result?.agentName).toBe("gemini/2.5-flash");
+    });
+  });
+
+  describe("getRecommendedTaskClassForModel", () => {
+    it("should return task class for default model", () => {
+      expect(getRecommendedTaskClassForModel("claude/opus-4.6")).toBe(
+        "architecture"
+      );
+      expect(getRecommendedTaskClassForModel("gemini/2.5-flash")).toBe("eval");
+      expect(getRecommendedTaskClassForModel("gemini/2.5-pro")).toBe(
+        "large-context"
+      );
+    });
+
+    it("should return first matching task class when model appears in multiple", () => {
+      // claude/haiku-4.5 appears in both review and eval defaults
+      const result = getRecommendedTaskClassForModel("claude/haiku-4.5");
+      expect(["review", "eval"]).toContain(result);
+    });
+
+    it("should return undefined for unknown model", () => {
+      expect(getRecommendedTaskClassForModel("unknown/model")).toBeUndefined();
+    });
+
+    it("should not return task class for escalation-only models", () => {
+      // claude/opus-4.6 is a default for architecture, not just escalation
+      expect(getRecommendedTaskClassForModel("claude/opus-4.6")).toBe(
+        "architecture"
+      );
+    });
+  });
+
+  describe("task class mapping consistency", () => {
+    it("should not have duplicate task classes", () => {
+      const taskClasses = TASK_CLASS_MAPPINGS.map((m) => m.taskClass);
+      const uniqueClasses = new Set(taskClasses);
+      expect(uniqueClasses.size).toBe(taskClasses.length);
+    });
+
+    it("should have valid model names format", () => {
+      for (const mapping of TASK_CLASS_MAPPINGS) {
+        for (const model of [
+          ...mapping.defaultModels,
+          ...mapping.escalationModels,
+        ]) {
+          // Model names should follow provider/model-name format
+          expect(model).toMatch(/^[a-z]+\/[a-z0-9.-]+$/);
+        }
+      }
+    });
+
+    it("should have valid variants only for models that support them", () => {
+      // Architecture has max variant - only Opus 4.6 supports it
+      const archMapping = getTaskClassMapping("architecture");
+      expect(archMapping?.defaultVariant).toBe("max");
+      expect(archMapping?.defaultModels).toContain("claude/opus-4.6");
+
+      // Deep-coding has high variant
+      const deepMapping = getTaskClassMapping("deep-coding");
+      expect(deepMapping?.defaultVariant).toBe("high");
+    });
+  });
+});

--- a/packages/shared/src/task-class-routing.ts
+++ b/packages/shared/src/task-class-routing.ts
@@ -1,0 +1,186 @@
+/**
+ * Task-Class Model Routing
+ *
+ * Provides intelligent model selection based on task type, automatically routing
+ * work to appropriate cost/capability tiers while preserving user override capability.
+ *
+ * Task classes map common work types to recommended models:
+ * - routine: Fast coding, bug fixes → cheap models
+ * - deep-coding: Large refactoring → mid-tier
+ * - review: Code review, exploration → cheap
+ * - eval: Summaries, labeling → efficient flash models
+ * - architecture: Hard planning → frontier tier
+ * - large-context: Cross-file comparison → high-context models
+ */
+
+export const TASK_CLASSES = [
+  "routine",
+  "deep-coding",
+  "review",
+  "eval",
+  "architecture",
+  "large-context",
+] as const;
+
+export type TaskClass = (typeof TASK_CLASSES)[number];
+
+export interface TaskClassMapping {
+  taskClass: TaskClass;
+  displayName: string;
+  description: string;
+  /** Default models in priority order (first available wins) */
+  defaultModels: string[];
+  /** Escalation models when defaults unavailable */
+  escalationModels: string[];
+  /** Default variant to apply (e.g., "high" for architecture tasks) */
+  defaultVariant?: string;
+}
+
+export const TASK_CLASS_MAPPINGS: TaskClassMapping[] = [
+  {
+    taskClass: "routine",
+    displayName: "Routine",
+    description: "Fast coding, simple bug fixes",
+    defaultModels: ["codex/gpt-5.4-mini", "claude/sonnet-4.5"],
+    escalationModels: ["codex/gpt-5.4", "claude/opus-4.5"],
+  },
+  {
+    taskClass: "deep-coding",
+    displayName: "Deep Coding",
+    description: "Large refactoring, multi-file changes",
+    defaultModels: ["codex/gpt-5.4", "claude/opus-4.5"],
+    escalationModels: ["claude/opus-4.6"],
+    defaultVariant: "high",
+  },
+  {
+    taskClass: "review",
+    displayName: "Review",
+    description: "Code review, exploration",
+    defaultModels: ["codex/gpt-5.4-mini", "claude/haiku-4.5"],
+    escalationModels: ["claude/sonnet-4.5"],
+  },
+  {
+    taskClass: "eval",
+    displayName: "Eval",
+    description: "Summaries, labeling, maintenance",
+    defaultModels: ["gemini/2.5-flash", "claude/haiku-4.5"],
+    escalationModels: ["claude/sonnet-4.5"],
+  },
+  {
+    taskClass: "architecture",
+    displayName: "Architecture",
+    description: "Complex planning, hard debugging",
+    defaultModels: ["claude/opus-4.6", "codex/gpt-5.4-pro"],
+    escalationModels: [],
+    defaultVariant: "max",
+  },
+  {
+    taskClass: "large-context",
+    displayName: "Large Context",
+    description: "Cross-file comparison, repo triage",
+    defaultModels: ["gemini/2.5-pro"],
+    escalationModels: ["claude/opus-4.6"],
+  },
+];
+
+/**
+ * Get the mapping for a specific task class
+ */
+export function getTaskClassMapping(
+  taskClass: TaskClass
+): TaskClassMapping | undefined {
+  return TASK_CLASS_MAPPINGS.find((m) => m.taskClass === taskClass);
+}
+
+/**
+ * Get all task class mappings (for UI dropdowns)
+ */
+export function getAllTaskClassMappings(): TaskClassMapping[] {
+  return TASK_CLASS_MAPPINGS;
+}
+
+/**
+ * Check if a string is a valid task class
+ */
+export function isValidTaskClass(value: string): value is TaskClass {
+  return TASK_CLASSES.includes(value as TaskClass);
+}
+
+export interface ResolvedTaskClassModel {
+  agentName: string;
+  selectedVariant?: string;
+  /** Whether fallback/escalation was used */
+  wasEscalated: boolean;
+}
+
+/**
+ * Resolve the best model for a given task class based on available models.
+ *
+ * Resolution order:
+ * 1. Try each default model in order
+ * 2. Try each escalation model in order
+ * 3. Return null if no model available
+ *
+ * @param taskClass - The task class to resolve
+ * @param availableModels - List of available model names (e.g., from provider status)
+ * @returns Resolved model info or null if none available
+ */
+export function resolveModelForTaskClass(
+  taskClass: TaskClass,
+  availableModels: string[]
+): ResolvedTaskClassModel | null {
+  const mapping = getTaskClassMapping(taskClass);
+  if (!mapping) {
+    return null;
+  }
+
+  const availableSet = new Set(availableModels);
+
+  // Try default models first
+  for (const model of mapping.defaultModels) {
+    if (availableSet.has(model)) {
+      return {
+        agentName: model,
+        selectedVariant: mapping.defaultVariant,
+        wasEscalated: false,
+      };
+    }
+  }
+
+  // Try escalation models
+  for (const model of mapping.escalationModels) {
+    if (availableSet.has(model)) {
+      return {
+        agentName: model,
+        selectedVariant: mapping.defaultVariant,
+        wasEscalated: true,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the recommended task class for a given model name.
+ * This is the inverse lookup - given a model, what task class is it best suited for?
+ *
+ * Returns the first task class where this model appears as a default,
+ * or undefined if the model isn't a default for any class.
+ */
+export function getRecommendedTaskClassForModel(
+  modelName: string
+): TaskClass | undefined {
+  for (const mapping of TASK_CLASS_MAPPINGS) {
+    if (mapping.defaultModels.includes(modelName)) {
+      return mapping.taskClass;
+    }
+  }
+  return undefined;
+}
+
+/** Selection source tracking for analytics */
+export type AgentSelectionSource =
+  | "explicit"
+  | "task-class-default"
+  | "system-default";


### PR DESCRIPTION
## Summary

Implements task-class model routing from the 30-day research roadmap - automatically selecting appropriate models based on work type while preserving user override capability.

- **Task classes**: routine, deep-coding, review, eval, architecture, large-context
- **Auto-routing**: Selects cost-effective models based on task type
- **Escalation**: Falls back to higher-tier models when defaults unavailable
- **UI integration**: Task-class picker auto-populates agent selection

## Key Changes

| File | Change |
|------|--------|
| `packages/shared/src/task-class-routing.ts` | NEW - types, mappings, resolver functions |
| `packages/shared/src/agent-selection.ts` | Extended with task-class resolution |
| `packages/convex/convex/schema.ts` | Added taskClass, agentSelectionSource fields |
| `apps/client/.../DashboardInputControls.tsx` | Task-class selector UI |

## Test plan

- [x] `bun check` passes
- [x] `bun run test` passes (all 17 packages)
- [x] Unit tests for task-class-routing.ts
- [ ] Manual: Select "Routine" -> verify cheap model auto-selected
- [ ] Manual: Select "Architecture" -> verify opus auto-selected