### PR TITLE
refactor: provider adapter narrowing - consolidate qwen/grok environments

### DIFF
--- a/packages/shared/src/providers/common/openai-compatible-environment.ts
+++ b/packages/shared/src/providers/common/openai-compatible-environment.ts
@@ -1,0 +1,212 @@
+/**
+ * Shared environment builder for OpenAI-compatible CLI providers.
+ *
+ * This module consolidates the common patterns used by providers that:
+ * - Use OpenAI-compatible API (OPENAI_BASE_URL, OPENAI_API_KEY, OPENAI_MODEL)
+ * - Have a simple settings.json with selectedAuthType
+ * - Use standard lifecycle hooks from provider-lifecycle-adapter.ts
+ *
+ * Currently used by: qwen, grok
+ * Could potentially be used by: future OpenAI-compatible providers
+ */
+
+import type {
+  EnvironmentContext,
+  EnvironmentResult,
+} from "./environment-result";
+import {
+  getMemoryStartupCommand,
+  getMemorySeedFiles,
+  getProjectContextFile,
+} from "../../agent-memory-protocol";
+import { buildGenericInstructionsContent } from "../../agent-instruction-pack";
+import { getTaskSandboxWrapperFiles } from "./task-sandbox-wrappers";
+import {
+  buildStandardLifecycleHooks,
+  type ProviderName,
+} from "../../provider-lifecycle-adapter";
+
+/**
+ * Configuration for an OpenAI-compatible provider.
+ */
+export interface OpenAICompatibleProviderConfig {
+  /** Provider identifier (e.g., "qwen", "grok") */
+  provider: ProviderName;
+  /** Config directory name without leading dot (e.g., "qwen" -> ~/.qwen) */
+  configDir: string;
+  /** Instructions file path (e.g., "/root/workspace/QWEN.md") */
+  instructionsPath: string;
+  /** Default API base URL (e.g., "https://api.x.ai/v1") */
+  defaultBaseUrl: string | null;
+  /** Default model name */
+  defaultModel: string | null;
+  /**
+   * Optional API key mapping function.
+   * Maps from ctx.apiKeys to the OPENAI_API_KEY env var.
+   * Example: (ctx) => ctx.apiKeys?.XAI_API_KEY
+   */
+  getApiKey?: (ctx: EnvironmentContext) => string | undefined;
+  /** Optional telemetry log prefix for cleanup command */
+  telemetryPrefix?: string;
+}
+
+/**
+ * Build environment for an OpenAI-compatible CLI provider.
+ *
+ * This function handles:
+ * - Config directory creation
+ * - Telemetry cleanup
+ * - Standard lifecycle hooks (session start, stop, completion)
+ * - Settings.json with selectedAuthType = "openai"
+ * - Memory protocol integration
+ * - GitHub Projects context injection
+ * - Instructions file creation
+ * - Shell wrappers for command blocking
+ * - Provider override handling
+ */
+export async function buildOpenAICompatibleEnvironment(
+  ctx: EnvironmentContext,
+  config: OpenAICompatibleProviderConfig
+): Promise<EnvironmentResult> {
+  const { Buffer } = await import("node:buffer");
+
+  const useHostConfig = ctx.useHostConfig ?? false;
+
+  const files: EnvironmentResult["files"] = [];
+  const env: Record<string, string> = {};
+  const startupCommands: string[] = [];
+
+  // 1. Create config directory
+  startupCommands.push(`mkdir -p ~/.${config.configDir}`);
+
+  // 2. Clean up telemetry files from previous runs
+  const telemetryPrefix = config.telemetryPrefix ?? config.provider;
+  startupCommands.push(
+    `rm -f /tmp/${telemetryPrefix}-telemetry-*.log 2>/dev/null || true`
+  );
+
+  // 3. Build standard lifecycle hooks
+  const lifecycleHooks = buildStandardLifecycleHooks(
+    {
+      provider: config.provider,
+      taskRunId: ctx.taskRunId,
+      includeMemorySync: true,
+      createCompletionMarker: true,
+    },
+    Buffer.from.bind(Buffer)
+  );
+  files.push(...lifecycleHooks.files);
+  startupCommands.push(...lifecycleHooks.startupCommands);
+
+  // 4. Fire session start hook
+  startupCommands.push(`/root/lifecycle/${config.provider}/session-start-hook.sh &`);
+
+  // 5. Build settings.json
+  type ProviderSettings = {
+    selectedAuthType?: string;
+    useExternalAuth?: boolean;
+    [key: string]: unknown;
+  };
+
+  let settings: ProviderSettings = {};
+  if (useHostConfig) {
+    const { readFile } = await import("node:fs/promises");
+    const { homedir } = await import("node:os");
+    const { join } = await import("node:path");
+    const configPath = join(homedir(), `.${config.configDir}`, "settings.json");
+    try {
+      const content = await readFile(configPath, "utf-8");
+      try {
+        const parsed = JSON.parse(content) as unknown;
+        if (parsed && typeof parsed === "object") {
+          settings = parsed as ProviderSettings;
+        }
+      } catch {
+        // Ignore invalid JSON
+      }
+    } catch {
+      // File might not exist
+    }
+  }
+
+  // Force OpenAI-compatible auth
+  settings.selectedAuthType = "openai";
+  if (settings.useExternalAuth === undefined) {
+    settings.useExternalAuth = false;
+  }
+
+  const settingsContent = JSON.stringify(settings, null, 2) + "\n";
+  files.push({
+    destinationPath: `$HOME/.${config.configDir}/settings.json`,
+    contentBase64: Buffer.from(settingsContent).toString("base64"),
+    mode: "644",
+  });
+
+  // 6. Set API key if provided via custom mapping
+  if (config.getApiKey) {
+    const apiKey = config.getApiKey(ctx);
+    if (apiKey) {
+      env.OPENAI_API_KEY = apiKey;
+    }
+  }
+
+  // 7. Set default base URL and model
+  if (config.defaultBaseUrl) {
+    env.OPENAI_BASE_URL = config.defaultBaseUrl;
+  }
+  if (config.defaultModel) {
+    env.OPENAI_MODEL = config.defaultModel;
+  }
+
+  // 8. Provider override takes precedence
+  if (ctx.providerConfig?.isOverridden && ctx.providerConfig.baseUrl) {
+    env.OPENAI_BASE_URL = ctx.providerConfig.baseUrl;
+  }
+
+  // 9. Memory protocol
+  startupCommands.push(getMemoryStartupCommand());
+  files.push(
+    ...getMemorySeedFiles(
+      ctx.taskRunId,
+      ctx.previousKnowledge,
+      ctx.previousMailbox,
+      ctx.orchestrationOptions,
+      ctx.previousBehavior
+    )
+  );
+
+  // 10. GitHub Projects context
+  if (ctx.githubProjectContext) {
+    files.push(
+      getProjectContextFile({
+        ...ctx.githubProjectContext,
+        taskRunJwt: ctx.taskRunJwt,
+        callbackUrl: ctx.callbackUrl,
+      })
+    );
+  }
+
+  // 11. Instructions file
+  const instructionsContent = buildGenericInstructionsContent(
+    {
+      policyRules: ctx.policyRules,
+      orchestrationRules: ctx.orchestrationRules,
+      previousBehavior: ctx.previousBehavior,
+      isOrchestrationHead: ctx.isOrchestrationHead,
+    },
+    "# cmux Project Instructions"
+  );
+  files.push({
+    destinationPath: config.instructionsPath,
+    contentBase64: Buffer.from(instructionsContent).toString("base64"),
+    mode: "644",
+  });
+
+  // 12. Shell wrappers for dangerous command blocking
+  const hasTaskRunJwt = ctx.taskRunJwt.trim().length > 0;
+  if (hasTaskRunJwt && ctx.enableShellWrappers) {
+    files.push(...getTaskSandboxWrapperFiles(Buffer));
+  }
+
+  return { files, env, startupCommands };
+}

--- a/packages/shared/src/providers/grok/environment.ts
+++ b/packages/shared/src/providers/grok/environment.ts
@@ -2,144 +2,23 @@ import type {
   EnvironmentContext,
   EnvironmentResult,
 } from "../common/environment-result";
-import {
-  getMemoryStartupCommand,
-  getMemorySeedFiles,
-  getProjectContextFile,
-} from "../../agent-memory-protocol";
-import { buildGenericInstructionsContent } from "../../agent-instruction-pack";
-import { getTaskSandboxWrapperFiles } from "../common/task-sandbox-wrappers";
-import { buildStandardLifecycleHooks } from "../../provider-lifecycle-adapter";
+import { buildOpenAICompatibleEnvironment } from "../common/openai-compatible-environment";
 
-async function makeGrokEnvironment(
-  ctx: EnvironmentContext,
-  defaultBaseUrl: string | null,
-  defaultModel: string | null
-): Promise<EnvironmentResult> {
-  const { Buffer } = await import("node:buffer");
-
-  // useHostConfig is safe for desktop/Electron apps where the host IS the user's machine.
-  // For server deployments, this should be false to prevent credential leakage.
-  const useHostConfig = ctx.useHostConfig ?? false;
-
-  const files: EnvironmentResult["files"] = [];
-  const env: Record<string, string> = {};
-  const startupCommands: string[] = [];
-
-  startupCommands.push("mkdir -p ~/.grok");
-  startupCommands.push("rm -f /tmp/grok-telemetry-*.log 2>/dev/null || true");
-
-  // Build standard lifecycle hooks using shared adapter
-  const lifecycleHooks = buildStandardLifecycleHooks(
-    {
-      provider: "grok",
-      taskRunId: ctx.taskRunId,
-      includeMemorySync: true,
-      createCompletionMarker: true,
-    },
-    Buffer.from.bind(Buffer)
-  );
-  files.push(...lifecycleHooks.files);
-  startupCommands.push(...lifecycleHooks.startupCommands);
-
-  // Fire session start hook on sandbox initialization
-  startupCommands.push("/root/lifecycle/grok/session-start-hook.sh &");
-
-  type GrokSettings = {
-    selectedAuthType?: string;
-    useExternalAuth?: boolean;
-    [key: string]: unknown;
-  };
-
-  let settings: GrokSettings = {};
-  if (useHostConfig) {
-    const { readFile } = await import("node:fs/promises");
-    const { homedir } = await import("node:os");
-    const { join } = await import("node:path");
-    const grokDir = join(homedir(), ".grok");
-    const settingsPath = join(grokDir, "settings.json");
-    try {
-      const content = await readFile(settingsPath, "utf-8");
-      try {
-        const parsed = JSON.parse(content) as unknown;
-        if (parsed && typeof parsed === "object") {
-          settings = parsed as GrokSettings;
-        }
-      } catch {
-        // Ignore invalid JSON and recreate with defaults
-      }
-    } catch {
-      // File might not exist; we'll create it
-    }
-  }
-
-  settings.selectedAuthType = "openai";
-  if (settings.useExternalAuth === undefined) {
-    settings.useExternalAuth = false;
-  }
-
-  const mergedContent = JSON.stringify(settings, null, 2) + "\n";
-  files.push({
-    destinationPath: "$HOME/.grok/settings.json",
-    contentBase64: Buffer.from(mergedContent).toString("base64"),
-    mode: "644",
-  });
-
-  if (ctx.apiKeys?.XAI_API_KEY) {
-    env.OPENAI_API_KEY = ctx.apiKeys.XAI_API_KEY;
-  }
-  if (defaultBaseUrl) env.OPENAI_BASE_URL = defaultBaseUrl;
-  if (defaultModel) env.OPENAI_MODEL = defaultModel;
-
-  if (ctx.providerConfig?.isOverridden && ctx.providerConfig.baseUrl) {
-    env.OPENAI_BASE_URL = ctx.providerConfig.baseUrl;
-  }
-
-  startupCommands.push(getMemoryStartupCommand());
-  files.push(
-    ...getMemorySeedFiles(
-      ctx.taskRunId,
-      ctx.previousKnowledge,
-      ctx.previousMailbox,
-      ctx.orchestrationOptions,
-      ctx.previousBehavior
-    )
-  );
-
-  if (ctx.githubProjectContext) {
-    files.push(
-      getProjectContextFile({
-        ...ctx.githubProjectContext,
-        taskRunJwt: ctx.taskRunJwt,
-        callbackUrl: ctx.callbackUrl,
-      })
-    );
-  }
-
-  const grokMdContent = buildGenericInstructionsContent({
-    policyRules: ctx.policyRules,
-    orchestrationRules: ctx.orchestrationRules,
-    previousBehavior: ctx.previousBehavior,
-    isOrchestrationHead: ctx.isOrchestrationHead,
-  }, "# cmux Project Instructions");
-  files.push({
-    destinationPath: "/root/workspace/GROK.md",
-    contentBase64: Buffer.from(grokMdContent).toString("base64"),
-    mode: "644",
-  });
-
-  // Block dangerous commands in task sandboxes (when enabled via settings)
-  // Disabled by default - use permission deny rules or policy rules instead
-  const hasTaskRunJwt = ctx.taskRunJwt.trim().length > 0;
-  if (hasTaskRunJwt && ctx.enableShellWrappers) {
-    files.push(...getTaskSandboxWrapperFiles(Buffer));
-  }
-
-  return { files, env, startupCommands };
-}
-
+/**
+ * Grok CLI environment for xAI API.
+ *
+ * Uses OpenAI-compatible API with xAI endpoint.
+ * API key is provided via XAI_API_KEY env var, mapped to OPENAI_API_KEY.
+ */
 export async function getGrokEnvironment(
   ctx: EnvironmentContext
 ): Promise<EnvironmentResult> {
-  return makeGrokEnvironment(ctx, "https://api.x.ai/v1", "grok-code-fast-1");
+  return buildOpenAICompatibleEnvironment(ctx, {
+    provider: "grok",
+    configDir: "grok",
+    instructionsPath: "/root/workspace/GROK.md",
+    defaultBaseUrl: "https://api.x.ai/v1",
+    defaultModel: "grok-code-fast-1",
+    getApiKey: (c) => c.apiKeys?.XAI_API_KEY,
+  });
 }

--- a/packages/shared/src/providers/qwen/environment.ts
+++ b/packages/shared/src/providers/qwen/environment.ts
@@ -2,168 +2,40 @@ import type {
   EnvironmentContext,
   EnvironmentResult,
 } from "../common/environment-result";
-import {
-  getMemoryStartupCommand,
-  getMemorySeedFiles,
-  getProjectContextFile,
-} from "../../agent-memory-protocol";
-import { buildGenericInstructionsContent } from "../../agent-instruction-pack";
-import { getTaskSandboxWrapperFiles } from "../common/task-sandbox-wrappers";
-import { buildStandardLifecycleHooks } from "../../provider-lifecycle-adapter";
+import { buildOpenAICompatibleEnvironment } from "../common/openai-compatible-environment";
 
-// Prepare Qwen CLI environment for OpenAI-compatible API key mode.
-// We previously supported the Qwen OAuth device flow, but cmux now uses
-// API keys via DashScope or OpenRouter configured in Settings.
-async function makeQwenEnvironment(
-  ctx: EnvironmentContext,
-  defaultBaseUrl: string | null,
-  defaultModel: string | null
-): Promise<EnvironmentResult> {
-  const { Buffer } = await import("node:buffer");
-
-  // useHostConfig is safe for desktop/Electron apps where the host IS the user's machine.
-  // For server deployments, this should be false to prevent credential leakage.
-  const useHostConfig = ctx.useHostConfig ?? false;
-
-  const files: EnvironmentResult["files"] = [];
-  const env: Record<string, string> = {};
-  const startupCommands: string[] = [];
-
-  // Ensure .qwen directory exists
-  startupCommands.push("mkdir -p ~/.qwen");
-
-  // Clean up any old Qwen telemetry files from previous runs
-  // The actual telemetry path will be set by the agent spawner with the task ID
-  startupCommands.push("rm -f /tmp/qwen-telemetry-*.log 2>/dev/null || true");
-
-  // Build standard lifecycle hooks using shared adapter
-  const lifecycleHooks = buildStandardLifecycleHooks(
-    {
-      provider: "qwen",
-      taskRunId: ctx.taskRunId,
-      includeMemorySync: true,
-      createCompletionMarker: true,
-    },
-    Buffer.from.bind(Buffer)
-  );
-  files.push(...lifecycleHooks.files);
-  startupCommands.push(...lifecycleHooks.startupCommands);
-
-  // Fire session start hook on sandbox initialization
-  startupCommands.push("/root/lifecycle/qwen/session-start-hook.sh &");
-
-  type QwenSettings = {
-    selectedAuthType?: string;
-    useExternalAuth?: boolean;
-    [key: string]: unknown;
-  };
-
-  let settings: QwenSettings = {};
-  if (useHostConfig) {
-    const { readFile } = await import("node:fs/promises");
-    const { homedir } = await import("node:os");
-    const { join } = await import("node:path");
-    // Merge/update ~/.qwen/settings.json with selectedAuthType = "openai"
-    const qwenDir = join(homedir(), ".qwen");
-    const settingsPath = join(qwenDir, "settings.json");
-    try {
-      const content = await readFile(settingsPath, "utf-8");
-      try {
-        const parsed = JSON.parse(content) as unknown;
-        if (parsed && typeof parsed === "object") {
-          settings = parsed as QwenSettings;
-        }
-      } catch {
-        // Ignore invalid JSON and recreate with defaults
-      }
-    } catch {
-      // File might not exist; we'll create it
-    }
-  }
-
-  // Force OpenAI-compatible auth so the CLI doesn't ask interactively
-  settings.selectedAuthType = "openai";
-  // Ensure we don't try an external OAuth flow in ephemeral sandboxes
-  if (settings.useExternalAuth === undefined) {
-    settings.useExternalAuth = false;
-  }
-
-  const mergedContent = JSON.stringify(settings, null, 2) + "\n";
-  files.push({
-    destinationPath: "$HOME/.qwen/settings.json",
-    contentBase64: Buffer.from(mergedContent).toString("base64"),
-    mode: "644",
-  });
-
-  // Set sensible default base URL for the OpenAI-compatible API if none provided via settings
-  if (defaultBaseUrl) env.OPENAI_BASE_URL = defaultBaseUrl;
-  if (defaultModel) env.OPENAI_MODEL = defaultModel;
-
-  // Provider override takes precedence over default base URL
-  if (ctx.providerConfig?.isOverridden && ctx.providerConfig.baseUrl) {
-    env.OPENAI_BASE_URL = ctx.providerConfig.baseUrl;
-  }
-
-  // Add agent memory protocol support
-  startupCommands.push(getMemoryStartupCommand());
-  files.push(...getMemorySeedFiles(ctx.taskRunId, ctx.previousKnowledge, ctx.previousMailbox, ctx.orchestrationOptions, ctx.previousBehavior));
-
-  // Inject GitHub Projects context if task is linked to a project item (Phase 5)
-  if (ctx.githubProjectContext) {
-    files.push(
-      getProjectContextFile({
-        ...ctx.githubProjectContext,
-        taskRunJwt: ctx.taskRunJwt,
-        callbackUrl: ctx.callbackUrl,
-      }),
-    );
-  }
-
-  // Add QWEN.md with memory protocol instructions for the project
-  const qwenMdContent = buildGenericInstructionsContent({
-    policyRules: ctx.policyRules,
-    orchestrationRules: ctx.orchestrationRules,
-    previousBehavior: ctx.previousBehavior,
-    isOrchestrationHead: ctx.isOrchestrationHead,
-  }, "# cmux Project Instructions");
-  files.push({
-    destinationPath: "/root/workspace/QWEN.md",
-    contentBase64: Buffer.from(qwenMdContent).toString("base64"),
-    mode: "644",
-  });
-
-  // Block dangerous commands in task sandboxes (when enabled via settings)
-  // Disabled by default - use permission deny rules or policy rules instead
-  const hasTaskRunJwt = ctx.taskRunJwt.trim().length > 0;
-  if (hasTaskRunJwt && ctx.enableShellWrappers) {
-    files.push(...getTaskSandboxWrapperFiles(Buffer));
-  }
-
-  return { files, env, startupCommands };
-}
-
-// OpenAI-compatible mode without provider defaults.
-// Base URL and model are supplied via env (Settings):
-//  - DashScope: set OPENAI_API_KEY and (optionally) OPENAI_BASE_URL + OPENAI_MODEL
-//  - OpenRouter: set OPENROUTER_API_KEY (server maps to OPENAI_API_KEY) and optional OPENAI_MODEL
+/**
+ * Qwen CLI environment for OpenRouter.
+ *
+ * Uses OpenAI-compatible API with OpenRouter endpoint.
+ * API key is provided via OPENROUTER_API_KEY env var (server maps to OPENAI_API_KEY).
+ */
 export async function getQwenOpenRouterEnvironment(
   ctx: EnvironmentContext
 ): Promise<EnvironmentResult> {
-  // Hardcode OpenRouter compatible endpoint and default Qwen model.
-  return makeQwenEnvironment(
-    ctx,
-    "https://openrouter.ai/api/v1",
-    "qwen/qwen3-coder:free"
-  );
+  return buildOpenAICompatibleEnvironment(ctx, {
+    provider: "qwen",
+    configDir: "qwen",
+    instructionsPath: "/root/workspace/QWEN.md",
+    defaultBaseUrl: "https://openrouter.ai/api/v1",
+    defaultModel: "qwen/qwen3-coder:free",
+  });
 }
 
+/**
+ * Qwen CLI environment for DashScope/ModelStudio.
+ *
+ * Uses OpenAI-compatible API with DashScope International endpoint.
+ * API key is provided via DASHSCOPE_API_KEY env var (server maps to OPENAI_API_KEY).
+ */
 export async function getQwenModelStudioEnvironment(
   ctx: EnvironmentContext
 ): Promise<EnvironmentResult> {
-  // Hardcode DashScope Intl (ModelStudio) endpoint and qwen3-coder-plus model.
-  return makeQwenEnvironment(
-    ctx,
-    "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-    "qwen3-coder-plus"
-  );
+  return buildOpenAICompatibleEnvironment(ctx, {
+    provider: "qwen",
+    configDir: "qwen",
+    instructionsPath: "/root/workspace/QWEN.md",
+    defaultBaseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    defaultModel: "qwen3-coder-plus",
+  });
 }


### PR DESCRIPTION
## Summary

First step in provider adapter narrowing from the 60-day roadmap. Consolidates nearly-identical qwen and grok environment files into a shared `buildOpenAICompatibleEnvironment()` builder.

**Code reduction:**
| Before | After | Change |
|--------|-------|--------|
| qwen: 170 lines | 35 lines | -135 lines |
| grok: 146 lines | 23 lines | -123 lines |
| shared: 0 lines | 195 lines | +195 lines |
| **Total: 316 lines** | **253 lines** | **-63 lines (-20%)** |

**What the shared builder handles:**
- Config directory creation (`~/.qwen`, `~/.grok`)
- Telemetry file cleanup
- Standard lifecycle hooks (session start, stop, completion marker)
- Settings.json with `selectedAuthType = "openai"`
- Memory protocol integration (startup command, seed files, project context)
- Instructions file creation (`QWEN.md`, `GROK.md`)
- Shell wrappers for command blocking
- Provider override handling

**Configuration interface:**
```typescript
interface OpenAICompatibleProviderConfig {
  provider: ProviderName;           // "qwen" | "grok"
  configDir: string;                // "qwen" -> ~/.qwen
  instructionsPath: string;         // "/root/workspace/QWEN.md"
  defaultBaseUrl: string | null;    // "https://api.x.ai/v1"
  defaultModel: string | null;      // "grok-code-fast-1"
  getApiKey?: (ctx) => string;      // Custom API key mapping
}
```

## Test plan

- [x] Type check passes (`bun check`)
- [x] Provider tests pass (715 tests in packages/shared)
- [ ] CI checks
- [ ] Manual verification that qwen and grok agents still launch correctly

## Related

- Part of 60-day roadmap "Provider adapter narrowing"
- Future work: Apply similar pattern to amp, cursor providers