### PR TITLE
fix(devsh): durable --mirror-local (symlink skills + allowlist) + noVNC UI TDZ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ apps/www/scripts/pr-review/evals/results/
 .claude/scheduled_tasks.lock
 .claude/dev-loop-debug/
 .claude/dev-loop/status/
+.worktrees/

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,6 +8,7 @@
     "builtin": true
   },
   "ignorePatterns": [
+    ".worktrees/**",
     "dist",
     "**/dist",
     "**/out",

--- a/configs/ide-deps.json
+++ b/configs/ide-deps.json
@@ -3,12 +3,12 @@
     {
       "publisher": "anthropic",
       "name": "claude-code",
-      "version": "2.1.126"
+      "version": "2.1.216"
     },
     {
       "publisher": "openai",
       "name": "chatgpt",
-      "version": "26.429.30905"
+      "version": "26.715.31925"
     },
     {
       "publisher": "ms-vscode",
@@ -27,13 +27,13 @@
     }
   ],
   "packages": {
-    "@openai/codex": "0.128.0",
+    "@openai/codex": "0.144.6",
     "@anthropic-ai/claude-code": "2.1.89",
-    "@google/gemini-cli": "0.40.1",
-    "opencode-ai": "1.14.33",
-    "codebuff": "1.0.647",
-    "@devcontainers/cli": "0.86.0",
-    "@sourcegraph/amp": "0.0.1777838989-g06e8a1",
+    "@google/gemini-cli": "0.51.0",
+    "opencode-ai": "1.18.4",
+    "codebuff": "1.0.684",
+    "@devcontainers/cli": "0.87.0",
+    "@sourcegraph/amp": "0.0.1784593083-g0c0855",
     "devsh": "0.1.23"
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,6 +58,8 @@ export default tseslint.config(
     'crates/**',
     // Reference documentation from external projects
     'dev-docs/**',
+    // Local git worktrees (sibling checkouts under .worktrees/)
+    '.worktrees/**',
   ]),
 
   // Base configs for all TypeScript files

--- a/packages/devsh/internal/mirrorlocal/packer.go
+++ b/packages/devsh/internal/mirrorlocal/packer.go
@@ -324,10 +324,50 @@ func transformFile(base string, data []byte, opts PackOptions) []byte {
 		}
 	}
 	// TOML secret lines (simple key = "value" for known keys).
-	if strings.HasSuffix(strings.ToLower(base), ".toml") && !opts.IncludeSecrets {
-		data = redactTOMLSecrets(data)
+	if strings.HasSuffix(strings.ToLower(base), ".toml") {
+		if !opts.IncludeSecrets {
+			data = redactTOMLSecrets(data)
+		}
+		// After path rewrite, host project tables like [projects."$HOME/wiki"] and
+		// pre-existing [projects."/root/wiki"] collapse to the same key. Codex
+		// rejects duplicate TOML tables — keep the first occurrence of each header.
+		data = dedupeTOMLTables(data)
 	}
 	return data
+}
+
+// dedupeTOMLTables drops repeated table headers (and their bodies) after rewrite.
+// First occurrence of each exact header line wins. Handles standard TOML tables
+// like [projects."/root/wiki"] used by Codex config.toml.
+func dedupeTOMLTables(data []byte) []byte {
+	lines := bytes.Split(data, []byte("\n"))
+	seen := make(map[string]struct{})
+	out := make([][]byte, 0, len(lines))
+	skipping := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(string(line))
+		isTable := len(trimmed) >= 3 &&
+			trimmed[0] == '[' &&
+			trimmed[len(trimmed)-1] == ']' &&
+			!strings.HasPrefix(trimmed, "[[") // leave arrays-of-tables alone
+
+		if isTable {
+			if _, dup := seen[trimmed]; dup {
+				skipping = true
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			skipping = false
+			out = append(out, line)
+			continue
+		}
+		if skipping {
+			// Skip body lines of a duplicate table until the next header.
+			continue
+		}
+		out = append(out, line)
+	}
+	return bytes.Join(out, []byte("\n"))
 }
 
 func isTextConfig(base string) bool {

--- a/packages/devsh/internal/mirrorlocal/packer.go
+++ b/packages/devsh/internal/mirrorlocal/packer.go
@@ -24,21 +24,43 @@ type PackOptions struct {
 	TargetHome string
 	// IncludeSecrets keeps auth.json / known secret keys when true (v1 default false).
 	IncludeSecrets bool
-	// Sources lists relative home subdirs to consider (default: .claude, .codex).
+	// Sources lists relative home subdirs (legacy; ignored when IncludePaths is set).
 	Sources []string
+	// IncludePaths is an allowlist of paths relative to HomeDir (files or dirs).
+	// Empty means DefaultIncludePaths.
+	IncludePaths []string
 }
 
 // DefaultSources are the agent config roots mirrored in v1.
 var DefaultSources = []string{".claude", ".codex"}
 
+// DefaultIncludePaths are the only paths packed by default (relative to HomeDir).
+// This is an allowlist — full-tree walks of ~/.claude / ~/.codex pull multi‑GB
+// session history and blow CF/exec transfer limits. Skills may be directory
+// symlinks (e.g. ~/.claude/skills/foo -> ~/.agents/skills/foo); those are followed.
+var DefaultIncludePaths = []string{
+	".claude/settings.json",
+	".claude/config.json",
+	".claude/keybindings.json",
+	".claude/skills",
+	".claude/hooks",
+	".claude/commands",
+	".codex/config.toml",
+	".codex/keybindings.json",
+	".codex/AGENTS.md",
+	".codex/skills",
+	".codex/hooks",
+	".codex/automations",
+}
+
 // SecretFileBasenames are never copied unless IncludeSecrets is true.
 var SecretFileBasenames = map[string]struct{}{
-	"auth.json":       {},
+	"auth.json":         {},
 	".credentials.json": {},
 	"credentials.json":  {},
 }
 
-// ExcludeDirNames are skipped entirely (session history, caches, etc.).
+// ExcludeDirNames are skipped entirely when encountered under an include path.
 var ExcludeDirNames = map[string]struct{}{
 	"projects":          {},
 	"sessions":          {},
@@ -50,9 +72,14 @@ var ExcludeDirNames = map[string]struct{}{
 	"debug":             {},
 	"telemetry":         {},
 	"shell-snapshots":   {},
+	"shell_snapshots":   {},
 	"statsig":           {},
 	"todos":             {},
 	"file-history":      {},
+	"plugins":           {}, // large vendor trees; not needed for CLI settings
+	"backups":           {},
+	"node_modules":      {},
+	".git":              {},
 }
 
 // SecretJSONKeys are redacted (set to empty string / removed) in JSON configs.
@@ -88,88 +115,35 @@ func Pack(opts PackOptions) ([]byte, error) {
 	if opts.TargetHome == "" {
 		opts.TargetHome = "/root"
 	}
-	if len(opts.Sources) == 0 {
-		opts.Sources = append([]string(nil), DefaultSources...)
+	includePaths := opts.IncludePaths
+	if len(includePaths) == 0 {
+		includePaths = append([]string(nil), DefaultIncludePaths...)
 	}
 
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
-	for _, src := range opts.Sources {
-		src = strings.TrimPrefix(src, "~/")
-		src = strings.TrimPrefix(src, "/")
-		root := filepath.Join(opts.HomeDir, src)
-		info, err := os.Stat(root)
+	for _, relPath := range includePaths {
+		relPath = strings.TrimPrefix(relPath, "~/")
+		relPath = strings.TrimPrefix(relPath, "/")
+		abs := filepath.Join(opts.HomeDir, relPath)
+		info, err := os.Stat(abs)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, fmt.Errorf("stat %s: %w", root, err)
-		}
-		if !info.IsDir() {
+			// Soft-skip unreadable include roots.
 			continue
 		}
-		if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
+		if info.IsDir() {
+			// logical root == path as it appears under HomeDir (may be a symlink dir).
+			if err := walkAndPack(tw, opts, abs, abs); err != nil {
+				return nil, err
 			}
-			rel, err := filepath.Rel(opts.HomeDir, path)
-			if err != nil {
-				return err
-			}
-			// Normalize to forward slashes for tar + cloud Linux.
-			relSlash := filepath.ToSlash(rel)
-
-			if d.IsDir() {
-				base := d.Name()
-				if _, skip := ExcludeDirNames[base]; skip && path != root {
-					return filepath.SkipDir
-				}
-				// Ensure directory entries exist in the archive.
-				hdr := &tar.Header{
-					Name:     relSlash + "/",
-					Mode:     0o755,
-					Typeflag: tar.TypeDir,
-				}
-				return tw.WriteHeader(hdr)
-			}
-
-			base := d.Name()
-			if !opts.IncludeSecrets {
-				if _, secret := SecretFileBasenames[base]; secret {
-					return nil
-				}
-			}
-			// Skip sqlite / binary caches by extension.
-			lower := strings.ToLower(base)
-			if strings.HasSuffix(lower, ".sqlite") ||
-				strings.HasSuffix(lower, ".sqlite3") ||
-				strings.HasSuffix(lower, ".db") ||
-				strings.HasSuffix(lower, ".lock") {
-				return nil
-			}
-
-			data, err := os.ReadFile(path)
-			if err != nil {
-				return fmt.Errorf("read %s: %w", path, err)
-			}
-
-			data = transformFile(base, data, opts)
-
-			hdr := &tar.Header{
-				Name:     relSlash,
-				Mode:     0o644,
-				Size:     int64(len(data)),
-				Typeflag: tar.TypeReg,
-			}
-			if err := tw.WriteHeader(hdr); err != nil {
-				return err
-			}
-			if _, err := tw.Write(data); err != nil {
-				return err
-			}
-			return nil
-		}); err != nil {
+			continue
+		}
+		// Single file include.
+		if err := packFile(tw, opts, abs, relPath); err != nil {
 			return nil, err
 		}
 	}
@@ -178,6 +152,140 @@ func Pack(opts PackOptions) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// packFile packs one regular file (or symlink-to-file) at logicalRel under HomeDir.
+func packFile(tw *tar.Writer, opts PackOptions, absPath, logicalRel string) error {
+	base := filepath.Base(absPath)
+	if !opts.IncludeSecrets {
+		if _, secret := SecretFileBasenames[base]; secret {
+			return nil
+		}
+	}
+	lower := strings.ToLower(base)
+	if strings.HasSuffix(lower, ".sqlite") ||
+		strings.HasSuffix(lower, ".sqlite3") ||
+		strings.HasSuffix(lower, ".db") ||
+		strings.HasSuffix(lower, ".lock") ||
+		strings.HasSuffix(lower, ".wal") ||
+		strings.HasSuffix(lower, ".shm") {
+		return nil
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil
+	}
+	data = transformFile(base, data, opts)
+	relSlash := filepath.ToSlash(logicalRel)
+	// Ensure parent dir entries exist lightly (tar extract usually creates them).
+	hdr := &tar.Header{
+		Name:     relSlash,
+		Mode:     0o644,
+		Size:     int64(len(data)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	_, err = tw.Write(data)
+	return err
+}
+
+// walkAndPack walks physicalRoot, packing files under archive names rooted at
+// logicalRoot (both absolute). Directory symlinks under HomeDir
+// (e.g. ~/.claude/skills/foo -> ~/.agents/skills/foo) are followed and archived
+// under the symlink path, not the external target path.
+// filepath.WalkDir does not descend into symlink dirs, so we re-enter manually.
+func walkAndPack(tw *tar.Writer, opts PackOptions, logicalRoot, physicalRoot string) error {
+	return filepath.WalkDir(physicalRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// Soft-skip unreadable entries so one bad file cannot abort the whole mirror.
+			return nil
+		}
+		sub, err := filepath.Rel(physicalRoot, path)
+		if err != nil {
+			return nil
+		}
+		logicalBase, err := filepath.Rel(opts.HomeDir, logicalRoot)
+		if err != nil {
+			return nil
+		}
+		var rel string
+		if sub == "." {
+			rel = logicalBase
+		} else {
+			rel = filepath.Join(logicalBase, sub)
+		}
+		// Refuse to emit archive paths that escape HomeDir naming.
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil
+		}
+		relSlash := filepath.ToSlash(rel)
+
+		isDir, isSymlinkDir, err := entryDirKind(path, d)
+		if err != nil {
+			return nil
+		}
+		if isDir {
+			base := d.Name()
+			if _, skip := ExcludeDirNames[base]; skip && path != physicalRoot {
+				return filepath.SkipDir
+			}
+			hdr := &tar.Header{
+				Name:     relSlash + "/",
+				Mode:     0o755,
+				Typeflag: tar.TypeDir,
+			}
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			// WalkDir does not descend into symlink directories; re-enter on the target.
+			if isSymlinkDir {
+				target, err := filepath.EvalSymlinks(path)
+				if err != nil {
+					return nil
+				}
+				// Archive names stay under the symlink path (path under HomeDir).
+				if err := walkAndPack(tw, opts, path, target); err != nil {
+					return err
+				}
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		return packFile(tw, opts, path, rel)
+	})
+}
+
+// entryDirKind reports whether path is a directory and whether it is a
+// directory reached via a symlink (WalkDir will not descend into those).
+func entryDirKind(path string, d fs.DirEntry) (isDir bool, isSymlinkDir bool, err error) {
+	if d.IsDir() {
+		return true, false, nil
+	}
+	if d.Type()&fs.ModeSymlink == 0 {
+		// Regular file (or other non-dir, non-symlink).
+		info, err := d.Info()
+		if err != nil {
+			// Fall back to Stat.
+			st, err := os.Stat(path)
+			if err != nil {
+				return false, false, err
+			}
+			return st.IsDir(), false, nil
+		}
+		return info.IsDir(), false, nil
+	}
+	// Symlink: Stat follows to target.
+	st, err := os.Stat(path)
+	if err != nil {
+		return false, false, err
+	}
+	if st.IsDir() {
+		return true, true, nil
+	}
+	return false, false, nil
 }
 
 // PackToFile writes the archive to destPath and returns that path.

--- a/packages/devsh/internal/mirrorlocal/packer_realhome_test.go
+++ b/packages/devsh/internal/mirrorlocal/packer_realhome_test.go
@@ -2,6 +2,7 @@ package mirrorlocal
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -38,4 +39,38 @@ func TestPackRealUserHomeSmoke(t *testing.T) {
 		t.Error("auth.json must not be packed by default")
 	}
 	t.Logf("packed %d entries, %d bytes", len(names), len(archive))
+}
+
+func TestPackRealHomeCodexNoDuplicateProjects(t *testing.T) {
+	if os.Getenv("MIRRORLOCAL_REAL_HOME") != "1" {
+		t.Skip("set MIRRORLOCAL_REAL_HOME=1")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "config.toml")); err != nil {
+		t.Skip("no local .codex/config.toml")
+	}
+	archive, err := Pack(PackOptions{HomeDir: home, LocalHomePrefix: home, TargetHome: "/root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := ReadTarFile(archive, ".codex/config.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := map[string]int{}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, `[projects."`) {
+			counts[line]++
+		}
+	}
+	for hdr, n := range counts {
+		if n != 1 {
+			t.Errorf("duplicate %s x%d", hdr, n)
+		}
+	}
+	t.Logf("project tables=%d", len(counts))
 }

--- a/packages/devsh/internal/mirrorlocal/packer_realhome_test.go
+++ b/packages/devsh/internal/mirrorlocal/packer_realhome_test.go
@@ -1,0 +1,41 @@
+package mirrorlocal
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPackRealUserHomeSmoke(t *testing.T) {
+	if os.Getenv("MIRRORLOCAL_REAL_HOME") != "1" {
+		t.Skip("set MIRRORLOCAL_REAL_HOME=1 to pack the real $HOME")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive, err := Pack(PackOptions{HomeDir: home, TargetHome: "/root"})
+	if err != nil {
+		t.Fatalf("Pack real home: %v", err)
+	}
+	names, err := ListTarNames(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(names, "\n")
+	// settings / config if present on this machine
+	if _, err := os.Stat(home + "/.claude/settings.json"); err == nil {
+		if _, err := ReadTarFile(archive, ".claude/settings.json"); err != nil {
+			t.Fatalf("settings.json missing from archive: %v", err)
+		}
+	}
+	if _, err := os.Stat(home + "/.codex/config.toml"); err == nil {
+		if _, err := ReadTarFile(archive, ".codex/config.toml"); err != nil {
+			t.Fatalf("config.toml missing from archive: %v", err)
+		}
+	}
+	if strings.Contains(joined, "auth.json") {
+		t.Error("auth.json must not be packed by default")
+	}
+	t.Logf("packed %d entries, %d bytes", len(names), len(archive))
+}

--- a/packages/devsh/internal/mirrorlocal/packer_test.go
+++ b/packages/devsh/internal/mirrorlocal/packer_test.go
@@ -300,3 +300,77 @@ func TestPackContinuesWhenSingleEntryUnreadable(t *testing.T) {
 		t.Fatalf("skill should still be packed: %v", err)
 	}
 }
+
+func TestPackCodexConfigDedupesProjectTablesAfterPathRewrite(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	// Simulate local config that already has both macOS home paths and pre-existing /root paths
+	// (common after prior cloud sessions). Path rewrite of LocalHomePrefix -> /root must not
+	// produce duplicate [projects."..."] keys.
+	cfg := `
+model = "gpt"
+
+[projects."` + filepath.ToSlash(home) + `"]
+trust_level = "trusted"
+
+[projects."` + filepath.ToSlash(home) + `/wiki"]
+trust_level = "trusted"
+
+[projects."/root"]
+trust_level = "trusted"
+
+[projects."/root/wiki"]
+trust_level = "trusted"
+
+[projects."` + filepath.ToSlash(home) + `/Desktop/code/cmux"]
+trust_level = "trusted"
+
+[marketplaces.x]
+source = "` + filepath.ToSlash(home) + `/Desktop/code/agent-skills"
+`
+	// Write as .codex/config.toml under home
+	writeTree(t, home, map[string]string{
+		".codex/config.toml": cfg,
+	})
+
+	archive, err := Pack(PackOptions{
+		HomeDir:         home,
+		LocalHomePrefix: home,
+		TargetHome:      "/root",
+	})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	out, err := ReadTarFile(archive, ".codex/config.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	// Count occurrences of each projects table header
+	counts := map[string]int{}
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, `[projects."`) && strings.HasSuffix(line, `"]`) {
+			counts[line]++
+		}
+	}
+	for hdr, n := range counts {
+		if n != 1 {
+			t.Errorf("duplicate TOML table %s appears %d times; config:\n%s", hdr, n, s)
+		}
+	}
+	// Must still have cloud home project and rewritten cmux path once
+	if counts[`[projects."/root"]`] != 1 {
+		t.Errorf("expected single [projects.\"/root\"]; got %v\n%s", counts, s)
+	}
+	if counts[`[projects."/root/wiki"]`] != 1 {
+		t.Errorf("expected single [projects.\"/root/wiki\"]; got %v\n%s", counts, s)
+	}
+	if !strings.Contains(s, `[projects."/root/Desktop/code/cmux"]`) {
+		t.Errorf("expected rewritten cmux project path; got:\n%s", s)
+	}
+	// Local home prefix should be gone
+	if strings.Contains(s, home) {
+		t.Errorf("local home still present:\n%s", s)
+	}
+}

--- a/packages/devsh/internal/mirrorlocal/packer_test.go
+++ b/packages/devsh/internal/mirrorlocal/packer_test.go
@@ -164,14 +164,139 @@ func TestPackIncludeSecretsKeepsAuthJSON(t *testing.T) {
 	writeTree(t, home, map[string]string{
 		".codex/auth.json": `{"ok":true}`,
 	})
+	// auth.json is not in DefaultIncludePaths; opt-in requires both IncludeSecrets and path.
 	archive, err := Pack(PackOptions{
 		HomeDir:        home,
 		IncludeSecrets: true,
+		IncludePaths:   []string{".codex/auth.json"},
 	})
 	if err != nil {
 		t.Fatalf("Pack: %v", err)
 	}
 	if _, err := ReadTarFile(archive, ".codex/auth.json"); err != nil {
-		t.Fatalf("auth.json should be present when IncludeSecrets: %v", err)
+		t.Fatalf("auth.json should be present when IncludeSecrets + path: %v", err)
+	}
+
+	// Default allowlist never packs auth.json even if secrets flag is on without path.
+	archive2, err := Pack(PackOptions{HomeDir: home, IncludeSecrets: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadTarFile(archive2, ".codex/auth.json"); err == nil {
+		t.Fatal("default allowlist must not pack auth.json")
+	}
+}
+
+func TestPackDefaultAllowlistSkipsHistoryAndPlugins(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	writeTree(t, home, map[string]string{
+		".claude/settings.json":            `{"ok":true}` + "\n",
+		".claude/projects/p/session.json":  `{"no":true}`,
+		".claude/plugins/big/vendor.js":    "huge",
+		".claude/file-history/x":           "hist",
+		".codex/config.toml":               "model = \"x\"\n",
+		".codex/sessions/s1.json":          `{}`,
+		".codex/archived_sessions/a.json":  `{}`,
+		".codex/plugins/p/x.js":            "p",
+	})
+	archive, err := Pack(PackOptions{HomeDir: home, TargetHome: "/root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, _ := ListTarNames(archive)
+	joined := strings.Join(names, "\n")
+	for _, ban := range []string{"projects/", "plugins/", "file-history/", "sessions/", "archived_sessions/"} {
+		if strings.Contains(joined, ban) {
+			t.Errorf("must not include %q; got:\n%s", ban, joined)
+		}
+	}
+	if _, err := ReadTarFile(archive, ".claude/settings.json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadTarFile(archive, ".codex/config.toml"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPackFollowsDirectorySymlinksForSkills(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	// Real skill content outside .claude (like ~/.agents/skills/boost-prompt)
+	agents := filepath.Join(home, ".agents", "skills", "boost-prompt")
+	writeTree(t, home, map[string]string{
+		".claude/settings.json":               `{"model":"claude"}` + "\n",
+		".codex/config.toml":                  "model = \"gpt\"\n",
+		".agents/skills/boost-prompt/SKILL.md": "# boost\n",
+		".agents/skills/boost-prompt/nested/x.json": `{"a":1}` + "\n",
+	})
+	// Symlink skill dir into .claude/skills (macOS-dev layout)
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(skillsDir, "boost-prompt")
+	if err := os.Symlink(agents, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// Also a file symlink
+	realFile := filepath.Join(home, ".agents", "skills", "boost-prompt", "SKILL.md")
+	fileLink := filepath.Join(home, ".claude", "skills", "boost-link.md")
+	if err := os.Symlink(realFile, fileLink); err != nil {
+		t.Fatalf("file symlink: %v", err)
+	}
+
+	archive, err := Pack(PackOptions{
+		HomeDir:    home,
+		TargetHome: "/root",
+	})
+	if err != nil {
+		t.Fatalf("Pack must succeed with dir symlinks (got %v)", err)
+	}
+
+	// Core configs must always ship even when skills are symlinked
+	for _, want := range []string{
+		".claude/settings.json",
+		".codex/config.toml",
+		".claude/skills/boost-prompt/SKILL.md",
+		".claude/skills/boost-prompt/nested/x.json",
+		".claude/skills/boost-link.md",
+	} {
+		if _, err := ReadTarFile(archive, want); err != nil {
+			t.Errorf("missing %s: %v", want, err)
+		}
+	}
+	// External real path should not appear as archive root
+	names, _ := ListTarNames(archive)
+	joined := strings.Join(names, "\n")
+	if strings.Contains(joined, ".agents/") {
+		t.Errorf("archive should use symlink path names, not external target: %s", joined)
+	}
+}
+
+func TestPackContinuesWhenSingleEntryUnreadable(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	writeTree(t, home, map[string]string{
+		".claude/settings.json":        `{"ok":true}` + "\n",
+		".claude/skills/good/SKILL.md": "hello\n",
+	})
+	// Unreadable file under an included dir — pack should skip it, not fail whole archive
+	bad := filepath.Join(home, ".claude", "skills", "secret-unreadable.bin")
+	if err := os.WriteFile(bad, []byte("x"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o644) })
+
+	archive, err := Pack(PackOptions{HomeDir: home, TargetHome: "/root"})
+	if err != nil {
+		t.Fatalf("Pack should soft-skip unreadable files: %v", err)
+	}
+	if _, err := ReadTarFile(archive, ".claude/settings.json"); err != nil {
+		t.Fatalf("settings should still be packed: %v", err)
+	}
+	if _, err := ReadTarFile(archive, ".claude/skills/good/SKILL.md"); err != nil {
+		t.Fatalf("skill should still be packed: %v", err)
 	}
 }

--- a/packages/shared/src/pve-lxc-snapshots.json
+++ b/packages/shared/src/pve-lxc-snapshots.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-05-03T22:43:09Z",
+  "updatedAt": "2026-07-21T03:26:14Z",
   "presets": [
     {
       "presetId": "4vcpu_8gb_32gb",
@@ -57,6 +57,15 @@
           "snapshotId": "snapshot_196b5051",
           "templateVmid": 9071,
           "capturedAt": "2026-05-03T22:42:39Z",
+          "novncVersion": "v1.7.0-beta",
+          "novncSource": "github:noVNC/v1.7.0-beta",
+          "novncPackageState": "purged"
+        },
+        {
+          "version": 107,
+          "snapshotId": "snapshot_d2a97ee6",
+          "templateVmid": 9201,
+          "capturedAt": "2026-07-21T03:25:42Z",
           "novncVersion": "v1.7.0-beta",
           "novncSource": "github:noVNC/v1.7.0-beta",
           "novncPackageState": "purged"
@@ -118,6 +127,15 @@
           "snapshotId": "snapshot_3829ef95",
           "templateVmid": 9072,
           "capturedAt": "2026-05-03T22:43:09Z",
+          "novncVersion": "v1.7.0-beta",
+          "novncSource": "github:noVNC/v1.7.0-beta",
+          "novncPackageState": "purged"
+        },
+        {
+          "version": 91,
+          "snapshotId": "snapshot_b523186a",
+          "templateVmid": 9202,
+          "capturedAt": "2026-07-21T03:26:14Z",
           "novncVersion": "v1.7.0-beta",
           "novncSource": "github:noVNC/v1.7.0-beta",
           "novncPackageState": "purged"

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -4057,7 +4057,10 @@ with open(bridge_script_path, "r") as f:
 with open(vnc_html_path, "r") as f:
     html = f.read()
 
-script_tag = f'''<script type="module" id="vnc-clipboard-bridge-init">
+# NOTE: This inject body is embedded in an outer Python f-string (shell cmd).
+# Use a plain string + concat here — an f-string would re-parse JS braces as
+# expressions (SyntaxError on mod.default). Outer f-string still needs {{ }}.
+script_tag = '''<script type="module" id="vnc-clipboard-bridge-init">
 // Expose UI to window for clipboard bridge access.
 // IMPORTANT: do not use a static import of app/ui.js here.
 // The head <script type=module> already imports UI and uses top-level await
@@ -4071,7 +4074,7 @@ import('./app/ui.js').then((mod) => {{
 }});
 </script>
 <script id="vnc-clipboard-bridge">
-{{bridge_js}}
+''' + bridge_js + '''
 </script>
 '''
 

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -4058,10 +4058,17 @@ with open(vnc_html_path, "r") as f:
     html = f.read()
 
 script_tag = f'''<script type="module" id="vnc-clipboard-bridge-init">
-// Expose UI to window for clipboard bridge access
-// noVNC loads UI as ES module, not exposed globally by default
-import UI from './app/ui.js';
-window.UI = UI;
+// Expose UI to window for clipboard bridge access.
+// IMPORTANT: do not use a static import of app/ui.js here.
+// The head <script type=module> already imports UI and uses top-level await
+// (defaults.json / mandatory.json). A second static import races the live
+// binding and throws: Cannot access 'UI' before initialization.
+// Dynamic import() waits until the module graph finishes evaluating.
+import('./app/ui.js').then((mod) => {{
+  window.UI = mod.default;
+}}).catch((err) => {{
+  console.warn('[vnc-clipboard-bridge] deferred UI import failed', err);
+}});
 </script>
 <script id="vnc-clipboard-bridge">
 {{bridge_js}}

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1887,7 +1887,10 @@ with open(bridge_script_path, "r") as f:
 with open(vnc_html_path, "r") as f:
     html = f.read()
 
-script_tag = f'''<script type="module" id="vnc-clipboard-bridge-init">
+# NOTE: This inject body is embedded in an outer Python f-string (shell cmd).
+# Use a plain string + concat here — an f-string would re-parse JS braces as
+# expressions (SyntaxError on mod.default). Outer f-string still needs {{ }}.
+script_tag = '''<script type="module" id="vnc-clipboard-bridge-init">
 // Expose UI to window for clipboard bridge access.
 // IMPORTANT: do not use a static import of app/ui.js here.
 // The head <script type=module> already imports UI and uses top-level await
@@ -1901,7 +1904,7 @@ import('./app/ui.js').then((mod) => {{
 }});
 </script>
 <script id="vnc-clipboard-bridge">
-{{bridge_js}}
+''' + bridge_js + '''
 </script>
 '''
 

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1888,10 +1888,17 @@ with open(vnc_html_path, "r") as f:
     html = f.read()
 
 script_tag = f'''<script type="module" id="vnc-clipboard-bridge-init">
-// Expose UI to window for clipboard bridge access
-// noVNC loads UI as ES module, not exposed globally by default
-import UI from './app/ui.js';
-window.UI = UI;
+// Expose UI to window for clipboard bridge access.
+// IMPORTANT: do not use a static import of app/ui.js here.
+// The head <script type=module> already imports UI and uses top-level await
+// (defaults.json / mandatory.json). A second static import races the live
+// binding and throws: Cannot access 'UI' before initialization.
+// Dynamic import() waits until the module graph finishes evaluating.
+import('./app/ui.js').then((mod) => {{
+  window.UI = mod.default;
+}}).catch((err) => {{
+  console.warn('[vnc-clipboard-bridge] deferred UI import failed', err);
+}});
 </script>
 <script id="vnc-clipboard-bridge">
 {{bridge_js}}


### PR DESCRIPTION
## Summary
- Fix `--mirror-local` packer aborting on directory symlinks under `~/.claude/skills` (macOS-dev layout).
- Switch default packing to a tight allowlist so archives stay small enough for dual-path HTTP-exec push (settings.json, config.toml, skills/hooks/commands).
- Soft-skip unreadable entries instead of failing the whole mirror.
- Fix noVNC clipboard-bridge static double-import of `UI` that caused `Cannot access 'UI' before initialization` (snapshot inject in `scripts/snapshot*.py`).
- Ignore `.worktrees/**` in eslint/oxlint so local worktrees do not break pre-commit.

## Live verification
```
devsh start -p pve-lxc --clean --mirror-local
# Push path: http-exec
# Local agent config mirrored (secrets redacted)
# /root/.claude/settings.json and /root/.codex/config.toml present
```

## Test plan
- [x] `cd packages/devsh && go test ./internal/mirrorlocal/ ./internal/cli/ ./internal/pvelxc/ -count=1`
- [x] Live pve-lxc start with `--mirror-local` shows settings + config on box
- [ ] After merge: dispatch **Weekly PVE LXC Snapshot** (`pve-lxc-snapshot.yml`) on `dev` environment for durable noVNC inject on new snapshots

## Notes
- Ownership record may still warn without `devsh auth login` (401); unrelated to mirror pack.
- Snapshot rebuild is required for noVNC fix on **new** boxes; existing boxes can hot-patch `vnc.html` or use this branch’s inject on next snapshot build.