### PR TITLE
feat: add multi-provider token usage tracking infrastructure

### DIFF
--- a/apps/www/lib/analytics/track-gemini-proxy.ts
+++ b/apps/www/lib/analytics/track-gemini-proxy.ts
@@ -1,0 +1,81 @@
+import { captureServerPosthogEvent } from "@/lib/analytics/posthog-server";
+
+// Source identifies which product/feature is making the API call
+export type GeminiProxySource = "cmux" | "gemini-cli";
+
+type GeminiProxyEvent = {
+  // Core identifiers
+  teamId: string;
+  userId: string;
+  userEmail?: string;
+  taskRunId: string;
+
+  // Source/product identifier
+  source: GeminiProxySource;
+
+  // Request metadata
+  model: string;
+  stream: boolean;
+
+  // Response metadata
+  responseStatus: number;
+  latencyMs: number;
+
+  // Token usage (from Gemini response.usageMetadata)
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  /** Cached content tokens */
+  cachedContentTokenCount?: number;
+
+  // Error info (if applicable)
+  errorType?: string;
+};
+
+// Map source to span name for PostHog AI analytics
+function getSpanName(source: GeminiProxySource): string {
+  switch (source) {
+    case "cmux":
+      return "gemini-cmux";
+    case "gemini-cli":
+      return "gemini-cli-cmux";
+  }
+}
+
+export async function trackGeminiProxyRequest(
+  event: GeminiProxyEvent
+): Promise<void> {
+  // Use PostHog's $ai_generation event for LLM analytics
+  // See: https://posthog.com/docs/ai-engineering/observability
+  await captureServerPosthogEvent({
+    distinctId: event.userId,
+    event: "$ai_generation",
+    properties: {
+      // PostHog AI properties
+      $ai_model: event.model,
+      $ai_provider: "gemini",
+      $ai_input_tokens: event.promptTokenCount,
+      $ai_output_tokens: event.candidatesTokenCount,
+      $ai_latency: event.latencyMs / 1000, // PostHog expects seconds
+      $ai_http_status: event.responseStatus,
+      $ai_is_error: event.responseStatus >= 400,
+      $ai_error: event.errorType,
+      $ai_stream: event.stream,
+      $ai_trace_id: event.taskRunId,
+      $ai_span_name: getSpanName(event.source),
+
+      // Gemini-specific token details
+      gemini_cached_content_tokens: event.cachedContentTokenCount,
+
+      // Custom cmux properties
+      cmux_source: event.source,
+      cmux_team_id: event.teamId,
+      cmux_task_run_id: event.taskRunId,
+
+      // Associate user properties with this distinctId
+      $set: {
+        team_id: event.teamId,
+        ...(event.userEmail && { email: event.userEmail }),
+      },
+    },
+  });
+}

--- a/apps/www/lib/analytics/track-llm-usage.ts
+++ b/apps/www/lib/analytics/track-llm-usage.ts
@@ -1,0 +1,164 @@
+/**
+ * Unified LLM usage tracking for all providers.
+ *
+ * This module provides a common interface for tracking token usage across
+ * Anthropic, OpenAI, and Gemini providers, enabling cost analysis by task class.
+ */
+
+import { captureServerPosthogEvent } from "@/lib/analytics/posthog-server";
+
+export type LLMProvider = "anthropic" | "openai" | "gemini";
+
+export type LLMUsageSource =
+  | "cmux"
+  | "preview-new"
+  | "codex-cli"
+  | "gemini-cli";
+
+export interface LLMUsageEvent {
+  // Core identifiers
+  teamId: string;
+  userId: string;
+  userEmail?: string;
+  taskRunId: string;
+
+  // Provider info
+  provider: LLMProvider;
+  source: LLMUsageSource;
+
+  // Request metadata
+  model: string;
+  stream: boolean;
+
+  // Response metadata
+  responseStatus: number;
+  latencyMs: number;
+
+  // Unified token usage
+  inputTokens?: number;
+  outputTokens?: number;
+
+  // Provider-specific cache tokens
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+
+  // OpenAI-specific
+  reasoningTokens?: number;
+
+  // Task-class routing metadata (for cost analysis)
+  taskClass?: string;
+  agentSelectionSource?: string;
+
+  // Error info
+  errorType?: string;
+}
+
+// Map source to span name for PostHog AI analytics
+function getSpanName(provider: LLMProvider, source: LLMUsageSource): string {
+  return `${provider}-${source}`;
+}
+
+/**
+ * Track LLM usage for any provider with unified schema.
+ *
+ * Use this for new integrations or when you need task-class metadata.
+ * Provider-specific trackers (trackAnthropicProxyRequest, etc.) are
+ * still available for backward compatibility.
+ */
+export async function trackLLMUsage(event: LLMUsageEvent): Promise<void> {
+  await captureServerPosthogEvent({
+    distinctId: event.userId,
+    event: "$ai_generation",
+    properties: {
+      // PostHog AI properties
+      $ai_model: event.model,
+      $ai_provider: event.provider,
+      $ai_input_tokens: event.inputTokens,
+      $ai_output_tokens: event.outputTokens,
+      $ai_latency: event.latencyMs / 1000,
+      $ai_http_status: event.responseStatus,
+      $ai_is_error: event.responseStatus >= 400,
+      $ai_error: event.errorType,
+      $ai_stream: event.stream,
+      $ai_trace_id: event.taskRunId,
+      $ai_span_name: getSpanName(event.provider, event.source),
+
+      // Cache tokens (unified naming)
+      $ai_cache_read_input_tokens: event.cacheReadTokens,
+      $ai_cache_creation_input_tokens: event.cacheWriteTokens,
+
+      // Provider-specific extensions
+      openai_reasoning_tokens: event.reasoningTokens,
+
+      // Task-class routing metadata for cost analysis
+      cmux_task_class: event.taskClass,
+      cmux_agent_selection_source: event.agentSelectionSource,
+
+      // Custom cmux properties
+      cmux_source: event.source,
+      cmux_team_id: event.teamId,
+      cmux_task_run_id: event.taskRunId,
+
+      // Associate user properties with this distinctId
+      $set: {
+        team_id: event.teamId,
+        ...(event.userEmail && { email: event.userEmail }),
+      },
+    },
+  });
+}
+
+/**
+ * Calculate estimated cost for a request based on provider pricing.
+ *
+ * Note: These are approximate prices and should be updated periodically.
+ * For precise billing, use provider-specific usage APIs.
+ */
+export function estimateCost(event: LLMUsageEvent): number {
+  const { provider, model, inputTokens = 0, outputTokens = 0 } = event;
+
+  // Prices per 1M tokens (input/output)
+  const pricing: Record<string, { input: number; output: number }> = {
+    // Anthropic
+    "claude-3-5-sonnet-20241022": { input: 3, output: 15 },
+    "claude-sonnet-4-5-20261022": { input: 3, output: 15 },
+    "claude-3-5-haiku-20241022": { input: 0.8, output: 4 },
+    "claude-opus-4-6-20261022": { input: 15, output: 75 },
+    // OpenAI
+    "gpt-4o": { input: 2.5, output: 10 },
+    "gpt-4o-mini": { input: 0.15, output: 0.6 },
+    "o1": { input: 15, output: 60 },
+    "o1-mini": { input: 3, output: 12 },
+    // Gemini
+    "gemini-2.5-pro": { input: 1.25, output: 5 },
+    "gemini-2.5-flash": { input: 0.075, output: 0.3 },
+  };
+
+  // Find matching pricing (try exact match, then prefix match)
+  let prices = pricing[model];
+  if (!prices) {
+    const modelPrefix = Object.keys(pricing).find((key) =>
+      model.startsWith(key)
+    );
+    if (modelPrefix) {
+      prices = pricing[modelPrefix];
+    }
+  }
+
+  if (!prices) {
+    // Default fallback pricing
+    switch (provider) {
+      case "anthropic":
+        prices = { input: 3, output: 15 };
+        break;
+      case "openai":
+        prices = { input: 2.5, output: 10 };
+        break;
+      case "gemini":
+        prices = { input: 1.25, output: 5 };
+        break;
+    }
+  }
+
+  return (inputTokens * prices.input + outputTokens * prices.output) / 1_000_000;
+}

--- a/apps/www/lib/analytics/track-openai-proxy.ts
+++ b/apps/www/lib/analytics/track-openai-proxy.ts
@@ -1,0 +1,84 @@
+import { captureServerPosthogEvent } from "@/lib/analytics/posthog-server";
+
+// Source identifies which product/feature is making the API call
+export type OpenAIProxySource = "cmux" | "codex-cli";
+
+type OpenAIProxyEvent = {
+  // Core identifiers
+  teamId: string;
+  userId: string;
+  userEmail?: string;
+  taskRunId: string;
+
+  // Source/product identifier
+  source: OpenAIProxySource;
+
+  // Request metadata
+  model: string;
+  stream: boolean;
+
+  // Response metadata
+  responseStatus: number;
+  latencyMs: number;
+
+  // Token usage (from OpenAI response.usage)
+  promptTokens?: number;
+  completionTokens?: number;
+  /** Reasoning tokens for o1/o3 models */
+  reasoningTokens?: number;
+  /** Cached prompt tokens */
+  cachedTokens?: number;
+
+  // Error info (if applicable)
+  errorType?: string;
+};
+
+// Map source to span name for PostHog AI analytics
+function getSpanName(source: OpenAIProxySource): string {
+  switch (source) {
+    case "cmux":
+      return "openai-cmux";
+    case "codex-cli":
+      return "codex-cli-cmux";
+  }
+}
+
+export async function trackOpenAIProxyRequest(
+  event: OpenAIProxyEvent
+): Promise<void> {
+  // Use PostHog's $ai_generation event for LLM analytics
+  // See: https://posthog.com/docs/ai-engineering/observability
+  await captureServerPosthogEvent({
+    distinctId: event.userId,
+    event: "$ai_generation",
+    properties: {
+      // PostHog AI properties
+      $ai_model: event.model,
+      $ai_provider: "openai",
+      $ai_input_tokens: event.promptTokens,
+      $ai_output_tokens: event.completionTokens,
+      $ai_latency: event.latencyMs / 1000, // PostHog expects seconds
+      $ai_http_status: event.responseStatus,
+      $ai_is_error: event.responseStatus >= 400,
+      $ai_error: event.errorType,
+      $ai_stream: event.stream,
+      $ai_trace_id: event.taskRunId,
+      $ai_span_name: getSpanName(event.source),
+
+      // OpenAI-specific token details
+      openai_reasoning_tokens: event.reasoningTokens,
+      openai_cached_tokens: event.cachedTokens,
+
+      // Custom cmux properties
+      cmux_source: event.source,
+      cmux_team_id: event.teamId,
+      cmux_task_run_id: event.taskRunId,
+
+      // Associate user properties with this distinctId
+      $set: {
+        team_id: event.teamId,
+        ...(event.userEmail && { email: event.userEmail }),
+      },
+    },
+  });
+}

--- a/packages/convex/convex/analytics.ts
+++ b/packages/convex/convex/analytics.ts
@@ -26,6 +26,195 @@ function bucketByDay(timestamps: number[]): number[] {
   return days;
 }
 
+/**
+ * Get token usage analytics grouped by task class.
+ * Enables cost optimization by showing which task classes consume the most tokens.
+ */
+export const getTokenUsageByTaskClass = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    /** Number of days to look back (default 7) */
+    days: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const days = args.days ?? 7;
+    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
+    // Fetch completed runs with context usage in the time range
+    const runs = await ctx.db
+      .query("taskRuns")
+      .withIndex("by_team_user_status_created", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .eq("status", "completed")
+          .gte("createdAt", cutoff)
+      )
+      .collect();
+
+    // Aggregate by task class
+    const byTaskClass = new Map<
+      string,
+      {
+        runCount: number;
+        totalInputTokens: number;
+        totalOutputTokens: number;
+        avgInputTokens: number;
+        avgOutputTokens: number;
+      }
+    >();
+
+    for (const run of runs) {
+      const taskClass = run.taskClass ?? "unclassified";
+      const usage = run.contextUsage;
+
+      const existing = byTaskClass.get(taskClass) ?? {
+        runCount: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        avgInputTokens: 0,
+        avgOutputTokens: 0,
+      };
+
+      existing.runCount += 1;
+      if (usage) {
+        existing.totalInputTokens += usage.totalInputTokens;
+        existing.totalOutputTokens += usage.totalOutputTokens;
+      }
+
+      byTaskClass.set(taskClass, existing);
+    }
+
+    // Calculate averages
+    const result: Record<
+      string,
+      {
+        runCount: number;
+        totalInputTokens: number;
+        totalOutputTokens: number;
+        avgInputTokens: number;
+        avgOutputTokens: number;
+      }
+    > = {};
+
+    for (const [taskClass, data] of byTaskClass) {
+      result[taskClass] = {
+        ...data,
+        avgInputTokens:
+          data.runCount > 0
+            ? Math.round(data.totalInputTokens / data.runCount)
+            : 0,
+        avgOutputTokens:
+          data.runCount > 0
+            ? Math.round(data.totalOutputTokens / data.runCount)
+            : 0,
+      };
+    }
+
+    return {
+      byTaskClass: result,
+      totalRuns: runs.length,
+      period: { days, cutoff },
+    };
+  },
+});
+
+/**
+ * Get token usage analytics grouped by agent/model.
+ * Enables cost optimization by showing which models consume the most tokens.
+ */
+export const getTokenUsageByAgent = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    days: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const days = args.days ?? 7;
+    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
+    const runs = await ctx.db
+      .query("taskRuns")
+      .withIndex("by_team_user_status_created", (idx) =>
+        idx
+          .eq("teamId", teamId)
+          .eq("userId", userId)
+          .eq("status", "completed")
+          .gte("createdAt", cutoff)
+      )
+      .collect();
+
+    // Aggregate by agent name
+    const byAgent = new Map<
+      string,
+      {
+        runCount: number;
+        totalInputTokens: number;
+        totalOutputTokens: number;
+        taskClassBreakdown: Record<string, number>;
+      }
+    >();
+
+    for (const run of runs) {
+      const agentName = run.agentName ?? "unknown";
+      const taskClass = run.taskClass ?? "unclassified";
+      const usage = run.contextUsage;
+
+      const existing = byAgent.get(agentName) ?? {
+        runCount: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        taskClassBreakdown: {},
+      };
+
+      existing.runCount += 1;
+      if (usage) {
+        existing.totalInputTokens += usage.totalInputTokens;
+        existing.totalOutputTokens += usage.totalOutputTokens;
+      }
+      existing.taskClassBreakdown[taskClass] =
+        (existing.taskClassBreakdown[taskClass] ?? 0) + 1;
+
+      byAgent.set(agentName, existing);
+    }
+
+    const result: Record<
+      string,
+      {
+        runCount: number;
+        totalInputTokens: number;
+        totalOutputTokens: number;
+        avgInputTokens: number;
+        avgOutputTokens: number;
+        taskClassBreakdown: Record<string, number>;
+      }
+    > = {};
+
+    for (const [agentName, data] of byAgent) {
+      result[agentName] = {
+        ...data,
+        avgInputTokens:
+          data.runCount > 0
+            ? Math.round(data.totalInputTokens / data.runCount)
+            : 0,
+        avgOutputTokens:
+          data.runCount > 0
+            ? Math.round(data.totalOutputTokens / data.runCount)
+            : 0,
+      };
+    }
+
+    return {
+      byAgent: result,
+      totalRuns: runs.length,
+      period: { days, cutoff },
+    };
+  },
+});
+
 export const getDashboardStats = authQuery({
   args: {
     teamSlugOrId: v.string(),


### PR DESCRIPTION
## Summary

Add token usage tracking infrastructure for all LLM providers (OpenAI, Gemini) to complement existing Anthropic tracking:

- **PostHog analytics helpers**: 
  - `track-openai-proxy.ts`: OpenAI-specific tracking with reasoning tokens (o1/o3) and cached tokens
  - `track-gemini-proxy.ts`: Gemini-specific tracking with cached content tokens
  - `track-llm-usage.ts`: Unified interface supporting all providers with cost estimation

- **Convex analytics queries**:
  - `getTokenUsageByTaskClass`: Aggregate token usage grouped by task class for cost optimization
  - `getTokenUsageByAgent`: Aggregate token usage by model with task-class breakdown

This enables the "measure before optimize" principle from the 30-day roadmap - we can now track token spend across all providers and analyze by task class before making deeper infrastructure changes.

## Related

- Builds on task-class routing from #947
- Follows pattern from existing Anthropic tracking in `track-anthropic-proxy.ts`
- Addresses "Measure: prompt size, cache-hit rate, token spend by task class" from research roadmap

## Test plan

- [x] `bun check` passes (lint + typecheck)
- [x] Existing tests pass (1 network timeout unrelated to changes)
- [ ] Manual verification: Create task runs with different providers, verify PostHog events
- [ ] Manual verification: Check analytics queries return expected aggregations