### PR TITLE
ci: skip checks and tests for dev-docs-only changes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,10 +12,10 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-      - uses: actions/checkout@v4
       - id: filter
         uses: dorny/paths-filter@v3
         with:
+          token: ${{ github.token }}
           filters: |
             src:
               - '**'
@@ -119,7 +119,8 @@ jobs:
 
   # Simplify review for PRs (optional, runs in report-only mode)
   simplify-review:
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.src == 'true'
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            src:
+              - '**'
+              - '!dev-docs/**'
+
+  # Always reports success — satisfies branch protection when heavy jobs are skipped
   verify:
+    needs: changes
+    if: always() && needs.changes.outputs.src != 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Skipped — only dev-docs changed"
+
+  # Full checks — only runs when source files changed
+  verify-full:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-24.04
     environment: dev
     steps:

--- a/.github/workflows/sync-dev-docs.yml
+++ b/.github/workflows/sync-dev-docs.yml
@@ -50,8 +50,6 @@ jobs:
           git add dev-docs
           git commit -m "chore: sync dev-docs from dev-docs-cmux"
           git push -u origin "$BRANCH"
-          gh workflow run checks.yml --ref "$BRANCH"
-          gh workflow run tests.yml --ref "$BRANCH"
           gh pr create \
             --title "chore: sync dev-docs from dev-docs-cmux" \
             --body "Automated sync from karlorz/dev-docs-cmux repository." \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            src:
+              - '**'
+              - '!dev-docs/**'
+
+  # Always reports success — satisfies branch protection when heavy jobs are skipped
   test:
+    needs: changes
+    if: always() && needs.changes.outputs.src != 'true'
+    name: Run tests on ubuntu-24.04
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Skipped — only dev-docs changed"
+
+  # Full test suite — only runs when source files changed
+  test-full:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Run tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     environment: dev
@@ -132,6 +158,8 @@ jobs:
           bun run test
 
   python-sdk:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     name: Validate Python SDK
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-      - uses: actions/checkout@v4
       - id: filter
         uses: dorny/paths-filter@v3
         with:
+          token: ${{ github.token }}
           filters: |
             src:
               - '**'


### PR DESCRIPTION
## Summary
- Add `paths-ignore: ['dev-docs/**']` to `checks.yml` and `tests.yml` so documentation-only commits no longer trigger the two heaviest CI workflows
- Remove manual `gh workflow run checks.yml/tests.yml` from `sync-dev-docs.yml` that force-ran CI on the dev-docs sync branch

## Why
PRs like #1072 ("chore: sync dev-docs from dev-docs-cmux") that only change `dev-docs/` files were needlessly triggering `checks.yml` and `tests.yml` — the two most expensive workflows (Bun/Node/Go/Rust setup, full dependency install, compile, and test). The Docker build workflows are already properly gated by `paths` filters and were not the problem.

## Test plan
- [ ] Merge a dev-docs-only change and confirm `checks.yml` and `tests.yml` are skipped
- [ ] Merge a code change (e.g. `packages/shared/`) and confirm both workflows still run
- [ ] Trigger `sync-dev-docs.yml` manually and confirm the PR is created without forcing CI on the branch