### PR TITLE
feat(models): add team-managed custom Claude models

### DIFF
--- a/apps/client/src/components/settings/sections/ModelCatalogSection.tsx
+++ b/apps/client/src/components/settings/sections/ModelCatalogSection.tsx
@@ -427,11 +427,6 @@ export function ModelCatalogSection({
     const searchLower = searchQuery.toLowerCase();
 
     const filtered = models.filter((entry) => {
-      // Filter out unavailable models (no API key configured)
-      if (!isModelAvailable(entry)) {
-        return false;
-      }
-
       // Apply search filter
       if (searchQuery) {
         const matchesSearch =
@@ -456,7 +451,7 @@ export function ModelCatalogSection({
 
     // Group by vendor using shared utility (preserves sort order within vendor)
     return groupModelsByVendor(filtered);
-  }, [models, searchQuery, sourceFilter, showDisabledOnly, isModelAvailable]);
+  }, [models, searchQuery, sourceFilter, showDisabledOnly]);
 
   const customClaudeModels = useMemo(
     () =>
@@ -766,6 +761,7 @@ export function ModelCatalogSection({
                         toggleEnabledMutation.isPending &&
                         toggleEnabledMutation.variables?.modelName ===
                           entry.name;
+                      const isAvailable = isModelAvailable(entry);
                       const isDragging = draggedModel === entry.name;
                       const isDragOver = dragOverModel === entry.name;
                       return (
@@ -837,6 +833,12 @@ export function ModelCatalogSection({
                                 <span className="inline-flex items-center gap-0.5 rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
                                   <Zap className="h-2.5 w-2.5" />
                                   Reasoning
+                                </span>
+                              )}
+
+                              {!isAvailable && (
+                                <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                                  Needs setup
                                 </span>
                               )}
 

--- a/apps/client/src/components/settings/sections/ModelCatalogSection.tsx
+++ b/apps/client/src/components/settings/sections/ModelCatalogSection.tsx
@@ -9,7 +9,18 @@ import type { AgentVendor } from "@cmux/shared/agent-catalog";
 import { Switch, Button, Spinner } from "@heroui/react";
 import { useMutation } from "@tanstack/react-query";
 import { useConvex } from "convex/react";
-import { GripVertical, RefreshCw, Search, Database, Zap } from "lucide-react";
+import {
+  GripVertical,
+  RefreshCw,
+  Search,
+  Database,
+  Zap,
+  Pencil,
+  Plus,
+  Save,
+  Trash2,
+  X,
+} from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { cachedGetUser } from "@/lib/cachedGetUser";
@@ -29,7 +40,7 @@ interface Model {
   name: string;
   displayName: string;
   vendor: string;
-  source: "curated" | "discovered";
+  source: "curated" | "discovered" | "custom";
   discoveredFrom?: string;
   discoveredAt?: number;
   requiredApiKeys: string[];
@@ -41,12 +52,17 @@ interface Model {
   disabledReason?: string;
   createdAt: number;
   updatedAt: number;
+  customModelId?: string;
+  customModelDescription?: string;
 }
+
+const CUSTOM_CLAUDE_MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 
 const SOURCE_FILTER_OPTIONS = [
   { value: "all", label: "All Sources" },
   { value: "curated", label: "Curated" },
   { value: "discovered", label: "Discovered" },
+  { value: "custom", label: "Custom" },
 ];
 
 export function ModelCatalogSection({
@@ -55,13 +71,21 @@ export function ModelCatalogSection({
   const convex = useConvex();
   const [searchQuery, setSearchQuery] = useState("");
   const [sourceFilter, setSourceFilter] = useState<
-    "all" | "curated" | "discovered"
+    "all" | "curated" | "discovered" | "custom"
   >("all");
   const [showDisabledOnly, setShowDisabledOnly] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isSeeding, setIsSeeding] = useState(false);
   const [draggedModel, setDraggedModel] = useState<string | null>(null);
   const [dragOverModel, setDragOverModel] = useState<string | null>(null);
+  const [customModelIdInput, setCustomModelIdInput] = useState("");
+  const [customDisplayNameInput, setCustomDisplayNameInput] = useState("");
+  const [customDescriptionInput, setCustomDescriptionInput] = useState("");
+  const [editingCustomModelName, setEditingCustomModelName] = useState<
+    string | null
+  >(null);
+  const [editDisplayNameInput, setEditDisplayNameInput] = useState("");
+  const [editDescriptionInput, setEditDescriptionInput] = useState("");
 
   const { models, refetchModels, isLoading } = useTeamModelCatalog(teamSlugOrId);
   const { isModelAvailable } = useModelAvailability(teamSlugOrId);
@@ -108,11 +132,154 @@ export function ModelCatalogSection({
     },
   });
 
+  const createCustomModelMutation = useMutation({
+    mutationFn: async ({
+      modelId,
+      displayName,
+      description,
+    }: {
+      modelId: string;
+      displayName: string;
+      description?: string;
+    }) => {
+      return await convex.mutation(api.models.createCustomClaudeModel, {
+        teamSlugOrId,
+        modelId,
+        displayName,
+        description,
+      });
+    },
+    onSuccess: () => {
+      toast.success("Custom Claude model added");
+      setCustomModelIdInput("");
+      setCustomDisplayNameInput("");
+      setCustomDescriptionInput("");
+      void refetchModels();
+    },
+    onError: (error) => {
+      toast.error("Failed to add custom Claude model");
+      console.error("Create custom Claude model error:", error);
+    },
+  });
+
+  const updateCustomModelMutation = useMutation({
+    mutationFn: async ({
+      name,
+      displayName,
+      description,
+    }: {
+      name: string;
+      displayName: string;
+      description?: string;
+    }) => {
+      return await convex.mutation(api.models.updateCustomClaudeModel, {
+        teamSlugOrId,
+        name,
+        displayName,
+        description,
+      });
+    },
+    onSuccess: () => {
+      toast.success("Custom Claude model updated");
+      setEditingCustomModelName(null);
+      setEditDisplayNameInput("");
+      setEditDescriptionInput("");
+      void refetchModels();
+    },
+    onError: (error) => {
+      toast.error("Failed to update custom Claude model");
+      console.error("Update custom Claude model error:", error);
+    },
+  });
+
+  const deleteCustomModelMutation = useMutation({
+    mutationFn: async ({ name }: { name: string }) => {
+      return await convex.mutation(api.models.deleteCustomClaudeModel, {
+        teamSlugOrId,
+        name,
+      });
+    },
+    onSuccess: () => {
+      toast.success("Custom Claude model deleted");
+      setEditingCustomModelName(null);
+      setEditDisplayNameInput("");
+      setEditDescriptionInput("");
+      void refetchModels();
+    },
+    onError: (error) => {
+      toast.error("Failed to delete custom Claude model");
+      console.error("Delete custom Claude model error:", error);
+    },
+  });
+
   const handleToggleEnabled = useCallback(
     (modelName: string, enabled: boolean) => {
       toggleEnabledMutation.mutate({ modelName, enabled });
     },
     [toggleEnabledMutation],
+  );
+
+  const handleCreateCustomModel = useCallback(() => {
+    const modelId = customModelIdInput.trim();
+    const displayName = customDisplayNameInput.trim();
+    const description = customDescriptionInput.trim();
+    if (!modelId || !displayName) {
+      toast.error("Model ID and display name are required");
+      return;
+    }
+    if (!CUSTOM_CLAUDE_MODEL_ID_PATTERN.test(modelId)) {
+      toast.error(
+        "Invalid model ID. Use letters, numbers, dot, underscore, colon, or hyphen.",
+      );
+      return;
+    }
+
+    createCustomModelMutation.mutate({
+      modelId,
+      displayName,
+      description: description || undefined,
+    });
+  }, [
+    createCustomModelMutation,
+    customDescriptionInput,
+    customDisplayNameInput,
+    customModelIdInput,
+  ]);
+
+  const startEditingCustomModel = useCallback((model: Model) => {
+    setEditingCustomModelName(model.name);
+    setEditDisplayNameInput(model.displayName);
+    setEditDescriptionInput(model.customModelDescription ?? "");
+  }, []);
+
+  const cancelEditingCustomModel = useCallback(() => {
+    setEditingCustomModelName(null);
+    setEditDisplayNameInput("");
+    setEditDescriptionInput("");
+  }, []);
+
+  const handleSaveCustomModel = useCallback(
+    (name: string) => {
+      const displayName = editDisplayNameInput.trim();
+      const description = editDescriptionInput.trim();
+      if (!displayName) {
+        toast.error("Display name is required");
+        return;
+      }
+      updateCustomModelMutation.mutate({
+        name,
+        displayName,
+        description: description || undefined,
+      });
+    },
+    [editDescriptionInput, editDisplayNameInput, updateCustomModelMutation],
+  );
+
+  const handleDeleteCustomModel = useCallback(
+    (name: string) => {
+      deleteCustomModelMutation.mutate({ name });
+    },
+    [deleteCustomModelMutation],
   );
 
   // Trigger discovery refresh via www API
@@ -291,12 +458,21 @@ export function ModelCatalogSection({
     return groupModelsByVendor(filtered);
   }, [models, searchQuery, sourceFilter, showDisabledOnly, isModelAvailable]);
 
+  const customClaudeModels = useMemo(
+    () =>
+      (models ?? [])
+        .filter((model) => model.source === "custom")
+        .sort((a, b) => a.sortOrder - b.sortOrder),
+    [models],
+  );
+
   const enabledCount = models?.filter((m) => m.enabled).length ?? 0;
   const totalCount = models?.length ?? 0;
   const curatedCount =
     models?.filter((m) => m.source === "curated").length ?? 0;
   const discoveredCount =
     models?.filter((m) => m.source === "discovered").length ?? 0;
+  const customCount = models?.filter((m) => m.source === "custom").length ?? 0;
 
   if (isLoading) {
     return (
@@ -353,9 +529,168 @@ export function ModelCatalogSection({
     <div className="space-y-4">
       <SettingSection
         title="Model Catalog"
-        description={`${enabledCount} of ${totalCount} models enabled (${curatedCount} curated, ${discoveredCount} discovered)`}
+        description={`${enabledCount} of ${totalCount} models enabled (${curatedCount} curated, ${discoveredCount} discovered, ${customCount} custom)`}
       >
         <div className="p-4 space-y-4">
+          <div className="rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
+            <div className="mb-3">
+              <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                Custom Claude Models
+              </h3>
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                Add team-defined Claude model entries routed through an
+                Anthropic-compatible custom endpoint.
+              </p>
+            </div>
+
+            <div className="grid gap-2 sm:grid-cols-3">
+              <input
+                type="text"
+                value={customModelIdInput}
+                onChange={(event) => setCustomModelIdInput(event.target.value)}
+                placeholder="Model ID (e.g. gpt-5.2-codex)"
+                className="rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+              />
+              <input
+                type="text"
+                value={customDisplayNameInput}
+                onChange={(event) =>
+                  setCustomDisplayNameInput(event.target.value)
+                }
+                placeholder="Display name"
+                className="rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+              />
+              <div className="flex items-center gap-2">
+                <Button
+                  color="primary"
+                  isLoading={createCustomModelMutation.isPending}
+                  onPress={handleCreateCustomModel}
+                  startContent={!createCustomModelMutation.isPending && <Plus className="h-4 w-4" />}
+                >
+                  Add
+                </Button>
+              </div>
+            </div>
+
+            <div className="mt-2">
+              <input
+                type="text"
+                value={customDescriptionInput}
+                onChange={(event) =>
+                  setCustomDescriptionInput(event.target.value)
+                }
+                placeholder="Optional description"
+                className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+              />
+            </div>
+
+            <div className="mt-3 space-y-2">
+              {customClaudeModels.length === 0 ? (
+                <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                  No custom Claude models configured for this team.
+                </p>
+              ) : (
+                customClaudeModels.map((model) => {
+                  const isEditing = editingCustomModelName === model.name;
+                  const isDeleting =
+                    deleteCustomModelMutation.isPending &&
+                    deleteCustomModelMutation.variables?.name === model.name;
+                  const isSaving =
+                    updateCustomModelMutation.isPending &&
+                    updateCustomModelMutation.variables?.name === model.name;
+
+                  return (
+                    <div
+                      key={model.name}
+                      className="rounded-lg border border-neutral-200 px-3 py-2 dark:border-neutral-800"
+                    >
+                      {isEditing ? (
+                        <div className="space-y-2">
+                          <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                            {model.name}
+                          </p>
+                          <input
+                            type="text"
+                            value={editDisplayNameInput}
+                            onChange={(event) =>
+                              setEditDisplayNameInput(event.target.value)
+                            }
+                            placeholder="Display name"
+                            className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+                          />
+                          <input
+                            type="text"
+                            value={editDescriptionInput}
+                            onChange={(event) =>
+                              setEditDescriptionInput(event.target.value)
+                            }
+                            placeholder="Optional description"
+                            className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-500"
+                          />
+                          <div className="flex items-center gap-2">
+                            <Button
+                              size="sm"
+                              color="primary"
+                              isLoading={isSaving}
+                              onPress={() => handleSaveCustomModel(model.name)}
+                              startContent={!isSaving && <Save className="h-3.5 w-3.5" />}
+                            >
+                              Save
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="bordered"
+                              onPress={cancelEditingCustomModel}
+                              startContent={<X className="h-3.5 w-3.5" />}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100 truncate">
+                              {model.displayName}
+                            </p>
+                            <p className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
+                              {model.name}
+                            </p>
+                            {model.customModelDescription ? (
+                              <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+                                {model.customModelDescription}
+                              </p>
+                            ) : null}
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Button
+                              size="sm"
+                              variant="light"
+                              onPress={() => startEditingCustomModel(model)}
+                              startContent={<Pencil className="h-3.5 w-3.5" />}
+                            >
+                              Edit
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="light"
+                              color="danger"
+                              isLoading={isDeleting}
+                              onPress={() => handleDeleteCustomModel(model.name)}
+                              startContent={!isDeleting && <Trash2 className="h-3.5 w-3.5" />}
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </div>
+
           {/* Controls */}
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-1 items-center gap-3">
@@ -376,7 +711,7 @@ export function ModelCatalogSection({
                 value={sourceFilter}
                 onChange={(e) =>
                   setSourceFilter(
-                    e.target.value as "all" | "curated" | "discovered",
+                    e.target.value as "all" | "curated" | "discovered" | "custom",
                   )
                 }
                 className="rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
@@ -474,6 +809,10 @@ export function ModelCatalogSection({
                               {entry.source === "curated" ? (
                                 <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
                                   Curated
+                                </span>
+                              ) : entry.source === "custom" ? (
+                                <span className="inline-flex items-center rounded-full bg-teal-100 px-2 py-0.5 text-[10px] font-medium text-teal-700 dark:bg-teal-900/30 dark:text-teal-400">
+                                  Custom
                                 </span>
                               ) : (
                                 <span className="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-[10px] font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">

--- a/apps/www/app/(home)/settings/models/models-client.tsx
+++ b/apps/www/app/(home)/settings/models/models-client.tsx
@@ -10,7 +10,7 @@ type Model = {
   name: string;
   displayName: string;
   vendor: string;
-  source: "curated" | "discovered";
+  source: "curated" | "discovered" | "custom";
   discoveredFrom?: string;
   requiredApiKeys: string[];
   tier: "free" | "paid";

--- a/packages/convex/convex/models.ts
+++ b/packages/convex/convex/models.ts
@@ -14,6 +14,25 @@ const CUSTOM_CLAUDE_AGENT_PREFIX = "claude/";
 const CUSTOM_CLAUDE_DEFAULT_CONTEXT_WINDOW = 200000;
 const CUSTOM_CLAUDE_DEFAULT_MAX_OUTPUT_TOKENS = 32000;
 const CUSTOM_CLAUDE_MODEL_TAGS = ["custom", "proxy"] as const;
+const LEGACY_PRESEEDED_CUSTOM_CLAUDE_MODEL_NAMES = new Set([
+  "claude/gpt-5.1-codex-mini",
+]);
+
+function isLegacyPreseededCustomClaudeModel(model: {
+  name: string;
+  source?: string;
+}): boolean {
+  return (
+    model.source === "curated" &&
+    LEGACY_PRESEEDED_CUSTOM_CLAUDE_MODEL_NAMES.has(model.name)
+  );
+}
+
+function filterLegacyPreseededCustomClaudeModels<
+  T extends { name: string; source?: string },
+>(models: T[]): T[] {
+  return models.filter((model) => !isLegacyPreseededCustomClaudeModel(model));
+}
 
 function normalizeCustomClaudeModelId(rawModelId: string): string {
   return rawModelId.trim();
@@ -118,7 +137,9 @@ export const list = query({
       .query("models")
       .withIndex("by_enabled", (q) => q.eq("enabled", true))
       .collect();
-    return models.sort((a, b) => a.sortOrder - b.sortOrder);
+    return filterLegacyPreseededCustomClaudeModels(models).sort(
+      (a, b) => a.sortOrder - b.sortOrder,
+    );
   },
 });
 
@@ -146,7 +167,9 @@ export const listAll = authQuery({
 
     const hiddenModels = new Set(teamVisibility?.hiddenModels ?? []);
     const mergedModels = [
-      ...models.map((model) => applyCatalogVariantOverrides(model)),
+      ...filterLegacyPreseededCustomClaudeModels(models).map((model) =>
+        applyCatalogVariantOverrides(model),
+      ),
       ...customClaudeModels.map((model) => toCustomClaudeModelCatalogEntry(model)),
     ].sort((a, b) => a.sortOrder - b.sortOrder);
 
@@ -210,7 +233,9 @@ export const listAvailable = authQuery({
       .filter((model) => model.enabled)
       .map((model) => toCustomClaudeModelCatalogEntry(model));
     const mergedModels = [
-      ...models.map((model) => applyCatalogVariantOverrides(model)),
+      ...filterLegacyPreseededCustomClaudeModels(models).map((model) =>
+        applyCatalogVariantOverrides(model),
+      ),
       ...enabledCustomClaudeModels,
     ].sort((a, b) => a.sortOrder - b.sortOrder);
 
@@ -461,13 +486,27 @@ export const createCustomClaudeModel = authMutation({
           .collect(),
       ]);
 
-    if (existingGlobalModel || existingCustomModel) {
+    const hasLegacyGlobalCollision =
+      existingGlobalModel !== null &&
+      isLegacyPreseededCustomClaudeModel(existingGlobalModel);
+
+    if (existingGlobalModel && !hasLegacyGlobalCollision) {
       throw new Error(`Model already exists: ${name}`);
+    }
+
+    if (existingCustomModel) {
+      throw new Error(`Model already exists: ${name}`);
+    }
+
+    if (existingGlobalModel && hasLegacyGlobalCollision) {
+      await ctx.db.delete(existingGlobalModel._id);
     }
 
     const maxSortOrder = Math.max(
       -1,
-      ...allModels.map((model) => model.sortOrder),
+      ...filterLegacyPreseededCustomClaudeModels(allModels).map(
+        (model) => model.sortOrder,
+      ),
       ...allTeamCustomModels.map((model) => model.sortOrder),
     );
     const now = Date.now();

--- a/packages/convex/convex/models.ts
+++ b/packages/convex/convex/models.ts
@@ -9,6 +9,62 @@ import {
   requiresAnthropicCustomEndpoint,
 } from "@cmux/shared/providers/anthropic/models";
 
+const CUSTOM_CLAUDE_MODEL_ID_REGEX = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const CUSTOM_CLAUDE_AGENT_PREFIX = "claude/";
+const CUSTOM_CLAUDE_DEFAULT_CONTEXT_WINDOW = 200000;
+const CUSTOM_CLAUDE_DEFAULT_MAX_OUTPUT_TOKENS = 32000;
+const CUSTOM_CLAUDE_MODEL_TAGS = ["custom", "proxy"] as const;
+
+function normalizeCustomClaudeModelId(rawModelId: string): string {
+  return rawModelId.trim();
+}
+
+function normalizeOptionalDescription(rawDescription: string | undefined): string | undefined {
+  const normalized = rawDescription?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function buildCustomClaudeModelName(modelId: string): string {
+  return `${CUSTOM_CLAUDE_AGENT_PREFIX}${modelId}`;
+}
+
+function toCustomClaudeModelCatalogEntry(
+  customModel: {
+    _id: string;
+    name: string;
+    modelId: string;
+    displayName: string;
+    description?: string;
+    enabled: boolean;
+    sortOrder: number;
+    createdAt: number;
+    updatedAt: number;
+  },
+) {
+  return {
+    _id: customModel._id,
+    name: customModel.name,
+    displayName: customModel.displayName,
+    vendor: "anthropic",
+    source: "custom" as const,
+    requiredApiKeys: ["ANTHROPIC_API_KEY"],
+    tier: "paid" as const,
+    tags: [...CUSTOM_CLAUDE_MODEL_TAGS],
+    enabled: customModel.enabled,
+    sortOrder: customModel.sortOrder,
+    variants: [],
+    defaultVariant: undefined,
+    disabled: false,
+    disabledReason: undefined,
+    contextWindow: CUSTOM_CLAUDE_DEFAULT_CONTEXT_WINDOW,
+    maxOutputTokens: CUSTOM_CLAUDE_DEFAULT_MAX_OUTPUT_TOKENS,
+    createdAt: customModel.createdAt,
+    updatedAt: customModel.updatedAt,
+    customModelId: customModel.modelId,
+    customModelDescription: customModel.description,
+  };
+}
+
 function catalogDefinesVariants(
   catalogEntry: (typeof AGENT_CATALOG)[number] | undefined,
 ): boolean {
@@ -76,8 +132,12 @@ export const listAll = authQuery({
   handler: async (ctx, args) => {
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
 
-    const [models, teamVisibility] = await Promise.all([
+    const [models, customClaudeModels, teamVisibility] = await Promise.all([
       ctx.db.query("models").collect(),
+      ctx.db
+        .query("teamCustomClaudeModels")
+        .withIndex("by_team", (q) => q.eq("teamId", teamId))
+        .collect(),
       ctx.db
         .query("teamModelVisibility")
         .withIndex("by_team", (q) => q.eq("teamId", teamId))
@@ -85,11 +145,14 @@ export const listAll = authQuery({
     ]);
 
     const hiddenModels = new Set(teamVisibility?.hiddenModels ?? []);
+    const mergedModels = [
+      ...models.map((model) => applyCatalogVariantOverrides(model)),
+      ...customClaudeModels.map((model) => toCustomClaudeModelCatalogEntry(model)),
+    ].sort((a, b) => a.sortOrder - b.sortOrder);
 
-    return models
-      .sort((a, b) => a.sortOrder - b.sortOrder)
+    return mergedModels
       .map((model) => ({
-        ...applyCatalogVariantOverrides(model),
+        ...model,
         hiddenForTeam: hiddenModels.has(model.name),
       }));
   },
@@ -114,11 +177,15 @@ export const listAvailable = authQuery({
       `[listAvailable] teamSlugOrId=${args.teamSlugOrId}, resolved teamId=${teamId}`,
     );
 
-    const [models, teamVisibility, workspaceSettings, anthropicOverride] =
+    const [models, customClaudeModels, teamVisibility, workspaceSettings, anthropicOverride] =
       await Promise.all([
         ctx.db
           .query("models")
           .withIndex("by_enabled", (q) => q.eq("enabled", true))
+          .collect(),
+        ctx.db
+          .query("teamCustomClaudeModels")
+          .withIndex("by_team", (q) => q.eq("teamId", teamId))
           .collect(),
         ctx.db
           .query("teamModelVisibility")
@@ -139,20 +206,26 @@ export const listAvailable = authQuery({
       ]);
     const hiddenModels = new Set(teamVisibility?.hiddenModels ?? []);
 
-    console.log(`[listAvailable] Found ${models.length} enabled models`);
+    const enabledCustomClaudeModels = customClaudeModels
+      .filter((model) => model.enabled)
+      .map((model) => toCustomClaudeModelCatalogEntry(model));
+    const mergedModels = [
+      ...models.map((model) => applyCatalogVariantOverrides(model)),
+      ...enabledCustomClaudeModels,
+    ].sort((a, b) => a.sortOrder - b.sortOrder);
+
+    console.log(`[listAvailable] Found ${mergedModels.length} enabled models`);
     console.log(
       `[listAvailable] Found ${hiddenModels.size} team-hidden models`,
     );
 
-    const visibleModels = models.filter(
+    const visibleModels = mergedModels.filter(
       (model) => !hiddenModels.has(model.name),
     );
 
     // If showAll is true, return all team-visible enabled models without credential filtering
     if (args.showAll) {
-      return visibleModels
-        .sort((a, b) => a.sortOrder - b.sortOrder)
-        .map((model) => applyCatalogVariantOverrides(model));
+      return visibleModels.sort((a, b) => a.sortOrder - b.sortOrder);
     }
 
     // Get team's configured API keys
@@ -219,9 +292,7 @@ export const listAvailable = authQuery({
     console.log(
       `[listAvailable] Returning ${availableModels.length} available models`,
     );
-    return availableModels
-      .sort((a, b) => a.sortOrder - b.sortOrder)
-      .map((model) => applyCatalogVariantOverrides(model));
+    return availableModels.sort((a, b) => a.sortOrder - b.sortOrder);
   },
 });
 
@@ -236,23 +307,40 @@ export const setEnabled = authMutation({
   },
   handler: async (ctx, args) => {
     // Verify user has access to the team
-    await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
 
-    const model = await ctx.db
-      .query("models")
-      .withIndex("by_name", (q) => q.eq("name", args.modelName))
-      .first();
+    const [model, customModel] = await Promise.all([
+      ctx.db
+        .query("models")
+        .withIndex("by_name", (q) => q.eq("name", args.modelName))
+        .first(),
+      ctx.db
+        .query("teamCustomClaudeModels")
+        .withIndex("by_team_name", (q) =>
+          q.eq("teamId", teamId).eq("name", args.modelName),
+        )
+        .first(),
+    ]);
 
-    if (!model) {
-      throw new Error(`Model not found: ${args.modelName}`);
+    if (customModel) {
+      await ctx.db.patch(customModel._id, {
+        enabled: args.enabled,
+        updatedAt: Date.now(),
+        updatedBy: userId,
+      });
+      return { success: true };
     }
 
-    await ctx.db.patch(model._id, {
-      enabled: args.enabled,
-      updatedAt: Date.now(),
-    });
+    if (model) {
+      await ctx.db.patch(model._id, {
+        enabled: args.enabled,
+        updatedAt: Date.now(),
+      });
+      return { success: true };
+    }
 
-    return { success: true };
+    throw new Error(`Model not found: ${args.modelName}`);
   },
 });
 
@@ -267,38 +355,221 @@ export const reorder = authMutation({
   },
   handler: async (ctx, args) => {
     // Verify user has access to the team
-    await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
 
     const now = Date.now();
+    const [models, customModels] = await Promise.all([
+      ctx.db.query("models").collect(),
+      ctx.db
+        .query("teamCustomClaudeModels")
+        .withIndex("by_team", (q) => q.eq("teamId", teamId))
+        .collect(),
+    ]);
 
-    // Batch fetch all models by name using parallel queries
-    const models = await Promise.all(
-      args.modelNames.map((name) =>
+    const modelByName = new Map(models.map((model) => [model.name, model]));
+    const customModelByName = new Map(
+      customModels.map((model) => [model.name, model]),
+    );
+
+    const patches: Array<Promise<unknown>> = [];
+    args.modelNames.forEach((name, index) => {
+      const model = modelByName.get(name);
+      if (model) {
+        patches.push(
+          ctx.db.patch(model._id, {
+            sortOrder: index,
+            updatedAt: now,
+          }),
+        );
+      }
+
+      const customModel = customModelByName.get(name);
+      if (customModel) {
+        patches.push(
+          ctx.db.patch(customModel._id, {
+            sortOrder: index,
+            updatedAt: now,
+            updatedBy: userId,
+          }),
+        );
+      }
+    });
+
+    await Promise.all(patches);
+
+    return { success: true };
+  },
+});
+
+/**
+ * Team query: list custom Claude models configured for this team.
+ */
+export const listTeamCustomClaudeModels = authQuery({
+  args: {
+    teamSlugOrId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    return ctx.db
+      .query("teamCustomClaudeModels")
+      .withIndex("by_team_sort_order", (q) => q.eq("teamId", teamId))
+      .collect();
+  },
+});
+
+/**
+ * Team mutation: create a custom Claude model entry.
+ */
+export const createCustomClaudeModel = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    modelId: v.string(),
+    displayName: v.string(),
+    description: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const modelId = normalizeCustomClaudeModelId(args.modelId);
+    if (!CUSTOM_CLAUDE_MODEL_ID_REGEX.test(modelId)) {
+      throw new Error(
+        "Invalid model ID. Use letters, numbers, dot, underscore, colon, or hyphen.",
+      );
+    }
+
+    const displayName = args.displayName.trim();
+    if (!displayName) {
+      throw new Error("Display name is required");
+    }
+
+    const name = buildCustomClaudeModelName(modelId);
+    const [existingGlobalModel, existingCustomModel, allModels, allTeamCustomModels] =
+      await Promise.all([
         ctx.db
           .query("models")
           .withIndex("by_name", (q) => q.eq("name", name))
           .first(),
-      ),
-    );
+        ctx.db
+          .query("teamCustomClaudeModels")
+          .withIndex("by_team_name", (q) => q.eq("teamId", teamId).eq("name", name))
+          .first(),
+        ctx.db.query("models").collect(),
+        ctx.db
+          .query("teamCustomClaudeModels")
+          .withIndex("by_team", (q) => q.eq("teamId", teamId))
+          .collect(),
+      ]);
 
-    // Build name-to-model map for efficient lookup
-    const modelByName = new Map(
-      args.modelNames.map((name, i) => [name, models[i]]),
-    );
+    if (existingGlobalModel || existingCustomModel) {
+      throw new Error(`Model already exists: ${name}`);
+    }
 
-    // Batch update all models with new sort orders
-    await Promise.all(
-      args.modelNames.map((name, i) => {
-        const model = modelByName.get(name);
-        if (model) {
-          return ctx.db.patch(model._id, {
-            sortOrder: i,
-            updatedAt: now,
-          });
-        }
-        return Promise.resolve();
-      }),
+    const maxSortOrder = Math.max(
+      -1,
+      ...allModels.map((model) => model.sortOrder),
+      ...allTeamCustomModels.map((model) => model.sortOrder),
     );
+    const now = Date.now();
+
+    const insertedId = await ctx.db.insert("teamCustomClaudeModels", {
+      teamId,
+      name,
+      modelId,
+      displayName,
+      description: normalizeOptionalDescription(args.description),
+      enabled: true,
+      sortOrder: maxSortOrder + 1,
+      createdAt: now,
+      updatedAt: now,
+      createdBy: userId,
+      updatedBy: userId,
+    });
+
+    return {
+      success: true,
+      modelId: insertedId,
+      name,
+    };
+  },
+});
+
+/**
+ * Team mutation: update display metadata for a custom Claude model.
+ */
+export const updateCustomClaudeModel = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    name: v.string(),
+    displayName: v.string(),
+    description: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+    const displayName = args.displayName.trim();
+    if (!displayName) {
+      throw new Error("Display name is required");
+    }
+
+    const customModel = await ctx.db
+      .query("teamCustomClaudeModels")
+      .withIndex("by_team_name", (q) => q.eq("teamId", teamId).eq("name", args.name))
+      .first();
+
+    if (!customModel) {
+      throw new Error(`Custom Claude model not found: ${args.name}`);
+    }
+
+    await ctx.db.patch(customModel._id, {
+      displayName,
+      description: normalizeOptionalDescription(args.description),
+      updatedAt: Date.now(),
+      updatedBy: userId,
+    });
+
+    return { success: true };
+  },
+});
+
+/**
+ * Team mutation: delete a custom Claude model.
+ */
+export const deleteCustomClaudeModel = authMutation({
+  args: {
+    teamSlugOrId: v.string(),
+    name: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = ctx.identity.subject;
+    const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
+
+    const [customModel, teamVisibility] = await Promise.all([
+      ctx.db
+        .query("teamCustomClaudeModels")
+        .withIndex("by_team_name", (q) => q.eq("teamId", teamId).eq("name", args.name))
+        .first(),
+      ctx.db
+        .query("teamModelVisibility")
+        .withIndex("by_team", (q) => q.eq("teamId", teamId))
+        .first(),
+    ]);
+
+    if (!customModel) {
+      throw new Error(`Custom Claude model not found: ${args.name}`);
+    }
+
+    await ctx.db.delete(customModel._id);
+
+    if (teamVisibility?.hiddenModels.includes(args.name)) {
+      await ctx.db.patch(teamVisibility._id, {
+        hiddenModels: teamVisibility.hiddenModels.filter(
+          (modelName) => modelName !== args.name,
+        ),
+        updatedAt: Date.now(),
+        updatedBy: userId,
+      });
+    }
 
     return { success: true };
   },

--- a/packages/convex/convex/models.ts
+++ b/packages/convex/convex/models.ts
@@ -137,7 +137,8 @@ export const list = query({
       .query("models")
       .withIndex("by_enabled", (q) => q.eq("enabled", true))
       .collect();
-    return filterLegacyPreseededCustomClaudeModels(models).sort(
+    const visibleGlobalModels = filterLegacyPreseededCustomClaudeModels(models);
+    return visibleGlobalModels.sort(
       (a, b) => a.sortOrder - b.sortOrder,
     );
   },
@@ -166,8 +167,9 @@ export const listAll = authQuery({
     ]);
 
     const hiddenModels = new Set(teamVisibility?.hiddenModels ?? []);
+    const visibleGlobalModels = filterLegacyPreseededCustomClaudeModels(models);
     const mergedModels = [
-      ...filterLegacyPreseededCustomClaudeModels(models).map((model) =>
+      ...visibleGlobalModels.map((model) =>
         applyCatalogVariantOverrides(model),
       ),
       ...customClaudeModels.map((model) => toCustomClaudeModelCatalogEntry(model)),
@@ -232,8 +234,9 @@ export const listAvailable = authQuery({
     const enabledCustomClaudeModels = customClaudeModels
       .filter((model) => model.enabled)
       .map((model) => toCustomClaudeModelCatalogEntry(model));
+    const visibleGlobalModels = filterLegacyPreseededCustomClaudeModels(models);
     const mergedModels = [
-      ...filterLegacyPreseededCustomClaudeModels(models).map((model) =>
+      ...visibleGlobalModels.map((model) =>
         applyCatalogVariantOverrides(model),
       ),
       ...enabledCustomClaudeModels,
@@ -486,11 +489,10 @@ export const createCustomClaudeModel = authMutation({
           .collect(),
       ]);
 
-    const hasLegacyGlobalCollision =
-      existingGlobalModel !== null &&
-      isLegacyPreseededCustomClaudeModel(existingGlobalModel);
-
-    if (existingGlobalModel && !hasLegacyGlobalCollision) {
+    if (
+      existingGlobalModel &&
+      !isLegacyPreseededCustomClaudeModel(existingGlobalModel)
+    ) {
       throw new Error(`Model already exists: ${name}`);
     }
 
@@ -498,7 +500,7 @@ export const createCustomClaudeModel = authMutation({
       throw new Error(`Model already exists: ${name}`);
     }
 
-    if (existingGlobalModel && hasLegacyGlobalCollision) {
+    if (existingGlobalModel) {
       await ctx.db.delete(existingGlobalModel._id);
     }
 

--- a/packages/convex/convex/schema.ts
+++ b/packages/convex/convex/schema.ts
@@ -939,6 +939,24 @@ const convexSchema = defineSchema({
     updatedBy: v.optional(v.string()),
   }).index("by_team", ["teamId"]),
 
+  // Team-scoped custom Claude models surfaced in settings/dashboard model pickers.
+  teamCustomClaudeModels: defineTable({
+    teamId: v.string(),
+    name: v.string(), // Agent name, e.g. "claude/gpt-5.1-codex-mini-custom"
+    modelId: v.string(), // Model ID sent to Anthropic-compatible endpoint
+    displayName: v.string(),
+    description: v.optional(v.string()),
+    enabled: v.boolean(),
+    sortOrder: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    createdBy: v.optional(v.string()),
+    updatedBy: v.optional(v.string()),
+  })
+    .index("by_team", ["teamId"])
+    .index("by_team_name", ["teamId", "name"])
+    .index("by_team_sort_order", ["teamId", "sortOrder"]),
+
   // Source repo mappings for Codex-style worktrees
   // Maps projects to local repo paths per user
   sourceRepoMappings: defineTable({

--- a/packages/convex/convex/teamModelVisibility.ts
+++ b/packages/convex/convex/teamModelVisibility.ts
@@ -35,10 +35,16 @@ export const toggleModel = authMutation({
     const teamId = await resolveTeamIdLoose(ctx, args.teamSlugOrId);
 
     // Parallel fetch: validate model exists while fetching team visibility
-    const [model, existing] = await Promise.all([
+    const [model, customModel, existing] = await Promise.all([
       ctx.db
         .query("models")
         .withIndex("by_name", (q) => q.eq("name", args.modelName))
+        .first(),
+      ctx.db
+        .query("teamCustomClaudeModels")
+        .withIndex("by_team_name", (q) =>
+          q.eq("teamId", teamId).eq("name", args.modelName),
+        )
         .first(),
       ctx.db
         .query("teamModelVisibility")
@@ -46,7 +52,7 @@ export const toggleModel = authMutation({
         .first(),
     ]);
 
-    if (!model) {
+    if (!model && !customModel) {
       throw new Error(`Model not found: ${args.modelName}`);
     }
 

--- a/packages/shared/src/agent-selection.ts
+++ b/packages/shared/src/agent-selection.ts
@@ -8,7 +8,7 @@ import {
   createCodexVariantConfig,
   type CodexReasoningEffort,
 } from "./providers/openai/configs";
-import { createDynamicClaudeConfig } from "./providers/anthropic/configs";
+import * as anthropicConfigs from "./providers/anthropic/configs";
 import { createOpencodeFreeDynamicConfig } from "./providers/opencode/configs";
 import {
   resolveModelForTaskClass,
@@ -36,7 +36,8 @@ function resolveAgentConfig(
     return staticConfig;
   }
 
-  const dynamicClaudeConfig = createDynamicClaudeConfig(agentName);
+  const dynamicClaudeConfig =
+    anthropicConfigs.createDynamicClaudeConfig?.(agentName);
   if (dynamicClaudeConfig) {
     return dynamicClaudeConfig;
   }

--- a/packages/shared/src/agent-selection.ts
+++ b/packages/shared/src/agent-selection.ts
@@ -8,6 +8,7 @@ import {
   createCodexVariantConfig,
   type CodexReasoningEffort,
 } from "./providers/openai/configs";
+import { createDynamicClaudeConfig } from "./providers/anthropic/configs";
 import { createOpencodeFreeDynamicConfig } from "./providers/opencode/configs";
 import {
   resolveModelForTaskClass,
@@ -33,6 +34,11 @@ function resolveAgentConfig(
   );
   if (staticConfig) {
     return staticConfig;
+  }
+
+  const dynamicClaudeConfig = createDynamicClaudeConfig(agentName);
+  if (dynamicClaudeConfig) {
+    return dynamicClaudeConfig;
   }
 
   const dynamicOpenCodeConfig = createOpencodeFreeDynamicConfig(agentName);

--- a/packages/shared/src/provider-registry.test.ts
+++ b/packages/shared/src/provider-registry.test.ts
@@ -356,13 +356,6 @@ describe("CLAUDE_MODEL_SPECS", () => {
         nativeModelId: "claude-haiku-4-5-20251001",
         requiresCustomEndpoint: false,
       },
-      {
-        nameSuffix: "gpt-5.1-codex-mini",
-        family: undefined,
-        launchModel: "gpt-5.1-codex-mini",
-        nativeModelId: "gpt-5.1-codex-mini",
-        requiresCustomEndpoint: true,
-      },
     ]);
   });
 });

--- a/packages/shared/src/providers/anthropic/catalog.test.ts
+++ b/packages/shared/src/providers/anthropic/catalog.test.ts
@@ -53,15 +53,6 @@ describe("CLAUDE_CATALOG", () => {
     expect(haiku?.tags).toContain("fast");
   });
 
-  it("includes GPT-5.1 Codex Mini as a proxy-backed Claude model", () => {
-    const model = CLAUDE_CATALOG.find(
-      (e) => e.name === "claude/gpt-5.1-codex-mini",
-    );
-    expect(model).toBeDefined();
-    expect(model?.requiredApiKeys).toEqual(["ANTHROPIC_API_KEY"]);
-    expect(model?.tags).toContain("proxy");
-  });
-
   it("all tiers are paid", () => {
     for (const entry of CLAUDE_CATALOG) {
       expect(entry.tier).toBe("paid");

--- a/packages/shared/src/providers/anthropic/catalog.ts
+++ b/packages/shared/src/providers/anthropic/catalog.ts
@@ -100,17 +100,4 @@ export const CLAUDE_CATALOG: AgentCatalogEntry[] = [
     contextWindow: 200000,
     maxOutputTokens: 8000,
   },
-  {
-    name: "claude/gpt-5.1-codex-mini",
-    displayName: "GPT-5.1 Codex Mini",
-    description:
-      "Claude Code routed to GPT-5.1 Codex Mini through an Anthropic-compatible custom endpoint.",
-    vendor: "anthropic",
-    requiredApiKeys: ["ANTHROPIC_API_KEY"],
-    tier: "paid",
-    tags: ["fast", "custom", "proxy"],
-    variants: [],
-    contextWindow: 200000,
-    maxOutputTokens: 32000,
-  },
 ];

--- a/packages/shared/src/providers/anthropic/configs.test.ts
+++ b/packages/shared/src/providers/anthropic/configs.test.ts
@@ -3,6 +3,7 @@ import {
   CLAUDE_AGENT_CONFIGS,
   createApplyClaudeApiKeys,
   createApplyClaudeApiKeysWithOptions,
+  createDynamicClaudeConfig,
 } from "./configs";
 import { ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN } from "../../apiKeys";
 
@@ -225,5 +226,21 @@ describe("CLAUDE_AGENT_CONFIGS", () => {
       expect(config).toBeDefined();
       expect(config?.args).toContain("gpt-5.1-codex-mini");
     });
+  });
+});
+
+describe("createDynamicClaudeConfig", () => {
+  it("creates proxy-only Claude configs for valid custom model names", () => {
+    const config = createDynamicClaudeConfig("claude/custom-model-01");
+    expect(config).toBeDefined();
+    expect(config?.name).toBe("claude/custom-model-01");
+    expect(config?.args).toContain("--model");
+    expect(config?.args).toContain("custom-model-01");
+    expect(config?.apiKeys).toEqual([ANTHROPIC_API_KEY]);
+  });
+
+  it("returns undefined for invalid custom model names", () => {
+    expect(createDynamicClaudeConfig("claude/custom/model/01")).toBeUndefined();
+    expect(createDynamicClaudeConfig("codex/gpt-5.4")).toBeUndefined();
   });
 });

--- a/packages/shared/src/providers/anthropic/configs.test.ts
+++ b/packages/shared/src/providers/anthropic/configs.test.ts
@@ -175,14 +175,10 @@ describe("CLAUDE_AGENT_CONFIGS", () => {
     }
   });
 
-  it("native configs keep OAuth + API key while proxy-only config uses API key only", () => {
+  it("native Claude configs keep OAuth + API key support", () => {
     for (const config of CLAUDE_AGENT_CONFIGS) {
       expect(config.apiKeys).toContain(ANTHROPIC_API_KEY);
-      if (config.name === "claude/gpt-5.1-codex-mini") {
-        expect(config.apiKeys).not.toContain(CLAUDE_CODE_OAUTH_TOKEN);
-      } else {
-        expect(config.apiKeys).toContain(CLAUDE_CODE_OAUTH_TOKEN);
-      }
+      expect(config.apiKeys).toContain(CLAUDE_CODE_OAUTH_TOKEN);
     }
   });
 
@@ -219,13 +215,6 @@ describe("CLAUDE_AGENT_CONFIGS", () => {
       expect(config?.args).toContain("haiku");
     });
 
-    it("includes GPT-5.1 Codex Mini as a direct custom model launch", () => {
-      const config = CLAUDE_AGENT_CONFIGS.find(
-        (c) => c.name === "claude/gpt-5.1-codex-mini",
-      );
-      expect(config).toBeDefined();
-      expect(config?.args).toContain("gpt-5.1-codex-mini");
-    });
   });
 });
 
@@ -242,5 +231,11 @@ describe("createDynamicClaudeConfig", () => {
   it("returns undefined for invalid custom model names", () => {
     expect(createDynamicClaudeConfig("claude/custom/model/01")).toBeUndefined();
     expect(createDynamicClaudeConfig("codex/gpt-5.4")).toBeUndefined();
+  });
+
+  it("supports previously pre-seeded proxy model ids as custom entries", () => {
+    const config = createDynamicClaudeConfig("claude/gpt-5.1-codex-mini");
+    expect(config).toBeDefined();
+    expect(config?.apiKeys).toEqual([ANTHROPIC_API_KEY]);
   });
 });

--- a/packages/shared/src/providers/anthropic/configs.ts
+++ b/packages/shared/src/providers/anthropic/configs.ts
@@ -68,19 +68,17 @@ export function createApplyClaudeApiKeysWithOptions(options?: {
   };
 }
 
-function createClaudeConfig(nameSuffix: string): AgentConfig {
-  const spec = getClaudeModelSpecByAgentName(`claude/${nameSuffix}`);
-  if (!spec) {
-    throw new Error(`Unknown Claude model family for ${nameSuffix}`);
-  }
-
+function createClaudeConfigFromSpec(
+  spec: NonNullable<ReturnType<typeof getClaudeModelSpecByAgentName>>,
+  agentName: string,
+): AgentConfig {
   const allowOAuth = !spec.requiresCustomEndpoint;
   const apiKeys = allowOAuth
     ? [CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY]
     : [ANTHROPIC_API_KEY];
 
   return {
-    name: `claude/${nameSuffix}`,
+    name: agentName,
     command: "claude",
     args: [
       "--allow-dangerously-skip-permissions",
@@ -98,6 +96,30 @@ function createClaudeConfig(nameSuffix: string): AgentConfig {
   };
 }
 
+function createClaudeConfig(nameSuffix: string): AgentConfig {
+  const agentName = `claude/${nameSuffix}`;
+  const spec = getClaudeModelSpecByAgentName(agentName);
+  if (!spec) {
+    throw new Error(`Unknown Claude model family for ${nameSuffix}`);
+  }
+  return createClaudeConfigFromSpec(spec, agentName);
+}
+
 export const CLAUDE_AGENT_CONFIGS: AgentConfig[] = CLAUDE_MODEL_SPECS.map(
   (spec) => createClaudeConfig(spec.nameSuffix),
 );
+
+export function createDynamicClaudeConfig(
+  agentName: string,
+): AgentConfig | undefined {
+  if (!agentName.startsWith("claude/")) {
+    return undefined;
+  }
+
+  const spec = getClaudeModelSpecByAgentName(agentName);
+  if (!spec) {
+    return undefined;
+  }
+
+  return createClaudeConfigFromSpec(spec, agentName);
+}

--- a/packages/shared/src/providers/anthropic/environment.test.ts
+++ b/packages/shared/src/providers/anthropic/environment.test.ts
@@ -443,7 +443,7 @@ describe("getClaudeEnvironment", () => {
 
     expect(env.ANTHROPIC_BASE_URL).toBe("https://gateway.example.com");
     expect(env.ANTHROPIC_CUSTOM_MODEL_OPTION).toBe("gpt-5.1-codex-mini");
-    expect(env.ANTHROPIC_CUSTOM_MODEL_OPTION_NAME).toBe("GPT-5.1 Codex Mini");
+    expect(env.ANTHROPIC_CUSTOM_MODEL_OPTION_NAME).toBe("gpt-5.1-codex-mini");
   });
 
   it("rejects proxy-only Claude models without a custom endpoint", async () => {

--- a/packages/shared/src/providers/anthropic/models.test.ts
+++ b/packages/shared/src/providers/anthropic/models.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getClaudeModelSpecByAgentName,
   hasAnthropicCustomEndpointConfigured,
   requiresAnthropicCustomEndpoint,
 } from "./models";
@@ -10,6 +11,30 @@ describe("anthropic model helpers", () => {
       true,
     );
     expect(requiresAnthropicCustomEndpoint("claude/opus-4.6")).toBe(false);
+  });
+
+  it("treats unknown claude/* names as custom-endpoint models", () => {
+    expect(requiresAnthropicCustomEndpoint("claude/my-proxy-model-01")).toBe(
+      true,
+    );
+    expect(requiresAnthropicCustomEndpoint("claude/my/proxy/model")).toBe(
+      false,
+    );
+  });
+
+  it("builds dynamic model specs for valid custom claude models", () => {
+    expect(getClaudeModelSpecByAgentName("claude/my-proxy-model-01")).toEqual({
+      nameSuffix: "my-proxy-model-01",
+      launchModel: "my-proxy-model-01",
+      nativeModelId: "my-proxy-model-01",
+      requiresCustomEndpoint: true,
+      customModelOptionName: "my-proxy-model-01",
+      customModelOptionDescription:
+        "Claude Code via an Anthropic-compatible custom endpoint.",
+    });
+    expect(getClaudeModelSpecByAgentName("claude/my/proxy/model")).toBe(
+      undefined,
+    );
   });
 
   it("accepts bypassed user Anthropic base URLs as custom endpoints", () => {

--- a/packages/shared/src/providers/anthropic/models.ts
+++ b/packages/shared/src/providers/anthropic/models.ts
@@ -49,6 +49,8 @@ export interface ClaudeModelSpec {
   customModelOptionSupportedCapabilities?: string[];
 }
 
+const CUSTOM_CLAUDE_MODEL_ID_REGEX = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
 export const CLAUDE_MODEL_SPECS: ClaudeModelSpec[] = [
   {
     nameSuffix: "opus-4.6",
@@ -91,6 +93,36 @@ export const CLAUDE_MODEL_SPECS: ClaudeModelSpec[] = [
   },
 ];
 
+function getDynamicCustomClaudeModelSpec(
+  agentName: string,
+): ClaudeModelSpec | undefined {
+  if (!agentName.startsWith("claude/")) {
+    return undefined;
+  }
+
+  const customModelId = agentName.slice("claude/".length).trim();
+  if (!customModelId) {
+    return undefined;
+  }
+
+  if (
+    CLAUDE_MODEL_SPECS.some((spec) => customModelId === spec.nameSuffix) ||
+    !CUSTOM_CLAUDE_MODEL_ID_REGEX.test(customModelId)
+  ) {
+    return undefined;
+  }
+
+  return {
+    nameSuffix: customModelId,
+    launchModel: customModelId,
+    nativeModelId: customModelId,
+    requiresCustomEndpoint: true,
+    customModelOptionName: customModelId,
+    customModelOptionDescription:
+      "Claude Code via an Anthropic-compatible custom endpoint.",
+  };
+}
+
 export function getClaudeModelSpecByAgentName(
   agentName: string | undefined,
 ): ClaudeModelSpec | undefined {
@@ -98,9 +130,14 @@ export function getClaudeModelSpecByAgentName(
     return undefined;
   }
 
-  return CLAUDE_MODEL_SPECS.find(
+  const staticSpec = CLAUDE_MODEL_SPECS.find(
     (spec) => agentName === `claude/${spec.nameSuffix}`,
   );
+  if (staticSpec) {
+    return staticSpec;
+  }
+
+  return getDynamicCustomClaudeModelSpec(agentName);
 }
 
 export function getClaudeModelFamily(

--- a/packages/shared/src/providers/anthropic/models.ts
+++ b/packages/shared/src/providers/anthropic/models.ts
@@ -82,15 +82,6 @@ export const CLAUDE_MODEL_SPECS: ClaudeModelSpec[] = [
     launchModel: "haiku",
     nativeModelId: "claude-haiku-4-5-20251001",
   },
-  {
-    nameSuffix: "gpt-5.1-codex-mini",
-    launchModel: "gpt-5.1-codex-mini",
-    nativeModelId: "gpt-5.1-codex-mini",
-    requiresCustomEndpoint: true,
-    customModelOptionName: "GPT-5.1 Codex Mini",
-    customModelOptionDescription:
-      "Claude Code via an Anthropic-compatible custom endpoint.",
-  },
 ];
 
 function getDynamicCustomClaudeModelSpec(


### PR DESCRIPTION
## Summary
- add team-scoped Convex storage for custom Claude model entries
- add CRUD mutations + list integration so custom models appear with global catalog models
- support enable/disable, reorder, and visibility checks for custom entries
- add dynamic Claude runtime config/spec fallback for valid claude/modelId names
- add Model Catalog UI to add/edit/delete custom Claude models

## Validation
- bun run test src/providers/anthropic/models.test.ts src/providers/anthropic/configs.test.ts src/agent-selection.test.ts (packages/shared)
- bun run typecheck (apps/client)
- pre-commit hook bun check (lint + typecheck)
