### PR TITLE
fix: normalize PVE noVNC snapshot version state

### DIFF
--- a/packages/shared/src/pve-lxc-snapshots.json
+++ b/packages/shared/src/pve-lxc-snapshots.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-04-11T22:52:54Z",
+  "updatedAt": "2026-04-13T16:03:10Z",
   "presets": [
     {
       "presetId": "4vcpu_8gb_32gb",
@@ -69,6 +69,15 @@
           "snapshotId": "snapshot_8ff6caa9",
           "templateVmid": 9091,
           "capturedAt": "2026-04-11T22:52:23Z"
+        },
+        {
+          "version": 102,
+          "snapshotId": "snapshot_8ae8a907",
+          "templateVmid": 9110,
+          "capturedAt": "2026-04-13T16:02:40Z",
+          "novncVersion": "v1.7.0-beta",
+          "novncSource": "github:noVNC/v1.7.0-beta",
+          "novncPackageState": "purged"
         }
       ]
     },
@@ -139,6 +148,15 @@
           "snapshotId": "snapshot_e680e0e5",
           "templateVmid": 9094,
           "capturedAt": "2026-04-11T22:52:54Z"
+        },
+        {
+          "version": 86,
+          "snapshotId": "snapshot_a1af1fd7",
+          "templateVmid": 9111,
+          "capturedAt": "2026-04-13T16:03:10Z",
+          "novncVersion": "v1.7.0-beta",
+          "novncSource": "github:noVNC/v1.7.0-beta",
+          "novncPackageState": "purged"
         }
       ]
     }

--- a/packages/shared/src/pve-lxc-snapshots.test.ts
+++ b/packages/shared/src/pve-lxc-snapshots.test.ts
@@ -70,6 +70,19 @@ describe("pve lxc snapshots manifest", () => {
     }
   });
 
+  it("tracks canonical noVNC runtime metadata when present", () => {
+    for (const preset of PVE_LXC_SNAPSHOT_PRESETS) {
+      for (const version of preset.versions) {
+        if (!version.novncVersion) {
+          continue;
+        }
+        expect(version.novncVersion).toBeTruthy();
+        expect(version.novncSource).toBeTruthy();
+        expect(version.novncPackageState).toBeTruthy();
+      }
+    }
+  });
+
   it("has required fields for each preset", () => {
     for (const preset of PVE_LXC_SNAPSHOT_PRESETS) {
       expect(preset.presetId).toBeTruthy();

--- a/packages/shared/src/pve-lxc-snapshots.ts
+++ b/packages/shared/src/pve-lxc-snapshots.ts
@@ -19,12 +19,18 @@ const presetIdSchema = z
  * Schema v2: Template-based versions for linked-clone support.
  * Each version has a snapshotId and templateVmid (the VMID of the template container).
  */
+const novncMetadataSchema = z.object({
+  novncVersion: z.string(),
+  novncSource: z.string(),
+  novncPackageState: z.string(),
+});
+
 export const pveLxcTemplateVersionSchema = z.object({
   version: z.number().int().positive(),
   snapshotId: z.string().regex(/^snapshot_[a-z0-9]+$/i),
   templateVmid: z.number().int().positive(),
   capturedAt: isoDateStringSchema,
-});
+}).and(novncMetadataSchema.partial());
 
 export const pveLxcTemplatePresetSchema = z
   .object({

--- a/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
@@ -36,6 +36,11 @@ timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 log_dir="logs/pve-lxc-networkd"
 mkdir -p "${log_dir}"
 
+run_novnc_verify() {
+  local id="$1"
+  devsh exec "${id}" "set -euo pipefail; expected_version='v1.7.0-beta'; marker=\$(cat /etc/cmux/novnc-version 2>/dev/null || true); if [[ \"\${marker}\" != \"\${expected_version}\" ]]; then echo \"FAIL: expected /etc/cmux/novnc-version=\${expected_version}, got \${marker:-missing}\" >&2; exit 1; fi; if dpkg-query -W -f='\${Status}\\n' novnc 2>/dev/null | grep -q '^install ok installed$'; then echo 'FAIL: distro novnc package is still installed' >&2; exit 1; fi; if ! grep -q 'vnc-clipboard-bridge' /usr/share/novnc/vnc.html 2>/dev/null; then echo 'FAIL: vnc-clipboard-bridge missing from /usr/share/novnc/vnc.html' >&2; exit 1; fi; curl -I --max-time 5 http://127.0.0.1:39380/vnc.html >/dev/null"
+}
+
 readarray -t snapshot_lines < <(
   python3 - "${results_json}" <<'PY'
 import json
@@ -118,12 +123,27 @@ for line in "${snapshot_lines[@]}"; do
     exit 1
   fi
 
+  if ! run_novnc_verify "${active_id}"; then
+    echo "ERROR: noVNC runtime verification failed for ${active_id} (${snapshot_id})" >&2
+    echo "Diagnostics: ${diag_out}" >&2
+    exit 1
+  fi
+
   echo "Re-checking after 30s (post-boot overwrite detection)..."
   sleep 30
   if ! "${verify}" "${active_id}"; then
     late_diag_out="${log_dir}/diag.runtime.late.${preset}.${snapshot_id}.${active_id}.${timestamp}.txt"
     "${diag}" "${active_id}" "${late_diag_out}" || true
     echo "ERROR: runtime verification regressed after boot for ${active_id} (${snapshot_id})" >&2
+    echo "Diagnostics (early): ${diag_out}" >&2
+    echo "Diagnostics (late): ${late_diag_out}" >&2
+    exit 1
+  fi
+
+  if ! run_novnc_verify "${active_id}"; then
+    late_diag_out="${log_dir}/diag.runtime.late.${preset}.${snapshot_id}.${active_id}.${timestamp}.txt"
+    "${diag}" "${active_id}" "${late_diag_out}" || true
+    echo "ERROR: noVNC runtime verification regressed after boot for ${active_id} (${snapshot_id})" >&2
     echo "Diagnostics (early): ${diag_out}" >&2
     echo "Diagnostics (late): ${late_diag_out}" >&2
     exit 1

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -95,6 +95,48 @@ PVE_SNAPSHOT_MANIFEST_PATH = (
 )
 CURRENT_MANIFEST_SCHEMA_VERSION = 2
 
+NOVNC_VERSION = "v1.7.0-beta"
+NOVNC_DIR = "/usr/share/novnc"
+NOVNC_MARKER_FILE = f"{NOVNC_DIR}/.cmux-novnc-version"
+NOVNC_DURABLE_MARKER = "/etc/cmux/novnc-version"
+NOVNC_PACKAGE_NAME = "novnc"
+NOVNC_SOURCE = f"github:noVNC/{NOVNC_VERSION}"
+NOVNC_ARCHIVE_URL = (
+    f"https://github.com/novnc/noVNC/archive/refs/tags/{NOVNC_VERSION}.tar.gz"
+)
+NOVNC_PACKAGE_STATE = "purged"
+
+
+def _build_novnc_shell_vars() -> str:
+    return "\n".join(
+        [
+            f"NOVNC_VERSION={shlex.quote(NOVNC_VERSION)}",
+            f"NOVNC_DIR={shlex.quote(NOVNC_DIR)}",
+            f"MARKER_FILE={shlex.quote(NOVNC_MARKER_FILE)}",
+            f"DURABLE_MARKER={shlex.quote(NOVNC_DURABLE_MARKER)}",
+            f"NOVNC_PACKAGE_NAME={shlex.quote(NOVNC_PACKAGE_NAME)}",
+            f"NOVNC_SOURCE={shlex.quote(NOVNC_SOURCE)}",
+            f"NOVNC_ARCHIVE_URL={shlex.quote(NOVNC_ARCHIVE_URL)}",
+        ]
+    )
+
+
+def _build_novnc_metadata() -> dict[str, str]:
+    return {
+        "novncVersion": NOVNC_VERSION,
+        "novncSource": NOVNC_SOURCE,
+        "novncPackageState": NOVNC_PACKAGE_STATE,
+    }
+
+
+def _build_novnc_description_lines() -> tuple[str, str, str]:
+    metadata = _build_novnc_metadata()
+    return (
+        f"novncVersion: {metadata['novncVersion']}",
+        f"novncSource: {metadata['novncSource']}",
+        f"novncPackageState: {metadata['novncPackageState']}",
+    )
+
 # Default template VMID (should be created via pve-lxc-template.sh)
 DEFAULT_TEMPLATE_VMID = 9000
 
@@ -1476,6 +1518,9 @@ class PveTemplateVersionEntry(t.TypedDict):
     snapshotId: str
     templateVmid: int  # The VMID of the template container
     capturedAt: str
+    novncVersion: t.NotRequired[str]
+    novncSource: t.NotRequired[str]
+    novncPackageState: t.NotRequired[str]
 
 
 class PveTemplatePresetEntry(t.TypedDict):
@@ -1534,6 +1579,7 @@ def _resolve_repo_relative_path(repo_root: Path, path: str) -> Path:
 
 
 def _serialize_template_result(result: TemplateRunResult) -> dict[str, t.Any]:
+    metadata = _build_novnc_metadata()
     return {
         "presetId": result.preset.preset_id,
         "label": result.preset.label,
@@ -1544,6 +1590,7 @@ def _serialize_template_result(result: TemplateRunResult) -> dict[str, t.Any]:
         "vcpus": result.preset.vcpus,
         "memoryMib": result.preset.memory_mib,
         "diskSizeMib": result.preset.disk_size_mib,
+        **metadata,
     }
 
 
@@ -1610,6 +1657,7 @@ def _build_template_description(
         f"presetId: {preset_id}" if preset_id else "presetId: unknown",
         f"capturedAt: {captured_at}",
         f"sourceVmid: {source_vmid}",
+        *_build_novnc_description_lines(),
     ]
     if hostname:
         lines.append(f"hostname: {hostname}")
@@ -1725,6 +1773,7 @@ def _add_version_to_preset(
         "snapshotId": snapshot_id,
         "templateVmid": template_vmid,
         "capturedAt": captured_at,
+        **_build_novnc_metadata(),
     }
     preset_entry["versions"].append(version_entry)
     preset_entry["versions"].sort(key=lambda entry: entry["version"])
@@ -1773,6 +1822,7 @@ def _update_manifest_with_template(
         "snapshotId": snapshot_id,
         "templateVmid": template_vmid,
         "capturedAt": captured_at,
+        **_build_novnc_metadata(),
     }
     preset_entry["versions"].append(version_entry)
     preset_entry["versions"].sort(key=lambda entry: entry["version"])
@@ -2409,7 +2459,7 @@ async def task_install_base_packages(ctx: PveTaskContext) -> None:
             ruby-full perl software-properties-common \
             tigervnc-standalone-server tigervnc-common \
             xvfb \
-            x11-xserver-utils xterm novnc \
+            x11-xserver-utils xterm \
             dbus-x11 openbox xclip xsel parcellite \
             tmux \
             bubblewrap \
@@ -2447,40 +2497,59 @@ async def task_install_base_packages(ctx: PveTaskContext) -> None:
 @registry.task(
     name="upgrade-novnc",
     deps=("install-base-packages",),
-    description="Upgrade noVNC to 1.7.0-beta for improved clipboard sync",
+    description="Install managed noVNC 1.7.0-beta for improved clipboard sync",
 )
 @update_registry.task(
     name="upgrade-novnc",
     deps=(),  # Safe to run anytime in update mode
-    description="Upgrade noVNC to 1.7.0-beta for improved clipboard sync",
+    description="Install managed noVNC 1.7.0-beta for improved clipboard sync",
 )
 async def task_upgrade_novnc(ctx: PveTaskContext) -> None:
     """
-    Upgrade noVNC from Ubuntu's 1.3.0 to GitHub's 1.7.0-beta.
+    Install managed noVNC from GitHub and remove the distro novnc package.
 
     The newer version includes PR #1993 which adds automatic clipboard sync
     between the browser and VNC session, improving clipboard paste reliability.
     See: https://github.com/novnc/noVNC/pull/1993
     """
+    shell_vars = _build_novnc_shell_vars()
     cmd = textwrap.dedent(
-        """
+        f"""
         set -eux
 
-        NOVNC_VERSION="v1.7.0-beta"
-        NOVNC_DIR="/usr/share/novnc"
-        MARKER_FILE="${NOVNC_DIR}/.cmux-novnc-version"
+        {shell_vars}
+
+        package_present=0
+        if dpkg-query -W -f='${{Status}}\\n' "$NOVNC_PACKAGE_NAME" 2>/dev/null | grep -q '^install ok installed$'; then
+            package_present=1
+        fi
 
         # Log current state for debugging
         echo "[upgrade-novnc] Current noVNC state:"
         echo "[upgrade-novnc]   Directory exists: $([ -d "$NOVNC_DIR" ] && echo yes || echo no)"
         echo "[upgrade-novnc]   Marker file: $(cat "$MARKER_FILE" 2>/dev/null || echo 'not found')"
+        echo "[upgrade-novnc]   Durable marker: $(cat "$DURABLE_MARKER" 2>/dev/null || echo 'not found')"
         echo "[upgrade-novnc]   vnc.html exists: $([ -f "$NOVNC_DIR/vnc.html" ] && echo yes || echo no)"
+        echo "[upgrade-novnc]   distro package installed: $([ "$package_present" -eq 1 ] && echo yes || echo no)"
 
-        # Check if already upgraded by looking for version marker
-        if [ -f "$MARKER_FILE" ] && grep -qF "$NOVNC_VERSION" "$MARKER_FILE" 2>/dev/null; then
-            # Double-check the actual files exist (marker might be stale)
+        if [ "$package_present" -eq 1 ]; then
+            echo "[upgrade-novnc] Removing distro package $NOVNC_PACKAGE_NAME to avoid stale version reporting..."
+            DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 purge -y "$NOVNC_PACKAGE_NAME"
+            DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 autoremove -y
+        fi
+
+        package_present=0
+        if dpkg-query -W -f='${{Status}}\\n' "$NOVNC_PACKAGE_NAME" 2>/dev/null | grep -q '^install ok installed$'; then
+            package_present=1
+        fi
+
+        # Check if already upgraded by looking for version marker and package removal state
+        if [ "$package_present" -eq 0 ] \
+            && [ -f "$MARKER_FILE" ] \
+            && grep -qF "$NOVNC_VERSION" "$MARKER_FILE" 2>/dev/null; then
             if [ -f "$NOVNC_DIR/vnc.html" ] && [ -f "$NOVNC_DIR/core/rfb.js" ]; then
-                echo "[upgrade-novnc] Already at $NOVNC_VERSION, skipping"
+                install -Dm0644 "$MARKER_FILE" "$DURABLE_MARKER"
+                echo "[upgrade-novnc] Already at $NOVNC_VERSION with distro package removed, skipping"
                 exit 0
             else
                 echo "[upgrade-novnc] Marker says $NOVNC_VERSION but files missing, re-installing"
@@ -2491,11 +2560,10 @@ async def task_upgrade_novnc(ctx: PveTaskContext) -> None:
         cd /tmp
         rm -rf noVNC-* novnc-*.tar.gz novnc.tar.gz
 
-        # Download with retries
         for attempt in 1 2 3; do
             echo "[upgrade-novnc] Download attempt $attempt/3..."
             if curl -fsSL --retry 3 --retry-delay 5 \
-                "https://github.com/novnc/noVNC/archive/refs/tags/${NOVNC_VERSION}.tar.gz" \
+                "$NOVNC_ARCHIVE_URL" \
                 -o novnc.tar.gz; then
                 break
             fi
@@ -2506,7 +2574,6 @@ async def task_upgrade_novnc(ctx: PveTaskContext) -> None:
             sleep 5
         done
 
-        # Verify download
         if [ ! -f novnc.tar.gz ] || [ ! -s novnc.tar.gz ]; then
             echo "[upgrade-novnc] ERROR: Downloaded file is missing or empty" >&2
             ls -la novnc.tar.gz 2>/dev/null || true
@@ -2514,7 +2581,6 @@ async def task_upgrade_novnc(ctx: PveTaskContext) -> None:
         fi
         echo "[upgrade-novnc] Downloaded $(stat -c%s novnc.tar.gz 2>/dev/null || echo '?') bytes"
 
-        # Extract
         tar xzf novnc.tar.gz
         EXTRACTED_DIR="$(ls -d noVNC-* 2>/dev/null | head -1)"
 
@@ -2524,60 +2590,54 @@ async def task_upgrade_novnc(ctx: PveTaskContext) -> None:
             exit 1
         fi
 
-        # Verify extracted content has expected files
         if [ ! -f "$EXTRACTED_DIR/vnc.html" ] || [ ! -f "$EXTRACTED_DIR/core/rfb.js" ]; then
             echo "[upgrade-novnc] ERROR: Extracted archive missing expected files" >&2
             ls -la "$EXTRACTED_DIR/" 2>/dev/null || true
             exit 1
         fi
 
-        # Backup original vnc.html if it has our bridge script (will be re-injected later)
         HAD_BRIDGE=0
         if grep -q "vnc-clipboard-bridge" "$NOVNC_DIR/vnc.html" 2>/dev/null; then
             HAD_BRIDGE=1
         fi
 
-        # Replace noVNC installation
         echo "[upgrade-novnc] Installing noVNC $NOVNC_VERSION to $NOVNC_DIR..."
 
-        # Preserve any custom configuration symlinks
         OLD_INDEX=""
         if [ -L "$NOVNC_DIR/index.html" ]; then
             OLD_INDEX="$(readlink -f "$NOVNC_DIR/index.html" 2>/dev/null || true)"
         fi
 
-        # Clear and replace
-        rm -rf "${NOVNC_DIR:?}"/*
+        install -d "$NOVNC_DIR"
+        rm -rf "${{NOVNC_DIR:?}}"/*
         cp -r "$EXTRACTED_DIR"/* "$NOVNC_DIR/"
 
-        # Re-create vnc.html symlink as index.html if it existed
         if [ -n "$OLD_INDEX" ] && [ -f "$NOVNC_DIR/vnc.html" ]; then
             ln -sf vnc.html "$NOVNC_DIR/index.html"
         fi
 
-        # Write version marker
         echo "$NOVNC_VERSION" > "$MARKER_FILE"
+        install -Dm0644 "$MARKER_FILE" "$DURABLE_MARKER"
 
-        # Some later tasks can replace noVNC files; keep a second marker outside
-        # the noVNC tree so we can restore the in-tree marker if needed.
-        install -Dm0644 "$MARKER_FILE" /etc/cmux/novnc-version
-
-        # Cleanup
         rm -rf /tmp/noVNC-* /tmp/novnc.tar.gz
 
-        # Final verification
         if [ ! -f "$NOVNC_DIR/vnc.html" ] || [ ! -f "$NOVNC_DIR/core/rfb.js" ]; then
             echo "[upgrade-novnc] ERROR: Installation verification failed" >&2
             ls -la "$NOVNC_DIR/" 2>/dev/null || true
             exit 1
         fi
 
+        if dpkg-query -W -f='${{Status}}\\n' "$NOVNC_PACKAGE_NAME" 2>/dev/null | grep -q '^install ok installed$'; then
+            echo "[upgrade-novnc] ERROR: Distro package $NOVNC_PACKAGE_NAME is still installed" >&2
+            exit 1
+        fi
+
         echo "[upgrade-novnc] Successfully installed noVNC $NOVNC_VERSION"
-        echo "[upgrade-novnc] Verified files:"
+        echo "[upgrade-novnc]   source: $NOVNC_SOURCE"
+        echo "[upgrade-novnc]   package state: $NOVNC_PACKAGE_STATE"
         echo "[upgrade-novnc]   vnc.html: $(ls -la "$NOVNC_DIR/vnc.html")"
         echo "[upgrade-novnc]   marker: $(cat "$MARKER_FILE")"
 
-        # Note: vnc-clipboard-bridge will be re-injected by install-vnc-clipboard-bridge task
         if [ "$HAD_BRIDGE" = "1" ]; then
             echo "[upgrade-novnc] Note: clipboard bridge will be re-injected"
         fi
@@ -3830,20 +3890,18 @@ async def task_install_vnc_clipboard_bridge(ctx: PveTaskContext) -> None:
     and injects the text into the VNC session using noVNC's RFB API.
     """
     repo = shlex.quote(ctx.remote_repo_root)
+    shell_vars = _build_novnc_shell_vars()
     cmd = textwrap.dedent(
         f"""
         set -eux
 
-        NOVNC_DIR="/usr/share/novnc"
+        {shell_vars}
         VNC_HTML="$NOVNC_DIR/vnc.html"
         BRIDGE_SCRIPT="{repo}/packages/sandbox/scripts/vnc-clipboard-bridge.js"
-        MARKER_FILE="$NOVNC_DIR/.cmux-novnc-version"
-        DURABLE_MARKER="/etc/cmux/novnc-version"
-        EXPECTED_VERSION="v1.7.0-beta"
 
         ensure_markers() {{
             install -d /etc/cmux
-            printf '%s\n' "$EXPECTED_VERSION" > "$MARKER_FILE"
+            printf '%s\n' "$NOVNC_VERSION" > "$MARKER_FILE"
             install -Dm0644 "$MARKER_FILE" "$DURABLE_MARKER"
         }}
 
@@ -3868,11 +3926,11 @@ async def task_install_vnc_clipboard_bridge(ctx: PveTaskContext) -> None:
         cp "$VNC_HTML" "$VNC_HTML.backup"
 
         # Inject the script before </body> using Python for reliable multiline handling
-        BRIDGE_SCRIPT_PATH="$BRIDGE_SCRIPT" python3 << 'INJECT_SCRIPT'
+        VNC_HTML_PATH="$VNC_HTML" BRIDGE_SCRIPT_PATH="$BRIDGE_SCRIPT" python3 << 'INJECT_SCRIPT'
 import os
 import sys
 
-vnc_html_path = "/usr/share/novnc/vnc.html"
+vnc_html_path = os.environ.get("VNC_HTML_PATH", "/usr/share/novnc/vnc.html")
 bridge_script_path = os.environ["BRIDGE_SCRIPT_PATH"]
 
 with open(bridge_script_path, "r") as f:
@@ -4553,21 +4611,19 @@ async def task_verify_novnc_installation(ctx: PveTaskContext) -> None:
     Final verification that noVNC 1.7.0-beta is correctly installed.
     This task runs after all noVNC-related tasks to catch any issues.
     """
+    shell_vars = _build_novnc_shell_vars()
     cmd = textwrap.dedent(
-        """
+        f"""
         set -eux
 
-        NOVNC_DIR="/usr/share/novnc"
-        MARKER_FILE="${NOVNC_DIR}/.cmux-novnc-version"
-        EXPECTED_VERSION="v1.7.0-beta"
+        {shell_vars}
 
         echo "[verify-novnc] Checking noVNC installation..."
 
-        # Check marker file
         if [ ! -f "$MARKER_FILE" ]; then
-            if [ -f /etc/cmux/novnc-version ]; then
-                echo "[verify-novnc] Restoring missing marker from /etc/cmux/novnc-version"
-                install -Dm0644 /etc/cmux/novnc-version "$MARKER_FILE"
+            if [ -f "$DURABLE_MARKER" ]; then
+                echo "[verify-novnc] Restoring missing marker from $DURABLE_MARKER"
+                install -Dm0644 "$DURABLE_MARKER" "$MARKER_FILE"
             else
                 echo "[verify-novnc] ERROR: Version marker file not found: $MARKER_FILE" >&2
                 echo "[verify-novnc] noVNC upgrade task may not have run" >&2
@@ -4577,14 +4633,13 @@ async def task_verify_novnc_installation(ctx: PveTaskContext) -> None:
         fi
 
         INSTALLED_VERSION="$(cat "$MARKER_FILE")"
-        if [ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ]; then
+        if [ "$INSTALLED_VERSION" != "$NOVNC_VERSION" ]; then
             echo "[verify-novnc] ERROR: Version mismatch" >&2
-            echo "[verify-novnc]   Expected: $EXPECTED_VERSION" >&2
+            echo "[verify-novnc]   Expected: $NOVNC_VERSION" >&2
             echo "[verify-novnc]   Found: $INSTALLED_VERSION" >&2
             exit 1
         fi
 
-        # Check critical files exist
         if [ ! -f "$NOVNC_DIR/vnc.html" ]; then
             echo "[verify-novnc] ERROR: vnc.html not found" >&2
             exit 1
@@ -4595,13 +4650,19 @@ async def task_verify_novnc_installation(ctx: PveTaskContext) -> None:
             exit 1
         fi
 
-        # Check clipboard bridge is injected
         if ! grep -q "vnc-clipboard-bridge" "$NOVNC_DIR/vnc.html" 2>/dev/null; then
             echo "[verify-novnc] ERROR: Clipboard bridge not found in vnc.html" >&2
             exit 1
         fi
 
-        echo "[verify-novnc] OK: noVNC $EXPECTED_VERSION installed with clipboard bridge"
+        if dpkg-query -W -f='${{Status}}\n' "$NOVNC_PACKAGE_NAME" 2>/dev/null | grep -q '^install ok installed$'; then
+            echo "[verify-novnc] ERROR: Distro package $NOVNC_PACKAGE_NAME is still installed" >&2
+            exit 1
+        fi
+
+        echo "[verify-novnc] OK: noVNC $NOVNC_VERSION installed with clipboard bridge"
+        echo "[verify-novnc]   Source: $NOVNC_SOURCE"
+        echo "[verify-novnc]   Package state: $NOVNC_PACKAGE_STATE"
         echo "[verify-novnc]   Marker: $(cat "$MARKER_FILE")"
         echo "[verify-novnc]   vnc.html: $(stat -c '%s bytes' "$NOVNC_DIR/vnc.html")"
         echo "[verify-novnc]   Bridge: $(grep -c 'vnc-clipboard-bridge' "$NOVNC_DIR/vnc.html") occurrences"
@@ -5116,6 +5177,7 @@ async def update_existing_template(
         "capturedAt": captured_at,
         "node": node,
         "sourceVmid": source_vmid,
+        **_build_novnc_metadata(),
     }
 
 
@@ -5159,10 +5221,31 @@ async def _verify_template_artifacts(
         ("/builtins/build/index.js", "cmux-worker service"),
         ("/usr/local/bin/worker-daemon", "Go worker-daemon (SSH/PTY proxy)"),
         ("/usr/local/bin/cmux-token-init", "Auth token generator script"),
+        (NOVNC_MARKER_FILE, "managed noVNC version marker"),
+        (f"{NOVNC_DIR}/vnc.html", "managed noVNC vnc.html"),
+        (f"{NOVNC_DIR}/core/rfb.js", "managed noVNC core/rfb.js"),
     ])
 
     # Verify artifacts exist
     missing: list[str] = []
+
+    novnc_pkg_cmd = (
+        f"dpkg-query -W -f='${{Status}}\\n' {shlex.quote(NOVNC_PACKAGE_NAME)} 2>/dev/null "
+        "| grep -q '^install ok installed$' && echo installed || echo absent"
+    )
+    try:
+        result = await client.aexec_in_container(vmid, novnc_pkg_cmd, timeout=30, check=False)
+        if result.returncode != 0 or "installed" in result.stdout:
+            missing.append(
+                f"  - distro noVNC package should be absent: {NOVNC_PACKAGE_NAME}"
+            )
+            console.info(f"[verify] MISSING: distro noVNC package removal for {NOVNC_PACKAGE_NAME}")
+        else:
+            console.info(f"[verify] OK: distro noVNC package removed ({NOVNC_PACKAGE_NAME})")
+    except Exception as e:
+        missing.append(f"  - distro noVNC package removal check failed: {e}")
+        console.info(f"[verify] ERROR checking distro noVNC package removal: {e}")
+
     for path, description in artifacts:
         check_cmd = f"test -e {shlex.quote(path)} && echo exists || echo missing"
         try:

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -2519,44 +2519,14 @@ async def task_upgrade_novnc(ctx: PveTaskContext) -> None:
 
         {shell_vars}
 
-        package_present=0
-        if dpkg-query -W -f='${{Status}}\\n' "$NOVNC_PACKAGE_NAME" 2>/dev/null | grep -q '^install ok installed$'; then
-            package_present=1
-        fi
+        echo "[upgrade-novnc] Installing managed noVNC $NOVNC_VERSION"
 
-        # Log current state for debugging
-        echo "[upgrade-novnc] Current noVNC state:"
-        echo "[upgrade-novnc]   Directory exists: $([ -d "$NOVNC_DIR" ] && echo yes || echo no)"
-        echo "[upgrade-novnc]   Marker file: $(cat "$MARKER_FILE" 2>/dev/null || echo 'not found')"
-        echo "[upgrade-novnc]   Durable marker: $(cat "$DURABLE_MARKER" 2>/dev/null || echo 'not found')"
-        echo "[upgrade-novnc]   vnc.html exists: $([ -f "$NOVNC_DIR/vnc.html" ] && echo yes || echo no)"
-        echo "[upgrade-novnc]   distro package installed: $([ "$package_present" -eq 1 ] && echo yes || echo no)"
-
-        if [ "$package_present" -eq 1 ]; then
+        if dpkg-query -W -f='${{Status}}\n' "$NOVNC_PACKAGE_NAME" 2>/dev/null | grep -q '^install ok installed$'; then
             echo "[upgrade-novnc] Removing distro package $NOVNC_PACKAGE_NAME to avoid stale version reporting..."
             DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 purge -y "$NOVNC_PACKAGE_NAME"
             DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 autoremove -y
         fi
 
-        package_present=0
-        if dpkg-query -W -f='${{Status}}\\n' "$NOVNC_PACKAGE_NAME" 2>/dev/null | grep -q '^install ok installed$'; then
-            package_present=1
-        fi
-
-        # Check if already upgraded by looking for version marker and package removal state
-        if [ "$package_present" -eq 0 ] \
-            && [ -f "$MARKER_FILE" ] \
-            && grep -qF "$NOVNC_VERSION" "$MARKER_FILE" 2>/dev/null; then
-            if [ -f "$NOVNC_DIR/vnc.html" ] && [ -f "$NOVNC_DIR/core/rfb.js" ]; then
-                install -Dm0644 "$MARKER_FILE" "$DURABLE_MARKER"
-                echo "[upgrade-novnc] Already at $NOVNC_VERSION with distro package removed, skipping"
-                exit 0
-            else
-                echo "[upgrade-novnc] Marker says $NOVNC_VERSION but files missing, re-installing"
-            fi
-        fi
-
-        echo "[upgrade-novnc] Downloading noVNC $NOVNC_VERSION from GitHub..."
         cd /tmp
         rm -rf noVNC-* novnc-*.tar.gz novnc.tar.gz
 
@@ -2600,8 +2570,6 @@ async def task_upgrade_novnc(ctx: PveTaskContext) -> None:
         if grep -q "vnc-clipboard-bridge" "$NOVNC_DIR/vnc.html" 2>/dev/null; then
             HAD_BRIDGE=1
         fi
-
-        echo "[upgrade-novnc] Installing noVNC $NOVNC_VERSION to $NOVNC_DIR..."
 
         OLD_INDEX=""
         if [ -L "$NOVNC_DIR/index.html" ]; then
@@ -3373,13 +3341,13 @@ async def task_package_vscode_extension(ctx: PveTaskContext) -> None:
 
 @registry.task(
     name="install-ide-extensions",
-    deps=("install-openvscode", "install-coder", "install-cmux-code", "package-vscode-extension", "restart-execd-early"),
+    deps=("install-openvscode", "install-coder", "install-cmux-code", "package-vscode-extension", "restart-execd-early", "build-worker-daemon"),
     description="Preinstall language extensions for the IDE",
 )
 @update_registry.task(
     name="install-ide-extensions",
     # Depends on restart-execd-early to ensure the new execd is running before this task
-    deps=("package-vscode-extension", "restart-execd-early"),
+    deps=("package-vscode-extension", "restart-execd-early", "build-worker-daemon"),
     description="Preinstall language extensions for the IDE",
 )
 async def task_install_ide_extensions(ctx: PveTaskContext) -> None:
@@ -4598,12 +4566,12 @@ async def task_cleanup_build_artifacts(ctx: PveTaskContext) -> None:
 
 @registry.task(
     name="verify-novnc-installation",
-    deps=("install-vnc-clipboard-bridge",),
+    deps=("build-cdp-proxy", "install-vnc-clipboard-bridge"),
     description="Verify noVNC 1.7.0-beta is correctly installed with clipboard bridge",
 )
 @update_registry.task(
     name="verify-novnc-installation",
-    deps=("install-vnc-clipboard-bridge",),
+    deps=("build-cdp-proxy", "install-vnc-clipboard-bridge"),
     description="Verify noVNC 1.7.0-beta is correctly installed with clipboard bridge",
 )
 async def task_verify_novnc_installation(ctx: PveTaskContext) -> None:
@@ -5894,8 +5862,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--repo-root",
-        default=".",
-        help="Repository root (default: current directory)",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="Repository root (default: script repo root)",
     )
     parser.add_argument(
         "--results-json",
@@ -6022,11 +5990,17 @@ def main() -> None:
         set_git_diff_mode(False)
 
     # Pre-flight check: validate MCP server script syntax before building snapshot
+    repo_root = Path(args.repo_root).resolve()
     print("[pre-flight] Validating MCP server script syntax...")
     import subprocess
     try:
         result = subprocess.run(
-            ["bun", "test", "packages/shared/src/agent-memory-protocol.test.ts"],
+            [
+                "bun",
+                "test",
+                "./src/agent-memory-protocol.test.ts",
+            ],
+            cwd=str(repo_root / "packages" / "shared"),
             capture_output=True,
             text=True,
             timeout=60,


### PR DESCRIPTION
## Summary
- remove the distro `novnc` package from the PVE LXC snapshot rebuild flow and fail verification if it comes back
- keep the upstream-managed noVNC marker/version metadata as the canonical snapshot state
- extend runtime smoke coverage and shared manifest parsing for the new noVNC metadata

## Test plan
- [x] `python -m py_compile scripts/snapshot-pvelxc.py`
- [x] `bash -n scripts/pve/pve-lxc-snapshot-runtime-smoke.sh`
- [x] `bunx tsgo --noEmit -p packages/shared/tsconfig.json`
- [x] `cd packages/shared && bunx vitest run src/pve-lxc-snapshots.test.ts`
- [x] Verified the new runtime guard fails on existing snapshot `snapshot_1aaabb23` because distro `novnc` is still installed
- [ ] Rebuild a new PVE snapshot during non-rush hours and run the smoke test against the rebuilt artifact