### PR TITLE
docs: route knowledge sharing through SkillWiki

### DIFF
--- a/CLAUDE.local-legacy.md
+++ b/CLAUDE.local-legacy.md
@@ -193,13 +193,13 @@ When working on PVE-LXC sandbox features, use `apps/edge-router-pvelxc/`. Deploy
 cd apps/edge-router-pvelxc && bun run deploy
 ```
 
-## External Knowledge Sharing (Obsidian + GitHub)
-This repository requires structured external knowledge sharing for major technical direction updates.
+## External Knowledge Sharing (SkillWiki + GitHub)
+This legacy file must not define a separate knowledge target. Use the active repository memory in `CLAUDE.md` / `AGENTS.md`.
 
 ### Default Target
-- Local-first vault path: `~/Documents/obsidian_vault`.
-- Trends project notes path: `5️⃣-Projects/GitHub/trends/`.
-- If local vault is unavailable, use `obsidian-gh-knowledge` configured default repository (config-driven fallback).
+- Resolve the current SkillWiki vault with `skillwiki path`; do not hard-code a vault path in this legacy memory file.
+- cmux project workspace: `<resolved-vault>/projects/cmux/`.
+- If `skillwiki path` cannot resolve a current vault, run `skillwiki doctor` and report the failure instead of falling back to legacy Obsidian vaults or repositories.
 
 ### When To Update Shared Knowledge
 Update notes when any of the following changes land:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,9 +325,11 @@ Message types: `handoff`, `request`, `status`
 
 ## External Knowledge Sharing
 
-- Update shared Obsidian/GitHub notes for major architecture, governance, workflow, API, or workspace-isolation changes.
-- Use the local-first vault at `~/Documents/obsidian_vault`.
-- If the local vault is unavailable, use the `obsidian-gh-knowledge` fallback configured in the environment.
+- Update shared SkillWiki/GitHub notes for major architecture, governance, workflow, API, workspace-isolation, runtime, or sandbox-provider changes.
+- Resolve the current SkillWiki vault with `skillwiki path`; do not hard-code or infer the vault path in repository memory.
+- Do not use legacy Obsidian vault paths as the active cmux knowledge base.
+- Write cmux project work under `<resolved-vault>/projects/cmux/` and typed cross-project knowledge under the appropriate SkillWiki Layer 2 directory (`concepts/`, `queries/`, `comparisons/`, or `entities/`) with `provenance_projects: ["[[cmux]]"]` when relevant.
+- If `skillwiki path` cannot resolve a current vault, run `skillwiki doctor` and report the failure instead of falling back to a legacy vault or repository.
 - Include the date, a concise decision summary, affected repo-relative paths, and related PR or commit IDs.
 - Never include secrets or credentials in shared notes, and keep volatile TODOs out of long-lived knowledge documents.
 - Do not turn this file into a phase ledger, migration queue, mockup dump, or large architecture diagram.


### PR DESCRIPTION
## Summary
- replace legacy Obsidian knowledge-sharing targets in active CLAUDE/AGENTS memory with SkillWiki resolver guidance
- make the legacy local memory file defer to active SkillWiki memory instead of defining its own vault target
- require `skillwiki path`/`skillwiki doctor` instead of hard-coded vault paths or legacy fallbacks

## Verification
- pre-commit hook ran `bun check` and passed
- active cmux wiki pages/captures were also cleaned to use resolver-based SkillWiki commands and pushed to `karlorz/wiki`

## Notes
- no direct merge requested; waiting for user approval per repo policy