### PR TITLE
feat: add operator presets for orchestration settings bundling

### DIFF
--- a/apps/client/src/components/orchestration/OrchestrationSpawnDialog.tsx
+++ b/apps/client/src/components/orchestration/OrchestrationSpawnDialog.tsx
@@ -4,39 +4,32 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cmux/convex/api";
 import { useConvex } from "convex/react";
 import { toast } from "sonner";
-import { ChevronDown } from "lucide-react";
+import {
+  ChevronDown,
+  Zap,
+  Target,
+  Search,
+  Building2,
+  Box,
+  type LucideIcon,
+} from "lucide-react";
 import { FormDialog } from "@/components/ui/form-dialog";
+import { applyPresetToSpawnOptions, type OperatorPreset } from "@cmux/shared";
 
-// Behavior presets that combine recommended model + profile settings
-const BEHAVIOR_PRESETS = [
-  {
-    id: "quick",
-    name: "Quick Task",
-    description: "Fast execution with minimal review",
-    icon: "⚡",
-    model: "", // auto-select (uses haiku)
-    profile: "", // no profile
-    priority: 5,
-  },
-  {
-    id: "standard",
-    name: "Standard",
-    description: "Balanced speed and quality (recommended)",
-    icon: "🎯",
-    model: "", // auto-select
-    profile: "", // no profile
-    priority: 5,
-  },
-  {
-    id: "thorough",
-    name: "Thorough Review",
-    description: "Extra validation and testing",
-    icon: "🔍",
-    model: "", // will prefer opus if available
-    profile: "", // no profile, but priority lower
-    priority: 3,
-  },
-] as const;
+/**
+ * Map icon name to Lucide component.
+ */
+const ICON_MAP: Record<string, LucideIcon> = {
+  zap: Zap,
+  target: Target,
+  search: Search,
+  building: Building2,
+  box: Box,
+};
+
+function getPresetIcon(iconName: string): LucideIcon {
+  return ICON_MAP[iconName] ?? Box;
+}
 
 interface OrchestrationSpawnDialogProps {
   teamSlugOrId: string;
@@ -53,23 +46,33 @@ export function OrchestrationSpawnDialog({
   const queryClient = useQueryClient();
 
   const [prompt, setPrompt] = useState("");
-  const [selectedPreset, setSelectedPreset] = useState("standard");
+  const [selectedPresetId, setSelectedPresetId] = useState("standard");
   const [showAdvanced, setShowAdvanced] = useState(false);
   // Advanced options (hidden by default)
   const [priority, setPriority] = useState(5);
   const [selectedModel, setSelectedModel] = useState("");
   const [selectedVariant, setSelectedVariant] = useState("");
   const [selectedProfile, setSelectedProfile] = useState("");
+  const [selectedTaskClass, setSelectedTaskClass] = useState<
+    string | undefined
+  >(undefined);
+
+  // Fetch operator presets (built-in + custom)
+  const { data: presets } = useQuery(
+    convexQuery(api.operatorPresets.list, { teamSlugOrId }),
+  );
 
   // Apply preset settings when preset changes
   const handlePresetChange = (presetId: string) => {
-    setSelectedPreset(presetId);
-    const preset = BEHAVIOR_PRESETS.find((p) => p.id === presetId);
+    setSelectedPresetId(presetId);
+    const preset = presets?.find((p: OperatorPreset) => p.id === presetId);
     if (preset) {
-      setPriority(preset.priority);
-      setSelectedModel(preset.model);
-      setSelectedVariant("");
-      setSelectedProfile(preset.profile);
+      const options = applyPresetToSpawnOptions(preset);
+      setPriority(options.priority);
+      setSelectedModel(options.agentName ?? "");
+      setSelectedVariant(options.selectedVariant ?? "");
+      setSelectedProfile(options.supervisorProfileId ?? "");
+      setSelectedTaskClass(options.taskClass);
     }
   };
 
@@ -109,6 +112,7 @@ export function OrchestrationSpawnDialog({
       if (selectedModel && selectedVariant)
         metadata.selectedVariant = selectedVariant;
       if (selectedProfile) metadata.supervisorProfileId = selectedProfile;
+      if (selectedTaskClass) metadata.taskClass = selectedTaskClass;
       const taskId = await convex.mutation(
         api.orchestrationQueries.createTask,
         {
@@ -128,6 +132,7 @@ export function OrchestrationSpawnDialog({
       setSelectedModel("");
       setSelectedVariant("");
       setSelectedProfile("");
+      setSelectedTaskClass(undefined);
       onOpenChange(false);
       void queryClient.invalidateQueries();
     },
@@ -180,27 +185,40 @@ export function OrchestrationSpawnDialog({
         <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
           Behavior
         </label>
-        <div className="grid grid-cols-3 gap-2">
-          {BEHAVIOR_PRESETS.map((preset) => (
-            <button
-              key={preset.id}
-              type="button"
-              onClick={() => handlePresetChange(preset.id)}
-              className={`flex flex-col items-center rounded-lg border p-3 text-center transition-colors ${
-                selectedPreset === preset.id
-                  ? "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20"
-                  : "border-neutral-200 hover:border-neutral-300 dark:border-neutral-700 dark:hover:border-neutral-600"
-              }`}
-            >
-              <span className="text-lg mb-1">{preset.icon}</span>
-              <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
-                {preset.name}
-              </span>
-              <span className="text-[10px] text-neutral-500 dark:text-neutral-400 mt-0.5">
-                {preset.description}
-              </span>
-            </button>
-          ))}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          {!presets && (
+            <div className="col-span-full text-center text-sm text-neutral-500 py-4">
+              Loading presets...
+            </div>
+          )}
+          {presets?.map((preset: OperatorPreset) => {
+            const IconComponent = getPresetIcon(preset.icon);
+            return (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={() => handlePresetChange(preset.id)}
+                className={`flex flex-col items-center rounded-lg border p-3 text-center transition-colors ${
+                  selectedPresetId === preset.id
+                    ? "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20"
+                    : "border-neutral-200 hover:border-neutral-300 dark:border-neutral-700 dark:hover:border-neutral-600"
+                }`}
+              >
+                <IconComponent className="h-5 w-5 mb-1 text-neutral-600 dark:text-neutral-400" />
+                <span className="text-xs font-medium text-neutral-900 dark:text-neutral-100">
+                  {preset.name}
+                </span>
+                <span className="text-[10px] text-neutral-500 dark:text-neutral-400 mt-0.5 line-clamp-2">
+                  {preset.description}
+                </span>
+                {!preset.isBuiltin && (
+                  <span className="text-[9px] text-blue-500 dark:text-blue-400 mt-1">
+                    Custom
+                  </span>
+                )}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -87,6 +87,7 @@ import type * as morphInstanceMaintenance from "../morphInstanceMaintenance.js";
 import type * as morphInstances from "../morphInstances.js";
 import type * as notifications_http from "../notifications_http.js";
 import type * as operatorInputQueue from "../operatorInputQueue.js";
+import type * as operatorPresets from "../operatorPresets.js";
 import type * as operatorVerification from "../operatorVerification.js";
 import type * as operatorVerification_actions from "../operatorVerification_actions.js";
 import type * as orchestrate from "../orchestrate.js";
@@ -247,6 +248,7 @@ declare const fullApi: ApiFromModules<{
   morphInstances: typeof morphInstances;
   notifications_http: typeof notifications_http;
   operatorInputQueue: typeof operatorInputQueue;
+  operatorPresets: typeof operatorPresets;
   operatorVerification: typeof operatorVerification;
   operatorVerification_actions: typeof operatorVerification_actions;
   orchestrate: typeof orchestrate;

--- a/packages/convex/convex/operatorPresets.ts
+++ b/packages/convex/convex/operatorPresets.ts
@@ -1,0 +1,228 @@
+import { v } from "convex/values";
+import { resolveTeamIdLoose } from "../_shared/team";
+import { authMutation, authQuery } from "./users/utils";
+import {
+  BUILTIN_PRESETS,
+  isBuiltinPresetId,
+  type OperatorPreset,
+} from "@cmux/shared";
+
+const taskClassValidator = v.optional(
+  v.union(
+    v.literal("routine"),
+    v.literal("deep-coding"),
+    v.literal("review"),
+    v.literal("eval"),
+    v.literal("architecture"),
+    v.literal("large-context")
+  )
+);
+
+/**
+ * List all presets for a team (built-in + custom).
+ * Built-in presets are always returned first.
+ */
+export const list = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+
+    // Get custom presets from DB
+    const customPresets = await ctx.db
+      .query("operatorPresets")
+      .withIndex("by_team", (q) => q.eq("teamId", teamId))
+      .collect();
+
+    // Map DB records to OperatorPreset type
+    const customMapped: OperatorPreset[] = customPresets.map((p) => ({
+      id: p._id,
+      name: p.name,
+      description: p.description ?? "",
+      icon: p.icon ?? "box",
+      taskClass: p.taskClass,
+      agentName: p.agentName,
+      selectedVariant: p.selectedVariant,
+      supervisorProfileId: p.supervisorProfileId,
+      priority: p.priority,
+      isBuiltin: false,
+    }));
+
+    // Return built-ins first, then custom
+    return [...BUILTIN_PRESETS, ...customMapped];
+  },
+});
+
+/**
+ * Get a single preset by ID.
+ * Works for both built-in and custom presets.
+ */
+export const get = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+    presetId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Check if it's a built-in preset
+    if (isBuiltinPresetId(args.presetId)) {
+      return BUILTIN_PRESETS.find((p) => p.id === args.presetId) ?? null;
+    }
+
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+
+    // Try to find custom preset by querying instead of direct get
+    // to avoid type inference issues with generic ID
+    const presets = await ctx.db
+      .query("operatorPresets")
+      .withIndex("by_team", (q) => q.eq("teamId", teamId))
+      .collect();
+
+    const preset = presets.find((p) => p._id === args.presetId);
+    if (!preset) return null;
+
+    return {
+      id: preset._id,
+      name: preset.name,
+      description: preset.description ?? "",
+      icon: preset.icon ?? "box",
+      taskClass: preset.taskClass,
+      agentName: preset.agentName,
+      selectedVariant: preset.selectedVariant,
+      supervisorProfileId: preset.supervisorProfileId,
+      priority: preset.priority,
+      isBuiltin: false,
+    } satisfies OperatorPreset;
+  },
+});
+
+/**
+ * Create a new custom preset.
+ */
+export const create = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    name: v.string(),
+    description: v.optional(v.string()),
+    icon: v.optional(v.string()),
+    taskClass: taskClassValidator,
+    agentName: v.optional(v.string()),
+    selectedVariant: v.optional(v.string()),
+    supervisorProfileId: v.optional(v.id("supervisorProfiles")),
+    priority: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+    const now = Date.now();
+
+    // Validate name uniqueness within team
+    const existing = await ctx.db
+      .query("operatorPresets")
+      .withIndex("by_team_name", (q) =>
+        q.eq("teamId", teamId).eq("name", args.name)
+      )
+      .first();
+
+    if (existing) {
+      throw new Error(`Preset with name "${args.name}" already exists`);
+    }
+
+    // Don't allow names that match built-in presets
+    if (BUILTIN_PRESETS.some((p) => p.name === args.name)) {
+      throw new Error(`Cannot use reserved preset name "${args.name}"`);
+    }
+
+    const id = await ctx.db.insert("operatorPresets", {
+      teamId,
+      userId,
+      name: args.name,
+      description: args.description,
+      icon: args.icon,
+      taskClass: args.taskClass,
+      agentName: args.agentName,
+      selectedVariant: args.selectedVariant,
+      supervisorProfileId: args.supervisorProfileId,
+      priority: args.priority,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return id;
+  },
+});
+
+/**
+ * Update an existing custom preset.
+ */
+export const update = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    presetId: v.id("operatorPresets"),
+    name: v.optional(v.string()),
+    description: v.optional(v.string()),
+    icon: v.optional(v.string()),
+    taskClass: taskClassValidator,
+    agentName: v.optional(v.string()),
+    selectedVariant: v.optional(v.string()),
+    supervisorProfileId: v.optional(v.id("supervisorProfiles")),
+    priority: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const preset = await ctx.db.get(args.presetId);
+
+    if (!preset || preset.teamId !== teamId) {
+      throw new Error("Preset not found");
+    }
+
+    // If updating name, check uniqueness
+    if (args.name && args.name !== preset.name) {
+      const existing = await ctx.db
+        .query("operatorPresets")
+        .withIndex("by_team_name", (q) =>
+          q.eq("teamId", teamId).eq("name", args.name!)
+        )
+        .first();
+
+      if (existing) {
+        throw new Error(`Preset with name "${args.name}" already exists`);
+      }
+
+      if (BUILTIN_PRESETS.some((p) => p.name === args.name)) {
+        throw new Error(`Cannot use reserved preset name "${args.name}"`);
+      }
+    }
+
+    const { teamSlugOrId: _, presetId: __, ...updates } = args;
+    const filtered = Object.fromEntries(
+      Object.entries(updates).filter(([, v]) => v !== undefined)
+    );
+
+    await ctx.db.patch(args.presetId, {
+      ...filtered,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/**
+ * Delete a custom preset.
+ * Built-in presets cannot be deleted.
+ */
+export const remove = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    presetId: v.id("operatorPresets"),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const preset = await ctx.db.get(args.presetId);
+
+    if (!preset || preset.teamId !== teamId) {
+      throw new Error("Preset not found");
+    }
+
+    await ctx.db.delete(args.presetId);
+  },
+});

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -2695,6 +2695,37 @@ const convexSchema = defineSchema({
     updatedAt: v.number(),
   }).index("by_team", ["teamId"]),
 
+  // Operator presets - user-configurable bundles of orchestration settings
+  operatorPresets: defineTable({
+    teamId: v.string(),
+    userId: v.string(), // Creator
+    // Display
+    name: v.string(),
+    description: v.optional(v.string()),
+    icon: v.optional(v.string()), // Lucide icon name
+    // Spawn settings
+    taskClass: v.optional(
+      v.union(
+        v.literal("routine"),
+        v.literal("deep-coding"),
+        v.literal("review"),
+        v.literal("eval"),
+        v.literal("architecture"),
+        v.literal("large-context")
+      )
+    ), // Task class for automatic model selection
+    agentName: v.optional(v.string()), // Explicit agent (overrides taskClass)
+    selectedVariant: v.optional(v.string()), // Effort/reasoning level
+    supervisorProfileId: v.optional(v.id("supervisorProfiles")),
+    priority: v.number(), // Queue priority (1-10)
+    // Timestamps
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_team", ["teamId"])
+    .index("by_team_user", ["teamId", "userId"])
+    .index("by_team_name", ["teamId", "name"]),
+
   // Session activity tracking for visual change dashboards
   sessionActivity: defineTable({
     // Link to task run

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,6 +57,7 @@ export {
   type NormalizedAgentSelection,
 } from "./agent-selection-core";
 export * from "./agent-catalog";
+export * from "./operator-presets";
 // Note: useNetwork hook is NOT exported here to avoid SSR issues.
 // Import directly from "@cmux/shared/hooks/use-network" in client components.
 // Note: Environment component utilities are NOT exported here.

--- a/packages/shared/src/operator-presets.test.ts
+++ b/packages/shared/src/operator-presets.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import {
+  BUILTIN_PRESETS,
+  BUILTIN_PRESET_IDS,
+  getBuiltinPreset,
+  isBuiltinPresetId,
+  mergePresetsWithBuiltins,
+  applyPresetToSpawnOptions,
+  type OperatorPreset,
+} from "./operator-presets";
+
+describe("operator-presets", () => {
+  describe("BUILTIN_PRESETS", () => {
+    it("has 4 built-in presets", () => {
+      expect(BUILTIN_PRESETS).toHaveLength(4);
+    });
+
+    it("all built-in presets have required fields", () => {
+      for (const preset of BUILTIN_PRESETS) {
+        expect(preset.id).toBeTruthy();
+        expect(preset.name).toBeTruthy();
+        expect(preset.description).toBeTruthy();
+        expect(preset.icon).toBeTruthy();
+        expect(typeof preset.priority).toBe("number");
+        expect(preset.isBuiltin).toBe(true);
+      }
+    });
+
+    it("built-in presets have valid task classes", () => {
+      const validTaskClasses = [
+        "routine",
+        "deep-coding",
+        "review",
+        "eval",
+        "architecture",
+        "large-context",
+      ];
+      for (const preset of BUILTIN_PRESETS) {
+        if (preset.taskClass) {
+          expect(validTaskClasses).toContain(preset.taskClass);
+        }
+      }
+    });
+  });
+
+  describe("getBuiltinPreset", () => {
+    it("returns preset for valid ID", () => {
+      const preset = getBuiltinPreset("quick");
+      expect(preset).toBeDefined();
+      expect(preset?.name).toBe("Quick Task");
+    });
+
+    it("returns undefined for invalid ID", () => {
+      const preset = getBuiltinPreset("nonexistent" as never);
+      expect(preset).toBeUndefined();
+    });
+  });
+
+  describe("isBuiltinPresetId", () => {
+    it("returns true for built-in IDs", () => {
+      for (const id of BUILTIN_PRESET_IDS) {
+        expect(isBuiltinPresetId(id)).toBe(true);
+      }
+    });
+
+    it("returns false for custom IDs", () => {
+      expect(isBuiltinPresetId("custom-preset")).toBe(false);
+      expect(isBuiltinPresetId("")).toBe(false);
+    });
+  });
+
+  describe("mergePresetsWithBuiltins", () => {
+    it("returns all built-ins when custom is empty", () => {
+      const result = mergePresetsWithBuiltins([]);
+      expect(result).toHaveLength(BUILTIN_PRESETS.length);
+    });
+
+    it("adds custom presets after built-ins", () => {
+      const custom: OperatorPreset = {
+        id: "my-preset",
+        name: "My Preset",
+        description: "Custom",
+        icon: "star",
+        priority: 5,
+        isBuiltin: false,
+      };
+      const result = mergePresetsWithBuiltins([custom]);
+      expect(result).toHaveLength(BUILTIN_PRESETS.length + 1);
+      expect(result[result.length - 1].id).toBe("my-preset");
+    });
+
+    it("overrides built-in with custom of same ID", () => {
+      const override: OperatorPreset = {
+        id: "quick", // Same as built-in
+        name: "My Quick",
+        description: "Custom quick",
+        icon: "bolt",
+        priority: 1,
+        isBuiltin: false,
+      };
+      const result = mergePresetsWithBuiltins([override]);
+      // Should have 3 built-ins (minus quick) + 1 custom
+      expect(result).toHaveLength(BUILTIN_PRESETS.length);
+      const quickPreset = result.find((p) => p.id === "quick");
+      expect(quickPreset?.name).toBe("My Quick");
+    });
+  });
+
+  describe("applyPresetToSpawnOptions", () => {
+    it("extracts spawn options from preset", () => {
+      const preset: OperatorPreset = {
+        id: "test",
+        name: "Test",
+        description: "Test preset",
+        icon: "test",
+        taskClass: "architecture",
+        agentName: "claude/opus-4.6",
+        selectedVariant: "max",
+        supervisorProfileId: "profile-123",
+        priority: 2,
+        isBuiltin: false,
+      };
+
+      const options = applyPresetToSpawnOptions(preset);
+
+      expect(options.taskClass).toBe("architecture");
+      expect(options.agentName).toBe("claude/opus-4.6");
+      expect(options.selectedVariant).toBe("max");
+      expect(options.supervisorProfileId).toBe("profile-123");
+      expect(options.priority).toBe(2);
+    });
+
+    it("handles preset with minimal fields", () => {
+      const preset: OperatorPreset = {
+        id: "minimal",
+        name: "Minimal",
+        description: "",
+        icon: "box",
+        priority: 5,
+        isBuiltin: false,
+      };
+
+      const options = applyPresetToSpawnOptions(preset);
+
+      expect(options.taskClass).toBeUndefined();
+      expect(options.agentName).toBeUndefined();
+      expect(options.selectedVariant).toBeUndefined();
+      expect(options.supervisorProfileId).toBeUndefined();
+      expect(options.priority).toBe(5);
+    });
+  });
+});

--- a/packages/shared/src/operator-presets.ts
+++ b/packages/shared/src/operator-presets.ts
@@ -1,0 +1,131 @@
+/**
+ * Operator Presets - Pre-configured bundles of orchestration settings.
+ *
+ * Presets reduce settings sprawl by grouping related configurations
+ * into meaningful combinations that can be selected with one click.
+ */
+
+import type { TaskClass } from "./task-class-routing";
+
+/**
+ * Built-in preset IDs. These are system-provided and cannot be deleted.
+ */
+export const BUILTIN_PRESET_IDS = [
+  "quick",
+  "standard",
+  "thorough",
+  "architecture",
+] as const;
+
+export type BuiltinPresetId = (typeof BUILTIN_PRESET_IDS)[number];
+
+/**
+ * Preset configuration shape.
+ */
+export interface OperatorPreset {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  /** Task class for automatic model selection (if agentName not set) */
+  taskClass?: TaskClass;
+  /** Explicit agent/model name (overrides taskClass routing) */
+  agentName?: string;
+  /** Model variant/effort level */
+  selectedVariant?: string;
+  /** Supervisor profile ID reference */
+  supervisorProfileId?: string;
+  /** Queue priority (1 = highest, 10 = lowest) */
+  priority: number;
+  /** Whether this is a built-in preset (non-deletable) */
+  isBuiltin: boolean;
+}
+
+/**
+ * Built-in presets available to all teams.
+ * These provide sensible defaults without requiring configuration.
+ */
+export const BUILTIN_PRESETS: OperatorPreset[] = [
+  {
+    id: "quick",
+    name: "Quick Task",
+    description: "Fast execution with minimal review",
+    icon: "zap",
+    taskClass: "routine",
+    priority: 5,
+    isBuiltin: true,
+  },
+  {
+    id: "standard",
+    name: "Standard",
+    description: "Balanced speed and quality (recommended)",
+    icon: "target",
+    taskClass: "deep-coding",
+    priority: 5,
+    isBuiltin: true,
+  },
+  {
+    id: "thorough",
+    name: "Thorough Review",
+    description: "Extra validation and testing",
+    icon: "search",
+    taskClass: "review",
+    priority: 3,
+    isBuiltin: true,
+  },
+  {
+    id: "architecture",
+    name: "Architecture",
+    description: "Complex planning with frontier models",
+    icon: "building",
+    taskClass: "architecture",
+    priority: 2,
+    isBuiltin: true,
+  },
+];
+
+/**
+ * Get a built-in preset by ID.
+ */
+export function getBuiltinPreset(id: BuiltinPresetId): OperatorPreset | undefined {
+  return BUILTIN_PRESETS.find((p) => p.id === id);
+}
+
+/**
+ * Check if a preset ID is a built-in preset.
+ */
+export function isBuiltinPresetId(id: string): id is BuiltinPresetId {
+  return BUILTIN_PRESET_IDS.includes(id as BuiltinPresetId);
+}
+
+/**
+ * Merge custom presets with built-in presets.
+ * Custom presets with the same ID override built-ins.
+ */
+export function mergePresetsWithBuiltins(
+  customPresets: OperatorPreset[]
+): OperatorPreset[] {
+  const customIds = new Set(customPresets.map((p) => p.id));
+  const builtins = BUILTIN_PRESETS.filter((p) => !customIds.has(p.id));
+  return [...builtins, ...customPresets];
+}
+
+/**
+ * Apply a preset to spawn options.
+ * Returns the fields to be used when creating a task.
+ */
+export function applyPresetToSpawnOptions(preset: OperatorPreset): {
+  taskClass?: TaskClass;
+  agentName?: string;
+  selectedVariant?: string;
+  supervisorProfileId?: string;
+  priority: number;
+} {
+  return {
+    taskClass: preset.taskClass,
+    agentName: preset.agentName,
+    selectedVariant: preset.selectedVariant,
+    supervisorProfileId: preset.supervisorProfileId,
+    priority: preset.priority,
+  };
+}


### PR DESCRIPTION
## Summary

Introduces user-configurable operator presets that bundle orchestration settings into reusable configurations, reducing settings sprawl as recommended in the 60-day research roadmap.

- Add `operatorPresets` table to Convex schema with team-scoped storage
- Create `packages/shared/src/operator-presets.ts` with built-in presets
- Add Convex CRUD operations (`list`, `get`, `create`, `update`, `remove`)
- Update OrchestrationSpawnDialog to use dynamic presets from Convex
- Replace hardcoded `BEHAVIOR_PRESETS` with Convex-backed system

**Built-in presets:**
| Preset | Task Class | Description |
|--------|------------|-------------|
| Quick Task | routine | Fast execution with minimal review |
| Standard | deep-coding | Balanced speed and quality |
| Thorough Review | review | Extra validation and testing |
| Architecture | architecture | Complex planning with frontier models |

Custom presets can be created per-team and override built-ins by ID.

## Test plan

- [x] Unit tests for operator-presets shared module
- [ ] Verify OrchestrationSpawnDialog loads presets from Convex
- [ ] Test creating custom preset via Convex mutation
- [ ] Verify preset selection applies correct spawn options

## Related

- Part of 60-day roadmap item "operator presets" for settings sprawl reduction
- Builds on task-class model routing (#947)