### PR TITLE
chore: publish devsh v0.1.23 to npm

### DIFF
--- a/packages/devsh/npm/darwin-arm64/package.json
+++ b/packages/devsh/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devsh-darwin-arm64",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "devsh CLI binary for macOS ARM64 (Apple Silicon)",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/packages/devsh/npm/darwin-x64/package.json
+++ b/packages/devsh/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devsh-darwin-x64",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "devsh CLI binary for macOS x64 (Intel)",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/packages/devsh/npm/devsh/package.json
+++ b/packages/devsh/npm/devsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devsh",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Cloud VMs for development - spawn isolated dev environments instantly",
   "keywords": [
     "cli",
@@ -34,11 +34,11 @@
     "postinstall": "node lib/postinstall.js"
   },
   "optionalDependencies": {
-    "devsh-darwin-arm64": "0.1.22",
-    "devsh-darwin-x64": "0.1.22",
-    "devsh-linux-arm64": "0.1.22",
-    "devsh-linux-x64": "0.1.22",
-    "devsh-win32-x64": "0.1.22"
+    "devsh-darwin-arm64": "0.1.23",
+    "devsh-darwin-x64": "0.1.23",
+    "devsh-linux-arm64": "0.1.23",
+    "devsh-linux-x64": "0.1.23",
+    "devsh-win32-x64": "0.1.23"
   },
   "engines": {
     "node": ">=16"

--- a/packages/devsh/npm/linux-arm64/package.json
+++ b/packages/devsh/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devsh-linux-arm64",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "devsh CLI binary for Linux ARM64",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/packages/devsh/npm/linux-x64/package.json
+++ b/packages/devsh/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devsh-linux-x64",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "devsh CLI binary for Linux x64",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/packages/devsh/npm/win32-x64/package.json
+++ b/packages/devsh/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devsh-win32-x64",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "devsh CLI binary for Windows x64",
   "os": ["win32"],
   "cpu": ["x64"],


### PR DESCRIPTION
## Summary
- Bump devsh npm package versions from 0.1.22 to 0.1.23
- Includes 6 weeks of fixes: PVE-LXC workspace timezone, setup flow repairs, Opus 4.7 support, Claude model manifest unification

## Test plan
- [x] All 6 platform packages published to npmjs successfully
- [ ] Verify `npm i -g devsh` installs 0.1.23