### PR TITLE
fix: include PVE-LXC VNC auth token

### DIFF
--- a/packages/convex/convex/pve_lxc_actions.test.ts
+++ b/packages/convex/convex/pve_lxc_actions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { vncUrlWithToken } from "./pve_lxc_actions";
+
+describe("vncUrlWithToken", () => {
+  test("adds the VNC token query parameter to a base URL", () => {
+    expect(vncUrlWithToken("https://port-39380-pvelxc-abc.example.com", "token-123")).toBe(
+      "https://port-39380-pvelxc-abc.example.com/?tkn=token-123"
+    );
+  });
+
+  test("preserves path and unrelated query parameters", () => {
+    expect(
+      vncUrlWithToken(
+        "https://port-39380-pvelxc-abc.example.com/vnc.html?autoconnect=1&resize=scale",
+        "token-123"
+      )
+    ).toBe(
+      "https://port-39380-pvelxc-abc.example.com/vnc.html?autoconnect=1&resize=scale&tkn=token-123"
+    );
+  });
+
+  test("replaces a stale token", () => {
+    expect(
+      vncUrlWithToken(
+        "https://port-39380-pvelxc-abc.example.com/vnc.html?tkn=old-token&autoconnect=1",
+        "new-token"
+      )
+    ).toBe(
+      "https://port-39380-pvelxc-abc.example.com/vnc.html?tkn=new-token&autoconnect=1"
+    );
+  });
+
+  test("returns the original URL when no token is available", () => {
+    expect(vncUrlWithToken("https://port-39380-pvelxc-abc.example.com", null)).toBe(
+      "https://port-39380-pvelxc-abc.example.com"
+    );
+  });
+
+  test("returns undefined when no VNC URL is available", () => {
+    expect(vncUrlWithToken(undefined, "token-123")).toBeUndefined();
+  });
+});

--- a/packages/convex/convex/pve_lxc_actions.ts
+++ b/packages/convex/convex/pve_lxc_actions.ts
@@ -67,12 +67,17 @@ function extractNetworkingUrls(instance: PveLxcInstance) {
 }
 
 const VNC_AUTH_TOKEN_PATH = "/root/.worker-auth-token";
-const VNC_TOKEN_FETCH_ATTEMPTS = 6;
+const VNC_TOKEN_FETCH_ATTEMPTS = 3;
 const VNC_TOKEN_FETCH_DELAY_MS = 1_000;
+const VNC_TOKEN_EXEC_TIMEOUT_MS = 5_000;
+const VNC_TOKEN_POLL_EXEC_TIMEOUT_MS = 3_000;
 
-async function fetchVncAuthToken(instance: PveLxcInstance): Promise<string | null> {
+async function fetchVncAuthToken(
+  instance: PveLxcInstance,
+  timeoutMs: number = VNC_TOKEN_EXEC_TIMEOUT_MS,
+): Promise<string | null> {
   try {
-    const result = await instance.exec(`cat ${VNC_AUTH_TOKEN_PATH}`, { timeoutMs: 10_000 });
+    const result = await instance.exec(`cat ${VNC_AUTH_TOKEN_PATH}`, { timeoutMs });
     if (result.exit_code === 0 && result.stdout.trim()) {
       return result.stdout.trim();
     }
@@ -110,6 +115,31 @@ export function vncUrlWithToken(
 }
 
 /**
+ * Extract networking URLs and fetch the VNC auth token in parallel,
+ * returning the token-appended VNC URL along with the other service URLs.
+ */
+async function extractNetworkingUrlsWithAuth(
+  instance: PveLxcInstance,
+  tokenFetcher: (instance: PveLxcInstance) => Promise<string | null>,
+): Promise<{
+  vscodeUrl: string | undefined;
+  workerUrl: string | undefined;
+  vncUrl: string | undefined;
+  xtermUrl: string | undefined;
+}> {
+  const [urls, authToken] = await Promise.all([
+    Promise.resolve(extractNetworkingUrls(instance)),
+    tokenFetcher(instance),
+  ]);
+  return {
+    vscodeUrl: urls.vscodeUrl,
+    workerUrl: urls.workerUrl,
+    vncUrl: vncUrlWithToken(urls.vncUrl, authToken),
+    xtermUrl: urls.xtermUrl,
+  };
+}
+
+/**
  * Start a new PVE LXC container instance.
  */
 export const startInstance = internalAction({
@@ -130,16 +160,17 @@ export const startInstance = internalAction({
         metadata: args.metadata,
       });
 
-      const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = extractNetworkingUrls(instance);
-
-      const authToken = await waitForVncAuthToken(instance);
+      const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = await extractNetworkingUrlsWithAuth(
+        instance,
+        waitForVncAuthToken,
+      );
 
       return {
         instanceId: instance.id,
         status: "running",
         vscodeUrl,
         workerUrl,
-        vncUrl: vncUrlWithToken(vncUrl, authToken),
+        vncUrl,
         xtermUrl,
       };
     } catch (error) {
@@ -160,16 +191,17 @@ export const getInstance = internalAction({
     try {
       const client = getPveLxcClient();
       const instance = await client.instances.get({ instanceId: args.instanceId });
-      const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = extractNetworkingUrls(instance);
-
-      const authToken = await fetchVncAuthToken(instance);
+      const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = await extractNetworkingUrlsWithAuth(
+        instance,
+        (i) => fetchVncAuthToken(i, VNC_TOKEN_POLL_EXEC_TIMEOUT_MS),
+      );
 
       return {
         instanceId: args.instanceId,
         status: instance.status === "running" ? "running" : "stopped",
         vscodeUrl,
         workerUrl,
-        vncUrl: vncUrlWithToken(vncUrl, authToken),
+        vncUrl,
         xtermUrl,
       };
     } catch (err) {
@@ -290,9 +322,10 @@ export const resumeInstance = internalAction({
       const instance = await client.instances.get({ instanceId: args.instanceId });
       await instance.resume();
 
-      const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = extractNetworkingUrls(instance);
-
-      const authToken = await fetchVncAuthToken(instance);
+      const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = await extractNetworkingUrlsWithAuth(
+        instance,
+        waitForVncAuthToken,
+      );
 
       return {
         resumed: true,
@@ -300,7 +333,7 @@ export const resumeInstance = internalAction({
         status: "running",
         vscodeUrl,
         workerUrl,
-        vncUrl: vncUrlWithToken(vncUrl, authToken),
+        vncUrl,
         xtermUrl,
       };
     } catch (error) {

--- a/packages/convex/convex/pve_lxc_actions.ts
+++ b/packages/convex/convex/pve_lxc_actions.ts
@@ -66,6 +66,49 @@ function extractNetworkingUrls(instance: PveLxcInstance) {
   };
 }
 
+const VNC_AUTH_TOKEN_PATH = "/root/.worker-auth-token";
+const VNC_TOKEN_FETCH_ATTEMPTS = 6;
+const VNC_TOKEN_FETCH_DELAY_MS = 1_000;
+
+async function fetchVncAuthToken(instance: PveLxcInstance): Promise<string | null> {
+  try {
+    const result = await instance.exec(`cat ${VNC_AUTH_TOKEN_PATH}`, { timeoutMs: 10_000 });
+    if (result.exit_code === 0 && result.stdout.trim()) {
+      return result.stdout.trim();
+    }
+    console.error(
+      `[pve_lxc_actions] Failed to read VNC auth token: exit=${result.exit_code} stderr=${result.stderr}`,
+    );
+    return null;
+  } catch (err) {
+    console.error("[pve_lxc_actions] Could not fetch VNC auth token:", err);
+    return null;
+  }
+}
+
+async function waitForVncAuthToken(instance: PveLxcInstance): Promise<string | null> {
+  for (let attempt = 1; attempt <= VNC_TOKEN_FETCH_ATTEMPTS; attempt += 1) {
+    const token = await fetchVncAuthToken(instance);
+    if (token) {
+      return token;
+    }
+    if (attempt < VNC_TOKEN_FETCH_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, VNC_TOKEN_FETCH_DELAY_MS));
+    }
+  }
+  return null;
+}
+
+export function vncUrlWithToken(
+  vncUrl: string | undefined,
+  token: string | null
+): string | undefined {
+  if (!vncUrl || !token) return vncUrl;
+  const url = new URL(vncUrl);
+  url.searchParams.set("tkn", token);
+  return url.toString();
+}
+
 /**
  * Start a new PVE LXC container instance.
  */
@@ -89,12 +132,14 @@ export const startInstance = internalAction({
 
       const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = extractNetworkingUrls(instance);
 
+      const authToken = await waitForVncAuthToken(instance);
+
       return {
         instanceId: instance.id,
         status: "running",
         vscodeUrl,
         workerUrl,
-        vncUrl,
+        vncUrl: vncUrlWithToken(vncUrl, authToken),
         xtermUrl,
       };
     } catch (error) {
@@ -117,12 +162,14 @@ export const getInstance = internalAction({
       const instance = await client.instances.get({ instanceId: args.instanceId });
       const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = extractNetworkingUrls(instance);
 
+      const authToken = await fetchVncAuthToken(instance);
+
       return {
         instanceId: args.instanceId,
         status: instance.status === "running" ? "running" : "stopped",
         vscodeUrl,
         workerUrl,
-        vncUrl,
+        vncUrl: vncUrlWithToken(vncUrl, authToken),
         xtermUrl,
       };
     } catch (err) {
@@ -245,13 +292,15 @@ export const resumeInstance = internalAction({
 
       const { vscodeUrl, workerUrl, vncUrl, xtermUrl } = extractNetworkingUrls(instance);
 
+      const authToken = await fetchVncAuthToken(instance);
+
       return {
         resumed: true,
         instanceId: args.instanceId,
         status: "running",
         vscodeUrl,
         workerUrl,
-        vncUrl,
+        vncUrl: vncUrlWithToken(vncUrl, authToken),
         xtermUrl,
       };
     } catch (error) {


### PR DESCRIPTION
## Summary

- read the PVE-LXC worker auth token from running containers and append it to returned VNC URLs
- use bounded token polling on fresh container start so browser preview has a chance to work immediately
- add focused regression tests for VNC URL token handling

## Verification

- live checked `pvelxc-7d7ee032`: bare `/vnc.html` returns 403, tokenized URL sets session cookie and loads noVNC HTML
- `cd packages/convex && bun run test convex/pve_lxc_actions.test.ts`
- pre-commit hook: `bun check` passed

## Notes

- This fixes the cmux web app provider action path. `devsh status` may still display the bare service origin unless that CLI surface is updated separately.
- Broad root `bun run test packages/convex/convex/pve_lxc_actions.test.ts` also ran unintentionally and surfaced an unrelated timeout in `@cmux/shared` (`task-sandbox-wrappers.test.ts`); the focused Convex test passed.