### PR TITLE
feat: normalize lifecycle event types across activity stores

### DIFF
--- a/apps/client/src/components/ActivityStream.tsx
+++ b/apps/client/src/components/ActivityStream.tsx
@@ -32,7 +32,12 @@ import {
 import { ActivityStreamSkeleton } from "@/components/dashboard/DashboardSkeletons";
 import { formatDuration } from "@/lib/time";
 
+/**
+ * Activity types for dashboard timeline (canonical naming).
+ * Aligned with CANONICAL_EVENT_TYPES in agent-comm-events.ts.
+ */
 const ACTIVITY_TYPES = [
+  // Dashboard-specific events
   "tool_call",
   "file_edit",
   "file_read",
@@ -41,29 +46,60 @@ const ACTIVITY_TYPES = [
   "git_commit",
   "error",
   "thinking",
-  "session_start",
-  "session_stop",
+  // Session lifecycle (canonical)
+  "session_started",
   "session_resumed",
   "session_finished",
-  "stop_requested",
-  "stop_blocked",
-  "stop_failed",
+  // Stop lifecycle (canonical)
+  "session_stop_requested",
+  "session_stop_blocked",
+  "session_stop_failed",
+  // Context health (canonical)
   "context_warning",
   "context_compacted",
+  // Memory (canonical)
   "memory_loaded",
   "memory_scope_changed",
+  // Tool lifecycle (canonical)
   "tool_requested",
   "tool_completed",
-  "approval_requested",
+  // Approval (canonical)
+  "approval_required",
   "approval_resolved",
+  // Interaction
   "user_prompt",
   "subagent_start",
   "subagent_stop",
   "notification",
+  // Prompt/Turn (canonical)
   "prompt_submitted",
   "run_resumed",
+  // MCP (canonical)
   "mcp_capabilities_negotiated",
+  // Hook portability events
+  "task_created",
+  "plan_sync",
+  "simplify_track",
+  "precompact",
+  "postcompact",
+  "simplify_gate",
 ] as const;
+
+/**
+ * Normalize legacy event type names to canonical names.
+ * Handles backward compatibility for events stored with old naming.
+ */
+function normalizeActivityType(type: string): string {
+  const aliases: Record<string, string> = {
+    session_start: "session_started",
+    session_stop: "session_stop_requested",
+    stop_requested: "session_stop_requested",
+    stop_blocked: "session_stop_blocked",
+    stop_failed: "session_stop_failed",
+    approval_requested: "approval_required",
+  };
+  return aliases[type] ?? type;
+}
 
 type ActivityType = (typeof ACTIVITY_TYPES)[number];
 
@@ -166,18 +202,11 @@ const ACTIVITY_CONFIG: Record<ActivityType, ActivityConfig> = {
       "bg-neutral-100 text-neutral-700 dark:bg-neutral-900 dark:text-neutral-300",
     label: "Thinking",
   },
-  session_start: {
+  session_started: {
     icon: Play,
     colorClass: "text-blue-500 dark:text-blue-400",
     badgeClass: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200",
-    label: "Session Start",
-  },
-  session_stop: {
-    icon: Square,
-    colorClass: "text-neutral-500 dark:text-neutral-400",
-    badgeClass:
-      "bg-neutral-100 text-neutral-700 dark:bg-neutral-900 dark:text-neutral-300",
-    label: "Session Stop",
+    label: "Session Started",
   },
   session_resumed: {
     icon: RotateCcw,
@@ -192,21 +221,21 @@ const ACTIVITY_CONFIG: Record<ActivityType, ActivityConfig> = {
       "bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-200",
     label: "Session Finished",
   },
-  stop_requested: {
+  session_stop_requested: {
     icon: Square,
     colorClass: "text-amber-500 dark:text-amber-400",
     badgeClass:
       "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-200",
     label: "Stop Requested",
   },
-  stop_blocked: {
+  session_stop_blocked: {
     icon: AlertTriangle,
     colorClass: "text-amber-500 dark:text-amber-400",
     badgeClass:
       "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-200",
     label: "Stop Blocked",
   },
-  stop_failed: {
+  session_stop_failed: {
     icon: AlertTriangle,
     colorClass: "text-red-500 dark:text-red-400",
     badgeClass: "bg-red-100 text-red-700 dark:bg-red-950/50 dark:text-red-200",
@@ -251,12 +280,12 @@ const ACTIVITY_CONFIG: Record<ActivityType, ActivityConfig> = {
       "bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-200",
     label: "Tool Completed",
   },
-  approval_requested: {
+  approval_required: {
     icon: Shield,
     colorClass: "text-amber-500 dark:text-amber-400",
     badgeClass:
       "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-200",
-    label: "Approval Requested",
+    label: "Approval Required",
   },
   approval_resolved: {
     icon: ShieldCheck,
@@ -308,6 +337,46 @@ const ACTIVITY_CONFIG: Record<ActivityType, ActivityConfig> = {
     badgeClass: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200",
     label: "MCP Capabilities",
   },
+  // Hook portability events
+  task_created: {
+    icon: Play,
+    colorClass: "text-blue-500 dark:text-blue-400",
+    badgeClass: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200",
+    label: "Task Created",
+  },
+  plan_sync: {
+    icon: RotateCcw,
+    colorClass: "text-blue-500 dark:text-blue-400",
+    badgeClass: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200",
+    label: "Plan Sync",
+  },
+  simplify_track: {
+    icon: Search,
+    colorClass: "text-blue-500 dark:text-blue-400",
+    badgeClass: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-200",
+    label: "Simplify Track",
+  },
+  precompact: {
+    icon: Database,
+    colorClass: "text-amber-500 dark:text-amber-400",
+    badgeClass:
+      "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-200",
+    label: "Pre-Compact",
+  },
+  postcompact: {
+    icon: Database,
+    colorClass: "text-green-600 dark:text-green-400",
+    badgeClass:
+      "bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-200",
+    label: "Post-Compact",
+  },
+  simplify_gate: {
+    icon: Shield,
+    colorClass: "text-amber-500 dark:text-amber-400",
+    badgeClass:
+      "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-200",
+    label: "Simplify Gate",
+  },
 };
 
 function formatRelativeTime(timestamp: number): string {
@@ -351,12 +420,14 @@ function formatActivityTypeLabel(type: string): string {
 }
 
 function isKnownActivityType(type: string): type is ActivityType {
-  return ACTIVITY_TYPES.some((activityType) => activityType === type);
+  const normalized = normalizeActivityType(type);
+  return ACTIVITY_TYPES.some((activityType) => activityType === normalized);
 }
 
 function getActivityConfig(type: string): ActivityConfig {
-  if (isKnownActivityType(type)) {
-    return ACTIVITY_CONFIG[type];
+  const normalized = normalizeActivityType(type);
+  if (ACTIVITY_TYPES.some((t) => t === normalized)) {
+    return ACTIVITY_CONFIG[normalized as ActivityType];
   }
 
   return {
@@ -392,9 +463,10 @@ function getActivityMetadata(activity: ActivityLike): string[] {
     metadata.push(activity.toolName);
   }
 
-  switch (activity.type) {
-    case "session_start":
-    case "session_stop":
+  const normalizedType = normalizeActivityType(activity.type);
+  switch (normalizedType) {
+    case "session_started":
+    case "session_stop_requested":
     case "session_resumed":
       if (activity.providerSessionId) {
         metadata.push(`Session: ${activity.providerSessionId}`);
@@ -414,9 +486,8 @@ function getActivityMetadata(activity: ActivityLike): string[] {
         metadata.push(`Exit: ${activity.exitCode}`);
       }
       break;
-    case "stop_requested":
-    case "stop_blocked":
-    case "stop_failed":
+    case "session_stop_blocked":
+    case "session_stop_failed":
       if (activity.stopSource) {
         metadata.push(`Source: ${formatActivityValue(activity.stopSource)}`);
       }
@@ -454,7 +525,7 @@ function getActivityMetadata(activity: ActivityLike): string[] {
         metadata.push(`Size: ${formatBytes(activity.scopeBytes)}`);
       }
       break;
-    case "approval_requested":
+    case "approval_required":
       if (activity.approvalId) {
         metadata.push(`Approval: ${activity.approvalId}`);
       }
@@ -525,11 +596,12 @@ function getActivitySecondaryText(activity: ActivityLike): string | null {
     return trimmedDetail;
   }
 
-  if (activity.type === "stop_blocked" && activity.continuationPrompt) {
+  const normalizedType = normalizeActivityType(activity.type);
+  if (normalizedType === "session_stop_blocked" && activity.continuationPrompt) {
     return `Continuation prompt: ${activity.continuationPrompt}`;
   }
 
-  if (activity.type === "mcp_capabilities_negotiated") {
+  if (normalizedType === "mcp_capabilities_negotiated") {
     const capabilities = getEnabledMcpCapabilities(activity.mcpCapabilities);
     if (capabilities.length > 0) {
       return `Capabilities: ${capabilities.map(formatActivityValue).join(", ")}`;
@@ -884,16 +956,17 @@ export function ActivityStream({ taskRunId, provider }: ActivityStreamProps) {
         ) : (
           <div className="divide-y divide-neutral-100 dark:divide-neutral-900">
             {filteredActivities.map((activity) => {
+              const normalizedType = normalizeActivityType(activity.type);
               const { icon: Icon, colorClass, badgeClass, label } = getActivityConfig(
                 activity.type
               );
               const metadata = getActivityMetadata(activity);
               const secondaryText = getActivitySecondaryText(activity);
-              const isError = activity.type === "error" || activity.type === "stop_failed";
+              const isError = normalizedType === "error" || normalizedType === "session_stop_failed";
               const isWarning =
-                activity.type === "approval_requested" ||
-                activity.type === "stop_blocked" ||
-                activity.type === "context_warning";
+                normalizedType === "approval_required" ||
+                normalizedType === "session_stop_blocked" ||
+                normalizedType === "context_warning";
 
               return (
                 <div

--- a/packages/convex/convex/taskRunActivity_http.ts
+++ b/packages/convex/convex/taskRunActivity_http.ts
@@ -7,12 +7,18 @@ import { typedZid } from "@cmux/shared/utils/typed-zid";
 
 /**
  * Activity event types for dashboard timeline.
- * Extended to include canonical lifecycle events from agent-comm-events.ts.
  *
- * Phase 4 additions align with provider-lifecycle-adapter.ts for full parity.
+ * This list includes:
+ * 1. Canonical lifecycle events from agent-comm-events.ts (normalized naming)
+ * 2. Dashboard-specific events (tool_call, thinking, etc.) not in canonical set
+ *
+ * Naming convention: Use canonical names (e.g., session_started, session_stop_requested)
+ * to align with CANONICAL_EVENT_TYPES in agent-comm-events.ts.
+ *
+ * Legacy aliases are handled via CLIENT_TYPE_ALIASES for backward compatibility.
  */
 const ACTIVITY_TYPES = [
-  // Tool-use events (original)
+  // Tool-use events (dashboard-specific)
   "tool_call",
   "file_edit",
   "file_read",
@@ -21,38 +27,57 @@ const ACTIVITY_TYPES = [
   "git_commit",
   "error",
   "thinking",
-  // Session lifecycle events (Phase 2)
-  "session_start",
-  "session_stop",
+  // Session lifecycle events (canonical names)
+  "session_started", // was: session_start
   "session_resumed",
-  "session_finished", // P1: Clean session exit (distinct from error)
-  // Stop lifecycle events (Phase 4 - lifecycle parity)
-  "stop_requested",
-  "stop_blocked",
-  "stop_failed",
-  // Context health events (Phase 2)
+  "session_finished",
+  // Stop lifecycle events (canonical names)
+  "session_stop_requested", // was: stop_requested
+  "session_stop_blocked", // was: stop_blocked
+  "session_stop_failed", // was: stop_failed
+  // Context health events (canonical)
   "context_warning",
   "context_compacted",
-  // Memory events (Phase 2 + Phase 4)
+  // Memory events (canonical)
   "memory_loaded",
   "memory_scope_changed",
-  // Tool lifecycle events (Phase 4 - detailed tool tracking)
+  // Tool lifecycle events (canonical)
   "tool_requested",
   "tool_completed",
-  // Approval flow events (Phase 4 - runtime interruptions)
-  "approval_requested",
+  // Approval flow events (canonical names)
+  "approval_required", // was: approval_requested
   "approval_resolved",
-  // Interaction events (Phase 2)
+  // Interaction events (dashboard-specific)
   "user_prompt",
   "subagent_start",
   "subagent_stop",
   "notification",
-  // Prompt/Turn tracking events (P1 Lifecycle Parity)
-  "prompt_submitted", // P1: Track prompts/turns submitted to agent
-  "run_resumed", // P1: Resume from checkpoint/session
-  // MCP runtime events (P5 Lifecycle Parity)
-  "mcp_capabilities_negotiated", // P5: MCP server capability negotiation
+  // Prompt/Turn tracking events (canonical)
+  "prompt_submitted",
+  "run_resumed",
+  // MCP runtime events (canonical)
+  "mcp_capabilities_negotiated",
+  // Hook portability events (Phase 5)
+  "task_created",
+  "plan_sync",
+  "simplify_track",
+  "precompact",
+  "postcompact",
+  "simplify_gate",
 ] as const;
+
+/**
+ * Aliases for backward compatibility with legacy event names.
+ * Maps old names to canonical names for client-side migration.
+ */
+export const ACTIVITY_TYPE_ALIASES: Record<string, typeof ACTIVITY_TYPES[number]> = {
+  session_start: "session_started",
+  session_stop: "session_stop_requested",
+  stop_requested: "session_stop_requested",
+  stop_blocked: "session_stop_blocked",
+  stop_failed: "session_stop_failed",
+  approval_requested: "approval_required",
+};
 
 /**
  * Schema for activity events posted by agent hooks.

--- a/packages/shared/src/agent-comm-events.ts
+++ b/packages/shared/src/agent-comm-events.ts
@@ -597,6 +597,69 @@ export type AgentCommEvent =
  */
 export type AgentCommEventType = AgentCommEvent["type"];
 
+/**
+ * Canonical event types as a const array.
+ * This is the single source of truth for all event type names.
+ * Use this to derive validators in Convex and other subsystems.
+ */
+export const CANONICAL_EVENT_TYPES = [
+  // Task Lifecycle
+  "task_spawn_requested",
+  "task_started",
+  "task_status_changed",
+  "task_completed",
+  // Worker Communication
+  "worker_message",
+  "worker_status",
+  // Approval and Review
+  "approval_required",
+  "approval_resolved",
+  // Plan and Orchestration
+  "plan_updated",
+  "orchestration_completed",
+  // Provider Session
+  "provider_session_bound",
+  // Session Lifecycle
+  "session_started",
+  "session_resumed",
+  "session_stop_requested",
+  "session_stop_blocked",
+  "session_stop_failed",
+  "session_finished",
+  // Prompt and Turn
+  "prompt_submitted",
+  "run_resumed",
+  // Tool Lifecycle
+  "tool_requested",
+  "tool_completed",
+  // Memory and Instructions
+  "instructions_loaded",
+  "memory_loaded",
+  "memory_updated",
+  "memory_scope_changed",
+  // Context Health
+  "context_warning",
+  "context_compacted",
+  // MCP Runtime
+  "mcp_capabilities_negotiated",
+  // Operator Input Queue
+  "operator_input_queued",
+  "operator_input_drained",
+  "queue_full_rejected",
+] as const;
+
+/**
+ * Type assertion to ensure CANONICAL_EVENT_TYPES matches AgentCommEventType.
+ * This will cause a compile error if the types diverge.
+ */
+type _AssertCanonicalTypes = typeof CANONICAL_EVENT_TYPES[number] extends AgentCommEventType
+  ? AgentCommEventType extends typeof CANONICAL_EVENT_TYPES[number]
+    ? true
+    : never
+  : never;
+const _assertCanonicalTypes: _AssertCanonicalTypes = true;
+void _assertCanonicalTypes; // Prevent unused variable warning
+
 // =============================================================================
 // Event Utilities
 // =============================================================================


### PR DESCRIPTION
## Summary

Phase 1 of lifecycle event normalization from the 60-day roadmap. Unifies event type naming across three stores:

1. **agent-comm-events.ts** (canonical TypeScript contract)
2. **orchestrationEvents** (Convex persisted events)
3. **taskRunActivity** (dashboard activity stream)

### Changes

**New exports in agent-comm-events.ts:**
- `CANONICAL_EVENT_TYPES` - single source of truth for all 32+ event type names
- Compile-time type assertion ensures constant matches `AgentCommEventType` union

**Naming normalization:**
| Legacy Name | Canonical Name |
|-------------|----------------|
| `session_start` | `session_started` |
| `session_stop` | `session_stop_requested` |
| `stop_requested` | `session_stop_requested` |
| `stop_blocked` | `session_stop_blocked` |
| `stop_failed` | `session_stop_failed` |
| `approval_requested` | `approval_required` |

**Backward compatibility:**
- `ACTIVITY_TYPE_ALIASES` export in taskRunActivity_http.ts for server-side migration
- `normalizeActivityType()` helper in ActivityStream.tsx for client-side migration
- Existing stored events with legacy names still render correctly

**Hook portability events added:**
- `task_created`, `plan_sync`, `simplify_track`, `precompact`, `postcompact`, `simplify_gate`

## Related

- Implements 60-day roadmap item: "Lifecycle event normalization"
- Builds on hook portability from PRs #943-945
- Follows research in obsidian notes: `2026-03-26-cmux-runtime-lifecycle-repo-grounded-brief.md`

## Test plan

- [x] `bun check` passes (lint + typecheck)
- [x] All tests pass (`bun run test`)
- [ ] Manual: Verify ActivityStream renders both new and legacy event types
- [ ] Manual: Verify filter chips work with normalized types