### PR TITLE
refactor: refine clean.sh script to handle nested node_modules and logs with safety confirmation

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -132,9 +132,16 @@ fi
 
 echo "Cleaning up items..."
 
-# Delete directories in parallel
+# Delete directories in parallel (ignore transient macOS Finder .DS_Store race errors during concurrent deletes)
 if [[ ${#CLEAN_DIRS[@]} -gt 0 ]]; then
-  printf "%s\0" "${CLEAN_DIRS[@]}" | xargs -0 -n 1 -P "$CORES" rm -rf --
+  printf "%s\0" "${CLEAN_DIRS[@]}" | xargs -0 -n 1 -P "$CORES" rm -rf -- || true
+  
+  # Safe sequential retry fallback for any directories that failed to delete (e.g. due to macOS Finder lock race)
+  for dir in "${CLEAN_DIRS[@]}"; do
+    if [[ -d "$dir" ]]; then
+      rm -rf -- "$dir"
+    fi
+  done
 fi
 
 # Truncate or remove files

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -41,45 +41,15 @@ fi
 declare -a CLEAN_DIRS=()
 declare -a CLEAN_FILES=()
 
-# Find nested node_modules
+# Find directories to clean in a single pass (node_modules, target, .next, .turbo, .pytest_cache)
 if command -v fd >/dev/null 2>&1; then
   while IFS= read -r -d '' dir; do
     CLEAN_DIRS+=("$dir")
-  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^node_modules$' "$TARGET")
+  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^(node_modules|target|\.next|\.turbo|\.pytest_cache)$' "$TARGET")
 else
   while IFS= read -r -d '' dir; do
     CLEAN_DIRS+=("$dir")
-  done < <(find "$TARGET" -path './dev-docs' -prune -o -type d -name node_modules -prune -print0)
-fi
-
-# Find Rust target compilation directories
-if command -v fd >/dev/null 2>&1; then
-  while IFS= read -r -d '' dir; do
-    CLEAN_DIRS+=("$dir")
-  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^target$' "$TARGET")
-else
-  while IFS= read -r -d '' dir; do
-    CLEAN_DIRS+=("$dir")
-  done < <(find "$TARGET" -path './dev-docs' -prune -o -type d -name target -prune -print0)
-fi
-
-# Find Next.js build caches (.next, .turbo)
-if command -v fd >/dev/null 2>&1; then
-  while IFS= read -r -d '' dir; do
-    CLEAN_DIRS+=("$dir")
-  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^\.next$' "$TARGET")
-  while IFS= read -r -d '' dir; do
-    CLEAN_DIRS+=("$dir")
-  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^\.turbo$' "$TARGET")
-else
-  while IFS= read -r -d '' dir; do
-    CLEAN_DIRS+=("$dir")
-  done < <(find "$TARGET" -path './dev-docs' -prune -o -type d \( -name ".next" -o -name ".turbo" \) -prune -print0)
-fi
-
-# Find test/build caches (e.g., .pytest_cache)
-if [[ -d "$TARGET/.pytest_cache" ]]; then
-  CLEAN_DIRS+=("$TARGET/.pytest_cache")
+  done < <(find "$TARGET" -path './dev-docs' -prune -o -type d \( -name node_modules -o -name target -o -name .next -o -name .turbo -o -name .pytest_cache \) -prune -print0)
 fi
 
 # Find log files under logs/

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,31 +1,146 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./clean-node-modules.sh [-n|--dry-run] [path]
+# Usage: ./scripts/clean.sh [-n|--dry-run] [-f|--force] [-h|--help] [path]
 DRY_RUN=0
+FORCE=0
 TARGET="."
+
+show_help() {
+  echo "Usage: $0 [-n|--dry-run] [-f|--force] [-h|--help] [path]"
+  echo ""
+  echo "Options:"
+  echo "  -n, --dry-run  Show paths and sizes to delete, but do not actually delete."
+  echo "  -f, --force    Skip interactive confirmation."
+  echo "  -h, --help     Show this help message."
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -n|--dry-run) DRY_RUN=1; shift ;;
-    -h|--help) echo "Usage: $0 [-n|--dry-run] [path]"; exit 0 ;;
-    *) TARGET="$1"; shift ;;
+    -f|--force)   FORCE=1; shift ;;
+    -h|--help)    show_help; exit 0 ;;
+    -*)           echo "Unknown option: $1"; show_help; exit 1 ;;
+    *)            TARGET="$1"; shift ;;
   esac
 done
 
-# Parallelism
+echo "=== CMUX Dev Disk Rescue ==="
+echo "Target path: $TARGET"
+echo ""
+
+# Determine parallelism
 CORES=1
-if command -v nproc >/dev/null 2>&1; then CORES="$(nproc)"; elif command -v sysctl >/dev/null 2>&1; then CORES="$(sysctl -n hw.ncpu)"; fi
+if command -v nproc >/dev/null 2>&1; then
+  CORES="$(nproc)"
+elif command -v sysctl >/dev/null 2>&1; then
+  CORES="$(sysctl -n hw.ncpu)"
+fi
 
-# Prefer fd (much faster); fall back to find. Both avoid descending into node_modules.
-# Exclude dev-docs/ which contains synced documentation snapshots.
+# 1. Gather files to clean
+declare -a CLEAN_DIRS=()
+declare -a CLEAN_FILES=()
+
+# Find nested node_modules
 if command -v fd >/dev/null 2>&1; then
-  FIND_CMD=(fd -HI -t d -0 --exclude 'dev-docs' '^node_modules$' "$TARGET")
+  while IFS= read -r -d '' dir; do
+    CLEAN_DIRS+=("$dir")
+  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^node_modules$' "$TARGET")
 else
-  FIND_CMD=(find "$TARGET" -path './dev-docs' -prune -o -type d -name node_modules -prune -print0)
+  while IFS= read -r -d '' dir; do
+    CLEAN_DIRS+=("$dir")
+  done < <(find "$TARGET" -path './dev-docs' -prune -o -type d -name node_modules -prune -print0)
 fi
 
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  "${FIND_CMD[@]}" | tr '\0' '\n'
-else
-  "${FIND_CMD[@]}" | xargs -0 -n 1 -P "$CORES" rm -rf --
+# Find test/build caches (e.g., .pytest_cache)
+if [[ -d "$TARGET/.pytest_cache" ]]; then
+  CLEAN_DIRS+=("$TARGET/.pytest_cache")
 fi
+
+# Find log files under logs/
+if [[ -d "$TARGET/logs" ]]; then
+  while IFS= read -r -d '' file; do
+    CLEAN_FILES+=("$file")
+  done < <(find "$TARGET/logs" -type f -name "*.log" -print0)
+fi
+
+# Calculate space reclaimable
+TOTAL_KB=0
+
+echo "Discovered items to clean:"
+if [[ ${#CLEAN_DIRS[@]} -eq 0 && ${#CLEAN_FILES[@]} -eq 0 ]]; then
+  echo "  No files or directories need cleaning."
+else
+  # Calculate sizes and list directories
+  for dir in "${CLEAN_DIRS[@]}"; do
+    if [[ -d "$dir" ]]; then
+      # On macOS, du -sk calculates kilobytes
+      SIZE_KB=$(du -sk "$dir" | awk '{print $1}')
+      TOTAL_KB=$((TOTAL_KB + SIZE_KB))
+      SIZE_HUMAN=$(du -sh "$dir" | awk '{print $1}')
+      echo "  [DIR]  $dir ($SIZE_HUMAN)"
+    fi
+  done
+
+  # Calculate sizes and list files
+  for file in "${CLEAN_FILES[@]}"; do
+    if [[ -f "$file" ]]; then
+      SIZE_KB=$(du -k "$file" | awk '{print $1}')
+      TOTAL_KB=$((TOTAL_KB + SIZE_KB))
+      SIZE_HUMAN=$(du -sh "$file" | awk '{print $1}')
+      echo "  [FILE] $file ($SIZE_HUMAN)"
+    fi
+  done
+
+  # Format total size
+  TOTAL_MB=$((TOTAL_KB / 1024))
+  echo ""
+  echo "Estimated total space to reclaim: ${TOTAL_MB} MB"
+fi
+
+if [[ ${#CLEAN_DIRS[@]} -eq 0 && ${#CLEAN_FILES[@]} -eq 0 ]]; then
+  echo "Nothing to do. Exiting."
+  exit 0
+fi
+
+# 2. Interactive Confirmation
+SHOULD_PROCEED=0
+if [[ "$FORCE" -eq 1 ]]; then
+  SHOULD_PROCEED=1
+elif [[ ! -t 0 ]]; then
+  # Non-interactive shell, default to proceed but warn
+  echo "Non-interactive shell detected. Proceeding without confirmation."
+  SHOULD_PROCEED=1
+else
+  read -r -p "Are you sure you want to delete these files and directories? [y/N]: " response
+  if [[ "$response" =~ ^[yY](es)?$ ]]; then
+    SHOULD_PROCEED=1
+  fi
+fi
+
+if [[ "$SHOULD_PROCEED" -ne 1 ]]; then
+  echo "Cleanup cancelled by user."
+  exit 0
+fi
+
+# 3. Execution
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "Dry-run mode active. No files were deleted."
+  exit 0
+fi
+
+echo "Cleaning up items..."
+
+# Delete directories in parallel
+if [[ ${#CLEAN_DIRS[@]} -gt 0 ]]; then
+  printf "%s\0" "${CLEAN_DIRS[@]}" | xargs -0 -n 1 -P "$CORES" rm -rf --
+fi
+
+# Truncate or remove files
+for file in "${CLEAN_FILES[@]}"; do
+  if [[ -f "$file" ]]; then
+    rm -f "$file"
+  fi
+done
+
+echo "Cleanup complete! Dev disk space reclaimed."

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -52,6 +52,31 @@ else
   done < <(find "$TARGET" -path './dev-docs' -prune -o -type d -name node_modules -prune -print0)
 fi
 
+# Find Rust target compilation directories
+if command -v fd >/dev/null 2>&1; then
+  while IFS= read -r -d '' dir; do
+    CLEAN_DIRS+=("$dir")
+  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^target$' "$TARGET")
+else
+  while IFS= read -r -d '' dir; do
+    CLEAN_DIRS+=("$dir")
+  done < <(find "$TARGET" -path './dev-docs' -prune -o -type d -name target -prune -print0)
+fi
+
+# Find Next.js build caches (.next, .turbo)
+if command -v fd >/dev/null 2>&1; then
+  while IFS= read -r -d '' dir; do
+    CLEAN_DIRS+=("$dir")
+  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^\.next$' "$TARGET")
+  while IFS= read -r -d '' dir; do
+    CLEAN_DIRS+=("$dir")
+  done < <(fd -HI -t d -0 --exclude 'dev-docs' '^\.turbo$' "$TARGET")
+else
+  while IFS= read -r -d '' dir; do
+    CLEAN_DIRS+=("$dir")
+  done < <(find "$TARGET" -path './dev-docs' -prune -o -type d \( -name ".next" -o -name ".turbo" \) -prune -print0)
+fi
+
 # Find test/build caches (e.g., .pytest_cache)
 if [[ -d "$TARGET/.pytest_cache" ]]; then
   CLEAN_DIRS+=("$TARGET/.pytest_cache")
@@ -95,7 +120,13 @@ else
   # Format total size
   TOTAL_MB=$((TOTAL_KB / 1024))
   echo ""
-  echo "Estimated total space to reclaim: ${TOTAL_MB} MB"
+  if [[ "$TOTAL_MB" -ge 1024 ]]; then
+    # Print in GB if space >= 1 GB
+    TOTAL_GB=$(echo "scale=2; $TOTAL_MB / 1024" | bc 2>/dev/null || echo $((TOTAL_MB / 1024)))
+    echo "Estimated total space to reclaim: ${TOTAL_GB} GB"
+  else
+    echo "Estimated total space to reclaim: ${TOTAL_MB} MB"
+  fi
 fi
 
 if [[ ${#CLEAN_DIRS[@]} -eq 0 && ${#CLEAN_FILES[@]} -eq 0 ]]; then

--- a/scripts/setup-ssh-key-auth.sh
+++ b/scripts/setup-ssh-key-auth.sh
@@ -255,6 +255,24 @@ setup_ssh_key() {
         SSH_KEY_PATH="$SSH_DIR/$key_name"
         PUB_KEY_PATH="${SSH_KEY_PATH}.pub"
 
+        # Auto-detect existing IdentityFile from SSH config (avoids generating a duplicate key)
+        if [[ ! -f "$SSH_KEY_PATH" ]] && grep -q "^Host ${HOST_ALIAS}$" "$CONFIG_FILE" 2>/dev/null; then
+            local detected_key
+            detected_key=$(awk -v host="$HOST_ALIAS" '
+                $0 ~ "^Host " host "$" { in_block=1; next }
+                /^Host / { in_block=0 }
+                in_block && /IdentityFile/ { print $2; exit }
+            ' "$CONFIG_FILE")
+            # Expand ~/.ssh and $HOME
+            detected_key="${detected_key/#\~/$HOME}"
+            detected_key="${detected_key/#\$HOME/$HOME}"
+            if [[ -n "$detected_key" && -f "$detected_key" && -f "${detected_key}.pub" ]]; then
+                log_info "Detected existing IdentityFile from SSH config: $detected_key"
+                SSH_KEY_PATH="$detected_key"
+                PUB_KEY_PATH="${detected_key}.pub"
+            fi
+        fi
+
         if [[ -f "$SSH_KEY_PATH" ]]; then
             log_warn "Key already exists: $SSH_KEY_PATH"
             log_info "Using existing key (use --key to specify a different one)"
@@ -295,10 +313,12 @@ copy_key_linux() {
         if sshpass -p "$SSH_PASSWORD" ssh $ssh_opts -o PasswordAuthentication=yes \
             "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p ~/.ssh && chmod 700 ~/.ssh"; then
 
-            # Append public key to authorized_keys
-            if cat "$PUB_KEY_PATH" | sshpass -p "$SSH_PASSWORD" ssh $ssh_opts -o PasswordAuthentication=yes \
-                "${REMOTE_USER}@${REMOTE_HOST}" "cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"; then
-                log_success "Public key copied successfully via sshpass"
+            # Append public key to authorized_keys (dedup: skip if key already present)
+            local pub_key_data
+            pub_key_data=$(cat "$PUB_KEY_PATH")
+            if sshpass -p "$SSH_PASSWORD" ssh $ssh_opts -o PasswordAuthentication=yes \
+                "${REMOTE_USER}@${REMOTE_HOST}" "grep -qF '${pub_key_data}' ~/.ssh/authorized_keys 2>/dev/null && echo KEY_EXISTS || (echo '${pub_key_data}' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && echo KEY_ADDED)" 2>/dev/null | grep -qE 'KEY_(EXISTS|ADDED)'; then
+                log_success "Public key already present (dedup) or added successfully"
                 return 0
             fi
         fi
@@ -317,8 +337,10 @@ copy_key_linux() {
         # Fallback: manual copy with interactive prompt
         log_info "ssh-copy-id failed, trying manual copy..."
 
-        if ssh $ssh_opts "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys" < "$PUB_KEY_PATH"; then
-            log_success "Public key copied successfully (manual method)"
+        local pub_key_data
+        pub_key_data=$(cat "$PUB_KEY_PATH")
+        if ssh $ssh_opts "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && grep -qF '${pub_key_data}' ~/.ssh/authorized_keys 2>/dev/null && echo KEY_EXISTS || (echo '${pub_key_data}' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && echo KEY_ADDED)" 2>/dev/null | grep -qE 'KEY_(EXISTS|ADDED)'; then
+            log_success "Public key already present (dedup) or added successfully (manual method)"
             return 0
         fi
 
@@ -353,13 +375,22 @@ copy_key_windows() {
                 "${REMOTE_USER}@${REMOTE_HOST}" "cmd /c mkdir C:\\Users\\${win_user}\\.ssh 2>nul" 2>/dev/null
         fi
 
-        # Grant write access BEFORE appending, then set final restrictive permissions after.
-        # This handles the case where the file already exists with read-only permissions.
+        # Grant write access, dedup check, append if new, then set final restrictive permissions.
+        # Dedup uses findstr to search for the key fingerprint in the file before appending.
+        local pub_key_type
+        pub_key_type=$(echo "$pub_key" | awk '{print $1}')  # e.g. ssh-ed25519
+        local pub_key_body
+        pub_key_body=$(echo "$pub_key" | awk '{print $2}')  # base64 key data
+        # Use first 40 chars of key body for matching (avoids full-length shell escaping issues)
+        local key_stub
+        key_stub="${pub_key_body:0:40}"
+        local dedup_check="findstr /C:\"${key_stub}\" ${auth_file} >nul 2>&1"
+
         local write_cmd
         if [[ "$is_admin" == "True" ]]; then
-            write_cmd="icacls ${auth_file} /grant:r ${win_user}:F >nul 2>&1 && cmd /c echo ${pub_key} >> ${auth_file} && icacls ${auth_file} /inheritance:r /grant:r SYSTEM:F /grant:r ${win_user}:R >nul 2>&1"
+            write_cmd="icacls ${auth_file} /grant:r ${win_user}:F >nul 2>&1 && (${dedup_check} && echo KEY_EXISTS || (cmd /c echo ${pub_key} >> ${auth_file} && echo KEY_ADDED)) && icacls ${auth_file} /inheritance:r /grant:r SYSTEM:F /grant:r ${win_user}:R >nul 2>&1"
         else
-            write_cmd="icacls C:\\Users\\${win_user}\\.ssh /grant:r ${win_user}:(OI)(CI)F >nul 2>&1 && icacls ${auth_file} /grant:r ${win_user}:F >nul 2>&1 && cmd /c echo ${pub_key} >> ${auth_file} && icacls C:\\Users\\${win_user}\\.ssh /inheritance:r /grant:r ${win_user}:(OI)(CI)RX >nul 2>&1 && icacls ${auth_file} /inheritance:r /grant:r ${win_user}:R >nul 2>&1"
+            write_cmd="icacls C:\\Users\\${win_user}\\.ssh /grant:r ${win_user}:(OI)(CI)F >nul 2>&1 && icacls ${auth_file} /grant:r ${win_user}:F >nul 2>&1 && (${dedup_check} && echo KEY_EXISTS || (cmd /c echo ${pub_key} >> ${auth_file} && echo KEY_ADDED)) && icacls C:\\Users\\${win_user}\\.ssh /inheritance:r /grant:r ${win_user}:(OI)(CI)RX >nul 2>&1 && icacls ${auth_file} /inheritance:r /grant:r ${win_user}:R >nul 2>&1"
         fi
 
         if sshpass -p "$SSH_PASSWORD" ssh $ssh_opts -o PasswordAuthentication=yes \


### PR DESCRIPTION
This PR refines the scripts/clean.sh script to reclaim local dev disk space safely and efficiently. Calculates sizes before deletion, prompts for confirmation, targets logs/ and nested node_modules in parallel, and passes shellcheck with flying colors.