### PR TITLE
fix(cloudrouter): align E2B lite Go toolchain

### DIFF
--- a/packages/cloudrouter/template/e2b.lite.Dockerfile
+++ b/packages/cloudrouter/template/e2b.lite.Dockerfile
@@ -153,10 +153,13 @@ COPY worker/start-services-lite.sh /usr/local/bin/start-services-lite.sh
 RUN chmod +x /usr/local/bin/start-services-lite.sh
 
 # Install Go for building worker daemon
-RUN wget -q https://go.dev/dl/go1.24.2.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.24.2.linux-amd64.tar.gz \
-    && rm go1.24.2.linux-amd64.tar.gz
-ENV PATH="/usr/local/go/bin:$PATH"
+RUN wget -q https://go.dev/dl/go1.24.12.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.24.12.linux-amd64.tar.gz \
+    && rm go1.24.12.linux-amd64.tar.gz \
+    && ln -sf /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt \
+    && go version
+ENV PATH="/usr/local/go/bin:/usr/local/bin:$PATH"
 
 # Build Go worker daemon (standalone binary, no internal dependencies)
 RUN mkdir -p /tmp/worker-build/cmd
@@ -165,7 +168,7 @@ COPY go.sum /tmp/worker-build/go.sum
 COPY cmd/worker /tmp/worker-build/cmd/worker/
 RUN cd /tmp/worker-build && \
     go mod download && \
-    go build -ldflags="-s -w" -o /usr/local/bin/worker-daemon ./cmd/worker && \
+    CGO_ENABLED=0 go build -ldflags="-s -w" -o /usr/local/bin/worker-daemon ./cmd/worker && \
     rm -rf /tmp/worker-build
 
 # Install JupyterLab + basic data science packages


### PR DESCRIPTION
## Summary
- Align the E2B lite template Go install with packages/cloudrouter/go.mod toolchain go1.24.12.
- Add stable /usr/local/bin/go and /usr/local/bin/gofmt symlinks for the remote Docker build layer.
- Build the worker daemon with CGO_ENABLED=0 in the lite template.

## Verification
- Initial requested test failed: cd packages/cloudrouter/cmux-devbox-lite && bun run build:dev failed in the remote E2B worker-daemon build layer while the Dockerfile installed Go 1.24.2.
- Retest after fix: cd packages/cloudrouter/cmux-devbox-lite && bun run build:dev succeeded.
  - Template name: cmux-devbox-lite-dev
  - Template ID: 29qyvwzccfwyl8kaqjxg
  - Build ID: d1f43dbb-2926-4b8d-a93b-3669885b5c50
- Live E2B smoke test from cmux-devbox-lite-dev succeeded and sandbox was deleted.
  - Sandbox ID: i3b2q8jlbsr9b2oo8egza
  - Worker health returned status ok/provider e2b
  - Token files existed at /home/user/.worker-auth-token and /home/user/.vscode-token, 64 bytes each
  - go version reported go1.24.12 linux/amd64
  - docker was absent, as expected for lite
  - Xtigervnc, code-server-oss, jupyter-lab, and worker-daemon were running
  - No baked /root/lifecycle/memory, /home/user/lifecycle/memory, root/user Claude memory files, or root/user Codex instruction files were present
- Pre-commit hook ran bun check and passed lint/typecheck.