### PR TITLE
fix: VNC RFB remount, Electron auth handoff, and local package path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ apps/www/scripts/pr-review/evals/results/
 *.tsbuildinfo
 .claude/scheduled_tasks.lock
 .claude/dev-loop-debug/
+.claude/dev-loop/status/

--- a/apps/client/build-mac-workaround.sh
+++ b/apps/client/build-mac-workaround.sh
@@ -28,6 +28,10 @@ set +a  # Turn off auto-export
 ensure_native_core_built() {
   local native_dir="$ROOT_DIR/apps/server/native/core"
   echo "Ensuring native Rust addon (.node) is built..."
+  if [ "${SKIP_NATIVE_BUILD:-}" = "true" ] && ls "$native_dir"/*.node >/dev/null 2>&1; then
+    echo "SKIP_NATIVE_BUILD=true: reusing existing native .node binary (skip napi rebuild)"
+    return 0
+  fi
   if ls "$native_dir"/*.node >/dev/null 2>&1; then
     echo "Existing native binary detected; rebuilding for consistency..."
   else

--- a/apps/client/electron.vite.config.ts
+++ b/apps/client/electron.vite.config.ts
@@ -133,6 +133,9 @@ export default defineConfig({
       "process.env.NODE_ENV": JSON.stringify(
         isProduction ? "production" : "development"
       ),
+      // Pass through shell ON_TRACE=1 for VNC recovery / other debug call-site traces
+      "import.meta.env.ON_TRACE": JSON.stringify(process.env.ON_TRACE ?? ""),
+      "process.env.ON_TRACE": JSON.stringify(process.env.ON_TRACE ?? ""),
       global: "globalThis",
     },
     build: {

--- a/apps/client/electron/main/electron-auth-navigation.test.ts
+++ b/apps/client/electron/main/electron-auth-navigation.test.ts
@@ -22,12 +22,20 @@ describe("rewriteHandlerPathToHash", () => {
     );
   });
 
-  it("returns null when already hash-routed", () => {
+  it("returns null when already hash-routed with query in hash", () => {
     expect(
       rewriteHandlerPathToHash(
         "http://localhost:5173/#/handler/oauth-callback?code=1"
       )
     ).toBeNull();
+  });
+
+  it("merges outer search into hash when hash path lacks query", () => {
+    expect(
+      rewriteHandlerPathToHash(
+        "http://localhost:5173/?code=1#/handler/oauth-callback"
+      )
+    ).toBe("http://localhost:5173/#/handler/oauth-callback?code=1");
   });
 
   it("returns null for non-handler SPA paths", () => {

--- a/apps/client/electron/main/electron-auth-navigation.test.ts
+++ b/apps/client/electron/main/electron-auth-navigation.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSpaOrigins,
+  classifyAuthWindowNavigation,
+  classifyMainWindowNavigation,
+  isOAuthProviderUrl,
+  isSpaAuthCallback,
+  isSpaOrigin,
+  rewriteHandlerPathToHash,
+} from "./electron-auth-navigation";
+
+const SPA = ["http://localhost:5173", "https://cmux.local"] as const;
+
+describe("rewriteHandlerPathToHash", () => {
+  it("rewrites path-style Stack handler to hash router form", () => {
+    expect(
+      rewriteHandlerPathToHash(
+        "http://localhost:5173/handler/oauth-callback?code=abc&state=xyz"
+      )
+    ).toBe(
+      "http://localhost:5173/#/handler/oauth-callback?code=abc&state=xyz"
+    );
+  });
+
+  it("returns null when already hash-routed", () => {
+    expect(
+      rewriteHandlerPathToHash(
+        "http://localhost:5173/#/handler/oauth-callback?code=1"
+      )
+    ).toBeNull();
+  });
+
+  it("returns null for non-handler SPA paths", () => {
+    expect(
+      rewriteHandlerPathToHash("http://localhost:5173/sign-in")
+    ).toBeNull();
+  });
+});
+
+describe("isOAuthProviderUrl", () => {
+  it("detects Stack and GitHub hosts", () => {
+    expect(
+      isOAuthProviderUrl(
+        "https://api.stack-auth.com/api/v1/auth/oauth/authorize/github"
+      )
+    ).toBe(true);
+    expect(isOAuthProviderUrl("https://github.com/login/oauth/authorize")).toBe(
+      true
+    );
+    expect(isOAuthProviderUrl("https://api.stack-auth.com/session")).toBe(true);
+  });
+
+  it("rejects SPA and unrelated hosts", () => {
+    expect(isOAuthProviderUrl("http://localhost:5173/")).toBe(false);
+    expect(isOAuthProviderUrl("https://example.com")).toBe(false);
+  });
+});
+
+describe("classifyMainWindowNavigation", () => {
+  it("allows SPA navigations", () => {
+    expect(
+      classifyMainWindowNavigation("http://localhost:5173/#/sign-in", {
+        spaOrigins: SPA,
+      })
+    ).toEqual({ action: "allow" });
+  });
+
+  it("rewrites SPA /handler path callbacks", () => {
+    expect(
+      classifyMainWindowNavigation(
+        "http://localhost:5173/handler/oauth-callback?code=1",
+        { spaOrigins: SPA }
+      )
+    ).toEqual({
+      action: "rewrite-hash",
+      url: "http://localhost:5173/#/handler/oauth-callback?code=1",
+    });
+  });
+
+  it("routes OAuth hosts to auth-window", () => {
+    expect(
+      classifyMainWindowNavigation(
+        "https://api.stack-auth.com/api/v1/auth/oauth/authorize/github?x=1",
+        { spaOrigins: SPA }
+      )
+    ).toEqual({
+      action: "auth-window",
+      url: "https://api.stack-auth.com/api/v1/auth/oauth/authorize/github?x=1",
+    });
+  });
+
+  it("opens other http(s) externally", () => {
+    expect(
+      classifyMainWindowNavigation("https://docs.example.com/guide", {
+        spaOrigins: SPA,
+      })
+    ).toEqual({
+      action: "external",
+      url: "https://docs.example.com/guide",
+    });
+  });
+
+  it("allows non-http schemes", () => {
+    expect(
+      classifyMainWindowNavigation("devtools://devtools/bundled/index.html", {
+        spaOrigins: SPA,
+      })
+    ).toEqual({ action: "allow" });
+  });
+});
+
+describe("classifyAuthWindowNavigation", () => {
+  it("allows OAuth inside auth window", () => {
+    expect(
+      classifyAuthWindowNavigation("https://api.stack-auth.com/session", {
+        spaOrigins: SPA,
+      })
+    ).toEqual({ action: "allow" });
+  });
+
+  it("rewrites SPA handler callback for handoff to main", () => {
+    expect(
+      classifyAuthWindowNavigation(
+        "http://localhost:5173/handler/oauth-callback?code=z",
+        { spaOrigins: SPA }
+      )
+    ).toEqual({
+      action: "rewrite-hash",
+      url: "http://localhost:5173/#/handler/oauth-callback?code=z",
+    });
+  });
+});
+
+describe("isSpaAuthCallback", () => {
+  it("detects path and hash handler URLs on SPA", () => {
+    expect(
+      isSpaAuthCallback("http://localhost:5173/handler/oauth-callback", SPA)
+    ).toBe(true);
+    expect(
+      isSpaAuthCallback(
+        "http://localhost:5173/#/handler/oauth-callback?code=1",
+        SPA
+      )
+    ).toBe(true);
+    expect(isSpaAuthCallback("http://localhost:5173/#/sign-in", SPA)).toBe(
+      false
+    );
+  });
+});
+
+describe("buildSpaOrigins / isSpaOrigin", () => {
+  it("includes app host and renderer origin", () => {
+    const origins = buildSpaOrigins({
+      appHost: "cmux.local",
+      electronRendererUrl: "http://localhost:5173/",
+    });
+    expect(origins).toContain("https://cmux.local");
+    expect(origins).toContain("http://localhost:5173");
+    expect(isSpaOrigin("http://localhost:5173/foo", origins)).toBe(true);
+    expect(isSpaOrigin("https://cmux.local/index-electron.html", origins)).toBe(
+      true
+    );
+  });
+});

--- a/apps/client/electron/main/electron-auth-navigation.ts
+++ b/apps/client/electron/main/electron-auth-navigation.ts
@@ -1,0 +1,218 @@
+/**
+ * Pure helpers for Electron main-window auth navigation.
+ *
+ * Problem: Stack/GitHub OAuth navigates the main BrowserWindow away from the
+ * SPA, and Electron hash history never sees path-style /handler/* callbacks.
+ *
+ * Decisions (main window):
+ * - SPA origins: allow
+ * - /handler/* on SPA origin: rewrite to #/handler/* (hash router)
+ * - OAuth providers: open dedicated auth window (shared partition)
+ * - other http(s): open external browser; keep main on SPA
+ */
+
+export type AuthNavDecision =
+  | { action: "allow" }
+  | { action: "rewrite-hash"; url: string }
+  | { action: "auth-window"; url: string }
+  | { action: "external"; url: string };
+
+export type ClassifyMainWindowNavigationOptions = {
+  /** Origins considered the cmux SPA (e.g. http://localhost:5173, https://cmux.local) */
+  spaOrigins: readonly string[];
+};
+
+const OAUTH_HOST_SUFFIXES = [
+  "stack-auth.com",
+  "github.com",
+  "githubusercontent.com",
+  "google.com",
+  "accounts.google.com",
+  "login.microsoftonline.com",
+] as const;
+
+function normalizeOrigin(origin: string): string {
+  try {
+    return new URL(origin).origin;
+  } catch {
+    return origin.replace(/\/$/, "");
+  }
+}
+
+export function isSpaOrigin(
+  rawUrl: string,
+  spaOrigins: readonly string[]
+): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  const origin = url.origin;
+  return spaOrigins.some((candidate) => normalizeOrigin(candidate) === origin);
+}
+
+export function isOAuthProviderUrl(rawUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return false;
+  }
+  const host = url.hostname.toLowerCase();
+  return OAUTH_HOST_SUFFIXES.some(
+    (suffix) => host === suffix || host.endsWith(`.${suffix}`)
+  );
+}
+
+/**
+ * Convert path-style Stack handler URLs to hash-router form.
+ * http://localhost:5173/handler/oauth-callback?x=1
+ *   → http://localhost:5173/#/handler/oauth-callback?x=1
+ *
+ * Returns null when no rewrite is needed.
+ */
+export function rewriteHandlerPathToHash(rawUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  // Already hash-routed
+  if (url.hash.startsWith("#/handler")) {
+    return null;
+  }
+
+  if (!url.pathname.startsWith("/handler")) {
+    return null;
+  }
+
+  const rewritten = new URL(url.origin);
+  // URL.hash setter prefixes "#"; pathname already starts with "/"
+  rewritten.hash = `${url.pathname}${url.search}`;
+  return rewritten.toString();
+}
+
+/**
+ * Shared SPA / non-http classification.
+ * Returns a decision when the URL is non-http, invalid, or SPA; otherwise null.
+ */
+function classifySpaNavigation(
+  rawUrl: string,
+  spaOrigins: readonly string[]
+): AuthNavDecision | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { action: "allow" };
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return { action: "allow" };
+  }
+
+  if (!isSpaOrigin(rawUrl, spaOrigins)) {
+    return null;
+  }
+
+  const rewritten = rewriteHandlerPathToHash(rawUrl);
+  if (rewritten) {
+    return { action: "rewrite-hash", url: rewritten };
+  }
+  return { action: "allow" };
+}
+
+/**
+ * Classify a main-frame navigation for the app window.
+ * Non-http(s) schemes (devtools, about, file, chrome-error) are allowed.
+ */
+export function classifyMainWindowNavigation(
+  rawUrl: string,
+  options: ClassifyMainWindowNavigationOptions
+): AuthNavDecision {
+  const spaDecision = classifySpaNavigation(rawUrl, options.spaOrigins);
+  if (spaDecision) {
+    return spaDecision;
+  }
+
+  if (isOAuthProviderUrl(rawUrl)) {
+    return { action: "auth-window", url: rawUrl };
+  }
+
+  return { action: "external", url: rawUrl };
+}
+
+/**
+ * Auth child window: allow OAuth + SPA; rewrite path handler; otherwise external.
+ * Callers close the auth window when SPA callback is reached.
+ */
+export function classifyAuthWindowNavigation(
+  rawUrl: string,
+  options: ClassifyMainWindowNavigationOptions
+): AuthNavDecision {
+  const spaDecision = classifySpaNavigation(rawUrl, options.spaOrigins);
+  if (spaDecision) {
+    return spaDecision;
+  }
+
+  if (isOAuthProviderUrl(rawUrl)) {
+    return { action: "allow" };
+  }
+
+  return { action: "external", url: rawUrl };
+}
+
+/** True when URL is a Stack/handler callback on the SPA (path or hash). */
+export function isSpaAuthCallback(
+  rawUrl: string,
+  spaOrigins: readonly string[]
+): boolean {
+  if (!isSpaOrigin(rawUrl, spaOrigins)) {
+    return false;
+  }
+  try {
+    const url = new URL(rawUrl);
+    return (
+      url.pathname.startsWith("/handler") || url.hash.startsWith("#/handler")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function buildSpaOrigins(params: {
+  appHost: string;
+  electronRendererUrl?: string | null;
+  extraOrigins?: readonly string[];
+}): string[] {
+  const origins = new Set<string>();
+  origins.add(`https://${params.appHost}`);
+  origins.add(`http://${params.appHost}`);
+  origins.add("http://localhost:5173");
+  origins.add("http://127.0.0.1:5173");
+
+  if (params.electronRendererUrl) {
+    try {
+      origins.add(new URL(params.electronRendererUrl).origin);
+    } catch {
+      // ignore
+    }
+  }
+
+  for (const extra of params.extraOrigins ?? []) {
+    try {
+      origins.add(new URL(extra).origin);
+    } catch {
+      // ignore
+    }
+  }
+
+  return [...origins];
+}

--- a/apps/client/electron/main/electron-auth-navigation.ts
+++ b/apps/client/electron/main/electron-auth-navigation.ts
@@ -74,6 +74,9 @@ export function isOAuthProviderUrl(rawUrl: string): boolean {
  * http://localhost:5173/handler/oauth-callback?x=1
  *   → http://localhost:5173/#/handler/oauth-callback?x=1
  *
+ * Query string is kept on the hash path so TanStack hash history + StackHandler
+ * receive the OAuth code (location.pathname + location.search).
+ *
  * Returns null when no rewrite is needed.
  */
 export function rewriteHandlerPathToHash(rawUrl: string): string | null {
@@ -84,9 +87,21 @@ export function rewriteHandlerPathToHash(rawUrl: string): string | null {
     return null;
   }
 
-  // Already hash-routed
+  // Already hash-routed (optionally normalize query-on-search → query-in-hash)
   if (url.hash.startsWith("#/handler")) {
-    return null;
+    // e.g. http://host/#/handler/x with ?code= on the outer search is unusual;
+    // leave as-is if already hash-only.
+    if (!url.search) {
+      return null;
+    }
+    // Rare: path empty, search on origin, hash has path — merge search into hash
+    const hashBody = url.hash.slice(1); // drop leading #
+    if (hashBody.includes("?")) {
+      return null;
+    }
+    const rewritten = new URL(url.origin);
+    rewritten.hash = `${hashBody}${url.search}`;
+    return rewritten.toString();
   }
 
   if (!url.pathname.startsWith("/handler")) {

--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -927,13 +927,17 @@ function registerAppIpcHandlers(): void {
 
       return {
         ok: true as const,
+        scheme: cmuxProtocol,
         isPackaged: app.isPackaged,
         isDefaultProtocolClient,
+        // unpackaged electron-vite often fails OS default-handler check even after setAsDefault
+        defaultApp: process.defaultApp === true,
       };
     } catch (error) {
       mainWarn("Failed to get protocol status", error);
       return {
         ok: false as const,
+        scheme: env.NEXT_PUBLIC_CMUX_PROTOCOL,
         error: error instanceof Error ? error.message : String(error),
       };
     }

--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -1193,6 +1193,23 @@ function openAuthWindow(startUrl: string): void {
     return null;
   };
 
+  const tryHandoffFromAuthUrl = (
+    url: string,
+    source: string,
+    event?: Electron.Event
+  ): boolean => {
+    const decision = classifyAuthWindowNavigation(url, { spaOrigins });
+    const handoffUrl = resolveAuthCallbackHandoff(url, decision);
+    if (!handoffUrl) {
+      return false;
+    }
+    event?.preventDefault();
+    mainLog("[auth-nav] auth callback → main", { url: handoffUrl, source });
+    void loadMainWindowAuthCallback(handoffUrl);
+    closeAuthWindow();
+    return true;
+  };
+
   const handleAuthNav = (
     event: Electron.Event,
     url: string,
@@ -1204,12 +1221,7 @@ function openAuthWindow(startUrl: string): void {
     const decision = classifyAuthWindowNavigation(url, { spaOrigins });
     mainLog("[auth-nav] auth will-navigate", { url, decision: decision.action });
 
-    const handoffUrl = resolveAuthCallbackHandoff(url, decision);
-    if (handoffUrl) {
-      event.preventDefault();
-      mainLog("[auth-nav] auth callback → main", { url: handoffUrl });
-      void loadMainWindowAuthCallback(handoffUrl);
-      closeAuthWindow();
+    if (tryHandoffFromAuthUrl(url, "will-navigate", event)) {
       return;
     }
 
@@ -1225,9 +1237,46 @@ function openAuthWindow(startUrl: string): void {
   win.webContents.on("will-navigate", (event, url) => {
     handleAuthNav(event, url, true);
   });
-  win.webContents.on("will-redirect", (event, url) => {
-    handleAuthNav(event, url, true);
+  // Some OAuth redirects only surface on will-redirect / did-navigate.
+  win.webContents.on(
+    "will-redirect",
+    (event, url, _isInPlace, isMainFrame) => {
+      if (isMainFrame === false) {
+        return;
+      }
+      handleAuthNav(event, url, true);
+    }
+  );
+  win.webContents.on("did-navigate", (_event, url) => {
+    mainLog("[auth-nav] auth did-navigate", { url });
+    void tryHandoffFromAuthUrl(url, "did-navigate");
   });
+  win.webContents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
+    if (!isMainFrame) {
+      return;
+    }
+    mainLog("[auth-nav] auth did-navigate-in-page", { url });
+    void tryHandoffFromAuthUrl(url, "did-navigate-in-page");
+  });
+  win.webContents.on(
+    "did-fail-load",
+    (
+      _event,
+      errorCode,
+      errorDescription,
+      validatedURL,
+      isMainFrame
+    ) => {
+      if (!isMainFrame) {
+        return;
+      }
+      mainWarn("[auth-nav] auth did-fail-load", {
+        errorCode,
+        errorDescription,
+        validatedURL,
+      });
+    }
+  );
 
   win.webContents.setWindowOpenHandler((details) => {
     const targetUrl = normalizeBrowserUrl(details.url);

--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -65,6 +65,14 @@ import {
 } from "./stack-auth-cookies";
 import { computeSetAsDefaultProtocolClientCall } from "./protocol-registration";
 import {
+  buildSpaOrigins,
+  classifyAuthWindowNavigation,
+  classifyMainWindowNavigation,
+  isSpaAuthCallback,
+  isSpaOrigin,
+  type AuthNavDecision,
+} from "./electron-auth-navigation";
+import {
   MCP_HOST_CONFIG_IPC_CHANNELS,
   readClaudeJsonConfig,
   readCodexTomlConfig,
@@ -122,6 +130,8 @@ const LOG_ROTATION: LogRotationOptions = {
 let rendererLoaded = false;
 let pendingProtocolUrl: string | null = null;
 let mainWindow: BrowserWindow | null = null;
+/** Dedicated OAuth window (shared partition so Stack cookies land for SPA). */
+let authWindow: BrowserWindow | null = null;
 let previewReloadMenuItem: MenuItem | null = null;
 let previewBackMenuItem: MenuItem | null = null;
 let previewForwardMenuItem: MenuItem | null = null;
@@ -1076,6 +1086,226 @@ async function handleOrQueueProtocolUrl(url: string) {
   }
 }
 
+function getSpaOrigins(): string[] {
+  return buildSpaOrigins({
+    appHost: APP_HOST,
+    electronRendererUrl: process.env["ELECTRON_RENDERER_URL"] ?? null,
+  });
+}
+
+function getMainWindowSpaHomeUrl(): string {
+  if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
+    return process.env["ELECTRON_RENDERER_URL"];
+  }
+  return `https://${APP_HOST}/index-electron.html`;
+}
+
+function closeAuthWindow(): void {
+  if (!authWindow || authWindow.isDestroyed()) {
+    authWindow = null;
+    return;
+  }
+  try {
+    authWindow.close();
+  } catch {
+    // ignore
+  }
+  authWindow = null;
+}
+
+/**
+ * Apply a navigation decision for a main-frame load on the given webContents.
+ * Returns true if the default navigation should be cancelled.
+ */
+function applyAuthNavDecision(
+  decision: AuthNavDecision,
+  webContents: Electron.WebContents,
+  context: "main" | "auth"
+): boolean {
+  switch (decision.action) {
+    case "allow":
+      return false;
+    case "rewrite-hash": {
+      mainLog("[auth-nav] rewrite-hash", { context, url: decision.url });
+      void webContents.loadURL(decision.url);
+      return true;
+    }
+    case "auth-window": {
+      mainLog("[auth-nav] open auth-window", { url: decision.url });
+      openAuthWindow(decision.url);
+      return true;
+    }
+    case "external": {
+      mainLog("[auth-nav] open external", { context, url: decision.url });
+      void shell.openExternal(normalizeBrowserUrl(decision.url));
+      return true;
+    }
+    default: {
+      const _exhaustive: never = decision;
+      return _exhaustive;
+    }
+  }
+}
+
+function openAuthWindow(startUrl: string): void {
+  if (authWindow && !authWindow.isDestroyed()) {
+    mainLog("[auth-nav] reusing auth window", { url: startUrl });
+    void authWindow.loadURL(startUrl);
+    authWindow.focus();
+    return;
+  }
+
+  const spaOrigins = getSpaOrigins();
+  authWindow = new BrowserWindow({
+    width: 520,
+    height: 720,
+    show: true,
+    autoHideMenuBar: true,
+    title: "Sign in",
+    webPreferences: {
+      // Same partition as main so Stack cookies are visible to the SPA.
+      partition: PARTITION,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+    },
+  });
+
+  const win = authWindow;
+  win.on("closed", () => {
+    if (authWindow === win) {
+      authWindow = null;
+    }
+  });
+
+  /** SPA OAuth callback → main window URL, or null if not a handoff. */
+  const resolveAuthCallbackHandoff = (
+    url: string,
+    decision: AuthNavDecision
+  ): string | null => {
+    if (decision.action === "rewrite-hash") {
+      return decision.url;
+    }
+    // Hash-routed SPA callbacks classify as allow; path-form already rewrite-hash.
+    if (decision.action === "allow" && isSpaAuthCallback(url, spaOrigins)) {
+      return url;
+    }
+    return null;
+  };
+
+  const handleAuthNav = (
+    event: Electron.Event,
+    url: string,
+    isMainFrame?: boolean
+  ) => {
+    if (isMainFrame === false) {
+      return;
+    }
+    const decision = classifyAuthWindowNavigation(url, { spaOrigins });
+    mainLog("[auth-nav] auth will-navigate", { url, decision: decision.action });
+
+    const handoffUrl = resolveAuthCallbackHandoff(url, decision);
+    if (handoffUrl) {
+      event.preventDefault();
+      mainLog("[auth-nav] auth callback → main", { url: handoffUrl });
+      void loadMainWindowAuthCallback(handoffUrl);
+      closeAuthWindow();
+      return;
+    }
+
+    if (decision.action === "allow") {
+      return;
+    }
+
+    if (applyAuthNavDecision(decision, win.webContents, "auth")) {
+      event.preventDefault();
+    }
+  };
+
+  win.webContents.on("will-navigate", (event, url) => {
+    handleAuthNav(event, url, true);
+  });
+  win.webContents.on("will-redirect", (event, url) => {
+    handleAuthNav(event, url, true);
+  });
+
+  win.webContents.setWindowOpenHandler((details) => {
+    const targetUrl = normalizeBrowserUrl(details.url);
+    const decision = classifyAuthWindowNavigation(targetUrl, { spaOrigins });
+    const handoffUrl = resolveAuthCallbackHandoff(targetUrl, decision);
+    if (handoffUrl) {
+      void loadMainWindowAuthCallback(handoffUrl);
+      closeAuthWindow();
+      return { action: "deny" };
+    }
+    if (decision.action === "allow") {
+      void win.webContents.loadURL(targetUrl);
+      return { action: "deny" };
+    }
+    applyAuthNavDecision(decision, win.webContents, "auth");
+    return { action: "deny" };
+  });
+
+  mainLog("[auth-nav] creating auth window", { url: startUrl });
+  void win.loadURL(startUrl);
+}
+
+async function loadMainWindowAuthCallback(url: string): Promise<void> {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    mainWarn("[auth-nav] no main window for auth callback", { url });
+    return;
+  }
+  try {
+    await mainWindow.loadURL(url);
+    mainWindow.focus();
+  } catch (error) {
+    mainWarn("[auth-nav] failed to load auth callback on main", {
+      url,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // Fallback: reload SPA home so user can retry / session may still sync via cookies
+    try {
+      await mainWindow.loadURL(getMainWindowSpaHomeUrl());
+      mainWindow.focus();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function attachMainWindowAuthNavigationGuards(window: BrowserWindow): void {
+  const spaOrigins = getSpaOrigins();
+  const contents = window.webContents;
+
+  const onNavigate = (
+    event: Electron.Event,
+    url: string,
+    isMainFrame?: boolean
+  ) => {
+    if (isMainFrame === false) {
+      return;
+    }
+    const decision = classifyMainWindowNavigation(url, { spaOrigins });
+    if (decision.action === "allow") {
+      return;
+    }
+    mainLog("[auth-nav] main will-navigate", {
+      url,
+      decision: decision.action,
+    });
+    if (applyAuthNavDecision(decision, contents, "main")) {
+      event.preventDefault();
+    }
+  };
+
+  contents.on("will-navigate", (event, url) => {
+    onNavigate(event, url, true);
+  });
+  contents.on("will-redirect", (event, url) => {
+    onNavigate(event, url, true);
+  });
+}
+
 function createWindow(): void {
   const windowOptions: BrowserWindowConstructorOptions = {
     width: 1200,
@@ -1164,9 +1394,24 @@ function createWindow(): void {
     mainLog("did-navigate", { url });
   });
 
+  // Phase A/B/C1: keep SPA in main window; OAuth goes to dedicated auth window;
+  // path /handler/* rewrites to hash router form.
+  attachMainWindowAuthNavigationGuards(mainWindow);
+
   mainWindow.webContents.setWindowOpenHandler((details) => {
     const targetUrl = normalizeBrowserUrl(details.url);
-    shell.openExternal(targetUrl);
+    const spaOrigins = getSpaOrigins();
+    const decision = classifyMainWindowNavigation(targetUrl, { spaOrigins });
+    // Always deny popups: SPA stays in main, OAuth uses auth window, else external.
+    if (decision.action === "allow" && isSpaOrigin(targetUrl, spaOrigins)) {
+      void mainWindow?.loadURL(targetUrl);
+      return { action: "deny" };
+    }
+    if (decision.action === "allow") {
+      void shell.openExternal(targetUrl);
+      return { action: "deny" };
+    }
+    applyAuthNavDecision(decision, mainWindow.webContents, "main");
     return { action: "deny" };
   });
 

--- a/apps/client/electron/main/protocol-registration.test.ts
+++ b/apps/client/electron/main/protocol-registration.test.ts
@@ -34,7 +34,7 @@ describe("computeSetAsDefaultProtocolClientCall", () => {
       scheme: "manaflow",
       defaultApp: true,
       execPath: "/Electron",
-      argv: ["/Electron", "--inspect=0", "apps/client", "manaflow://auth-callback?a=b"],
+      argv: ["/Electron", "--inspect=0", "apps/client", "cmux-dev://auth-callback?a=b"],
     });
     expect(call).toEqual({
       kind: "withArgs",
@@ -49,7 +49,7 @@ describe("computeSetAsDefaultProtocolClientCall", () => {
       scheme: "manaflow",
       defaultApp: true,
       execPath: "/Electron",
-      argv: ["/Electron", "--inspect=0", "manaflow://auth-callback?a=b"],
+      argv: ["/Electron", "--inspect=0", "cmux-dev://auth-callback?a=b"],
     });
     expect(call).toEqual({ kind: "simple", scheme: "manaflow" });
   });

--- a/apps/client/electron/main/protocol-registration.ts
+++ b/apps/client/electron/main/protocol-registration.ts
@@ -34,7 +34,7 @@ export function computeSetAsDefaultProtocolClientCall(params: {
 
   // In development, Electron is launched as the "default app" (Electron.app).
   // Registering a protocol handler must include an app path argument so the OS
-  // can relaunch Electron with our app when a manaflow:// URL is opened.
+  // can relaunch Electron with our app when a cmux-dev:// (or configured scheme) URL is opened.
   const appPathArg = params.argv.slice(1).find(isLikelyAppPathArg);
   if (!appPathArg) {
     return { kind: "simple", scheme: params.scheme };

--- a/apps/client/electron/preload/index.d.ts
+++ b/apps/client/electron/preload/index.d.ts
@@ -50,8 +50,14 @@ declare global {
       app: {
         getProtocolStatus: () =>
           Promise<
-            | { ok: true; isPackaged: boolean; isDefaultProtocolClient: boolean }
-            | { ok: false; error: string }
+            | {
+                ok: true;
+                scheme: string;
+                isPackaged: boolean;
+                isDefaultProtocolClient: boolean;
+                defaultApp: boolean;
+              }
+            | { ok: false; scheme?: string; error: string }
           >;
       };
       mcpHostConfig: {

--- a/apps/client/electron/preload/index.ts
+++ b/apps/client/electron/preload/index.ts
@@ -219,10 +219,12 @@ const cmuxAPI = {
       ipcRenderer.invoke("cmux:app:get-protocol-status") as Promise<
         | {
             ok: true;
+            scheme: string;
             isPackaged: boolean;
             isDefaultProtocolClient: boolean;
+            defaultApp: boolean;
           }
-        | { ok: false; error: string }
+        | { ok: false; scheme?: string; error: string }
       >,
   },
   machine: {

--- a/apps/client/src/components/TaskPanelFactory.dom.test.tsx
+++ b/apps/client/src/components/TaskPanelFactory.dom.test.tsx
@@ -120,9 +120,15 @@ describe("TaskPanelFactory", () => {
       );
     });
 
-    expect(receivedProps).toHaveLength(2);
-    expect(receivedProps[0]?.isFocusEligible).toBe(true);
-    expect(receivedProps[1]?.isFocusEligible).toBe(false);
+    // Browser panel may re-render once as VNC RFB recovery arms; assert by key.
+    const workspaceProps = receivedProps.find(
+      (props) => props.persistKey === "workspace-key"
+    );
+    const browserProps = receivedProps.find(
+      (props) => props.persistKey === "browser-key"
+    );
+    expect(workspaceProps?.isFocusEligible).toBe(true);
+    expect(browserProps?.isFocusEligible).toBe(false);
 
     await act(async () => {
       root.unmount();

--- a/apps/client/src/components/TaskPanelFactory.tsx
+++ b/apps/client/src/components/TaskPanelFactory.tsx
@@ -31,6 +31,9 @@ import type { LiveDiffPanelProps } from "./LiveDiffPanel";
 import type { TestResultsPanelProps } from "./TestResultsPanel";
 import { shouldUseServerIframePreflight } from "@/hooks/useIframePreflight";
 import { useVncClipboardBridge } from "@/hooks/useVncClipboardBridge";
+import { useVncPreviewRecovery } from "@/hooks/useVncPreviewRecovery";
+import { RFB_TIMEOUT_ERROR_MESSAGE } from "@/lib/vnc-preview-recovery";
+import { Button } from "@/components/ui/button";
 
 const PANEL_DRAG_START_EVENT = "cmux:panel-drag-start";
 const PANEL_DRAG_END_EVENT = "cmux:panel-drag-end";
@@ -249,8 +252,22 @@ function BrowserPanelContent({
     enabled: isVncIframe,
   });
 
+  const {
+    recovery,
+    forcedStatus: rfbForcedStatus,
+    onIframeLoad: onRfbIframeLoad,
+    retry: retryRfb,
+    enabled: rfbRecoveryEnabled,
+    isBusy: rfbBusy,
+  } = useVncPreviewRecovery({
+    persistKey: browserPersistKey,
+    browserUrl,
+  });
+
+  const ariaBusy = rfbRecoveryEnabled ? rfbBusy : isBrowserBusy;
+
   return (
-    <div className={clsx("relative flex-1", isExpanded && "h-full")} aria-busy={isBrowserBusy}>
+    <div className={clsx("relative flex-1", isExpanded && "h-full")} aria-busy={ariaBusy}>
       <PersistentWebView
           key={browserPersistKey}
           persistKey={browserPersistKey}
@@ -261,10 +278,51 @@ function BrowserPanelContent({
           allow={TASK_RUN_IFRAME_ALLOW}
           sandbox={TASK_RUN_IFRAME_SANDBOX}
           retainOnUnmount
+          onLoad={onRfbIframeLoad}
           onStatusChange={setBrowserStatus}
-          fallback={<WorkspaceLoadingIndicator variant="browser" status="loading" />}
+          forcedStatus={rfbForcedStatus}
+          fallback={
+            <WorkspaceLoadingIndicator
+              variant="browser"
+              status="loading"
+              loadingTitle={
+                recovery.phase === "remounting"
+                  ? "Reconnecting remote desktop"
+                  : undefined
+              }
+              loadingDescription={
+                recovery.phase === "remounting"
+                  ? `Retrying VNC session (attempt ${recovery.autoRemountCount})…`
+                  : rfbRecoveryEnabled
+                    ? "Waiting for the remote desktop session to become ready…"
+                    : undefined
+              }
+            />
+          }
           fallbackClassName="bg-neutral-50 dark:bg-black"
-          errorFallback={<WorkspaceLoadingIndicator variant="browser" status="error" />}
+          errorFallback={
+            <WorkspaceLoadingIndicator
+              variant="browser"
+              status="error"
+              errorTitle="Remote desktop did not connect"
+              errorDescription={
+                recovery.errorMessage ?? RFB_TIMEOUT_ERROR_MESSAGE
+              }
+              action={
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="pointer-events-auto mt-2"
+                  onClick={() => {
+                    retryRfb();
+                  }}
+                >
+                  Retry connection
+                </Button>
+              }
+            />
+          }
           errorFallbackClassName="bg-neutral-50/95 dark:bg-black/95"
           loadTimeoutMs={45_000}
           isExpanded={isExpanded}

--- a/apps/client/src/components/sign-in-component.tsx
+++ b/apps/client/src/components/sign-in-component.tsx
@@ -2,6 +2,7 @@
 
 import { isElectron } from "@/lib/electron";
 import { getElectronBridge } from "@/lib/electron";
+import { env } from "@/client-env";
 import { WWW_ORIGIN } from "@/lib/wwwOrigin";
 import { SignIn, useUser } from "@stackframe/react";
 import { AnimatePresence, motion } from "framer-motion";
@@ -13,15 +14,33 @@ type SignInState =
   | { kind: "awaiting-browser"; sessionId: string }
   | { kind: "embedded" };
 
+type ProtocolStatus =
+  | {
+      ok: true;
+      scheme: string;
+      isPackaged: boolean;
+      isDefaultProtocolClient: boolean;
+      defaultApp: boolean;
+    }
+  | { ok: false; scheme?: string; error: string };
+
+/** Product display name (packaged app is cmux-next; scheme may be cmux-dev in dev). */
+const APP_DISPLAY_NAME = "cmux-next";
+
+function resolveDeeplinkScheme(status: ProtocolStatus | null): string {
+  if (status && "scheme" in status && status.scheme) {
+    return status.scheme;
+  }
+  return env.NEXT_PUBLIC_CMUX_PROTOCOL ?? "cmux-next";
+}
+
 export function SignInComponent() {
   const user = useUser({ or: "return-null" });
   const showSignIn = !user;
   const [state, setState] = useState<SignInState>({ kind: "idle" });
-  const [protocolStatus, setProtocolStatus] = useState<
-    | { ok: true; isPackaged: boolean; isDefaultProtocolClient: boolean }
-    | { ok: false; error: string }
-    | null
-  >(null);
+  const [protocolStatus, setProtocolStatus] = useState<ProtocolStatus | null>(
+    null
+  );
 
   // Track the current session to prevent stale callbacks
   const currentSessionRef = useRef<string | null>(null);
@@ -34,16 +53,23 @@ export function SignInComponent() {
     bridge.app
       .getProtocolStatus()
       .then((res) => {
-        setProtocolStatus(res);
+        setProtocolStatus(res as ProtocolStatus);
       })
       .catch((error: unknown) => {
         console.error("[SignIn] Failed to get protocol status:", error);
         setProtocolStatus({
           ok: false,
+          scheme: env.NEXT_PUBLIC_CMUX_PROTOCOL ?? "cmux-next",
           error: error instanceof Error ? error.message : String(error),
         });
       });
   }, []);
+
+  const deeplinkScheme = useMemo(
+    () => resolveDeeplinkScheme(protocolStatus),
+    [protocolStatus]
+  );
+  const deeplinkLabel = `${deeplinkScheme}://`;
 
   const browserSignInSupported = useMemo(() => {
     if (!isElectron) return true;
@@ -51,6 +77,10 @@ export function SignInComponent() {
     if (!protocolStatus.ok) return true;
     return protocolStatus.isDefaultProtocolClient;
   }, [protocolStatus]);
+
+  const isUnpackagedDev =
+    protocolStatus?.ok === true &&
+    (!protocolStatus.isPackaged || protocolStatus.defaultApp);
 
   // GitHub Desktop pattern: generate session ID, store it, open browser
   const handleSignInWithBrowser = useCallback(() => {
@@ -147,8 +177,8 @@ export function SignInComponent() {
                     </h2>
                     <p className="text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed">
                       {isAwaitingBrowser
-                        ? "Complete sign-in in your browser. Click \"Open Manaflow\" after signing in to return here."
-                        : "Your browser will redirect you back to Manaflow once you've signed in. If your browser asks for permission to launch Manaflow, please allow it."}
+                        ? `Complete sign-in in your browser. Click "Open ${APP_DISPLAY_NAME}" after signing in to return here.`
+                        : `Your browser will redirect you back to ${APP_DISPLAY_NAME} once you've signed in. If your browser asks for permission to launch ${APP_DISPLAY_NAME}, please allow it.`}
                     </p>
                   </div>
 
@@ -156,9 +186,16 @@ export function SignInComponent() {
                   {!browserSignInSupported && !isAwaitingBrowser && (
                     <div className="w-full p-3 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
                       <p className="text-xs text-amber-800 dark:text-amber-200">
-                        The <code className="font-mono">manaflow://</code>{" "}
-                        deeplink is not registered. Restart Manaflow to
-                        re-register, or use embedded sign-in.
+                        The{" "}
+                        <code className="font-mono">{deeplinkLabel}</code>{" "}
+                        deeplink is not registered
+                        {isUnpackagedDev
+                          ? " (common in unpackaged Electron dev — browser return often fails)"
+                          : ""}
+                        .{" "}
+                        {isUnpackagedDev
+                          ? "Use embedded sign-in below."
+                          : `Restart ${APP_DISPLAY_NAME} to re-register, or use embedded sign-in.`}
                       </p>
                     </div>
                   )}

--- a/apps/client/src/hooks/useVncPreviewRecovery.ts
+++ b/apps/client/src/hooks/useVncPreviewRecovery.ts
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+
+import { persistentIframeManager } from "@/lib/persistentIframeManager";
+import {
+  createInitialVncRfbState,
+  DEFAULT_MAX_AUTO_REMOUNTS,
+  DEFAULT_RFB_WAIT_MS,
+  forcedIframeStatusForRecovery,
+  isVncPreviewUrl,
+  onTrace,
+  parseVncRfbStatusMessage,
+  reduceVncRfbRecovery,
+  type VncRfbEvent,
+  type VncRfbRecoveryState,
+  VNC_RFB_READY_MESSAGE_TYPE,
+  VNC_RFB_TIMEOUT_MESSAGE_TYPE,
+} from "@/lib/vnc-preview-recovery";
+
+export interface UseVncPreviewRecoveryOptions {
+  /** Persistent iframe key used by persistentIframeManager */
+  persistKey: string;
+  /** Resolved browser preview URL (noVNC or other) */
+  browserUrl: string | null | undefined;
+  /** Parent-side RFB wait after iframe load (default 12s) */
+  waitMs?: number;
+  /** Automatic remount budget before error UI (default 2) */
+  maxAutoRemounts?: number;
+}
+
+export interface UseVncPreviewRecoveryResult {
+  recovery: VncRfbRecoveryState;
+  /** Force PersistentWebView status so HTML-load does not hide the loader */
+  forcedStatus: "loading" | "error" | null;
+  /** Call from iframe onLoad */
+  onIframeLoad: () => void;
+  /** Manual retry from error UI */
+  retry: () => void;
+  /** True while RFB recovery is active for a VNC URL */
+  enabled: boolean;
+  /** True when recovery says the browser surface is not yet usable */
+  isBusy: boolean;
+}
+
+function recoveryReducer(
+  state: VncRfbRecoveryState,
+  action: { event: VncRfbEvent; maxAutoRemounts: number }
+): VncRfbRecoveryState {
+  return reduceVncRfbRecovery(state, action.event, {
+    maxAutoRemounts: action.maxAutoRemounts,
+  });
+}
+
+/**
+ * Keeps browser preview from going black when noVNC HTML loads but RFB never
+ * becomes ready. Listens for sandbox bridge postMessages (when present) and
+ * always arms a parent-side timer after iframe load so older sandboxes recover
+ * via remount + error UI as well.
+ */
+export function useVncPreviewRecovery({
+  persistKey,
+  browserUrl,
+  waitMs = DEFAULT_RFB_WAIT_MS,
+  maxAutoRemounts = DEFAULT_MAX_AUTO_REMOUNTS,
+}: UseVncPreviewRecoveryOptions): UseVncPreviewRecoveryResult {
+  const enabled = isVncPreviewUrl(browserUrl);
+  const [recovery, dispatchRaw] = useReducer(
+    recoveryReducer,
+    undefined,
+    createInitialVncRfbState
+  );
+  const recoveryRef = useRef(recovery);
+  recoveryRef.current = recovery;
+
+  const waitTimerRef = useRef<number | null>(null);
+  const maxAutoRemountsRef = useRef(maxAutoRemounts);
+  maxAutoRemountsRef.current = maxAutoRemounts;
+  const waitMsRef = useRef(waitMs);
+  waitMsRef.current = waitMs;
+  const lastRemountGenRef = useRef(0);
+
+  const dispatch = useCallback((event: VncRfbEvent) => {
+    onTrace("dispatch", {
+      event: event.type,
+      persistKey,
+      phase: recoveryRef.current.phase,
+    });
+    dispatchRaw({ event, maxAutoRemounts: maxAutoRemountsRef.current });
+  }, [persistKey]);
+
+  const clearWaitTimer = useCallback(() => {
+    if (waitTimerRef.current !== null) {
+      window.clearTimeout(waitTimerRef.current);
+      waitTimerRef.current = null;
+    }
+  }, []);
+
+  const armWaitTimer = useCallback(() => {
+    clearWaitTimer();
+    waitTimerRef.current = window.setTimeout(() => {
+      waitTimerRef.current = null;
+      if (recoveryRef.current.phase === "waiting") {
+        console.warn(
+          `[VncPreviewRecovery] RFB wait timed out after ${waitMsRef.current}ms for ${persistKey}`
+        );
+        dispatch({ type: "WAIT_TIMEOUT" });
+      }
+    }, waitMsRef.current);
+  }, [clearWaitTimer, dispatch, persistKey]);
+
+  // Enable / disable when URL changes
+  useEffect(() => {
+    if (!enabled) {
+      clearWaitTimer();
+      dispatch({ type: "DISABLE" });
+      return;
+    }
+    dispatch({ type: "START" });
+    return () => {
+      clearWaitTimer();
+    };
+  }, [clearWaitTimer, dispatch, enabled, persistKey, browserUrl]);
+
+  // Reload iframe whenever remountGeneration advances
+  useEffect(() => {
+    if (!enabled) {
+      lastRemountGenRef.current = recovery.remountGeneration;
+      return;
+    }
+    if (recovery.remountGeneration === lastRemountGenRef.current) {
+      return;
+    }
+    lastRemountGenRef.current = recovery.remountGeneration;
+    if (recovery.remountGeneration === 0) {
+      return;
+    }
+
+    console.info(
+      `[VncPreviewRecovery] Remounting VNC preview (gen=${recovery.remountGeneration}, auto=${recovery.autoRemountCount}) key=${persistKey}`
+    );
+    const reloaded = persistentIframeManager.reloadIframe(persistKey);
+    if (!reloaded) {
+      // Iframe may not be registered yet; retry once on next frame
+      requestAnimationFrame(() => {
+        persistentIframeManager.reloadIframe(persistKey);
+      });
+    }
+    dispatch({ type: "REMOUNT_STARTED" });
+  }, [
+    dispatch,
+    enabled,
+    persistKey,
+    recovery.autoRemountCount,
+    recovery.remountGeneration,
+  ]);
+
+  // postMessage from sandbox clipboard bridge (new images) + safety
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const onMessage = (event: MessageEvent) => {
+      const iframe = persistentIframeManager.getIframeElement(persistKey);
+      if (!iframe?.contentWindow) {
+        return;
+      }
+      if (event.source !== iframe.contentWindow) {
+        return;
+      }
+
+      const parsed = parseVncRfbStatusMessage(event.data);
+      if (!parsed) {
+        return;
+      }
+
+      if (parsed.type === VNC_RFB_READY_MESSAGE_TYPE) {
+        clearWaitTimer();
+        console.info(`[VncPreviewRecovery] RFB ready for ${persistKey}`);
+        dispatch({ type: "RFB_READY" });
+        return;
+      }
+
+      if (parsed.type === VNC_RFB_TIMEOUT_MESSAGE_TYPE) {
+        console.warn(
+          `[VncPreviewRecovery] Bridge reported RFB timeout for ${persistKey}`,
+          parsed.retries
+        );
+        // Parent timer is authoritative for remount budget; still treat as timeout signal
+        dispatch({ type: "WAIT_TIMEOUT" });
+      }
+    };
+
+    window.addEventListener("message", onMessage);
+    return () => {
+      window.removeEventListener("message", onMessage);
+    };
+  }, [clearWaitTimer, dispatch, enabled, persistKey]);
+
+  const onIframeLoad = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+    dispatch({ type: "IFRAME_LOADED" });
+    // HTML loaded ≠ RFB ready; keep waiting
+    if (recoveryRef.current.phase !== "ready") {
+      armWaitTimer();
+    }
+  }, [armWaitTimer, dispatch, enabled]);
+
+  const retry = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+    clearWaitTimer();
+    dispatch({ type: "MANUAL_RETRY" });
+  }, [clearWaitTimer, dispatch, enabled]);
+
+  const forcedStatus = enabled
+    ? forcedIframeStatusForRecovery(recovery)
+    : null;
+
+  return {
+    recovery,
+    forcedStatus,
+    onIframeLoad,
+    retry,
+    enabled,
+    // idle/waiting/remounting/failed all mean the remote desktop is not usable yet
+    isBusy: enabled && recovery.phase !== "ready",
+  };
+}

--- a/apps/client/src/lib/vnc-preview-recovery.test.ts
+++ b/apps/client/src/lib/vnc-preview-recovery.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialVncRfbState,
+  DEFAULT_MAX_AUTO_REMOUNTS,
+  forcedIframeStatusForRecovery,
+  isVncPreviewUrl,
+  parseVncRfbStatusMessage,
+  reduceVncRfbRecovery,
+  RFB_TIMEOUT_ERROR_MESSAGE,
+  VNC_RFB_READY_MESSAGE_TYPE,
+  VNC_RFB_TIMEOUT_MESSAGE_TYPE,
+} from "./vnc-preview-recovery";
+
+describe("reduceVncRfbRecovery", () => {
+  it("starts in idle with zero remounts", () => {
+    const state = createInitialVncRfbState();
+    expect(state.phase).toBe("idle");
+    expect(state.autoRemountCount).toBe(0);
+    expect(state.remountGeneration).toBe(0);
+    expect(forcedIframeStatusForRecovery(state)).toBeNull();
+  });
+
+  it("START enters waiting with loading overlay", () => {
+    const state = reduceVncRfbRecovery(createInitialVncRfbState(), {
+      type: "START",
+    });
+    expect(state.phase).toBe("waiting");
+    expect(forcedIframeStatusForRecovery(state)).toBe("loading");
+  });
+
+  it("RFB_READY after load clears overlay", () => {
+    let state = reduceVncRfbRecovery(createInitialVncRfbState(), {
+      type: "START",
+    });
+    state = reduceVncRfbRecovery(state, { type: "IFRAME_LOADED" });
+    state = reduceVncRfbRecovery(state, { type: "RFB_READY" });
+    expect(state.phase).toBe("ready");
+    expect(state.errorMessage).toBeNull();
+    expect(forcedIframeStatusForRecovery(state)).toBeNull();
+  });
+
+  it("does not fail on WAIT_TIMEOUT before iframe has loaded", () => {
+    let state = reduceVncRfbRecovery(createInitialVncRfbState(), {
+      type: "START",
+    });
+    state = reduceVncRfbRecovery(state, { type: "WAIT_TIMEOUT" });
+    expect(state.phase).toBe("waiting");
+    expect(state.autoRemountCount).toBe(0);
+  });
+
+  it("auto-remounts on timeout up to max, then fails with error message", () => {
+    let state = reduceVncRfbRecovery(createInitialVncRfbState(), {
+      type: "START",
+    });
+    state = reduceVncRfbRecovery(state, { type: "IFRAME_LOADED" });
+
+    // First timeout → remount 1
+    state = reduceVncRfbRecovery(state, { type: "WAIT_TIMEOUT" });
+    expect(state.phase).toBe("remounting");
+    expect(state.autoRemountCount).toBe(1);
+    expect(state.remountGeneration).toBe(1);
+    expect(forcedIframeStatusForRecovery(state)).toBe("loading");
+
+    // Duplicate timeout while remounting is ignored (bridge + parent race)
+    const midRemount = reduceVncRfbRecovery(state, { type: "WAIT_TIMEOUT" });
+    expect(midRemount).toEqual(state);
+
+    // Remount load complete
+    state = reduceVncRfbRecovery(state, { type: "IFRAME_LOADED" });
+    expect(state.phase).toBe("waiting");
+    expect(state.iframeLoaded).toBe(true);
+
+    // Second timeout → remount 2
+    state = reduceVncRfbRecovery(state, { type: "WAIT_TIMEOUT" });
+    expect(state.phase).toBe("remounting");
+    expect(state.autoRemountCount).toBe(2);
+    expect(state.remountGeneration).toBe(2);
+
+    state = reduceVncRfbRecovery(state, { type: "IFRAME_LOADED" });
+
+    // Third timeout with max=2 → failed
+    state = reduceVncRfbRecovery(state, { type: "WAIT_TIMEOUT" }, {
+      maxAutoRemounts: DEFAULT_MAX_AUTO_REMOUNTS,
+    });
+    expect(state.phase).toBe("failed");
+    expect(state.errorMessage).toBe(RFB_TIMEOUT_ERROR_MESSAGE);
+    expect(forcedIframeStatusForRecovery(state)).toBe("error");
+  });
+
+  it("MANUAL_RETRY from failed resets auto count and bumps generation", () => {
+    let state = reduceVncRfbRecovery(createInitialVncRfbState(), {
+      type: "START",
+    });
+    state = reduceVncRfbRecovery(state, { type: "IFRAME_LOADED" });
+    // Exhaust remounts
+    for (let i = 0; i < DEFAULT_MAX_AUTO_REMOUNTS; i++) {
+      state = reduceVncRfbRecovery(state, { type: "WAIT_TIMEOUT" });
+      state = reduceVncRfbRecovery(state, { type: "IFRAME_LOADED" });
+    }
+    state = reduceVncRfbRecovery(state, { type: "WAIT_TIMEOUT" });
+    expect(state.phase).toBe("failed");
+    const genBefore = state.remountGeneration;
+
+    state = reduceVncRfbRecovery(state, { type: "MANUAL_RETRY" });
+    expect(state.phase).toBe("remounting");
+    expect(state.autoRemountCount).toBe(0);
+    expect(state.remountGeneration).toBe(genBefore + 1);
+    expect(state.errorMessage).toBeNull();
+    expect(forcedIframeStatusForRecovery(state)).toBe("loading");
+  });
+
+  it("late RFB_READY after failed clears the error", () => {
+    let state = reduceVncRfbRecovery(createInitialVncRfbState(), {
+      type: "START",
+    });
+    state = reduceVncRfbRecovery(state, { type: "IFRAME_LOADED" });
+    for (let i = 0; i < DEFAULT_MAX_AUTO_REMOUNTS + 1; i++) {
+      state = reduceVncRfbRecovery(state, { type: "WAIT_TIMEOUT" });
+      if (state.phase === "remounting") {
+        state = reduceVncRfbRecovery(state, { type: "IFRAME_LOADED" });
+      }
+    }
+    expect(state.phase).toBe("failed");
+    state = reduceVncRfbRecovery(state, { type: "RFB_READY" });
+    expect(state.phase).toBe("ready");
+    expect(state.errorMessage).toBeNull();
+  });
+
+  it("DISABLE resets to idle", () => {
+    let state = reduceVncRfbRecovery(createInitialVncRfbState(), {
+      type: "START",
+    });
+    state = reduceVncRfbRecovery(state, { type: "DISABLE" });
+    expect(state).toEqual(createInitialVncRfbState());
+  });
+});
+
+describe("isVncPreviewUrl", () => {
+  it("detects noVNC viewer URLs", () => {
+    expect(
+      isVncPreviewUrl(
+        "https://port-39380-pvelxc-x.example.com/vnc.html?tkn=abc&autoconnect=1"
+      )
+    ).toBe(true);
+    expect(isVncPreviewUrl("https://example.com/workspace")).toBe(false);
+    expect(isVncPreviewUrl(null)).toBe(false);
+  });
+});
+
+describe("parseVncRfbStatusMessage", () => {
+  it("parses ready and timeout postMessages", () => {
+    expect(parseVncRfbStatusMessage({ type: VNC_RFB_READY_MESSAGE_TYPE })).toEqual({
+      type: VNC_RFB_READY_MESSAGE_TYPE,
+    });
+    expect(
+      parseVncRfbStatusMessage({
+        type: VNC_RFB_TIMEOUT_MESSAGE_TYPE,
+        retries: 50,
+      })
+    ).toEqual({ type: VNC_RFB_TIMEOUT_MESSAGE_TYPE, retries: 50 });
+    expect(parseVncRfbStatusMessage({ type: "other" })).toBeNull();
+    expect(parseVncRfbStatusMessage(null)).toBeNull();
+  });
+});

--- a/apps/client/src/lib/vnc-preview-recovery.ts
+++ b/apps/client/src/lib/vnc-preview-recovery.ts
@@ -1,0 +1,279 @@
+/**
+ * Pure state machine for VNC browser preview recovery.
+ *
+ * Problem: noVNC's HTML loads (iframe onLoad) while RFB never becomes ready,
+ * so PersistentIframe marks "loaded" and shows a black canvas forever.
+ *
+ * This reducer drives: wait for RFB → auto-remount → surface error with manual retry.
+ *
+ * Debug: set ON_TRACE=1 (shell env for make dev-electron) or localStorage ON_TRACE=1
+ * to log every recovery transition with a stack trace.
+ */
+
+/** True when ON_TRACE=1 is set in the shell (injected by electron-vite) or localStorage. */
+export function isOnTraceEnabled(): boolean {
+  try {
+    // Injected at dev/build time from process.env.ON_TRACE (electron.vite.config.ts define)
+    const env = (import.meta as ImportMeta & { env?: { ON_TRACE?: string } })
+      .env;
+    if (env?.ON_TRACE === "1") return true;
+  } catch {
+    // ignore
+  }
+  try {
+    if (typeof process !== "undefined" && process.env?.ON_TRACE === "1") {
+      return true;
+    }
+  } catch {
+    // ignore
+  }
+  try {
+    if (
+      typeof window !== "undefined" &&
+      window.localStorage?.getItem("ON_TRACE") === "1"
+    ) {
+      return true;
+    }
+  } catch {
+    // ignore
+  }
+  return false;
+}
+
+export function onTrace(
+  label: string,
+  detail?: Record<string, unknown>
+): void {
+  if (!isOnTraceEnabled()) return;
+  const payload = detail ? { ...detail } : undefined;
+  // eslint-disable-next-line no-console
+  console.log(`[ON_TRACE][vnc-preview-recovery] ${label}`, payload ?? "");
+  // eslint-disable-next-line no-console
+  console.trace(`[ON_TRACE][vnc-preview-recovery] ${label} stack`);
+}
+
+export type VncRfbPhase =
+  | "idle"
+  | "waiting"
+  | "ready"
+  | "remounting"
+  | "failed";
+
+export type VncRfbEvent =
+  | { type: "START" }
+  | { type: "IFRAME_LOADED" }
+  | { type: "RFB_READY" }
+  | { type: "WAIT_TIMEOUT" }
+  | { type: "REMOUNT_STARTED" }
+  | { type: "MANUAL_RETRY" }
+  | { type: "DISABLE" };
+
+export interface VncRfbRecoveryState {
+  phase: VncRfbPhase;
+  /** Number of automatic remounts already performed in this recovery cycle. */
+  autoRemountCount: number;
+  /**
+   * Monotonic generation bumped on every remount (auto or manual).
+   * Consumers can use this as a React key suffix or reload signal.
+   */
+  remountGeneration: number;
+  errorMessage: string | null;
+  /** True after the iframe reported onLoad at least once while waiting. */
+  iframeLoaded: boolean;
+}
+
+export interface VncRfbRecoveryOptions {
+  maxAutoRemounts?: number;
+}
+
+export const DEFAULT_RFB_WAIT_MS = 12_000;
+export const DEFAULT_MAX_AUTO_REMOUNTS = 2;
+
+export const RFB_TIMEOUT_ERROR_MESSAGE =
+  "Remote desktop page loaded but the VNC session never became ready.";
+
+export const VNC_RFB_READY_MESSAGE_TYPE = "vnc-rfb-ready" as const;
+export const VNC_RFB_TIMEOUT_MESSAGE_TYPE = "vnc-rfb-timeout" as const;
+
+export type VncRfbStatusMessage =
+  | { type: typeof VNC_RFB_READY_MESSAGE_TYPE }
+  | { type: typeof VNC_RFB_TIMEOUT_MESSAGE_TYPE; retries?: number };
+
+export function createInitialVncRfbState(): VncRfbRecoveryState {
+  return {
+    phase: "idle",
+    autoRemountCount: 0,
+    remountGeneration: 0,
+    errorMessage: null,
+    iframeLoaded: false,
+  };
+}
+
+export function reduceVncRfbRecovery(
+  state: VncRfbRecoveryState,
+  event: VncRfbEvent,
+  options: VncRfbRecoveryOptions = {}
+): VncRfbRecoveryState {
+  const maxAutoRemounts = options.maxAutoRemounts ?? DEFAULT_MAX_AUTO_REMOUNTS;
+  const next = reduceVncRfbRecoveryInner(state, event, maxAutoRemounts);
+  if (next !== state && isOnTraceEnabled()) {
+    onTrace("reduce", {
+      event: event.type,
+      from: state.phase,
+      to: next.phase,
+      autoRemountCount: next.autoRemountCount,
+      remountGeneration: next.remountGeneration,
+      iframeLoaded: next.iframeLoaded,
+    });
+  }
+  return next;
+}
+
+function reduceVncRfbRecoveryInner(
+  state: VncRfbRecoveryState,
+  event: VncRfbEvent,
+  maxAutoRemounts: number
+): VncRfbRecoveryState {
+  switch (event.type) {
+    case "DISABLE":
+      return createInitialVncRfbState();
+
+    case "START":
+      return {
+        ...createInitialVncRfbState(),
+        phase: "waiting",
+      };
+
+    case "MANUAL_RETRY":
+      return {
+        phase: "remounting",
+        autoRemountCount: 0,
+        remountGeneration: state.remountGeneration + 1,
+        errorMessage: null,
+        iframeLoaded: false,
+      };
+
+    case "IFRAME_LOADED":
+      if (state.phase === "idle" || state.phase === "ready" || state.phase === "failed") {
+        return state;
+      }
+      // Remount completed HTML load → back to waiting for RFB
+      if (state.phase === "remounting") {
+        return {
+          ...state,
+          phase: "waiting",
+          iframeLoaded: true,
+        };
+      }
+      return {
+        ...state,
+        iframeLoaded: true,
+      };
+
+    case "RFB_READY":
+      if (state.phase === "idle" || state.phase === "failed") {
+        // Still accept ready after failed so a late RFB clears the error
+        if (state.phase === "failed") {
+          return {
+            ...state,
+            phase: "ready",
+            errorMessage: null,
+            iframeLoaded: true,
+          };
+        }
+        return state;
+      }
+      return {
+        ...state,
+        phase: "ready",
+        errorMessage: null,
+        iframeLoaded: true,
+      };
+
+    case "WAIT_TIMEOUT": {
+      // Only the "waiting" phase (after HTML load, before RFB) may time out.
+      // Ignore timeouts while remounting so bridge + parent timers cannot double-count.
+      if (state.phase !== "waiting") {
+        return state;
+      }
+      if (!state.iframeLoaded) {
+        return state;
+      }
+      if (state.autoRemountCount < maxAutoRemounts) {
+        return {
+          ...state,
+          phase: "remounting",
+          autoRemountCount: state.autoRemountCount + 1,
+          remountGeneration: state.remountGeneration + 1,
+          errorMessage: null,
+          iframeLoaded: false,
+        };
+      }
+      return {
+        ...state,
+        phase: "failed",
+        errorMessage: RFB_TIMEOUT_ERROR_MESSAGE,
+      };
+    }
+
+    case "REMOUNT_STARTED":
+      if (state.phase !== "remounting") {
+        return state;
+      }
+      return state;
+
+    default: {
+      const _exhaustive: never = event;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Overlay status forced onto PersistentWebView while RFB recovery is active.
+ * null = let the iframe's natural status drive the UI.
+ */
+export function forcedIframeStatusForRecovery(
+  state: VncRfbRecoveryState
+): "loading" | "error" | null {
+  switch (state.phase) {
+    case "waiting":
+    case "remounting":
+      // Keep shell loader until RFB is ready (not just HTML load)
+      return "loading";
+    case "failed":
+      return "error";
+    case "ready":
+    case "idle":
+      return null;
+    default: {
+      const _exhaustive: never = state.phase;
+      return _exhaustive;
+    }
+  }
+}
+
+export function isVncPreviewUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  return url.includes("/vnc.html");
+}
+
+export function parseVncRfbStatusMessage(
+  data: unknown
+): VncRfbStatusMessage | null {
+  if (typeof data !== "object" || data === null) {
+    return null;
+  }
+  const type = (data as { type?: unknown }).type;
+  if (type === VNC_RFB_READY_MESSAGE_TYPE) {
+    return { type: VNC_RFB_READY_MESSAGE_TYPE };
+  }
+  if (type === VNC_RFB_TIMEOUT_MESSAGE_TYPE) {
+    const retries = (data as { retries?: unknown }).retries;
+    return {
+      type: VNC_RFB_TIMEOUT_MESSAGE_TYPE,
+      retries: typeof retries === "number" ? retries : undefined,
+    };
+  }
+  return null;
+}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.browser.tsx
@@ -1,7 +1,9 @@
 import type { PersistentIframeStatus } from "@/components/persistent-iframe";
 import { PersistentWebView } from "@/components/persistent-webview";
 import { WorkspaceLoadingIndicator } from "@/components/workspace-loading-indicator";
+import { Button } from "@/components/ui/button";
 import { useVncClipboardBridge } from "@/hooks/useVncClipboardBridge";
+import { useVncPreviewRecovery } from "@/hooks/useVncPreviewRecovery";
 import { addBrowserReloadListener } from "@/lib/browser-reload-events";
 import { persistentIframeManager } from "@/lib/persistentIframeManager";
 import { getTaskRunBrowserPersistKey } from "@/lib/persistent-webview-keys";
@@ -13,6 +15,7 @@ import {
   resolveBrowserPreviewUrl,
   resolveBrowserPreviewWebsocketUrl,
 } from "@/lib/toProxyWorkspaceUrl";
+import { RFB_TIMEOUT_ERROR_MESSAGE } from "@/lib/vnc-preview-recovery";
 import { convexQueryClient } from "@/contexts/convex/convex-query-client";
 import { api } from "@cmux/convex/api";
 import {
@@ -92,6 +95,18 @@ function BrowserComponent() {
     enabled: isVncIframe,
   });
 
+  const {
+    recovery,
+    forcedStatus: rfbForcedStatus,
+    onIframeLoad: onRfbIframeLoad,
+    retry: retryRfb,
+    enabled: rfbRecoveryEnabled,
+    isBusy: rfbBusy,
+  } = useVncPreviewRecovery({
+    persistKey,
+    browserUrl,
+  });
+
   const hasBrowserView = Boolean(browserUrl);
   const isSupportedProvider =
     vscodeInfo?.provider === "morph" || vscodeInfo?.provider === "pve-lxc";
@@ -114,7 +129,8 @@ function BrowserComponent() {
 
   const onLoad = useCallback(() => {
     console.log(`Browser preview loaded for task run ${taskRunId}`);
-  }, [taskRunId]);
+    onRfbIframeLoad();
+  }, [onRfbIframeLoad, taskRunId]);
 
   const onError = useCallback(
     (error: Error) => {
@@ -145,8 +161,12 @@ function BrowserComponent() {
         });
         return;
       }
-      const reloaded = persistentIframeManager.reloadIframe(persistKey);
-      if (!reloaded) return;
+      if (rfbRecoveryEnabled) {
+        retryRfb();
+      } else {
+        const reloaded = persistentIframeManager.reloadIframe(persistKey);
+        if (!reloaded) return;
+      }
       requestAnimationFrame(() => {
         if (
           previousFocus instanceof HTMLElement &&
@@ -156,21 +176,73 @@ function BrowserComponent() {
         }
       });
     });
-  }, [persistKey, taskRunId, useDirectVncFallback]);
+  }, [
+    persistKey,
+    rfbRecoveryEnabled,
+    retryRfb,
+    taskRunId,
+    useDirectVncFallback,
+  ]);
 
-  const loadingFallback = useMemo(
-    () => <WorkspaceLoadingIndicator variant="browser" status="loading" />,
-    []
-  );
+  const loadingFallback = useMemo(() => {
+    const remounting = recovery.phase === "remounting";
+    return (
+      <WorkspaceLoadingIndicator
+        variant="browser"
+        status="loading"
+        loadingTitle={
+          remounting
+            ? "Reconnecting remote desktop"
+            : "Launching browser preview"
+        }
+        loadingDescription={
+          remounting
+            ? `Retrying VNC session (attempt ${recovery.autoRemountCount})…`
+            : rfbRecoveryEnabled
+              ? "Waiting for the remote desktop session to become ready…"
+              : undefined
+        }
+      />
+    );
+  }, [
+    recovery.autoRemountCount,
+    recovery.phase,
+    rfbRecoveryEnabled,
+  ]);
+
   const errorFallback = useMemo(
-    () => <WorkspaceLoadingIndicator variant="browser" status="error" />,
-    []
+    () => (
+      <WorkspaceLoadingIndicator
+        variant="browser"
+        status="error"
+        errorTitle="Remote desktop did not connect"
+        errorDescription={
+          recovery.errorMessage ?? RFB_TIMEOUT_ERROR_MESSAGE
+        }
+        action={
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="pointer-events-auto mt-2"
+            onClick={() => {
+              retryRfb();
+            }}
+          >
+            Retry connection
+          </Button>
+        }
+      />
+    ),
+    [recovery.errorMessage, retryRfb]
   );
 
   const hasBrowserConnection = Boolean(vncWebsocketUrl || browserUrl);
   const isBrowserBusy = useDirectVncFallback
     ? !hasBrowserConnection || vncStatus !== "connected"
-    : !hasBrowserConnection || browserStatus !== "loaded";
+    : rfbRecoveryEnabled
+      ? rfbBusy
+      : !hasBrowserConnection || browserStatus !== "loaded";
 
   return (
     <div className="flex flex-col grow bg-neutral-50 dark:bg-black">
@@ -192,6 +264,7 @@ function BrowserComponent() {
               onLoad={onLoad}
               onError={onError}
               onStatusChange={setBrowserStatus}
+              forcedStatus={rfbForcedStatus}
               fallback={loadingFallback}
               fallbackClassName="bg-neutral-50 dark:bg-black"
               errorFallback={errorFallback}

--- a/apps/client/src/routes/handler.$.tsx
+++ b/apps/client/src/routes/handler.$.tsx
@@ -8,8 +8,11 @@ export const Route = createFileRoute("/handler/$")({
 
 function HandlerComponent() {
   const location = useLocation();
+  // Hash history: OAuth query lands on location.search (or sometimes in the
+  // hash fragment). Stack needs path + query to exchange the code.
+  const handlerLocation = `${location.pathname}${location.search}`;
 
   return (
-    <StackHandler app={stackClientApp} location={location.pathname} fullPage />
+    <StackHandler app={stackClientApp} location={handlerLocation} fullPage />
   );
 }

--- a/apps/client/src/types/electron.d.ts
+++ b/apps/client/src/types/electron.d.ts
@@ -143,8 +143,14 @@ export interface CmuxAPI {
   app?: {
     getProtocolStatus: () =>
       Promise<
-        | { ok: true; isPackaged: boolean; isDefaultProtocolClient: boolean }
-        | { ok: false; error: string }
+        | {
+            ok: true;
+            scheme: string;
+            isPackaged: boolean;
+            isDefaultProtocolClient: boolean;
+            defaultApp: boolean;
+          }
+        | { ok: false; scheme?: string; error: string }
       >;
   };
   machine?: {

--- a/packages/sandbox/scripts/vnc-clipboard-bridge.js
+++ b/packages/sandbox/scripts/vnc-clipboard-bridge.js
@@ -69,11 +69,22 @@
   }
 
   /**
+   * Message types for RFB readiness — must match apps/client vnc-preview-recovery.ts
+   * so the parent can remount / surface errors instead of a black canvas.
+   */
+  var RFB_READY_MESSAGE_TYPE = 'vnc-rfb-ready';
+  var RFB_TIMEOUT_MESSAGE_TYPE = 'vnc-rfb-timeout';
+
+  /**
    * Wait for RFB instance to be available, then call callback.
    * RFB is only created after VNC connection is established.
+   *
+   * @param {function} callback - Called with RFB when ready
+   * @param {number} [maxRetries=120] - Attempts at 100ms (~12s default; longer than clipboard-only)
+   * @param {function} [onTimeout] - Called with retry count when RFB never appears
    */
-  function withRfbInstance(callback, maxRetries) {
-    maxRetries = maxRetries || 50; // 5 seconds max
+  function withRfbInstance(callback, maxRetries, onTimeout) {
+    maxRetries = maxRetries || 120; // 12 seconds max (matches parent RFB wait)
     var retries = 0;
 
     function tryGetRfb() {
@@ -87,10 +98,31 @@
         setTimeout(tryGetRfb, 100);
       } else {
         console.warn('[VNC Clipboard Bridge] RFB instance not available after ' + maxRetries + ' retries');
+        if (typeof onTimeout === 'function') {
+          onTimeout(retries);
+        }
       }
     }
 
     tryGetRfb();
+  }
+
+  function postToParent(payload) {
+    if (window.parent && window.parent !== window) {
+      try {
+        window.parent.postMessage(payload, '*');
+      } catch (err) {
+        console.warn('[VNC Clipboard Bridge] postMessage failed', err);
+      }
+    }
+  }
+
+  function notifyParentRfbReady() {
+    postToParent({ type: RFB_READY_MESSAGE_TYPE });
+  }
+
+  function notifyParentRfbTimeout(retries) {
+    postToParent({ type: RFB_TIMEOUT_MESSAGE_TYPE, retries: retries });
   }
 
   /**
@@ -379,8 +411,17 @@
     console.log('[VNC Clipboard Bridge] Clipboard sync listener attached to RFB');
   }
 
-  // Attach clipboard listener once RFB is available
-  withRfbInstance(setupClipboardListener);
+  // Attach clipboard listener once RFB is available, and notify parent of readiness.
+  // Parent (cmux Browser tab) keeps a loading overlay until RFB is ready; on timeout
+  // it remounts the webview and eventually surfaces an error instead of a black pane.
+  withRfbInstance(
+    function (rfb) {
+      setupClipboardListener(rfb);
+      notifyParentRfbReady();
+    },
+    120,
+    notifyParentRfbTimeout
+  );
 
   // Log initialization (debug)
   console.log('[VNC Clipboard Bridge] Initialized with keyboard listener and clipboard sync');

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -495,8 +495,14 @@ if [ ! -d "node_modules" ] || [ "$FORCE_INSTALL" = "true" ]; then
 fi
 
 # Build Rust N-API addon (required) - runs in parallel with Docker build
-echo -e "${GREEN}Building native Rust addon...${NC}"
-(cd "$APP_DIR/apps/server/native/core" && bunx napi build --platform) || exit 1
+NATIVE_CORE_DIR="$APP_DIR/apps/server/native/core"
+NATIVE_NODE_GLOB=("$NATIVE_CORE_DIR"/cmux_native_core.*.node)
+if [ "${SKIP_NATIVE_BUILD:-}" = "true" ] && [ -e "${NATIVE_NODE_GLOB[0]}" ]; then
+    echo -e "${YELLOW}Skipping native Rust addon rebuild (SKIP_NATIVE_BUILD=true, using existing .node)${NC}"
+else
+    echo -e "${GREEN}Building native Rust addon...${NC}"
+    (cd "$NATIVE_CORE_DIR" && bunx napi build --platform) || exit 1
+fi
 
 # Wait for Docker build to complete if it was started
 if [ -n "$DOCKER_BUILD_PID" ]; then


### PR DESCRIPTION
## Summary
- Remount VNC/noVNC preview when RFB never becomes ready (browser stuck-loading recovery).
- Show correct Electron deeplink scheme (`cmux-dev://` unpackaged vs `cmux-next://` packaged) on sign-in UI.
- Allow `SKIP_NATIVE_BUILD` for local mac packaging when rustc MSRV blocks native modules.
- Keep Stack OAuth in a dedicated auth window and hand off SPA/hash callbacks so GH redirect does not 404 the main window.
- Catch OAuth SPA callback after GH login (pathname + search) so session handoff works when Stack returns.

## Auth note (dev Electron)
- **Email/password** remains the day-to-day login path and works on dev Electron.
- **GitHub OAuth** still fails upstream at Stack/Hexclave (`api.stack-auth.com/api/v1/auth/oauth/callback/github` → session 404). That is outside this PR; password login is unaffected.

## Test plan
- [x] VNC remount/recovery unit paths covered in branch work
- [x] Electron auth navigation helpers + handler search coverage
- [ ] Smoke: `bun run dev:electron` → email/password sign-in
- [ ] Smoke: packaged app with SKIP_NATIVE_BUILD if needed
- [ ] GH OAuth still blocked on Stack until Hexclave project OAuth is fixed