### PR TITLE
chore(claude): deprecate in-session autopilot continue loop

### DIFF
--- a/.claude/commands/autopilot_reset.md
+++ b/.claude/commands/autopilot_reset.md
@@ -1,78 +1,32 @@
 ---
-description: Reset autopilot turn counter to allow session to run fresh
+description: "DEPRECATED: Claude autopilot continue-loop controls (no longer active)"
 argument-hint: "[optional: stop|status|status-all|all]"
 allowed-tools: Bash
 ---
 
-Reset or control the autopilot turn counter for the current session.
+# DEPRECATED: `/autopilot_reset`
 
-Mode: $ARGUMENTS (default: reset)
+**Status:** Deprecated as of 2026-07-20.
 
-## Auto-collected context
+Claude Code no longer registers the Stop continue-loop hook
+(`.claude/hooks/autopilot-keep-running.sh`) or the SessionStart bootstrap
+(`.claude/hooks/session-start.sh`). Resetting turn counters has no effect on
+live Claude sessions.
 
-### Current session status
-!`bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); "$ROOT"/scripts/autopilot-reset.sh --provider claude status'`
-
-## Actions
-
-Based on mode `$ARGUMENTS`:
-
-### reset (default)
-Reset the turn counter to 0, allowing another full cycle of autopilot turns.
-
-### stop
-Create a stop file to immediately stop autopilot on next turn.
-
-### status
-Show current session ID and status only.
-
-### status-all
-Show all active sessions with their status.
-
-### debug-on
-Enable Stop-hook debug logging for Claude autopilot without restarting the session.
-
-### debug-off
-Disable Stop-hook debug logging for Claude autopilot.
+See: `.claude/hooks/DEPRECATED.md`
 
 ## Instructions
 
-1. If mode is `status`: Just report the auto-collected context above, no action needed.
+1. Tell the user this command is **deprecated** and inactive for Claude Code.
+2. Summarize replacements:
+   - Explicit multi-turn work / plan execution skills
+   - Codex managed hooks when using Codex
+   - Sandbox task autopilot (`devsh --autopilot`) for long-running cmux work
+3. If they still want diagnostic state from leftover temp files, optionally run:
 
-2. If mode is `status-all`: Run this command via Bash tool to show all sessions:
 ```bash
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-"$ROOT"/scripts/autopilot-reset.sh --provider claude status-all
+"$ROOT"/scripts/autopilot-reset.sh --provider claude status
 ```
 
-3. If mode is `stop`: Run this command via Bash tool (current session only):
-```bash
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-"$ROOT"/scripts/autopilot-reset.sh --provider claude stop
-```
-
-4. If mode is `reset` or empty: Run this command via Bash tool (current session only):
-```bash
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-"$ROOT"/scripts/autopilot-reset.sh --provider claude reset
-```
-
-5. If mode is `all`: Run this command via Bash tool (all sessions):
-```bash
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-"$ROOT"/scripts/autopilot-reset.sh --provider claude all
-```
-
-6. If mode is `debug-on`: Run this command via Bash tool:
-```bash
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-"$ROOT"/scripts/autopilot-reset.sh --provider claude debug-on
-```
-
-7. If mode is `debug-off`: Run this command via Bash tool:
-```bash
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-"$ROOT"/scripts/autopilot-reset.sh --provider claude debug-off
-```
-
-Report the result to the user.
+Do **not** present reset/stop/debug modes as supported operational controls.

--- a/.claude/hooks/DEPRECATED.md
+++ b/.claude/hooks/DEPRECATED.md
@@ -1,0 +1,43 @@
+# Deprecated: Claude Code autopilot continue loop
+
+**Status:** Deprecated as of 2026-07-20  
+**Scope:** Claude Code *in-session* Stop/SessionStart continue-loop only
+
+## What was retired
+
+Project `.claude/settings.json` no longer registers:
+
+| Hook event | Script | Role |
+|---|---|---|
+| `SessionStart` | `session-start.sh` | Session ID / activity bootstrap for Claude autopilot state |
+| `Stop` | `autopilot-keep-running.sh` | Keep-alive continue loop (`CMUX_AUTOPILOT_ENABLED` / `CLAUDE_AUTOPILOT`) |
+
+Related Claude-only control surfaces are also deprecated:
+
+- `.claude/commands/autopilot_reset.md` (`/autopilot_reset`)
+- Claude provider mode of `scripts/autopilot-reset.sh`
+
+These files remain in the tree for reference and existing local tests, but they are **not wired** into Claude Code sessions anymore.
+
+## Still active (not deprecated)
+
+- `bun-check.sh` and `codex-review.sh` Stop hooks in `.claude/settings.json`
+- Codex managed hooks (`scripts/install-codex-home-hooks.sh`, `.codex/hooks/*`)
+- Shared cores used by non-Claude providers:
+  - `scripts/hooks/cmux-autopilot-stop-core.sh`
+  - `scripts/hooks/cmux-session-start-core.sh`
+- Product / sandbox task autopilot (`devsh --autopilot`, lifecycle E2E)
+- External multi-turn driver `scripts/agent-autopilot.sh` (process-level loop, not Claude Stop-hook continue)
+
+## Replacement
+
+Do not enable Claude in-process continue via Stop hooks. Prefer:
+
+1. Explicit user turns / plan execution skills
+2. Codex managed hooks when using Codex
+3. Sandbox task autopilot for long-running cmux work
+4. `scripts/agent-autopilot.sh` only when an external CLI loop is intentionally desired
+
+## Re-enable (not recommended)
+
+If you must temporarily restore Claude continue-loop behavior, re-register the two hooks in `.claude/settings.json` and set `CMUX_AUTOPILOT_ENABLED=1`. This is unsupported and may conflict with review/quality Stop hooks.

--- a/.claude/hooks/autopilot-keep-running.sh
+++ b/.claude/hooks/autopilot-keep-running.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
+# DEPRECATED (2026-07-20): Claude Code Stop-hook continue loop.
+# No longer registered in .claude/settings.json. See .claude/hooks/DEPRECATED.md.
+# Kept for reference and legacy tests only. Do not re-wire without an explicit decision.
 set -euo pipefail
+
+if [ "${CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT:-0}" != "1" ]; then
+  echo "DEPRECATED: Claude autopilot continue loop is disabled." >&2
+  echo "See .claude/hooks/DEPRECATED.md (set CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT=1 to force)." >&2
+  exit 0
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"

--- a/.claude/hooks/session-activity-capture.sh
+++ b/.claude/hooks/session-activity-capture.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Session activity capture script
-# Called by session-start hook (on start) and autopilot-keep-running hook (on end)
+# Called by session-start hook (on start) and autopilot-keep-running hook (on end).
+# NOTE (2026-07-20): Claude wrappers that invoked this are deprecated/unwired.
+# See .claude/hooks/DEPRECATED.md. Codex and other providers may still call it.
 # Captures git commits, PRs, and file changes for the session activity dashboard
 
 set -euo pipefail

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
+# DEPRECATED (2026-07-20): Claude Code SessionStart bootstrap for autopilot state.
+# No longer registered in .claude/settings.json. See .claude/hooks/DEPRECATED.md.
+# Kept for reference and legacy tests only. Do not re-wire without an explicit decision.
 set -euo pipefail
+
+if [ "${CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT:-0}" != "1" ]; then
+  echo "DEPRECATED: Claude session-start autopilot bootstrap is disabled." >&2
+  echo "See .claude/hooks/DEPRECATED.md (set CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT=1 to force)." >&2
+  exit 0
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"

--- a/.claude/hooks/test-completed-marker.sh
+++ b/.claude/hooks/test-completed-marker.sh
@@ -8,8 +8,15 @@
 #   bash .claude/hooks/test-completed-marker.sh
 #
 # Expected: all tests PASS
+#
+# NOTE (2026-07-20): Claude continue-loop hooks are deprecated/unwired from
+# .claude/settings.json. This suite uses CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT=1
+# for legacy coverage. See .claude/hooks/DEPRECATED.md.
 
 set -uo pipefail
+
+# Opt into deprecated Claude continue-loop scripts for legacy unit coverage.
+export CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT=1
 
 unset AUTOPILOT_DELAY AUTOPILOT_IDLE_THRESHOLD AUTOPILOT_MAX_TURNS AUTOPILOT_MONITORING_THRESHOLD
 unset CMUX_AUTOPILOT_DELAY CMUX_AUTOPILOT_IDLE_THRESHOLD CMUX_AUTOPILOT_MAX_TURNS CMUX_AUTOPILOT_MONITORING_THRESHOLD

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,29 +5,7 @@
     "lastShownTime": 1754013974739
   },
   "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh",
-            "type": "command",
-            "timeout": 5
-          }
-        ],
-        "matcher": ""
-      }
-    ],
     "Stop": [
-      {
-        "hooks": [
-          {
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/autopilot-keep-running.sh",
-            "type": "command",
-            "timeout": 10
-          }
-        ],
-        "matcher": ""
-      },
       {
         "hooks": [
           {

--- a/scripts/agent-autopilot.sh
+++ b/scripts/agent-autopilot.sh
@@ -39,6 +39,10 @@ Notes:
   - Codex autopilot relies on the managed ~/.codex home Stop and SessionStart hooks installed by scripts/install-codex-home-hooks.sh.
   - If the target workspace provides `.codex/hooks/autopilot-stop.sh` or `.codex/hooks/session-start.sh`, those repo-local wrappers override the managed home fallback.
   - For Claude Code and OpenCode, this relies on their own permission/config defaults.
+  - DEPRECATED (2026-07-20): Claude in-process Stop-hook continue-loop
+    (.claude/hooks/autopilot-keep-running.sh) is unwired. This script still
+    drives Claude via an external multi-invoke loop; it no longer depends on
+    Claude Stop hooks. See .claude/hooks/DEPRECATED.md.
 EOF
 }
 
@@ -280,10 +284,11 @@ if [[ "$default_hook_max_turns" -lt 1 ]]; then
 fi
 hook_max_turns="$(first_set "${AUTOPILOT_MAX_TURNS:-}" "${CMUX_AUTOPILOT_MAX_TURNS:-}" "${CLAUDE_AUTOPILOT_MAX_TURNS:-}" "$default_hook_max_turns")"
 
-# For Claude tool: export env vars for autopilot-keep-running hook integration
+# Claude: external multi-invoke loop only.
+# In-process Stop-hook continue-loop is deprecated/unwired (.claude/hooks/DEPRECATED.md).
+# Keep legacy env exports for any residual local re-enable experiments.
 if [[ "$TOOL" = "claude" ]]; then
-  # Explicitly enable the hook for this run. Ordinary sessions stay disabled
-  # unless AUTOPILOT_KEEP_RUNNING_DISABLED=0 is set.
+  echo "note: Claude Stop-hook continue-loop is deprecated; using external agent-autopilot loop only." >&2
   export AUTOPILOT_KEEP_RUNNING_DISABLED=0
   export AUTOPILOT_STOP_FILE="$STOP_FILE"
   export CLAUDE_AUTOPILOT_STOP_FILE="$STOP_FILE"

--- a/scripts/autopilot-reset.sh
+++ b/scripts/autopilot-reset.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Claude provider note (2026-07-20):
+# Claude Code Stop/SessionStart continue-loop hooks are deprecated and no longer
+# registered in .claude/settings.json. See .claude/hooks/DEPRECATED.md.
+# This script still manages leftover /tmp state and remains fully active for Codex.
 set -euo pipefail
 
 PROVIDER="${AUTOPILOT_PROVIDER:-claude}"
@@ -14,6 +18,8 @@ case "$PROVIDER" in
   claude)
     STATE_PREFIX="claude-autopilot"
     CURRENT_SESSION_FILE="/tmp/claude-current-session-id"
+    echo "WARNING: Claude autopilot continue-loop is DEPRECATED and unwired from .claude/settings.json." >&2
+    echo "See .claude/hooks/DEPRECATED.md. Commands only affect leftover /tmp state." >&2
     ;;
   codex)
     STATE_PREFIX="codex-autopilot"

--- a/scripts/hooks/cmux-autopilot-stop-core.sh
+++ b/scripts/hooks/cmux-autopilot-stop-core.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Shared Stop-hook continue-loop core used by provider wrappers.
+# Claude wrapper (.claude/hooks/autopilot-keep-running.sh) is DEPRECATED and
+# unwired from .claude/settings.json as of 2026-07-20. Codex and other
+# providers may still use this core. See .claude/hooks/DEPRECATED.md.
 set -euo pipefail
 
 PROVIDER="${CMUX_HOOK_PROVIDER:-generic}"

--- a/scripts/hooks/cmux-session-start-core.sh
+++ b/scripts/hooks/cmux-session-start-core.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Shared SessionStart core used by provider wrappers.
+# Claude wrapper (.claude/hooks/session-start.sh) is DEPRECATED and unwired
+# from .claude/settings.json as of 2026-07-20. Codex and other providers may
+# still use this core. See .claude/hooks/DEPRECATED.md.
 set -euo pipefail
 
 PROVIDER="${CMUX_HOOK_PROVIDER:-generic}"

--- a/scripts/test-autopilot-wrap-up.sh
+++ b/scripts/test-autopilot-wrap-up.sh
@@ -4,9 +4,16 @@
 #
 # Usage: ./scripts/test-autopilot-wrap-up.sh
 #
+# NOTE (2026-07-20): Claude continue-loop hooks are deprecated/unwired from
+# .claude/settings.json. This suite exercises legacy script behavior with an
+# explicit opt-in flag. See .claude/hooks/DEPRECATED.md.
+#
 # Extends the pattern from test-stop-hooks.sh.
 
 set -euo pipefail
+
+# Opt into deprecated Claude continue-loop scripts for legacy unit coverage.
+export CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT=1
 
 unset AUTOPILOT_DELAY AUTOPILOT_IDLE_THRESHOLD AUTOPILOT_MAX_TURNS AUTOPILOT_MONITORING_THRESHOLD
 unset CMUX_AUTOPILOT_DELAY CMUX_AUTOPILOT_IDLE_THRESHOLD CMUX_AUTOPILOT_MAX_TURNS CMUX_AUTOPILOT_MONITORING_THRESHOLD
@@ -18,7 +25,7 @@ AUTOPILOT_HOOK="$HOOKS_DIR/autopilot-keep-running.sh"
 
 source "$SCRIPT_DIR/lib/autopilot-test-helpers.sh"
 
-echo "=== Autopilot Wrap-Up Phase Tests ==="
+echo "=== Autopilot Wrap-Up Phase Tests (legacy / deprecated Claude continue-loop) ==="
 
 cleanup_session() {
   local sid="$1"

--- a/scripts/test-stop-hooks.sh
+++ b/scripts/test-stop-hooks.sh
@@ -4,11 +4,18 @@
 #
 # Usage: ./scripts/test-stop-hooks.sh
 #
+# NOTE (2026-07-20): Claude continue-loop hooks are deprecated/unwired from
+# .claude/settings.json. This suite exercises legacy script behavior with an
+# explicit opt-in flag. See .claude/hooks/DEPRECATED.md.
+#
 # Each test simulates the hook execution flow by calling the actual hook scripts
 # with crafted input JSON and environment variables, then verifying side effects
 # (flag files, debug log entries, exit codes).
 
 set -euo pipefail
+
+# Opt into deprecated Claude continue-loop scripts for legacy unit coverage.
+export CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT=1
 
 unset AUTOPILOT_DELAY AUTOPILOT_IDLE_THRESHOLD AUTOPILOT_MAX_TURNS AUTOPILOT_MONITORING_THRESHOLD
 unset CMUX_AUTOPILOT_DELAY CMUX_AUTOPILOT_IDLE_THRESHOLD CMUX_AUTOPILOT_MAX_TURNS CMUX_AUTOPILOT_MONITORING_THRESHOLD


### PR DESCRIPTION
## Summary
- Unregister Claude Code `SessionStart` (`session-start.sh`) and Stop continue-loop (`autopilot-keep-running.sh`) from `.claude/settings.json`.
- Keep quality/review Stop hooks: `bun-check.sh` and `codex-review.sh`.
- Soft-disable the Claude wrapper scripts by default; legacy unit tests opt in with `CMUX_ALLOW_DEPRECATED_CLAUDE_AUTOPILOT=1`.
- Mark `/autopilot_reset` and related Claude control surfaces as deprecated; document replacements in `.claude/hooks/DEPRECATED.md`.
- Codex managed hooks, shared cores for non-Claude providers, and product/sandbox task autopilot are intentionally unchanged.

## Test plan
- [x] Default invoke of `autopilot-keep-running.sh` / `session-start.sh` prints DEPRECATED and exits 0 without continue-loop.
- [x] `scripts/test-autopilot-wrap-up.sh` with suite opt-in: 24/24 passed.
- [x] `bun check` passed on branch tip.
- [ ] CI checks on this PR green (or only pre-existing unrelated reds).

## Notes
- Local-only `.gitignore` noise for `.claude/dev-loop/status/` was excluded from this PR.