### PR TITLE
fix(electron): guard null mainWindow in setWindowOpenHandler (TS18047)

### DIFF
--- a/apps/client/electron/main/electron-auth-navigation.test.ts
+++ b/apps/client/electron/main/electron-auth-navigation.test.ts
@@ -106,6 +106,16 @@ describe("classifyMainWindowNavigation", () => {
       action: "external",
       url: "https://docs.example.com/guide",
     });
+    // Non-allow decisions reaching applyAuthNavDecision must be external/auth-window/rewrite-hash
+    // (the main setWindowOpenHandler denies popups on a null/destroyed mainWindow per TS18047).
+    expect(
+      classifyMainWindowNavigation("https://example.com/path?q=2", {
+        spaOrigins: SPA,
+      })
+    ).toEqual({
+      action: "external",
+      url: "https://example.com/path?q=2",
+    });
   });
 
   it("allows non-http schemes", () => {

--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -1460,6 +1460,9 @@ function createWindow(): void {
       void shell.openExternal(targetUrl);
       return { action: "deny" };
     }
+    // mainWindow may be null/destroyed by the time this deferred popup
+    // handler runs (TS18047); deny rather than crash on webContents access.
+    if (!mainWindow || mainWindow.isDestroyed()) return { action: "deny" };
     applyAuthNavDecision(decision, mainWindow.webContents, "main");
     return { action: "deny" };
   });


### PR DESCRIPTION
## Summary

Fixes the \`verify-full\` CI typecheck failure on the post-VNC merge commit \`9de66542b\`:

\`\`\`text
apps/client/electron/main/index.ts(1463,36): error TS18047: 'mainWindow' is possibly 'null'.
\`\`\`

Failing CI run: https://github.com/karlorz/cmux/actions/runs/29740875917/job/88347119200

## Root cause

\`mainWindow\` is a module-scoped \`let mainWindow: BrowserWindow | null = null\` (line 132). In \`createWindow()\` it is assigned \`\`mainWindow = new BrowserWindow(...)\`\` (line 1384), which narrows TS to \`BrowserWindow\` for the synchronous setup that follows. The main window's \`setWindowOpenHandler\` callback registered at line 1450, however, runs **asynchronously** after \`createWindow()\` returns — so the module-scoped \`mainWindow\` is re-read inside the closure body and TS widens it back to \`BrowserWindow | null\`. The bare \`applyAuthNavDecision(decision, mainWindow.webContents, \"main\")\` at line 1463 therefore trips \`TS18047\` (property access on a possibly-null value).

The two \`decision.action === \"allow\"\` branches above (lines 1455 and 1459) already early-return, so only a non-\`allow\` decision (\`rewrite-hash\` / \`auth-window\` / \`external\`) can reach this call.

## Fix

Guard with the file's canonical \`if (!mainWindow || mainWindow.isDestroyed())\` pattern — used at 5 existing sites (e.g. \`loadMainWindowAuthCallback\` L1303, \`emitAutoUpdateToastIfPossible\` L756, \`emitToRenderer\` L326) — and deny the popup if the window is gone, matching the same \`{ action: \"deny\" }\` outcome as every other branch in this handler.

\`\`\`diff
+    // mainWindow may be null/destroyed by the time this deferred popup
+    // handler runs (TS18047); deny rather than crash on webContents access.
+    if (!mainWindow || mainWindow.isDestroyed()) return { action: \"deny\" };
     applyAuthNavDecision(decision, mainWindow.webContents, \"main\");
     return { action: \"deny\" };
\`\`\`

This is the **smallest behavior-preserving** repair:
- Does not use a non-null assertion (\`!\`) — per \`REVIEW.md\` policy.
- Matches the established canonical pattern (a 6th idiom is not introduced).
- Also covers the destroyed-but-non-null case a bare \`!mainWindow\` check would miss (the realistic scenario — the user closed the window; \`mainWindow\` is never re-assigned to \`null\` in this file).
- The live-window control flow is unchanged; only the destroyed-window case changes from a potential \`TypeError\` on \`.webContents\` access to a safe \`{ action: \"deny\" }\` — identical to the other three branches.

A sibling refactor-capture approach (\`const win = mainWindow\` after L1384, threading \`win.webContents\` through all synchronous registrations) was considered and rejected: it would churn the synchronous \`.on()\` registrations that TS already narrows correctly, expanding scope beyond a CI typecheck hotfix. The closure-scoped capture variant would also change behavior by short-circuiting the \`allow → shell.openExternal\` branch, which intentionally runs regardless of window state.

## Test

Adds one classification \`expect\` for a previously-untested external URL (\`https://example.com/path?q=2\`) to the existing \`\"opens other http(s) externally\"\` test in \`apps/client/electron/main/electron-auth-navigation.test.ts\`, at the same assertion strength as its siblings. The authoritative TS18047 regression gate is the typecheck itself (\`bunx tsgo --build --noEmit\`); \`applyAuthNavDecision\`'s exhaustive \`_exhaustive: never\` switch (L1144) is the compile-time guarantee for the decision-action union.

## Verification

Red-Green cycle (fresh evidence):
- **RED** (pristine \`origin/main\` at \`9de66542b\`): \`bun check\` → \`❌ Typecheck failed: apps/client/electron/main/index.ts(1463,36): error TS18047: 'mainWindow' is possibly 'null'.\`
- **GREEN** (this branch): \`bun check\` → \`✅ Lint and typecheck passed\` (exit 0).

Pre-commit hook ran \`bun check\` at commit time and passed. All 4 \`apps/client/electron/main/*.test.ts\` files pass (30 tests).

Known local baseline limitations (not related to this change, per the handoff): local Rust is 1.94.1 while \`kstring 2.0.4\` requires 1.96.0 (native server-core build fails locally); local Convex integration tests lack Stack Auth credentials. The Electron TS typecheck is independent of those.

## Scope

Only \`apps/client/electron/main/index.ts\` (+3) and \`apps/client/electron/main/electron-auth-navigation.test.ts\` (+10). No other files touched. Independent of the noVNC edge-router fix (#1266).

Reviewing — happy to address any concerns. Not merging without explicit approval.