### PR TITLE
fix(worker): dynamic Claude config fallback for completion detection

### DIFF
--- a/apps/server/src/agentSpawner.ts
+++ b/apps/server/src/agentSpawner.ts
@@ -7,6 +7,7 @@ import {
 } from "@cmux/shared/agentConfig";
 import { resolveAgentSelection } from "@cmux/shared/agent-selection";
 import { createOpencodeFreeDynamicConfig } from "@cmux/shared/providers/opencode/configs";
+import { createDynamicClaudeConfig } from "@cmux/shared/providers/anthropic/configs";
 import type { McpServerConfig, RunControlSummary } from "@cmux/shared";
 import type { PolicyRuleForInstructions, OrchestrationRuleForInstructions } from "@cmux/shared/agent-memory-protocol";
 import {
@@ -2613,7 +2614,7 @@ export async function spawnAllAgents(
               ];
             }
 
-            const dynamicConfig = createOpencodeFreeDynamicConfig(name);
+            const dynamicConfig = createOpencodeFreeDynamicConfig(name) ?? createDynamicClaudeConfig(name);
             if (dynamicConfig) {
               serverLogger.info(
                 `[AgentSpawner] Using dynamic config for discovered model: ${name}`,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from "@cmux/shared";
 import WebSocket from "ws";
 import { AGENT_CONFIGS } from "@cmux/shared/agentConfig";
+import { createDynamicClaudeConfig } from "@cmux/shared/providers/anthropic/configs";
 import type { Id } from "@cmux/convex/dataModel";
 
 import { getWorkerServerSocketOptions } from "@cmux/shared/node/socket";
@@ -293,6 +294,18 @@ async function runPreviewJobScreenshots({
 const Terminal = xtermHeadless.Terminal;
 
 // Configuration
+/**
+ * Resolve an agent config by name, falling back to dynamic Claude config
+ * for custom/unlisted models with the "claude/" prefix.
+ */
+function resolveAgentConfig(agentModel?: string) {
+  if (!agentModel) return undefined;
+  const staticConfig = AGENT_CONFIGS.find((c) => c.name === agentModel);
+  if (staticConfig) return staticConfig;
+  // Dynamic fallback for unlisted Claude models (e.g., claude/glm-5.1)
+  return createDynamicClaudeConfig(agentModel);
+}
+
 const WORKER_ID = process.env.WORKER_ID || `worker-${Date.now()}`;
 const WORKER_PORT = parseInt(process.env.WORKER_PORT || "39377", 10);
 const CONTAINER_IMAGE = process.env.CONTAINER_IMAGE || "cmux-worker";
@@ -1742,9 +1755,7 @@ async function createTerminal(
 
         // 7. Set up completion detection (same as tmux backend)
         const processStartTime = Date.now();
-        const agentConfig = options.agentModel
-          ? AGENT_CONFIGS.find((c) => c.name === options.agentModel)
-          : undefined;
+        const agentConfig = resolveAgentConfig(options.agentModel);
 
         if (!agentConfig && options.agentModel) {
           log("WARN", `[cmux-pty] Agent config not found for ${options.agentModel}`, {
@@ -2155,9 +2166,7 @@ async function createTerminal(
   const stopErrorCaptureAt = Date.now() + INITIAL_ERROR_CAPTURE_WINDOW_MS;
 
   // Config-driven completion detector
-  const agentConfig = options.agentModel
-    ? AGENT_CONFIGS.find((c) => c.name === options.agentModel)
-    : undefined;
+  const agentConfig = resolveAgentConfig(options.agentModel);
 
   if (!agentConfig && options.agentModel) {
     log("WARN", `Agent config not found for ${options.agentModel}`, {


### PR DESCRIPTION
## Summary

- Custom/unlisted Claude models (e.g. `claude/glm-5.1`) were not found in the static `AGENT_CONFIGS` array, so no `completionDetector` was set up on the worker
- This caused task runs using dynamic Claude models to hang in "running" state forever — the file-marker-based completion signal was never watched for
- Added `resolveAgentConfig()` helper in worker that falls back to `createDynamicClaudeConfig` for unlisted `claude/*` models
- Also wired up the same fallback on the server side in `agentSpawner`'s agent resolution (was only doing opencode dynamic config before)

## Root cause

The worker uses `AGENT_CONFIGS.find(c => c.name === agentModel)` which only matches curated models. Dynamic models like `claude/glm-5.1` resolve to `undefined` → no completion detector → task hangs forever.

## Test plan

- [ ] Spawn a task with a dynamic Claude model (e.g. `claude/glm-5.1`) and verify task completes after the agent finishes
- [ ] Verify curated models (opus-4.6, sonnet-4.5, haiku-4.5) still work as before
- [ ] Verify the server-side agentSpawner correctly resolves dynamic models for spawn