### PR TITLE
Add Claude model support to dashboard and settings pages

### DIFF
--- a/apps/client/src/components/dashboard/CostEstimationCard.tsx
+++ b/apps/client/src/components/dashboard/CostEstimationCard.tsx
@@ -3,7 +3,14 @@ import type { Id } from "@cmux/convex/dataModel";
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { memo } from "react";
-import { AlertTriangle, Clock, Cpu, DollarSign, RefreshCw, Zap } from "lucide-react";
+import {
+  AlertTriangle,
+  Clock,
+  Cpu,
+  DollarSign,
+  RefreshCw,
+  Zap,
+} from "lucide-react";
 
 type CostEstimationCardProps = {
   taskRunId: Id<"taskRuns">;
@@ -19,6 +26,7 @@ const ESTIMATED_COST_PER_MINUTE: Record<string, number> = {
   "claude/sonnet-4.5": 0.03,
   "claude/sonnet-4.6": 0.03,
   "claude/haiku-4.5": 0.005,
+  "claude/gpt-5.1-codex-mini": 0.02,
   // OpenAI Codex models
   "codex/gpt-5.4-xhigh": 0.12,
   "codex/gpt-5.1-codex-mini": 0.02,
@@ -80,7 +88,7 @@ export const CostEstimationCard = memo(function CostEstimationCard({
   teamSlugOrId,
 }: CostEstimationCardProps) {
   const taskRunQuery = useQuery(
-    convexQuery(api.taskRuns.get, { id: taskRunId, teamSlugOrId })
+    convexQuery(api.taskRuns.get, { id: taskRunId, teamSlugOrId }),
   );
 
   if (taskRunQuery.isLoading) {
@@ -88,15 +96,20 @@ export const CostEstimationCard = memo(function CostEstimationCard({
   }
 
   if (taskRunQuery.isError) {
-    const message = taskRunQuery.error?.message ?? "Failed to load cost estimate";
+    const message =
+      taskRunQuery.error?.message ?? "Failed to load cost estimate";
     return (
       <div className="rounded-xl border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950/30">
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-start gap-2 text-red-700 dark:text-red-300">
             <AlertTriangle className="mt-0.5 size-4 shrink-0" />
             <div>
-              <p className="text-sm font-medium">Failed to load cost estimate</p>
-              <p className="mt-1 text-xs text-red-600 dark:text-red-400">{message}</p>
+              <p className="text-sm font-medium">
+                Failed to load cost estimate
+              </p>
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                {message}
+              </p>
             </div>
           </div>
           <button
@@ -128,8 +141,7 @@ export const CostEstimationCard = memo(function CostEstimationCard({
   // Get cost rate for the model
   const agentName = taskRun.agentName ?? "default";
   const costPerMinute =
-    ESTIMATED_COST_PER_MINUTE[agentName] ??
-    ESTIMATED_COST_PER_MINUTE.default;
+    ESTIMATED_COST_PER_MINUTE[agentName] ?? ESTIMATED_COST_PER_MINUTE.default;
 
   // Estimate cost
   const estimatedCost = durationMinutes * costPerMinute;
@@ -177,31 +189,44 @@ export const CostEstimationCard = memo(function CostEstimationCard({
         </div>
         {taskRun.contextUsage && (
           <div className="flex items-center gap-2">
-            <Zap className={
-              taskRun.contextUsage.usagePercent !== undefined && taskRun.contextUsage.usagePercent >= 80
-                ? "size-3.5 text-amber-500"
-                : "size-3.5"
-            } />
+            <Zap
+              className={
+                taskRun.contextUsage.usagePercent !== undefined &&
+                taskRun.contextUsage.usagePercent >= 80
+                  ? "size-3.5 text-amber-500"
+                  : "size-3.5"
+              }
+            />
             <span>
-              Tokens: {formatTokenCount(taskRun.contextUsage.totalInputTokens)} in / {formatTokenCount(taskRun.contextUsage.totalOutputTokens)} out
+              Tokens: {formatTokenCount(taskRun.contextUsage.totalInputTokens)}{" "}
+              in / {formatTokenCount(taskRun.contextUsage.totalOutputTokens)}{" "}
+              out
               {taskRun.contextUsage.usagePercent !== undefined && (
-                <span className={
-                  taskRun.contextUsage.usagePercent >= 80
-                    ? "ml-1 text-amber-500 font-medium"
-                    : "ml-1 text-neutral-400 dark:text-neutral-500"
-                }>
+                <span
+                  className={
+                    taskRun.contextUsage.usagePercent >= 80
+                      ? "ml-1 text-amber-500 font-medium"
+                      : "ml-1 text-neutral-400 dark:text-neutral-500"
+                  }
+                >
                   ({taskRun.contextUsage.usagePercent}% context)
                 </span>
               )}
             </span>
           </div>
         )}
-        {taskRun.contextUsage?.usagePercent !== undefined && taskRun.contextUsage.usagePercent >= 80 && (
-          <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
-            <AlertTriangle className="size-3.5" />
-            <span className="font-medium">Context window {taskRun.contextUsage.usagePercent >= 95 ? "nearly full" : "filling up"}</span>
-          </div>
-        )}
+        {taskRun.contextUsage?.usagePercent !== undefined &&
+          taskRun.contextUsage.usagePercent >= 80 && (
+            <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+              <AlertTriangle className="size-3.5" />
+              <span className="font-medium">
+                Context window{" "}
+                {taskRun.contextUsage.usagePercent >= 95
+                  ? "nearly full"
+                  : "filling up"}
+              </span>
+            </div>
+          )}
       </div>
 
       {/* Disclaimer */}

--- a/apps/client/src/components/settings/sections/ModelCatalogSection.tsx
+++ b/apps/client/src/components/settings/sections/ModelCatalogSection.tsx
@@ -1,17 +1,16 @@
 import { AgentLogo } from "@/components/icons/agent-logos";
 import { SettingSection } from "@/components/settings/SettingSection";
+import {
+  useModelAvailability,
+  useTeamModelCatalog,
+} from "@/hooks/useTeamModelCatalog";
 import { api } from "@cmux/convex/api";
 import type { AgentVendor } from "@cmux/shared/agent-catalog";
-import {
-  hasAnthropicCustomEndpointConfigured,
-  requiresAnthropicCustomEndpoint,
-} from "@cmux/shared/providers/anthropic/models";
 import { Switch, Button, Spinner } from "@heroui/react";
-import { convexQuery } from "@convex-dev/react-query";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { useAction, useConvex } from "convex/react";
+import { useMutation } from "@tanstack/react-query";
+import { useConvex } from "convex/react";
 import { GripVertical, RefreshCw, Search, Database, Zap } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { cachedGetUser } from "@/lib/cachedGetUser";
 import {
@@ -64,116 +63,8 @@ export function ModelCatalogSection({
   const [draggedModel, setDraggedModel] = useState<string | null>(null);
   const [dragOverModel, setDragOverModel] = useState<string | null>(null);
 
-  // Query all models (admin view)
-  const {
-    data: models,
-    refetch: refetchModels,
-    isLoading,
-  } = useQuery(convexQuery(api.models.listAll, { teamSlugOrId }));
-
-  // Auto-seed models if none exist (self-healing mechanism)
-  const ensureModelsSeeded = useAction(api.modelDiscovery.ensureModelsSeeded);
-  const hasTriedSeeding = useRef(false);
-  useEffect(() => {
-    // Only try seeding once per component mount
-    if (hasTriedSeeding.current) return;
-    // Wait for query to complete
-    if (isLoading) return;
-    // If we have models, no need to seed
-    if (models && models.length > 0) return;
-
-    // No models found - trigger seeding
-    hasTriedSeeding.current = true;
-    console.log(
-      "[ModelCatalogSection] No models found, triggering auto-seed...",
-    );
-    ensureModelsSeeded({ teamSlugOrId })
-      .then((result) => {
-        if (result.seeded) {
-          console.log(
-            `[ModelCatalogSection] Auto-seeded ${result.count} models`,
-          );
-          void refetchModels();
-        }
-      })
-      .catch((error) => {
-        console.error("[ModelCatalogSection] Auto-seed failed:", error);
-      });
-  }, [models, isLoading, ensureModelsSeeded, teamSlugOrId, refetchModels]);
-
-  // Query API keys to determine model availability
-  const { data: apiKeys } = useQuery(
-    convexQuery(api.apiKeys.getAll, { teamSlugOrId }),
-  );
-  const { data: workspaceSettings } = useQuery(
-    convexQuery(api.workspaceSettings.get, { teamSlugOrId }),
-  );
-  const { data: anthropicOverride } = useQuery(
-    convexQuery(api.providerOverrides.getByProvider, {
-      teamSlugOrId,
-      providerId: "anthropic",
-    }),
-  );
-
-  // Build a Set of configured API key env vars for efficient lookup
-  const configuredApiKeys = useMemo(() => {
-    if (!apiKeys) return new Set<string>();
-    return new Set(apiKeys.map((k) => k.envVar));
-  }, [apiKeys]);
-  const storedApiKeys = useMemo(() => {
-    return (apiKeys ?? []).reduce<Record<string, string | undefined>>(
-      (acc, key) => {
-        acc[key.envVar] = key.value;
-        return acc;
-      },
-      {},
-    );
-  }, [apiKeys]);
-  const hasAnthropicCustomEndpoint = useMemo(
-    () =>
-      hasAnthropicCustomEndpointConfigured({
-        apiKeys: {
-          ANTHROPIC_BASE_URL: storedApiKeys.ANTHROPIC_BASE_URL,
-        },
-        bypassAnthropicProxy: workspaceSettings?.bypassAnthropicProxy ?? false,
-        providerOverrides: anthropicOverride
-          ? [
-              {
-                providerId: anthropicOverride.providerId,
-                enabled: anthropicOverride.enabled,
-                baseUrl: anthropicOverride.baseUrl,
-                apiFormat: anthropicOverride.apiFormat,
-              },
-            ]
-          : [],
-      }),
-    [
-      anthropicOverride,
-      storedApiKeys.ANTHROPIC_BASE_URL,
-      workspaceSettings?.bypassAnthropicProxy,
-    ],
-  );
-
-  // Check if a model is available (required API key is configured)
-  const isModelAvailable = useCallback(
-    (model: Model) => {
-      if (
-        requiresAnthropicCustomEndpoint(model.name) &&
-        !hasAnthropicCustomEndpoint
-      ) {
-        return false;
-      }
-      // Free models are always available
-      if (model.tier === "free") return true;
-      // If no API keys required, it's available
-      if (model.requiredApiKeys.length === 0) return true;
-      // Check if at least ONE of the required API keys is configured
-      return model.requiredApiKeys.some((requiredKey) =>
-        configuredApiKeys.has(requiredKey),
-      );
-    },
-    [configuredApiKeys, hasAnthropicCustomEndpoint],
-  );
+  const { models, refetchModels, isLoading } = useTeamModelCatalog(teamSlugOrId);
+  const { isModelAvailable } = useModelAvailability(teamSlugOrId);
 
   // Mutation to toggle model enabled state
   const toggleEnabledMutation = useMutation({

--- a/apps/client/src/components/settings/sections/ModelCatalogSection.tsx
+++ b/apps/client/src/components/settings/sections/ModelCatalogSection.tsx
@@ -2,6 +2,10 @@ import { AgentLogo } from "@/components/icons/agent-logos";
 import { SettingSection } from "@/components/settings/SettingSection";
 import { api } from "@cmux/convex/api";
 import type { AgentVendor } from "@cmux/shared/agent-catalog";
+import {
+  hasAnthropicCustomEndpointConfigured,
+  requiresAnthropicCustomEndpoint,
+} from "@cmux/shared/providers/anthropic/models";
 import { Switch, Button, Spinner } from "@heroui/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -10,7 +14,10 @@ import { GripVertical, RefreshCw, Search, Database, Zap } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { cachedGetUser } from "@/lib/cachedGetUser";
-import { getVendorDisplayName, groupModelsByVendor } from "@/lib/model-vendor-utils";
+import {
+  getVendorDisplayName,
+  groupModelsByVendor,
+} from "@/lib/model-vendor-utils";
 import { stackClientApp } from "@/lib/stack";
 import { WWW_ORIGIN } from "@/lib/wwwOrigin";
 
@@ -48,7 +55,9 @@ export function ModelCatalogSection({
 }: ModelCatalogSectionProps) {
   const convex = useConvex();
   const [searchQuery, setSearchQuery] = useState("");
-  const [sourceFilter, setSourceFilter] = useState<"all" | "curated" | "discovered">("all");
+  const [sourceFilter, setSourceFilter] = useState<
+    "all" | "curated" | "discovered"
+  >("all");
   const [showDisabledOnly, setShowDisabledOnly] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isSeeding, setIsSeeding] = useState(false);
@@ -56,9 +65,11 @@ export function ModelCatalogSection({
   const [dragOverModel, setDragOverModel] = useState<string | null>(null);
 
   // Query all models (admin view)
-  const { data: models, refetch: refetchModels, isLoading } = useQuery(
-    convexQuery(api.models.listAll, { teamSlugOrId })
-  );
+  const {
+    data: models,
+    refetch: refetchModels,
+    isLoading,
+  } = useQuery(convexQuery(api.models.listAll, { teamSlugOrId }));
 
   // Auto-seed models if none exist (self-healing mechanism)
   const ensureModelsSeeded = useAction(api.modelDiscovery.ensureModelsSeeded);
@@ -73,11 +84,15 @@ export function ModelCatalogSection({
 
     // No models found - trigger seeding
     hasTriedSeeding.current = true;
-    console.log("[ModelCatalogSection] No models found, triggering auto-seed...");
+    console.log(
+      "[ModelCatalogSection] No models found, triggering auto-seed...",
+    );
     ensureModelsSeeded({ teamSlugOrId })
       .then((result) => {
         if (result.seeded) {
-          console.log(`[ModelCatalogSection] Auto-seeded ${result.count} models`);
+          console.log(
+            `[ModelCatalogSection] Auto-seeded ${result.count} models`,
+          );
           void refetchModels();
         }
       })
@@ -88,7 +103,16 @@ export function ModelCatalogSection({
 
   // Query API keys to determine model availability
   const { data: apiKeys } = useQuery(
-    convexQuery(api.apiKeys.getAll, { teamSlugOrId })
+    convexQuery(api.apiKeys.getAll, { teamSlugOrId }),
+  );
+  const { data: workspaceSettings } = useQuery(
+    convexQuery(api.workspaceSettings.get, { teamSlugOrId }),
+  );
+  const { data: anthropicOverride } = useQuery(
+    convexQuery(api.providerOverrides.getByProvider, {
+      teamSlugOrId,
+      providerId: "anthropic",
+    }),
   );
 
   // Build a Set of configured API key env vars for efficient lookup
@@ -96,20 +120,59 @@ export function ModelCatalogSection({
     if (!apiKeys) return new Set<string>();
     return new Set(apiKeys.map((k) => k.envVar));
   }, [apiKeys]);
+  const storedApiKeys = useMemo(() => {
+    return (apiKeys ?? []).reduce<Record<string, string | undefined>>(
+      (acc, key) => {
+        acc[key.envVar] = key.value;
+        return acc;
+      },
+      {},
+    );
+  }, [apiKeys]);
+  const hasAnthropicCustomEndpoint = useMemo(
+    () =>
+      hasAnthropicCustomEndpointConfigured({
+        apiKeys: {
+          ANTHROPIC_BASE_URL: storedApiKeys.ANTHROPIC_BASE_URL,
+        },
+        bypassAnthropicProxy: workspaceSettings?.bypassAnthropicProxy ?? false,
+        providerOverrides: anthropicOverride
+          ? [
+              {
+                providerId: anthropicOverride.providerId,
+                enabled: anthropicOverride.enabled,
+                baseUrl: anthropicOverride.baseUrl,
+                apiFormat: anthropicOverride.apiFormat,
+              },
+            ]
+          : [],
+      }),
+    [
+      anthropicOverride,
+      storedApiKeys.ANTHROPIC_BASE_URL,
+      workspaceSettings?.bypassAnthropicProxy,
+    ],
+  );
 
   // Check if a model is available (required API key is configured)
   const isModelAvailable = useCallback(
     (model: Model) => {
+      if (
+        requiresAnthropicCustomEndpoint(model.name) &&
+        !hasAnthropicCustomEndpoint
+      ) {
+        return false;
+      }
       // Free models are always available
       if (model.tier === "free") return true;
       // If no API keys required, it's available
       if (model.requiredApiKeys.length === 0) return true;
       // Check if at least ONE of the required API keys is configured
       return model.requiredApiKeys.some((requiredKey) =>
-        configuredApiKeys.has(requiredKey)
+        configuredApiKeys.has(requiredKey),
       );
     },
-    [configuredApiKeys]
+    [configuredApiKeys, hasAnthropicCustomEndpoint],
   );
 
   // Mutation to toggle model enabled state
@@ -158,7 +221,7 @@ export function ModelCatalogSection({
     (modelName: string, enabled: boolean) => {
       toggleEnabledMutation.mutate({ modelName, enabled });
     },
-    [toggleEnabledMutation]
+    [toggleEnabledMutation],
   );
 
   // Trigger discovery refresh via www API
@@ -177,7 +240,7 @@ export function ModelCatalogSection({
 
       const endpoint = new URL(
         `/api/models/refresh?teamSlugOrId=${encodeURIComponent(teamSlugOrId)}`,
-        WWW_ORIGIN
+        WWW_ORIGIN,
       );
 
       const response = await fetch(endpoint.toString(), {
@@ -185,7 +248,7 @@ export function ModelCatalogSection({
         headers,
       });
 
-      const result = await response.json() as {
+      const result = (await response.json()) as {
         success: boolean;
         curated?: number;
         discovered?: number;
@@ -196,7 +259,7 @@ export function ModelCatalogSection({
 
       if (result.success) {
         toast.success(
-          `Discovery complete: ${result.curated ?? 0} curated, ${result.discovered ?? 0} discovered (${result.free ?? 0} free)`
+          `Discovery complete: ${result.curated ?? 0} curated, ${result.discovered ?? 0} discovered (${result.free ?? 0} free)`,
         );
         void refetchModels();
       } else {
@@ -226,7 +289,7 @@ export function ModelCatalogSection({
 
       const endpoint = new URL(
         `/api/models/seed?teamSlugOrId=${encodeURIComponent(teamSlugOrId)}`,
-        WWW_ORIGIN
+        WWW_ORIGIN,
       );
 
       const response = await fetch(endpoint.toString(), {
@@ -234,7 +297,7 @@ export function ModelCatalogSection({
         headers,
       });
 
-      const result = await response.json() as {
+      const result = (await response.json()) as {
         success: boolean;
         seededCount: number;
         error?: string;
@@ -259,10 +322,13 @@ export function ModelCatalogSection({
     setDraggedModel(modelName);
   }, []);
 
-  const handleDragOver = useCallback((e: React.DragEvent, modelName: string) => {
-    e.preventDefault();
-    setDragOverModel(modelName);
-  }, []);
+  const handleDragOver = useCallback(
+    (e: React.DragEvent, modelName: string) => {
+      e.preventDefault();
+      setDragOverModel(modelName);
+    },
+    [],
+  );
 
   const handleDragEnd = useCallback(() => {
     setDraggedModel(null);
@@ -293,7 +359,7 @@ export function ModelCatalogSection({
       setDraggedModel(null);
       setDragOverModel(null);
     },
-    [draggedModel, models, reorderMutation]
+    [draggedModel, models, reorderMutation],
   );
 
   // Filter and group models
@@ -336,8 +402,10 @@ export function ModelCatalogSection({
 
   const enabledCount = models?.filter((m) => m.enabled).length ?? 0;
   const totalCount = models?.length ?? 0;
-  const curatedCount = models?.filter((m) => m.source === "curated").length ?? 0;
-  const discoveredCount = models?.filter((m) => m.source === "discovered").length ?? 0;
+  const curatedCount =
+    models?.filter((m) => m.source === "curated").length ?? 0;
+  const discoveredCount =
+    models?.filter((m) => m.source === "discovered").length ?? 0;
 
   if (isLoading) {
     return (
@@ -361,7 +429,8 @@ export function ModelCatalogSection({
               No models in catalog
             </h3>
             <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-6">
-              Seed the catalog with curated models or discover new ones from providers.
+              Seed the catalog with curated models or discover new ones from
+              providers.
             </p>
             <div className="flex items-center justify-center gap-3">
               <Button
@@ -376,7 +445,9 @@ export function ModelCatalogSection({
                 variant="bordered"
                 isLoading={isRefreshing}
                 onPress={() => void handleRefresh()}
-                startContent={!isRefreshing && <RefreshCw className="h-4 w-4" />}
+                startContent={
+                  !isRefreshing && <RefreshCw className="h-4 w-4" />
+                }
               >
                 Discover Models
               </Button>
@@ -412,7 +483,11 @@ export function ModelCatalogSection({
               {/* Source filter */}
               <select
                 value={sourceFilter}
-                onChange={(e) => setSourceFilter(e.target.value as "all" | "curated" | "discovered")}
+                onChange={(e) =>
+                  setSourceFilter(
+                    e.target.value as "all" | "curated" | "discovered",
+                  )
+                }
                 className="rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
               >
                 {SOURCE_FILTER_OPTIONS.map((opt) => (
@@ -439,7 +514,9 @@ export function ModelCatalogSection({
                 variant="bordered"
                 isLoading={isRefreshing}
                 onPress={() => void handleRefresh()}
-                startContent={!isRefreshing && <RefreshCw className="h-4 w-4" />}
+                startContent={
+                  !isRefreshing && <RefreshCw className="h-4 w-4" />
+                }
               >
                 Discover
               </Button>
@@ -461,7 +538,8 @@ export function ModelCatalogSection({
                     {entries.map((entry) => {
                       const isToggling =
                         toggleEnabledMutation.isPending &&
-                        toggleEnabledMutation.variables?.modelName === entry.name;
+                        toggleEnabledMutation.variables?.modelName ===
+                          entry.name;
                       const isDragging = draggedModel === entry.name;
                       const isDragOver = dragOverModel === entry.name;
                       return (
@@ -473,7 +551,9 @@ export function ModelCatalogSection({
                           onDragEnd={handleDragEnd}
                           onDrop={() => handleDrop(entry.name)}
                           className={`flex items-center justify-between gap-4 px-3 py-2.5 cursor-grab active:cursor-grabbing transition-colors ${
-                            isDragging ? "opacity-50 bg-neutral-100 dark:bg-neutral-800" : ""
+                            isDragging
+                              ? "opacity-50 bg-neutral-100 dark:bg-neutral-800"
+                              : ""
                           } ${
                             isDragOver ? "bg-blue-50 dark:bg-blue-900/20" : ""
                           }`}
@@ -558,7 +638,7 @@ export function ModelCatalogSection({
                     })}
                   </div>
                 </div>
-              )
+              ),
             )}
 
             {filteredAndGroupedModels.size === 0 && (

--- a/apps/client/src/components/settings/sections/ModelManagementSection.tsx
+++ b/apps/client/src/components/settings/sections/ModelManagementSection.tsx
@@ -1,17 +1,16 @@
 import { AgentLogo } from "@/components/icons/agent-logos";
 import { SettingSection } from "@/components/settings/SettingSection";
+import {
+  useModelAvailability,
+  useTeamModelCatalog,
+} from "@/hooks/useTeamModelCatalog";
 import { api } from "@cmux/convex/api";
 import type { AgentVendor } from "@cmux/shared/agent-catalog";
-import {
-  hasAnthropicCustomEndpointConfigured,
-  requiresAnthropicCustomEndpoint,
-} from "@cmux/shared/providers/anthropic/models";
 import { Switch } from "@heroui/react";
-import { convexQuery } from "@convex-dev/react-query";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { useAction, useConvex } from "convex/react";
+import { useMutation } from "@tanstack/react-query";
+import { useConvex } from "convex/react";
 import { Search } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
   getVendorDisplayName,
@@ -44,123 +43,11 @@ export function ModelManagementSection({
   const [searchQuery, setSearchQuery] = useState("");
   const [showHiddenOnly, setShowHiddenOnly] = useState(false);
 
-  // Query all models from Convex database (includes disabled and discovered models)
   const {
-    data: convexModels,
-    refetch: refetchModels,
-    isLoading,
-  } = useQuery(convexQuery(api.models.listAll, { teamSlugOrId }));
-
-  // Auto-seed models if none exist (self-healing mechanism)
-  const ensureModelsSeeded = useAction(api.modelDiscovery.ensureModelsSeeded);
-  const hasTriedSeeding = useRef(false);
-  useEffect(() => {
-    // Only try seeding once per component mount
-    if (hasTriedSeeding.current) return;
-    // Wait for query to complete
-    if (isLoading) return;
-    // If we have models, no need to seed
-    if (convexModels && convexModels.length > 0) return;
-
-    // No models found - trigger seeding
-    hasTriedSeeding.current = true;
-    console.log(
-      "[ModelManagementSection] No models found, triggering auto-seed...",
-    );
-    ensureModelsSeeded({ teamSlugOrId })
-      .then((result) => {
-        if (result.seeded) {
-          console.log(
-            `[ModelManagementSection] Auto-seeded ${result.count} models`,
-          );
-          void refetchModels();
-        }
-      })
-      .catch((error) => {
-        console.error("[ModelManagementSection] Auto-seed failed:", error);
-      });
-  }, [
-    convexModels,
-    isLoading,
-    ensureModelsSeeded,
-    teamSlugOrId,
+    models: convexModels,
     refetchModels,
-  ]);
-
-  // Query API keys to determine model availability
-  const { data: apiKeys } = useQuery(
-    convexQuery(api.apiKeys.getAll, { teamSlugOrId }),
-  );
-  const { data: workspaceSettings } = useQuery(
-    convexQuery(api.workspaceSettings.get, { teamSlugOrId }),
-  );
-  const { data: anthropicOverride } = useQuery(
-    convexQuery(api.providerOverrides.getByProvider, {
-      teamSlugOrId,
-      providerId: "anthropic",
-    }),
-  );
-
-  // Build a Set of configured API key env vars for efficient lookup
-  const configuredApiKeys = useMemo(() => {
-    if (!apiKeys) return new Set<string>();
-    return new Set(apiKeys.map((k) => k.envVar));
-  }, [apiKeys]);
-  const storedApiKeys = useMemo(() => {
-    return (apiKeys ?? []).reduce<Record<string, string | undefined>>(
-      (acc, key) => {
-        acc[key.envVar] = key.value;
-        return acc;
-      },
-      {},
-    );
-  }, [apiKeys]);
-  const hasAnthropicCustomEndpoint = useMemo(
-    () =>
-      hasAnthropicCustomEndpointConfigured({
-        apiKeys: {
-          ANTHROPIC_BASE_URL: storedApiKeys.ANTHROPIC_BASE_URL,
-        },
-        bypassAnthropicProxy: workspaceSettings?.bypassAnthropicProxy ?? false,
-        providerOverrides: anthropicOverride
-          ? [
-              {
-                providerId: anthropicOverride.providerId,
-                enabled: anthropicOverride.enabled,
-                baseUrl: anthropicOverride.baseUrl,
-                apiFormat: anthropicOverride.apiFormat,
-              },
-            ]
-          : [],
-      }),
-    [
-      anthropicOverride,
-      storedApiKeys.ANTHROPIC_BASE_URL,
-      workspaceSettings?.bypassAnthropicProxy,
-    ],
-  );
-
-  // Check if a model is available (required API key is configured)
-  const isModelAvailable = useCallback(
-    (entry: ModelEntry) => {
-      if (
-        requiresAnthropicCustomEndpoint(entry.name) &&
-        !hasAnthropicCustomEndpoint
-      ) {
-        return false;
-      }
-      // Free models are always available
-      if (entry.tier === "free") return true;
-      // If no API keys required, it's available
-      if (!entry.requiredApiKeys || entry.requiredApiKeys.length === 0)
-        return true;
-      // Check if at least ONE of the required API keys is configured
-      return entry.requiredApiKeys.some((requiredKey) =>
-        configuredApiKeys.has(requiredKey),
-      );
-    },
-    [configuredApiKeys, hasAnthropicCustomEndpoint],
-  );
+  } = useTeamModelCatalog(teamSlugOrId);
+  const { isModelAvailable } = useModelAvailability(teamSlugOrId);
 
   const isVisibleForTeam = useCallback((entry: ModelEntry) => {
     return entry.enabled && !entry.hiddenForTeam;

--- a/apps/client/src/components/settings/sections/ModelManagementSection.tsx
+++ b/apps/client/src/components/settings/sections/ModelManagementSection.tsx
@@ -2,6 +2,10 @@ import { AgentLogo } from "@/components/icons/agent-logos";
 import { SettingSection } from "@/components/settings/SettingSection";
 import { api } from "@cmux/convex/api";
 import type { AgentVendor } from "@cmux/shared/agent-catalog";
+import {
+  hasAnthropicCustomEndpointConfigured,
+  requiresAnthropicCustomEndpoint,
+} from "@cmux/shared/providers/anthropic/models";
 import { Switch } from "@heroui/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -9,7 +13,10 @@ import { useAction, useConvex } from "convex/react";
 import { Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { getVendorDisplayName, groupModelsByVendor } from "@/lib/model-vendor-utils";
+import {
+  getVendorDisplayName,
+  groupModelsByVendor,
+} from "@/lib/model-vendor-utils";
 
 // Model entry from Convex database
 interface ModelEntry {
@@ -38,9 +45,11 @@ export function ModelManagementSection({
   const [showHiddenOnly, setShowHiddenOnly] = useState(false);
 
   // Query all models from Convex database (includes disabled and discovered models)
-  const { data: convexModels, refetch: refetchModels, isLoading } = useQuery(
-    convexQuery(api.models.listAll, { teamSlugOrId })
-  );
+  const {
+    data: convexModels,
+    refetch: refetchModels,
+    isLoading,
+  } = useQuery(convexQuery(api.models.listAll, { teamSlugOrId }));
 
   // Auto-seed models if none exist (self-healing mechanism)
   const ensureModelsSeeded = useAction(api.modelDiscovery.ensureModelsSeeded);
@@ -55,22 +64,41 @@ export function ModelManagementSection({
 
     // No models found - trigger seeding
     hasTriedSeeding.current = true;
-    console.log("[ModelManagementSection] No models found, triggering auto-seed...");
+    console.log(
+      "[ModelManagementSection] No models found, triggering auto-seed...",
+    );
     ensureModelsSeeded({ teamSlugOrId })
       .then((result) => {
         if (result.seeded) {
-          console.log(`[ModelManagementSection] Auto-seeded ${result.count} models`);
+          console.log(
+            `[ModelManagementSection] Auto-seeded ${result.count} models`,
+          );
           void refetchModels();
         }
       })
       .catch((error) => {
         console.error("[ModelManagementSection] Auto-seed failed:", error);
       });
-  }, [convexModels, isLoading, ensureModelsSeeded, teamSlugOrId, refetchModels]);
+  }, [
+    convexModels,
+    isLoading,
+    ensureModelsSeeded,
+    teamSlugOrId,
+    refetchModels,
+  ]);
 
   // Query API keys to determine model availability
   const { data: apiKeys } = useQuery(
-    convexQuery(api.apiKeys.getAll, { teamSlugOrId })
+    convexQuery(api.apiKeys.getAll, { teamSlugOrId }),
+  );
+  const { data: workspaceSettings } = useQuery(
+    convexQuery(api.workspaceSettings.get, { teamSlugOrId }),
+  );
+  const { data: anthropicOverride } = useQuery(
+    convexQuery(api.providerOverrides.getByProvider, {
+      teamSlugOrId,
+      providerId: "anthropic",
+    }),
   );
 
   // Build a Set of configured API key env vars for efficient lookup
@@ -78,20 +106,60 @@ export function ModelManagementSection({
     if (!apiKeys) return new Set<string>();
     return new Set(apiKeys.map((k) => k.envVar));
   }, [apiKeys]);
+  const storedApiKeys = useMemo(() => {
+    return (apiKeys ?? []).reduce<Record<string, string | undefined>>(
+      (acc, key) => {
+        acc[key.envVar] = key.value;
+        return acc;
+      },
+      {},
+    );
+  }, [apiKeys]);
+  const hasAnthropicCustomEndpoint = useMemo(
+    () =>
+      hasAnthropicCustomEndpointConfigured({
+        apiKeys: {
+          ANTHROPIC_BASE_URL: storedApiKeys.ANTHROPIC_BASE_URL,
+        },
+        bypassAnthropicProxy: workspaceSettings?.bypassAnthropicProxy ?? false,
+        providerOverrides: anthropicOverride
+          ? [
+              {
+                providerId: anthropicOverride.providerId,
+                enabled: anthropicOverride.enabled,
+                baseUrl: anthropicOverride.baseUrl,
+                apiFormat: anthropicOverride.apiFormat,
+              },
+            ]
+          : [],
+      }),
+    [
+      anthropicOverride,
+      storedApiKeys.ANTHROPIC_BASE_URL,
+      workspaceSettings?.bypassAnthropicProxy,
+    ],
+  );
 
   // Check if a model is available (required API key is configured)
   const isModelAvailable = useCallback(
     (entry: ModelEntry) => {
+      if (
+        requiresAnthropicCustomEndpoint(entry.name) &&
+        !hasAnthropicCustomEndpoint
+      ) {
+        return false;
+      }
       // Free models are always available
       if (entry.tier === "free") return true;
       // If no API keys required, it's available
-      if (!entry.requiredApiKeys || entry.requiredApiKeys.length === 0) return true;
+      if (!entry.requiredApiKeys || entry.requiredApiKeys.length === 0)
+        return true;
       // Check if at least ONE of the required API keys is configured
       return entry.requiredApiKeys.some((requiredKey) =>
-        configuredApiKeys.has(requiredKey)
+        configuredApiKeys.has(requiredKey),
       );
     },
-    [configuredApiKeys]
+    [configuredApiKeys, hasAnthropicCustomEndpoint],
   );
 
   const isVisibleForTeam = useCallback((entry: ModelEntry) => {
@@ -126,7 +194,7 @@ export function ModelManagementSection({
     (modelName: string, visible: boolean) => {
       toggleModelMutation.mutate({ modelName, hidden: !visible });
     },
-    [toggleModelMutation]
+    [toggleModelMutation],
   );
 
   // Filter and group models by vendor
@@ -158,7 +226,13 @@ export function ModelManagementSection({
 
     // Group by vendor using shared utility (preserves sort order within vendor)
     return groupModelsByVendor(filtered);
-  }, [convexModels, searchQuery, showHiddenOnly, isModelAvailable, isVisibleForTeam]);
+  }, [
+    convexModels,
+    searchQuery,
+    showHiddenOnly,
+    isModelAvailable,
+    isVisibleForTeam,
+  ]);
 
   // Count only available models (with API keys configured)
   const availableModels = convexModels?.filter(isModelAvailable) ?? [];
@@ -287,7 +361,9 @@ export function ModelManagementSection({
                               size="sm"
                               color="primary"
                               isSelected={isVisible}
-                              isDisabled={isToggling || isSystemDisabled || entry.disabled}
+                              isDisabled={
+                                isToggling || isSystemDisabled || entry.disabled
+                              }
                               onValueChange={(visible) =>
                                 handleSetVisibility(entry.name, visible)
                               }
@@ -298,7 +374,7 @@ export function ModelManagementSection({
                     })}
                   </div>
                 </div>
-              )
+              ),
             )}
 
             {filteredAndGroupedModels.size === 0 && (

--- a/apps/client/src/hooks/useTeamModelCatalog.ts
+++ b/apps/client/src/hooks/useTeamModelCatalog.ts
@@ -1,0 +1,132 @@
+import { api } from "@cmux/convex/api";
+import {
+  hasAnthropicCustomEndpointConfigured,
+  requiresAnthropicCustomEndpoint,
+} from "@cmux/shared/providers/anthropic/models";
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+type AvailableModelEntry = {
+  name: string;
+  tier: "free" | "paid";
+  requiredApiKeys?: string[];
+};
+
+export function useTeamModelCatalog(teamSlugOrId: string) {
+  const {
+    data: models,
+    refetch: refetchModels,
+    isLoading,
+  } = useQuery(convexQuery(api.models.listAll, { teamSlugOrId }));
+
+  const ensureModelsSeeded = useAction(api.modelDiscovery.ensureModelsSeeded);
+  const hasTriedSeeding = useRef(false);
+
+  useEffect(() => {
+    if (hasTriedSeeding.current || isLoading) {
+      return;
+    }
+
+    if (models && models.length > 0) {
+      return;
+    }
+
+    hasTriedSeeding.current = true;
+    console.log("[useTeamModelCatalog] No models found, triggering auto-seed...");
+    ensureModelsSeeded({ teamSlugOrId })
+      .then((result) => {
+        if (result.seeded) {
+          console.log(
+            `[useTeamModelCatalog] Auto-seeded ${result.count} models`,
+          );
+          void refetchModels();
+        }
+      })
+      .catch((error) => {
+        console.error("[useTeamModelCatalog] Auto-seed failed:", error);
+      });
+  }, [ensureModelsSeeded, isLoading, models, refetchModels, teamSlugOrId]);
+
+  return {
+    models,
+    refetchModels,
+    isLoading,
+  };
+}
+
+export function useModelAvailability(teamSlugOrId: string) {
+  const { data: apiKeys } = useQuery(
+    convexQuery(api.apiKeys.getAll, { teamSlugOrId }),
+  );
+  const { data: workspaceSettings } = useQuery(
+    convexQuery(api.workspaceSettings.get, { teamSlugOrId }),
+  );
+  const { data: anthropicOverride } = useQuery(
+    convexQuery(api.providerOverrides.getByProvider, {
+      teamSlugOrId,
+      providerId: "anthropic",
+    }),
+  );
+
+  const configuredApiKeys = useMemo(() => {
+    return new Set((apiKeys ?? []).map((key) => key.envVar));
+  }, [apiKeys]);
+
+  const hasAnthropicCustomEndpoint = useMemo(
+    () =>
+      hasAnthropicCustomEndpointConfigured({
+        apiKeys: {
+          ANTHROPIC_BASE_URL: apiKeys?.find(
+            (key) => key.envVar === "ANTHROPIC_BASE_URL",
+          )?.value,
+        },
+        bypassAnthropicProxy: workspaceSettings?.bypassAnthropicProxy ?? false,
+        providerOverrides: anthropicOverride
+          ? [
+              {
+                providerId: anthropicOverride.providerId,
+                enabled: anthropicOverride.enabled,
+                baseUrl: anthropicOverride.baseUrl,
+                apiFormat: anthropicOverride.apiFormat,
+              },
+            ]
+          : [],
+      }),
+    [
+      anthropicOverride,
+      apiKeys,
+      workspaceSettings?.bypassAnthropicProxy,
+    ],
+  );
+
+  const isModelAvailable = useCallback(
+    (model: AvailableModelEntry) => {
+      if (
+        requiresAnthropicCustomEndpoint(model.name) &&
+        !hasAnthropicCustomEndpoint
+      ) {
+        return false;
+      }
+
+      if (model.tier === "free") {
+        return true;
+      }
+
+      const requiredApiKeys = model.requiredApiKeys ?? [];
+      if (requiredApiKeys.length === 0) {
+        return true;
+      }
+
+      return requiredApiKeys.some((requiredKey) =>
+        configuredApiKeys.has(requiredKey),
+      );
+    },
+    [configuredApiKeys, hasAnthropicCustomEndpoint],
+  );
+
+  return {
+    isModelAvailable,
+  };
+}

--- a/packages/convex/convex/models.ts
+++ b/packages/convex/convex/models.ts
@@ -4,6 +4,10 @@ import { authMutation, authQuery } from "./users/utils";
 import { resolveTeamIdLoose } from "../_shared/team";
 import { isAuthFreeModel } from "@cmux/shared/providers/control-plane";
 import { AGENT_CATALOG } from "@cmux/shared/agent-catalog";
+import {
+  hasAnthropicCustomEndpointConfigured,
+  requiresAnthropicCustomEndpoint,
+} from "@cmux/shared/providers/anthropic/models";
 
 function catalogDefinesVariants(
   catalogEntry: (typeof AGENT_CATALOG)[number] | undefined,
@@ -104,21 +108,35 @@ export const listAvailable = authQuery({
   },
   handler: async (ctx, args) => {
     // Verify user has access to the team and get teamId
+    const userId = ctx.identity.subject;
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
     console.log(
       `[listAvailable] teamSlugOrId=${args.teamSlugOrId}, resolved teamId=${teamId}`,
     );
 
-    const [models, teamVisibility] = await Promise.all([
-      ctx.db
-        .query("models")
-        .withIndex("by_enabled", (q) => q.eq("enabled", true))
-        .collect(),
-      ctx.db
-        .query("teamModelVisibility")
-        .withIndex("by_team", (q) => q.eq("teamId", teamId))
-        .first(),
-    ]);
+    const [models, teamVisibility, workspaceSettings, anthropicOverride] =
+      await Promise.all([
+        ctx.db
+          .query("models")
+          .withIndex("by_enabled", (q) => q.eq("enabled", true))
+          .collect(),
+        ctx.db
+          .query("teamModelVisibility")
+          .withIndex("by_team", (q) => q.eq("teamId", teamId))
+          .first(),
+        ctx.db
+          .query("workspaceSettings")
+          .withIndex("by_team_user", (q) =>
+            q.eq("teamId", teamId).eq("userId", userId),
+          )
+          .first(),
+        ctx.db
+          .query("providerOverrides")
+          .withIndex("by_team_provider", (q) =>
+            q.eq("teamId", teamId).eq("providerId", "anthropic"),
+          )
+          .first(),
+      ]);
     const hiddenModels = new Set(teamVisibility?.hiddenModels ?? []);
 
     console.log(`[listAvailable] Found ${models.length} enabled models`);
@@ -144,9 +162,37 @@ export const listAvailable = authQuery({
       .collect();
 
     const configuredKeyEnvVars = new Set(apiKeys.map((k) => k.envVar));
+    const storedApiKeys = Object.fromEntries(
+      apiKeys.map((key) => [key.envVar, key.value]),
+    );
+    const hasAnthropicCustomEndpoint = hasAnthropicCustomEndpointConfigured({
+      apiKeys: {
+        ANTHROPIC_BASE_URL:
+          typeof storedApiKeys.ANTHROPIC_BASE_URL === "string"
+            ? storedApiKeys.ANTHROPIC_BASE_URL
+            : undefined,
+      },
+      bypassAnthropicProxy: workspaceSettings?.bypassAnthropicProxy ?? false,
+      providerOverrides: anthropicOverride
+        ? [
+            {
+              providerId: anthropicOverride.providerId,
+              enabled: anthropicOverride.enabled,
+              baseUrl: anthropicOverride.baseUrl,
+              apiFormat: anthropicOverride.apiFormat,
+            },
+          ]
+        : [],
+    });
 
     // Filter models by availability
     const availableModels = visibleModels.filter((model) => {
+      if (
+        requiresAnthropicCustomEndpoint(model.name) &&
+        !hasAnthropicCustomEndpoint
+      ) {
+        return false;
+      }
       // Auth-free free tier models are always available
       if (isAuthFreeModel(model)) return true;
       // Models with no required keys are available

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -130,6 +130,10 @@
       "import": "./src/providers/anthropic/configs.ts",
       "types": "./src/providers/anthropic/configs.ts"
     },
+    "./providers/anthropic/models": {
+      "import": "./src/providers/anthropic/models.ts",
+      "types": "./src/providers/anthropic/models.ts"
+    },
     "./providers/anthropic/environment": {
       "import": "./src/providers/anthropic/environment.ts",
       "types": "./src/providers/anthropic/environment.ts"

--- a/packages/shared/src/provider-registry.test.ts
+++ b/packages/shared/src/provider-registry.test.ts
@@ -311,32 +311,57 @@ describe("BASE_PROVIDERS", () => {
 });
 
 describe("CLAUDE_MODEL_SPECS", () => {
-  it("maps Claude agent names to stable families and native ids", () => {
-    expect(CLAUDE_MODEL_SPECS).toEqual([
+  it("maps Claude agent names to stable families, launch models, and native ids", () => {
+    expect(
+      CLAUDE_MODEL_SPECS.map((spec) => ({
+        nameSuffix: spec.nameSuffix,
+        family: spec.family,
+        launchModel: spec.launchModel,
+        nativeModelId: spec.nativeModelId,
+        requiresCustomEndpoint: spec.requiresCustomEndpoint ?? false,
+      })),
+    ).toEqual([
       {
         nameSuffix: "opus-4.6",
         family: "opus",
+        launchModel: "opus",
         nativeModelId: "claude-opus-4-6",
+        requiresCustomEndpoint: false,
       },
       {
         nameSuffix: "sonnet-4.6",
         family: "sonnet",
+        launchModel: "sonnet",
         nativeModelId: "claude-sonnet-4-6",
+        requiresCustomEndpoint: false,
       },
       {
         nameSuffix: "opus-4.5",
         family: "opus",
+        launchModel: "opus",
         nativeModelId: "claude-opus-4-5-20251101",
+        requiresCustomEndpoint: false,
       },
       {
         nameSuffix: "sonnet-4.5",
         family: "sonnet",
+        launchModel: "sonnet",
         nativeModelId: "claude-sonnet-4-5-20250929",
+        requiresCustomEndpoint: false,
       },
       {
         nameSuffix: "haiku-4.5",
         family: "haiku",
+        launchModel: "haiku",
         nativeModelId: "claude-haiku-4-5-20251001",
+        requiresCustomEndpoint: false,
+      },
+      {
+        nameSuffix: "gpt-5.1-codex-mini",
+        family: undefined,
+        launchModel: "gpt-5.1-codex-mini",
+        nativeModelId: "gpt-5.1-codex-mini",
+        requiresCustomEndpoint: true,
       },
     ]);
   });

--- a/packages/shared/src/providers/anthropic/catalog.test.ts
+++ b/packages/shared/src/providers/anthropic/catalog.test.ts
@@ -20,9 +20,10 @@ describe("CLAUDE_CATALOG", () => {
   it("all entries require CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY", () => {
     for (const entry of CLAUDE_CATALOG) {
       const hasClaudeToken = entry.requiredApiKeys.includes(
-        "CLAUDE_CODE_OAUTH_TOKEN"
+        "CLAUDE_CODE_OAUTH_TOKEN",
       );
-      const hasAnthropicKey = entry.requiredApiKeys.includes("ANTHROPIC_API_KEY");
+      const hasAnthropicKey =
+        entry.requiredApiKeys.includes("ANTHROPIC_API_KEY");
       expect(hasClaudeToken || hasAnthropicKey).toBe(true);
     }
   });
@@ -50,6 +51,15 @@ describe("CLAUDE_CATALOG", () => {
     const haiku = CLAUDE_CATALOG.find((e) => e.name === "claude/haiku-4.5");
     expect(haiku).toBeDefined();
     expect(haiku?.tags).toContain("fast");
+  });
+
+  it("includes GPT-5.1 Codex Mini as a proxy-backed Claude model", () => {
+    const model = CLAUDE_CATALOG.find(
+      (e) => e.name === "claude/gpt-5.1-codex-mini",
+    );
+    expect(model).toBeDefined();
+    expect(model?.requiredApiKeys).toEqual(["ANTHROPIC_API_KEY"]);
+    expect(model?.tags).toContain("proxy");
   });
 
   it("all tiers are paid", () => {

--- a/packages/shared/src/providers/anthropic/catalog.ts
+++ b/packages/shared/src/providers/anthropic/catalog.ts
@@ -100,4 +100,17 @@ export const CLAUDE_CATALOG: AgentCatalogEntry[] = [
     contextWindow: 200000,
     maxOutputTokens: 8000,
   },
+  {
+    name: "claude/gpt-5.1-codex-mini",
+    displayName: "GPT-5.1 Codex Mini",
+    description:
+      "Claude Code routed to GPT-5.1 Codex Mini through an Anthropic-compatible custom endpoint.",
+    vendor: "anthropic",
+    requiredApiKeys: ["ANTHROPIC_API_KEY"],
+    tier: "paid",
+    tags: ["fast", "custom", "proxy"],
+    variants: [],
+    contextWindow: 200000,
+    maxOutputTokens: 32000,
+  },
 ];

--- a/packages/shared/src/providers/anthropic/check-requirements.ts
+++ b/packages/shared/src/providers/anthropic/check-requirements.ts
@@ -1,76 +1,88 @@
 import type { ProviderRequirementsContext } from "../../agentConfig";
 
-export async function checkClaudeRequirements(
-  context?: ProviderRequirementsContext
-): Promise<string[]> {
-  const { access } = await import("node:fs/promises");
-  const { homedir } = await import("node:os");
-  const { join } = await import("node:path");
-  const { exec } = await import("node:child_process");
-  const { promisify } = await import("node:util");
-  const execAsync = promisify(exec);
+export function createCheckClaudeRequirements(options?: {
+  allowOAuth?: boolean;
+}) {
+  const allowOAuth = options?.allowOAuth ?? true;
 
-  const missing: string[] = [];
+  return async function checkClaudeRequirements(
+    context?: ProviderRequirementsContext,
+  ): Promise<string[]> {
+    const { access } = await import("node:fs/promises");
+    const { homedir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { exec } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execAsync = promisify(exec);
 
-  // Check if API keys are provided in settings (from context)
-  // Either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY works
-  const hasOAuthToken =
-    context?.apiKeys?.CLAUDE_CODE_OAUTH_TOKEN &&
-    context.apiKeys.CLAUDE_CODE_OAUTH_TOKEN.trim() !== "";
-  const hasApiKeyInSettings =
-    context?.apiKeys?.ANTHROPIC_API_KEY &&
-    context.apiKeys.ANTHROPIC_API_KEY.trim() !== "";
+    const missing: string[] = [];
 
-  // If user has provided credentials via settings, skip local checks
-  if (hasOAuthToken || hasApiKeyInSettings) {
-    return missing;
-  }
+    // Check if API keys are provided in settings (from context)
+    const hasOAuthToken =
+      allowOAuth &&
+      context?.apiKeys?.CLAUDE_CODE_OAUTH_TOKEN &&
+      context.apiKeys.CLAUDE_CODE_OAUTH_TOKEN.trim() !== "";
+    const hasApiKeyInSettings =
+      context?.apiKeys?.ANTHROPIC_API_KEY &&
+      context.apiKeys.ANTHROPIC_API_KEY.trim() !== "";
 
-  try {
-    // Check for .claude.json
-    await access(join(homedir(), ".claude.json"));
-  } catch {
-    missing.push(".claude.json file");
-  }
+    // If user has provided credentials via settings, skip local checks
+    if (hasOAuthToken || hasApiKeyInSettings) {
+      return missing;
+    }
 
-  try {
-    // Check for credentials
-    const hasCredentialsFile = await access(
-      join(homedir(), ".claude", ".credentials.json")
-    )
-      .then(() => true)
-      .catch(() => false);
+    try {
+      // Check for .claude.json
+      await access(join(homedir(), ".claude.json"));
+    } catch {
+      missing.push(".claude.json file");
+    }
 
-    if (!hasCredentialsFile) {
-      // Check for API key in keychain - try both Claude Code and Claude Code-credentials
-      let foundInKeychain = false;
+    try {
+      // Check for credentials
+      const hasCredentialsFile = await access(
+        join(homedir(), ".claude", ".credentials.json"),
+      )
+        .then(() => true)
+        .catch(() => false);
 
-      try {
-        await execAsync(
-          "security find-generic-password -a $USER -w -s 'Claude Code'"
-        );
-        foundInKeychain = true;
-      } catch {
-        // Try Claude Code-credentials as fallback
+      if (!hasCredentialsFile) {
+        // Check for API key in keychain - try both Claude Code and Claude Code-credentials
+        let foundInKeychain = false;
+
         try {
           await execAsync(
-            "security find-generic-password -a $USER -w -s 'Claude Code-credentials'"
+            "security find-generic-password -a $USER -w -s 'Claude Code'",
           );
           foundInKeychain = true;
         } catch {
-          // Neither keychain entry found
+          // Try Claude Code-credentials as fallback
+          if (allowOAuth) {
+            try {
+              await execAsync(
+                "security find-generic-password -a $USER -w -s 'Claude Code-credentials'",
+              );
+              foundInKeychain = true;
+            } catch {
+              // Neither keychain entry found
+            }
+          }
+        }
+
+        if (!foundInKeychain) {
+          missing.push(
+            allowOAuth
+              ? "Claude credentials (no .credentials.json, API key in keychain, or API key in Settings)"
+              : "Anthropic API key (no API key in keychain or Settings)",
+          );
         }
       }
-
-      if (!foundInKeychain) {
-        missing.push(
-          "Claude credentials (no .credentials.json, API key in keychain, or API key in Settings)"
-        );
-      }
+    } catch {
+      missing.push(allowOAuth ? "Claude credentials" : "Anthropic API key");
     }
-  } catch {
-    missing.push("Claude credentials");
-  }
 
-  return missing;
+    return missing;
+  };
 }
+
+export const checkClaudeRequirements = createCheckClaudeRequirements();

--- a/packages/shared/src/providers/anthropic/configs.test.ts
+++ b/packages/shared/src/providers/anthropic/configs.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { CLAUDE_AGENT_CONFIGS, createApplyClaudeApiKeys } from "./configs";
+import {
+  CLAUDE_AGENT_CONFIGS,
+  createApplyClaudeApiKeys,
+  createApplyClaudeApiKeysWithOptions,
+} from "./configs";
 import { ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN } from "../../apiKeys";
 
 describe("createApplyClaudeApiKeys", () => {
   const applyApiKeys = createApplyClaudeApiKeys();
+  const applyProxyOnlyApiKeys = createApplyClaudeApiKeysWithOptions({
+    allowOAuth: false,
+  });
 
   describe("OAuth token priority", () => {
     it("prefers OAuth token over API key when both are set", async () => {
@@ -11,7 +18,10 @@ describe("createApplyClaudeApiKeys", () => {
         CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-123",
         ANTHROPIC_API_KEY: "sk-ant-api-key-456",
       });
-      expect(result.env).toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token-123");
+      expect(result.env).toHaveProperty(
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "oauth-token-123",
+      );
       expect(result.env).not.toHaveProperty("ANTHROPIC_API_KEY");
     });
 
@@ -26,7 +36,9 @@ describe("createApplyClaudeApiKeys", () => {
       const result = await applyApiKeys({
         CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-123",
       });
-      expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-123" });
+      expect(result.env).toEqual({
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-123",
+      });
     });
   });
 
@@ -35,7 +47,10 @@ describe("createApplyClaudeApiKeys", () => {
       const result = await applyApiKeys({
         ANTHROPIC_API_KEY: "sk-ant-api-key-456",
       });
-      expect(result.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-ant-api-key-456");
+      expect(result.env).toHaveProperty(
+        "ANTHROPIC_API_KEY",
+        "sk-ant-api-key-456",
+      );
       expect(result.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
     });
 
@@ -44,7 +59,10 @@ describe("createApplyClaudeApiKeys", () => {
         CLAUDE_CODE_OAUTH_TOKEN: "",
         ANTHROPIC_API_KEY: "sk-ant-api-key-456",
       });
-      expect(result.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-ant-api-key-456");
+      expect(result.env).toHaveProperty(
+        "ANTHROPIC_API_KEY",
+        "sk-ant-api-key-456",
+      );
     });
 
     it("uses API key when OAuth token is whitespace only", async () => {
@@ -52,7 +70,10 @@ describe("createApplyClaudeApiKeys", () => {
         CLAUDE_CODE_OAUTH_TOKEN: "   ",
         ANTHROPIC_API_KEY: "sk-ant-api-key-456",
       });
-      expect(result.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-ant-api-key-456");
+      expect(result.env).toHaveProperty(
+        "ANTHROPIC_API_KEY",
+        "sk-ant-api-key-456",
+      );
     });
   });
 
@@ -92,6 +113,18 @@ describe("createApplyClaudeApiKeys", () => {
         ANTHROPIC_API_KEY: "",
       });
       expect(result.env).toEqual({});
+    });
+  });
+
+  describe("proxy-only mode", () => {
+    it("ignores OAuth tokens and uses Anthropic API key only", async () => {
+      const result = await applyProxyOnlyApiKeys({
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-123",
+        ANTHROPIC_API_KEY: "sk-ant-api-key-456",
+      });
+      expect(result.env).toEqual({
+        ANTHROPIC_API_KEY: "sk-ant-api-key-456",
+      });
     });
   });
 });
@@ -141,36 +174,56 @@ describe("CLAUDE_AGENT_CONFIGS", () => {
     }
   });
 
-  it("all configs have both OAuth and API key in apiKeys", () => {
+  it("native configs keep OAuth + API key while proxy-only config uses API key only", () => {
     for (const config of CLAUDE_AGENT_CONFIGS) {
-      expect(config.apiKeys).toContain(CLAUDE_CODE_OAUTH_TOKEN);
       expect(config.apiKeys).toContain(ANTHROPIC_API_KEY);
+      if (config.name === "claude/gpt-5.1-codex-mini") {
+        expect(config.apiKeys).not.toContain(CLAUDE_CODE_OAUTH_TOKEN);
+      } else {
+        expect(config.apiKeys).toContain(CLAUDE_CODE_OAUTH_TOKEN);
+      }
     }
   });
 
   describe("model mapping", () => {
     it("includes opus-4.6 config", () => {
-      const config = CLAUDE_AGENT_CONFIGS.find((c) => c.name === "claude/opus-4.6");
+      const config = CLAUDE_AGENT_CONFIGS.find(
+        (c) => c.name === "claude/opus-4.6",
+      );
       expect(config).toBeDefined();
       expect(config?.args).toContain("opus");
     });
 
     it("includes opus-4.5 config", () => {
-      const config = CLAUDE_AGENT_CONFIGS.find((c) => c.name === "claude/opus-4.5");
+      const config = CLAUDE_AGENT_CONFIGS.find(
+        (c) => c.name === "claude/opus-4.5",
+      );
       expect(config).toBeDefined();
       expect(config?.args).toContain("opus");
     });
 
     it("includes sonnet-4.5 config", () => {
-      const config = CLAUDE_AGENT_CONFIGS.find((c) => c.name === "claude/sonnet-4.5");
+      const config = CLAUDE_AGENT_CONFIGS.find(
+        (c) => c.name === "claude/sonnet-4.5",
+      );
       expect(config).toBeDefined();
       expect(config?.args).toContain("sonnet");
     });
 
     it("includes haiku-4.5 config", () => {
-      const config = CLAUDE_AGENT_CONFIGS.find((c) => c.name === "claude/haiku-4.5");
+      const config = CLAUDE_AGENT_CONFIGS.find(
+        (c) => c.name === "claude/haiku-4.5",
+      );
       expect(config).toBeDefined();
       expect(config?.args).toContain("haiku");
+    });
+
+    it("includes GPT-5.1 Codex Mini as a direct custom model launch", () => {
+      const config = CLAUDE_AGENT_CONFIGS.find(
+        (c) => c.name === "claude/gpt-5.1-codex-mini",
+      );
+      expect(config).toBeDefined();
+      expect(config?.args).toContain("gpt-5.1-codex-mini");
     });
   });
 });

--- a/packages/shared/src/providers/anthropic/configs.ts
+++ b/packages/shared/src/providers/anthropic/configs.ts
@@ -1,8 +1,8 @@
 import type { AgentConfig, EnvironmentResult } from "../../agentConfig";
 import { ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN } from "../../apiKeys";
-import { checkClaudeRequirements } from "./check-requirements";
+import { createCheckClaudeRequirements } from "./check-requirements";
 import { startClaudeCompletionDetector } from "./completion-detector";
-import { getClaudeModelFamily, CLAUDE_MODEL_SPECS } from "./models";
+import { CLAUDE_MODEL_SPECS, getClaudeModelSpecByAgentName } from "./models";
 import {
   CLAUDE_KEY_ENV_VARS_TO_UNSET,
   getClaudeEnvironment,
@@ -18,7 +18,17 @@ import {
  *      the request will be routed to platform Bedrock proxy
  * 3. No fallback - users must provide credentials to use Claude agents
  */
-export function createApplyClaudeApiKeys(): NonNullable<AgentConfig["applyApiKeys"]> {
+export function createApplyClaudeApiKeys(): NonNullable<
+  AgentConfig["applyApiKeys"]
+> {
+  return createApplyClaudeApiKeysWithOptions();
+}
+
+export function createApplyClaudeApiKeysWithOptions(options?: {
+  allowOAuth?: boolean;
+}): NonNullable<AgentConfig["applyApiKeys"]> {
+  const allowOAuth = options?.allowOAuth ?? true;
+
   return async (keys): Promise<Partial<EnvironmentResult>> => {
     // Base env vars to unset (prevent conflicts)
     const unsetEnv = [...CLAUDE_KEY_ENV_VARS_TO_UNSET];
@@ -27,7 +37,7 @@ export function createApplyClaudeApiKeys(): NonNullable<AgentConfig["applyApiKey
     const anthropicKey = keys.ANTHROPIC_API_KEY;
 
     // Priority 1: OAuth token (user pays via their subscription)
-    if (oauthToken && oauthToken.trim().length > 0) {
+    if (allowOAuth && oauthToken && oauthToken.trim().length > 0) {
       // Ensure ANTHROPIC_API_KEY is in the unset list
       if (!unsetEnv.includes("ANTHROPIC_API_KEY")) {
         unsetEnv.push("ANTHROPIC_API_KEY");
@@ -59,10 +69,15 @@ export function createApplyClaudeApiKeys(): NonNullable<AgentConfig["applyApiKey
 }
 
 function createClaudeConfig(nameSuffix: string): AgentConfig {
-  const family = getClaudeModelFamily(`claude/${nameSuffix}`);
-  if (!family) {
+  const spec = getClaudeModelSpecByAgentName(`claude/${nameSuffix}`);
+  if (!spec) {
     throw new Error(`Unknown Claude model family for ${nameSuffix}`);
   }
+
+  const allowOAuth = !spec.requiresCustomEndpoint;
+  const apiKeys = allowOAuth
+    ? [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY]
+    : [ANTHROPIC_API_KEY];
 
   return {
     name: `claude/${nameSuffix}`,
@@ -71,14 +86,14 @@ function createClaudeConfig(nameSuffix: string): AgentConfig {
       "--allow-dangerously-skip-permissions",
       "--dangerously-skip-permissions",
       "--model",
-      family,
+      spec.launchModel,
       "--ide",
       "$PROMPT",
     ],
     environment: getClaudeEnvironment,
-    checkRequirements: checkClaudeRequirements,
-    apiKeys: [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY],
-    applyApiKeys: createApplyClaudeApiKeys(),
+    checkRequirements: createCheckClaudeRequirements({ allowOAuth }),
+    apiKeys,
+    applyApiKeys: createApplyClaudeApiKeysWithOptions({ allowOAuth }),
     completionDetector: startClaudeCompletionDetector,
   };
 }

--- a/packages/shared/src/providers/anthropic/environment.test.ts
+++ b/packages/shared/src/providers/anthropic/environment.test.ts
@@ -429,6 +429,50 @@ describe("getClaudeEnvironment", () => {
     expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBeUndefined();
   });
 
+  it("injects custom model option env vars for proxy-only Claude models", async () => {
+    const env = await getClaudeEnvVars({
+      agentName: "claude/gpt-5.1-codex-mini",
+      apiKeys: {
+        ANTHROPIC_API_KEY: "sk-ant-api-key-123",
+        ANTHROPIC_BASE_URL: "https://gateway.example.com",
+      },
+      workspaceSettings: {
+        bypassAnthropicProxy: true,
+      },
+    });
+
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://gateway.example.com");
+    expect(env.ANTHROPIC_CUSTOM_MODEL_OPTION).toBe("gpt-5.1-codex-mini");
+    expect(env.ANTHROPIC_CUSTOM_MODEL_OPTION_NAME).toBe("GPT-5.1 Codex Mini");
+  });
+
+  it("rejects proxy-only Claude models without a custom endpoint", async () => {
+    await expect(
+      getClaudeEnvironment({
+        ...BASE_CONTEXT,
+        agentName: "claude/gpt-5.1-codex-mini",
+        apiKeys: {
+          ANTHROPIC_API_KEY: "sk-ant-api-key-123",
+        },
+      }),
+    ).rejects.toThrow(/requires an Anthropic-compatible custom endpoint/);
+  });
+
+  it("rejects proxy-only Claude models without an Anthropic API key", async () => {
+    await expect(
+      getClaudeEnvironment({
+        ...BASE_CONTEXT,
+        agentName: "claude/gpt-5.1-codex-mini",
+        apiKeys: {
+          ANTHROPIC_BASE_URL: "https://gateway.example.com",
+        },
+        workspaceSettings: {
+          bypassAnthropicProxy: true,
+        },
+      }),
+    ).rejects.toThrow(/requires an Anthropic API key/);
+  });
+
   it("rejects effort selection for routed third-party targets", async () => {
     await expect(
       getClaudeEnvironment({
@@ -472,10 +516,9 @@ describe("getClaudeEnvironment", () => {
         );
         expect(hookFile, `Hook ${hookPath} should exist`).toBeDefined();
 
-        const script = Buffer.from(
-          hookFile!.contentBase64,
-          "base64",
-        ).toString("utf-8");
+        const script = Buffer.from(hookFile!.contentBase64, "base64").toString(
+          "utf-8",
+        );
 
         // Thin stubs should reference the dispatch endpoint
         expect(
@@ -484,10 +527,9 @@ describe("getClaudeEnvironment", () => {
         ).toContain("/api/hooks/dispatch");
 
         // Thin stubs should have cache handling
-        expect(
-          script,
-          `Hook ${hookPath} should have cache file`,
-        ).toContain("CACHE_FILE=");
+        expect(script, `Hook ${hookPath} should have cache file`).toContain(
+          "CACHE_FILE=",
+        );
       }
     });
 
@@ -514,10 +556,9 @@ describe("getClaudeEnvironment", () => {
         const hookFile = result.files.find((f) => f.destinationPath === path);
         expect(hookFile, `Critical hook ${path} should exist`).toBeDefined();
 
-        const script = Buffer.from(
-          hookFile!.contentBase64,
-          "base64",
-        ).toString("utf-8");
+        const script = Buffer.from(hookFile!.contentBase64, "base64").toString(
+          "utf-8",
+        );
 
         for (const content of mustContain) {
           expect(
@@ -551,7 +592,8 @@ describe("getClaudeEnvironment", () => {
       const result = await getClaudeEnvironment(BASE_CONTEXT);
 
       const precompactHook = result.files.find(
-        (f) => f.destinationPath === "/root/lifecycle/claude/precompact-hook.sh",
+        (f) =>
+          f.destinationPath === "/root/lifecycle/claude/precompact-hook.sh",
       );
       expect(precompactHook).toBeDefined();
 

--- a/packages/shared/src/providers/anthropic/environment.ts
+++ b/packages/shared/src/providers/anthropic/environment.ts
@@ -8,6 +8,7 @@ import {
   CLAUDE_ROUTING_ENV_VARS,
   type ClaudeModelFamily,
   getClaudeModelSpecByAgentName,
+  hasAnthropicCustomEndpointConfigured,
 } from "./models";
 import {
   CMUX_ANTHROPIC_PROXY_PLACEHOLDER_API_KEY,
@@ -82,7 +83,10 @@ function resolveClaudeEffectiveTarget(
 }
 
 function resolveClaudeEffortLevel(
-  ctx: Pick<EnvironmentContext, "agentName" | "selectedVariant" | "providerConfig">,
+  ctx: Pick<
+    EnvironmentContext,
+    "agentName" | "selectedVariant" | "providerConfig"
+  >,
 ): string | undefined {
   const effort = ctx.selectedVariant?.trim();
   if (!effort) {
@@ -134,6 +138,7 @@ export async function getClaudeEnvironment(
   const env: Record<string, string> = {};
   const startupCommands: string[] = [];
   const effortLevel = resolveClaudeEffortLevel(ctx);
+  const modelSpec = getClaudeModelSpecByAgentName(ctx.agentName);
   const claudeLifecycleDir = "/root/lifecycle/claude";
   const claudeSecretsDir = `${claudeLifecycleDir}/secrets`;
   const claudeApiKeyHelperPath = `${claudeSecretsDir}/anthropic_key_helper.sh`;
@@ -594,6 +599,7 @@ exit 0`;
 
   // Check if user has provided an OAuth token (preferred) or API key
   const hasOAuthToken =
+    modelSpec?.requiresCustomEndpoint !== true &&
     ctx.apiKeys?.CLAUDE_CODE_OAUTH_TOKEN &&
     ctx.apiKeys.CLAUDE_CODE_OAUTH_TOKEN.trim().length > 0;
   const hasAnthropicApiKey =
@@ -601,6 +607,22 @@ exit 0`;
     ctx.apiKeys.ANTHROPIC_API_KEY.trim().length > 0;
   const userCustomBaseUrl = ctx.apiKeys?.ANTHROPIC_BASE_URL?.trim();
   const bypassProxy = ctx.workspaceSettings?.bypassAnthropicProxy ?? false;
+  const hasAnthropicCustomEndpoint = hasAnthropicCustomEndpointConfigured({
+    apiKeys: {
+      ANTHROPIC_BASE_URL: ctx.apiKeys?.ANTHROPIC_BASE_URL,
+    },
+    bypassAnthropicProxy: bypassProxy,
+    providerOverrides: ctx.providerConfig?.isOverridden
+      ? [
+          {
+            providerId: "anthropic",
+            enabled: true,
+            baseUrl: ctx.providerConfig.baseUrl,
+            apiFormat: ctx.providerConfig.apiFormat,
+          },
+        ]
+      : [],
+  });
   const hasTaskRunJwt = ctx.taskRunJwt.trim().length > 0;
   const routingConfig = ctx.providerConfig?.claudeRouting;
   const shouldApplyClaudeRouting =
@@ -608,6 +630,12 @@ exit 0`;
     ctx.providerConfig?.isOverridden === true &&
     ctx.providerConfig.apiFormat === "anthropic" &&
     routingConfig?.mode === "anthropic_compatible_gateway";
+
+  if (modelSpec?.requiresCustomEndpoint && !hasAnthropicApiKey) {
+    throw new Error(
+      `${ctx.agentName ?? "claude"} requires an Anthropic API key`,
+    );
+  }
 
   // If OAuth token is provided, write it to /etc/claude-code/env
   // The wrapper scripts (claude and other launchers) source this file before running claude-code
@@ -864,9 +892,31 @@ exit 0`;
             routingConfig.haiku,
           );
           if (routingConfig.subagentModel?.trim()) {
-            result.CLAUDE_CODE_SUBAGENT_MODEL = routingConfig.subagentModel.trim();
+            result.CLAUDE_CODE_SUBAGENT_MODEL =
+              routingConfig.subagentModel.trim();
           }
           result.ANTHROPIC_CUSTOM_MODEL_OPTION = "custom";
+        }
+
+        if (modelSpec?.requiresCustomEndpoint) {
+          if (!hasAnthropicCustomEndpoint) {
+            throw new Error(
+              `${ctx.agentName ?? "claude"} requires an Anthropic-compatible custom endpoint`,
+            );
+          }
+          result.ANTHROPIC_CUSTOM_MODEL_OPTION = modelSpec.nativeModelId;
+          if (modelSpec.customModelOptionName?.trim()) {
+            result.ANTHROPIC_CUSTOM_MODEL_OPTION_NAME =
+              modelSpec.customModelOptionName.trim();
+          }
+          if (modelSpec.customModelOptionDescription?.trim()) {
+            result.ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION =
+              modelSpec.customModelOptionDescription.trim();
+          }
+          if (modelSpec.customModelOptionSupportedCapabilities?.length) {
+            result.ANTHROPIC_CUSTOM_MODEL_OPTION_SUPPORTED_CAPABILITIES =
+              modelSpec.customModelOptionSupportedCapabilities.join(",");
+          }
         }
 
         return result;

--- a/packages/shared/src/providers/anthropic/models.test.ts
+++ b/packages/shared/src/providers/anthropic/models.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasAnthropicCustomEndpointConfigured,
+  requiresAnthropicCustomEndpoint,
+} from "./models";
+
+describe("anthropic model helpers", () => {
+  it("marks claude/gpt-5.1-codex-mini as requiring a custom endpoint", () => {
+    expect(requiresAnthropicCustomEndpoint("claude/gpt-5.1-codex-mini")).toBe(
+      true,
+    );
+    expect(requiresAnthropicCustomEndpoint("claude/opus-4.6")).toBe(false);
+  });
+
+  it("accepts bypassed user Anthropic base URLs as custom endpoints", () => {
+    expect(
+      hasAnthropicCustomEndpointConfigured({
+        apiKeys: {
+          ANTHROPIC_BASE_URL: "https://gateway.example.com",
+        },
+        bypassAnthropicProxy: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts enabled anthropic overrides with custom base URLs", () => {
+    expect(
+      hasAnthropicCustomEndpointConfigured({
+        providerOverrides: [
+          {
+            providerId: "anthropic",
+            enabled: true,
+            baseUrl: "https://gateway.example.com",
+            apiFormat: "anthropic",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects unbypassed user Anthropic base URLs", () => {
+    expect(
+      hasAnthropicCustomEndpointConfigured({
+        apiKeys: {
+          ANTHROPIC_BASE_URL: "https://gateway.example.com",
+        },
+        bypassAnthropicProxy: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/providers/anthropic/models.ts
+++ b/packages/shared/src/providers/anthropic/models.ts
@@ -5,19 +5,22 @@ export const CLAUDE_DEFAULT_MODEL_ENV_VARS = {
     model: "ANTHROPIC_DEFAULT_OPUS_MODEL",
     name: "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
     description: "ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION",
-    supportedCapabilities: "ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES",
+    supportedCapabilities:
+      "ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES",
   },
   sonnet: {
     model: "ANTHROPIC_DEFAULT_SONNET_MODEL",
     name: "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
     description: "ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION",
-    supportedCapabilities: "ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES",
+    supportedCapabilities:
+      "ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES",
   },
   haiku: {
     model: "ANTHROPIC_DEFAULT_HAIKU_MODEL",
     name: "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
     description: "ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION",
-    supportedCapabilities: "ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES",
+    supportedCapabilities:
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES",
   },
 } as const;
 
@@ -37,35 +40,54 @@ export const CLAUDE_ROUTING_ENV_VARS = [
 
 export interface ClaudeModelSpec {
   nameSuffix: string;
-  family: ClaudeModelFamily;
+  family?: ClaudeModelFamily;
+  launchModel: string;
   nativeModelId: string;
+  requiresCustomEndpoint?: boolean;
+  customModelOptionName?: string;
+  customModelOptionDescription?: string;
+  customModelOptionSupportedCapabilities?: string[];
 }
 
 export const CLAUDE_MODEL_SPECS: ClaudeModelSpec[] = [
   {
     nameSuffix: "opus-4.6",
     family: "opus",
+    launchModel: "opus",
     nativeModelId: "claude-opus-4-6",
   },
   {
     nameSuffix: "sonnet-4.6",
     family: "sonnet",
+    launchModel: "sonnet",
     nativeModelId: "claude-sonnet-4-6",
   },
   {
     nameSuffix: "opus-4.5",
     family: "opus",
+    launchModel: "opus",
     nativeModelId: "claude-opus-4-5-20251101",
   },
   {
     nameSuffix: "sonnet-4.5",
     family: "sonnet",
+    launchModel: "sonnet",
     nativeModelId: "claude-sonnet-4-5-20250929",
   },
   {
     nameSuffix: "haiku-4.5",
     family: "haiku",
+    launchModel: "haiku",
     nativeModelId: "claude-haiku-4-5-20251001",
+  },
+  {
+    nameSuffix: "gpt-5.1-codex-mini",
+    launchModel: "gpt-5.1-codex-mini",
+    nativeModelId: "gpt-5.1-codex-mini",
+    requiresCustomEndpoint: true,
+    customModelOptionName: "GPT-5.1 Codex Mini",
+    customModelOptionDescription:
+      "Claude Code via an Anthropic-compatible custom endpoint.",
   },
 ];
 
@@ -87,8 +109,49 @@ export function getClaudeModelFamily(
   return getClaudeModelSpecByAgentName(agentName)?.family;
 }
 
+export function getClaudeLaunchModel(
+  agentName: string | undefined,
+): string | undefined {
+  return getClaudeModelSpecByAgentName(agentName)?.launchModel;
+}
+
 export function getClaudeNativeModelId(
   agentName: string | undefined,
 ): string | undefined {
   return getClaudeModelSpecByAgentName(agentName)?.nativeModelId;
+}
+
+export function requiresAnthropicCustomEndpoint(
+  agentName: string | undefined,
+): boolean {
+  return (
+    getClaudeModelSpecByAgentName(agentName)?.requiresCustomEndpoint === true
+  );
+}
+
+export function hasAnthropicCustomEndpointConfigured(options?: {
+  apiKeys?: Record<string, string | undefined>;
+  bypassAnthropicProxy?: boolean;
+  providerOverrides?: Array<{
+    providerId: string;
+    enabled: boolean;
+    baseUrl?: string;
+    apiFormat?: string;
+  }>;
+}): boolean {
+  const userCustomBaseUrl = options?.apiKeys?.ANTHROPIC_BASE_URL?.trim();
+  if (options?.bypassAnthropicProxy && userCustomBaseUrl) {
+    return true;
+  }
+
+  return (
+    options?.providerOverrides?.some(
+      (override) =>
+        override.providerId === "anthropic" &&
+        override.enabled &&
+        Boolean(override.baseUrl?.trim()) &&
+        (override.apiFormat === undefined ||
+          override.apiFormat === "anthropic"),
+    ) ?? false
+  );
 }


### PR DESCRIPTION
## Task

image.png 

 image.png 

we have add backend for let agent claude  allow using claude/gpt-5.1-codex-mini when we using third party ai service proxy, but now user ui is not allow yet; please add the model for claude selection in /dashboard, and add extra model setting in /settings?section=model-catalog /settings?section=models for teams