### PR TITLE
fix(edge-router-pvelxc): pass through noVNC assets

### DIFF
--- a/apps/edge-router-pvelxc/package.json
+++ b/apps/edge-router-pvelxc/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "test": "bun test src/index.test.ts"
   },
   "devDependencies": {
     "wrangler": "4"

--- a/apps/edge-router-pvelxc/src/index.test.ts
+++ b/apps/edge-router-pvelxc/src/index.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from "bun:test";
+
+import worker from "./index";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("passes through noVNC JavaScript while preserving VS Code JavaScript rewriting", async () => {
+  const noVncJavaScript = "export class RFB {}";
+  const vsCodeJavaScript = "window.location.href = '/';";
+  const upstreamRequests: Request[] = [];
+
+  globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
+    if (!(input instanceof Request)) {
+      throw new Error("Expected the Worker to fetch a Request");
+    }
+
+    upstreamRequests.push(input);
+    const body = input.url.includes("port-39380-")
+      ? noVncJavaScript
+      : vsCodeJavaScript;
+
+    return new Response(body, {
+      headers: { "content-type": "application/javascript" },
+    });
+  };
+
+  const noVncRequest = new Request(
+    "https://port-39380-pvelxc-sandbox.alphasolves.com/core/rfb.js",
+  );
+  const noVncResponse = await worker.fetch(noVncRequest);
+
+  expect(await noVncResponse.text()).toBe(noVncJavaScript);
+  expect(upstreamRequests).toHaveLength(1);
+  expect(upstreamRequests[0]).toBe(noVncRequest);
+  expect(upstreamRequests[0]?.headers.get("X-Cmux-Proxied")).toBeNull();
+
+  const vsCodeRequest = new Request(
+    "https://port-39378-pvelxc-sandbox.alphasolves.com/workbench.js",
+  );
+  const vsCodeResponse = await worker.fetch(vsCodeRequest);
+
+  expect(await vsCodeResponse.text()).toContain("Injected by cmux proxy");
+});

--- a/apps/edge-router-pvelxc/src/index.ts
+++ b/apps/edge-router-pvelxc/src/index.ts
@@ -3,6 +3,7 @@
 
 // VS Code server port for PVE-LXC sandboxes
 const VSCODE_PORT = "39378";
+const VNC_PORT = "39380";
 
 // Regex to match http:// URLs pointing to the PVE-LXC public domain.
 // Used to rewrite insecure URLs to https:// in VS Code responses.
@@ -668,6 +669,10 @@ export default {
 
     const [, port, instanceId] = pvelxcMatch;
 
+    if (port === VNC_PORT) {
+      return fetch(request);
+    }
+
     // Serve the service worker file
     if (url.pathname === "/proxy-sw.js") {
       return new Response(SERVICE_WORKER_JS, {
@@ -709,16 +714,6 @@ export default {
     // WebSocket upgrades
     const upgradeHeader = request.headers.get("Upgrade");
     if (upgradeHeader?.toLowerCase() === "websocket") {
-      // VNC (port 39380): Pass through directly to CF Tunnel without Worker proxy
-      // The Worker's WebSocket proxy adds latency and doesn't support proper keepalive,
-      // causing disconnections from external networks due to CF's 100s idle timeout.
-      // CF Tunnel handles WebSocket keepalive correctly at the protocol level.
-      const VNC_PORT = "39380";
-      if (port === VNC_PORT) {
-        // Pass through to CF Tunnel - it will handle the WebSocket upgrade
-        return fetch(request);
-      }
-
       // Other WebSockets (VS Code, xterm): proxy through the Worker
       // Fetch the upstream WebSocket (use outbound which has X-Cmux-Proxied header)
       const upstreamResponse = await fetch(outbound);


### PR DESCRIPTION
## Summary
- pass all pvelxc port 39380 noVNC traffic through with the original request before Worker service-worker, CORS, proxy-header, rewrite, or buffering paths
- retain existing pvelxc port 39378 JavaScript rewriting
- add a focused exported-Worker regression test and package test command

## Verification
- `cd apps/edge-router-pvelxc && bun run test` — 1 pass, 0 failures
- `bun check` — passed lint, typecheck, and Claude-model sync; its OpenAPI precheck logs a non-fatal missing-local-credentials diagnostic
- Full `bun run test` baseline remains blocked by pre-existing missing Convex/Stack integration credentials and the local rustc 1.94.1 vs kstring 1.96.0 MSRV mismatch.

## Production deployment and live verification
- deployed `alphasolves-edge-router` version `7bf0196e-ad58-4390-8768-2dc4591af9c3` to the `*.alphasolves.com/*` route
- a cache-busted live port-39380 noVNC `core/rfb.js` request returned 122,305 bytes with no injected-proxy marker
- a signed browser run reached `noVNC_connected` in about two seconds, held a 1920×1080 canvas for 20 seconds, and reported zero console errors
- a live port-39378 VS Code script still included the expected cmux proxy-rewrite marker