### PR TITLE
fix(ci): add checkout before paths-filter in changes job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
+      - uses: actions/checkout@v4
       - id: filter
         uses: dorny/paths-filter@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
+      - uses: actions/checkout@v4
       - id: filter
         uses: dorny/paths-filter@v3
         with:


### PR DESCRIPTION
## Summary
- The `changes` job in both `checks.yml` and `tests.yml` uses `dorny/paths-filter@v3` to detect changed files, but was missing an `actions/checkout@v4` step before it
- Without checkout, `dorny/paths-filter` runs in an empty directory and fails with `fatal: not a git repository (or any of the parent directories): .git`
- This caused both Checks and Tests workflows to fail on every push to main (sha `efcb97f46`)

## Root cause
PR #1075 introduced the `changes` job with `dorny/paths-filter@v3` and `token: ${{ github.token }}` for API-based change detection. The assumption was that the token-based API mode wouldn't need a checkout, but `dorny/paths-filter@v3` still needs a git repo for local operations (e.g. `git branch --show-current`). The `token` parameter enables the GitHub API for fetching changed files, but the action still runs local git commands.

## Fix
Add `actions/checkout@v4` before the `dorny/paths-filter@v3` step in the `changes` job of both workflows.

## Test plan
- [ ] Merge this PR and verify the next push to main triggers successful Checks and Tests runs
- [ ] Push a dev-docs-only change and verify the `changes` job correctly outputs `src != true` (skipping heavy jobs)
- [ ] Push a source change and verify the `changes` job correctly outputs `src == true` (running full checks/tests)