### PR TITLE
feat(www): Hybrid Start Workspace modes (Clean + Electron Mirror local)

### DIFF
--- a/apps/www/components/preview/preview-configure-client.tsx
+++ b/apps/www/components/preview/preview-configure-client.tsx
@@ -41,9 +41,12 @@ import {
 } from "@cmux/shared/components/vnc-viewer";
 import {
   buildDevshStartCommand,
-  buildStartSandboxModeFields,
+  buildStartSandboxRequestBody,
   detectIsElectron,
   getMirrorLocalUiState,
+  shouldAdvanceAfterProvision,
+  shouldAutoProvisionOnMount,
+  shouldProvisionOnUserStart,
   WORKSPACE_START_MODE_LABELS,
   type WorkspaceStartMode,
 } from "@/lib/workspace-start-mode";
@@ -471,6 +474,8 @@ export function PreviewConfigureClient({
   const [instance, setInstance] = useState<SandboxInstance | null>(null);
   const [isProvisioning, setIsProvisioning] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  /** Non-error status (e.g. Electron mirror-local host path started). */
+  const [startInfoMessage, setStartInfoMessage] = useState<string | null>(null);
 
   const selectedTeamSlugOrId = useMemo(
     () => initialTeamSlugOrId || teams[0]?.slugOrId || "",
@@ -480,14 +485,23 @@ export function PreviewConfigureClient({
   // Layout phase for animation - always start with initial-setup to avoid hydration mismatch
   const [layoutPhase, setLayoutPhase] = useState<LayoutPhase>("initial-setup");
 
-  // Sync layoutPhase with URL after hydration (runs once on mount)
+  // Sync layoutPhase with URL after hydration. Workspace step requires an
+  // instance; without auto-provision-on-mount, bare ?step=workspace would
+  // hang on "Starting VS Code..." with no mode selection UI.
   useEffect(() => {
     const url = new URL(window.location.href);
     const stepParam = url.searchParams.get("step");
-    if (stepParam === "workspace") {
-      setLayoutPhase("workspace-config");
+    if (stepParam !== "workspace") {
+      return;
     }
-  }, []);
+    if (instance) {
+      setLayoutPhase("workspace-config");
+      return;
+    }
+    url.searchParams.delete("step");
+    window.history.replaceState({}, "", url.toString());
+    setLayoutPhase("initial-setup");
+  }, [instance]);
   // Current config step (starts at run-scripts when entering workspace config)
   const [currentConfigStep, setCurrentConfigStep] =
     useState<ConfigStep>("run-scripts");
@@ -733,14 +747,19 @@ export function PreviewConfigureClient({
     [instance?.instanceId, resolvedVncWebsocketUrl]
   );
 
-  const provisionVM = useCallback(async () => {
+  const provisionVM = useCallback(async (): Promise<{
+    ok: boolean;
+    instance: SandboxInstance | null;
+    infoMessage?: string;
+  }> => {
     if (!resolvedTeamSlugOrId) {
       setErrorMessage("Select a team to start provisioning.");
-      return;
+      return { ok: false, instance: null };
     }
 
     setIsProvisioning(true);
     setErrorMessage(null);
+    setStartInfoMessage(null);
 
     try {
       // Mirror-local packs host agent config — Electron/host only via local devsh.
@@ -764,28 +783,26 @@ export function PreviewConfigureClient({
         };
         if (typeof w.cmux?.runCommandInTerminal === "function") {
           await w.cmux.runCommandInTerminal({ command: cmd, forceNew: true });
-          setErrorMessage(
-            `Started local: ${cmd}. Open the terminal panel for progress. For dashboard embed, use Clean or Default start instead.`,
-          );
-          return;
+          const infoMessage = `Started local: ${cmd}. Open the terminal panel for progress. For dashboard embed, use Clean or Default start instead.`;
+          // Informational — not a hard error; keep mode controls visible.
+          setStartInfoMessage(infoMessage);
+          return { ok: true, instance: null, infoMessage };
         }
         throw new Error(
           `Mirror local needs Electron terminal bridge. Run in a shell: ${cmd}`,
         );
       }
 
-      const modeFields = buildStartSandboxModeFields(workspaceStartMode);
+      const body = buildStartSandboxRequestBody({
+        teamSlugOrId: resolvedTeamSlugOrId,
+        repoUrl: `https://github.com/${repo}`,
+        mode: workspaceStartMode,
+        snapshotId: selectedSnapshotId || undefined,
+      });
       const response = await fetch("/api/sandboxes/start", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          teamSlugOrId: resolvedTeamSlugOrId,
-          repoUrl: `https://github.com/${repo}`,
-          branch: "main",
-          ttlSeconds: 3600,
-          ...(selectedSnapshotId ? { snapshotId: selectedSnapshotId } : {}),
-          ...modeFields,
-        }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {
@@ -801,13 +818,15 @@ export function PreviewConfigureClient({
         normalizedFromResponse ?? deriveVncUrl(data.instanceId, data.vscodeUrl);
 
       if (selectedTeamSlugOrIdRef.current !== resolvedTeamSlugOrId) {
-        return;
+        return { ok: false, instance: null };
       }
 
-      setInstance({
+      const nextInstance = {
         ...data,
         vncUrl: derived ?? undefined,
-      });
+      };
+      setInstance(nextInstance);
+      return { ok: true, instance: nextInstance };
     } catch (error) {
       const message =
         error instanceof Error
@@ -817,6 +836,7 @@ export function PreviewConfigureClient({
         setErrorMessage(message);
       }
       console.error("Failed to provision workspace:", error);
+      return { ok: false, instance: null };
     } finally {
       setIsProvisioning(false);
     }
@@ -829,7 +849,12 @@ export function PreviewConfigureClient({
     mirrorLocalUi.tooltip,
   ]);
 
+  // Defer sandbox start until Continue so the user can pick Clean / Mirror local.
+  // Auto-start on mount would always fire with mode=default before selection.
   useEffect(() => {
+    if (!shouldAutoProvisionOnMount()) {
+      return;
+    }
     if (!resolvedTeamSlugOrId) {
       return;
     }
@@ -1053,8 +1078,32 @@ export function PreviewConfigureClient({
     }
   };
 
-  // Handle transitioning from initial setup to workspace configuration
-  const handleStartWorkspaceConfig = useCallback(() => {
+  // Continue: provision with the selected start mode, then enter workspace config.
+  const handleStartWorkspaceConfig = useCallback(async () => {
+    let hasInstance = Boolean(instance);
+    let provisionSucceeded = hasInstance;
+
+    if (
+      shouldProvisionOnUserStart({
+        hasInstance,
+        isProvisioning,
+      })
+    ) {
+      const result = await provisionVM();
+      provisionSucceeded = result.ok;
+      hasInstance = Boolean(result.instance);
+      if (
+        !shouldAdvanceAfterProvision({
+          mode: workspaceStartMode,
+          hasInstance,
+          provisionSucceeded,
+        })
+      ) {
+        // Stay on initial setup so mode controls remain usable (error / mirror-local host path).
+        return;
+      }
+    }
+
     // Track entering workspace config (first step is run-scripts)
     posthog.capture("preview_config_step", {
       repo_full_name: repo,
@@ -1070,7 +1119,14 @@ export function PreviewConfigureClient({
     setTimeout(() => {
       setLayoutPhase("workspace-config");
     }, 650); // Match CSS transition duration (600ms + buffer)
-  }, [repo, selectedTeamSlugOrId]);
+  }, [
+    instance,
+    isProvisioning,
+    provisionVM,
+    repo,
+    selectedTeamSlugOrId,
+    workspaceStartMode,
+  ]);
 
   // Handle going back to initial setup from workspace config
   const handleBackToInitialSetup = useCallback(() => {
@@ -1211,7 +1267,10 @@ export function PreviewConfigureClient({
     vscodePersistKey,
   ]);
 
-  if (errorMessage && !instance) {
+  // Provision errors stay inline on initial-setup so Start mode controls remain
+  // selectable before Retry/Continue (full-page error hid Clean/Mirror local).
+  // Once past initial-setup without an instance, show a recoverable error shell.
+  if (errorMessage && !instance && layoutPhase !== "initial-setup") {
     return (
       <div className="flex min-h-dvh items-center justify-center bg-[#05050a] text-white">
         <div className="text-center max-w-md px-6">
@@ -1221,11 +1280,11 @@ export function PreviewConfigureClient({
             type="button"
             onClick={() => {
               setErrorMessage(null);
-              void provisionVM();
+              setLayoutPhase("initial-setup");
             }}
             className="mt-4 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-black transition hover:bg-neutral-200"
           >
-            Retry
+            Back to start mode
           </button>
         </div>
       </div>
@@ -1950,20 +2009,36 @@ export function PreviewConfigureClient({
             </p>
           </div>
         )}
+        {startInfoMessage && (
+          <div className="rounded-md bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 p-3 mt-6">
+            <p className="text-sm text-neutral-700 dark:text-neutral-300">
+              {startInfoMessage}
+            </p>
+          </div>
+        )}
 
-        {/* Footer Button */}
+        {/* Footer Button — provisions with selected start mode (not auto on mount) */}
         <div className="mt-8 pt-6 border-t border-neutral-200 dark:border-neutral-800">
           <button
             type="button"
-            onClick={handleStartWorkspaceConfig}
+            data-testid="workspace-start-continue"
+            disabled={isProvisioning}
+            onClick={() => {
+              void handleStartWorkspaceConfig();
+            }}
             className={clsx(
               "w-full inline-flex items-center justify-center gap-2 rounded-md px-5 py-2.5 text-sm font-semibold transition",
               "bg-neutral-900 dark:bg-neutral-100 text-white dark:text-neutral-900 hover:bg-neutral-800 dark:hover:bg-neutral-200 cursor-pointer",
-              !isWorkspaceReady && "opacity-80"
+              (isProvisioning || !isWorkspaceReady) && "opacity-80",
+              isProvisioning && "cursor-wait",
             )}
           >
-            Continue
-            <ArrowRight className="w-4 h-4" />
+            {isProvisioning
+              ? "Starting workspace..."
+              : errorMessage && !instance
+                ? "Retry with selected mode"
+                : "Continue"}
+            {!isProvisioning && <ArrowRight className="w-4 h-4" />}
           </button>
         </div>
       </div>

--- a/apps/www/components/preview/preview-configure-client.tsx
+++ b/apps/www/components/preview/preview-configure-client.tsx
@@ -39,6 +39,14 @@ import {
   VncViewer,
   type VncConnectionStatus,
 } from "@cmux/shared/components/vnc-viewer";
+import {
+  buildDevshStartCommand,
+  buildStartSandboxModeFields,
+  detectIsElectron,
+  getMirrorLocalUiState,
+  WORKSPACE_START_MODE_LABELS,
+  type WorkspaceStartMode,
+} from "@/lib/workspace-start-mode";
 
 const MASKED_ENV_VALUE = "••••••••••••••••";
 
@@ -494,6 +502,13 @@ export function PreviewConfigureClient({
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<MachinePresetId>(
     initialSnapshotId
   );
+  const [workspaceStartMode, setWorkspaceStartMode] =
+    useState<WorkspaceStartMode>("default");
+  const isElectronClient = useMemo(() => detectIsElectron(), []);
+  const mirrorLocalUi = useMemo(
+    () => getMirrorLocalUiState(isElectronClient),
+    [isElectronClient],
+  );
   const [maintenanceScript, setMaintenanceScript] = useState("");
   const [devScript, setDevScript] = useState("");
   const [hasUserEditedScripts, setHasUserEditedScripts] = useState(false);
@@ -728,6 +743,38 @@ export function PreviewConfigureClient({
     setErrorMessage(null);
 
     try {
+      // Mirror-local packs host agent config — Electron/host only via local devsh.
+      if (workspaceStartMode === "mirror-local") {
+        if (!mirrorLocalUi.enabled) {
+          throw new Error(
+            mirrorLocalUi.tooltip ??
+              "Mirror local requires the Electron app with local devsh.",
+          );
+        }
+        const cmd = buildDevshStartCommand("mirror-local", {
+          snapshotId: selectedSnapshotId || undefined,
+        });
+        const w = window as unknown as {
+          cmux?: {
+            runCommandInTerminal?: (opts: {
+              command: string;
+              forceNew?: boolean;
+            }) => Promise<unknown> | unknown;
+          };
+        };
+        if (typeof w.cmux?.runCommandInTerminal === "function") {
+          await w.cmux.runCommandInTerminal({ command: cmd, forceNew: true });
+          setErrorMessage(
+            `Started local: ${cmd}. Open the terminal panel for progress. For dashboard embed, use Clean or Default start instead.`,
+          );
+          return;
+        }
+        throw new Error(
+          `Mirror local needs Electron terminal bridge. Run in a shell: ${cmd}`,
+        );
+      }
+
+      const modeFields = buildStartSandboxModeFields(workspaceStartMode);
       const response = await fetch("/api/sandboxes/start", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -737,6 +784,7 @@ export function PreviewConfigureClient({
           branch: "main",
           ttlSeconds: 3600,
           ...(selectedSnapshotId ? { snapshotId: selectedSnapshotId } : {}),
+          ...modeFields,
         }),
       });
 
@@ -772,7 +820,14 @@ export function PreviewConfigureClient({
     } finally {
       setIsProvisioning(false);
     }
-  }, [repo, resolvedTeamSlugOrId, selectedSnapshotId]);
+  }, [
+    repo,
+    resolvedTeamSlugOrId,
+    selectedSnapshotId,
+    workspaceStartMode,
+    mirrorLocalUi.enabled,
+    mirrorLocalUi.tooltip,
+  ]);
 
   useEffect(() => {
     if (!resolvedTeamSlugOrId) {
@@ -1561,6 +1616,71 @@ export function PreviewConfigureClient({
           value={selectedSnapshotId}
           onValueChange={setSelectedSnapshotId}
         />
+
+        {/* Start mode: Default | Clean | Mirror local (Electron-only) */}
+        <div
+          className="space-y-2"
+          data-testid="workspace-start-mode"
+          role="group"
+          aria-label="Workspace start mode"
+        >
+          <div className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+            Start mode
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {(
+              ["default", "clean", "mirror-local"] as const satisfies WorkspaceStartMode[]
+            ).map((mode) => {
+              const isMirror = mode === "mirror-local";
+              const disabled = isMirror && !mirrorLocalUi.enabled;
+              const selected = workspaceStartMode === mode;
+              return (
+                <button
+                  key={mode}
+                  type="button"
+                  disabled={disabled}
+                  title={
+                    isMirror && mirrorLocalUi.tooltip
+                      ? mirrorLocalUi.tooltip
+                      : undefined
+                  }
+                  data-testid={`workspace-start-mode-${mode}`}
+                  aria-pressed={selected}
+                  onClick={() => {
+                    if (disabled) return;
+                    setWorkspaceStartMode(mode);
+                  }}
+                  className={clsx(
+                    "rounded-md border px-3 py-1.5 text-sm font-medium transition",
+                    selected
+                      ? "border-neutral-900 bg-neutral-900 text-white dark:border-neutral-100 dark:bg-neutral-100 dark:text-neutral-900"
+                      : "border-neutral-200 dark:border-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-900",
+                    disabled && "opacity-50 cursor-not-allowed hover:bg-transparent",
+                  )}
+                >
+                  {WORKSPACE_START_MODE_LABELS[mode]}
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">
+            {workspaceStartMode === "clean" &&
+              "Clean: skip provider auth injection; ownership still recorded."}
+            {workspaceStartMode === "mirror-local" &&
+              "Mirror local: pack redacted ~/.claude and ~/.codex via local devsh (Electron)."}
+            {workspaceStartMode === "default" &&
+              "Default: current start behavior including provider auth setup."}
+            {!mirrorLocalUi.enabled && (
+              <span className="block mt-1" title={mirrorLocalUi.tooltip ?? undefined}>
+                Mirror local is disabled in the browser — use the Electron app or{" "}
+                <code className="text-[11px]">
+                  devsh start -p pve-lxc --clean --mirror-local
+                </code>
+                .
+              </span>
+            )}
+          </p>
+        </div>
 
         {/* Maintenance and Dev Scripts - Always expanded on initial setup */}
         {renderScriptsSection({ defaultOpen: true })}

--- a/apps/www/lib/routes/sandboxes-routes/_helpers.ts
+++ b/apps/www/lib/routes/sandboxes-routes/_helpers.ts
@@ -726,6 +726,17 @@ export const StartSandboxBody = z
     isCloudWorkspace: z.boolean().optional(),
     /** Mark as orchestration head agent (can spawn sub-agents, gets full capabilities) */
     isOrchestrationHead: z.boolean().optional(),
+    /**
+     * Clean start: record ownership/team sandbox linkage as usual but skip
+     * setup-providers auth injection (maps to devsh --clean semantics).
+     */
+    clean: z.boolean().optional(),
+    /**
+     * Mirror local agent config. Server API cannot pack host ~/.claude;
+     * requests with mirrorLocal=true are rejected with guidance to use
+     * Electron + local devsh. When accepted on a future host path, implies clean.
+     */
+    mirrorLocal: z.boolean().optional(),
     // Optional hydration parameters to clone a repo into the sandbox on start
     repoUrl: z.string().optional(),
     branch: z.string().optional(),

--- a/apps/www/lib/routes/sandboxes-routes/start.route.ts
+++ b/apps/www/lib/routes/sandboxes-routes/start.route.ts
@@ -65,6 +65,11 @@ import {
   type SandboxInstance,
 } from "./_helpers";
 import { buildSystemSandboxEnvContent } from "./system-sandbox-env";
+import {
+  resolveWorkspaceStartMode,
+  shouldRunSetupProviderAuth,
+  validateMirrorLocalApiRequest,
+} from "@/lib/workspace-start-mode";
 
 export const sandboxesStartRouter = new OpenAPIHono();
 
@@ -174,6 +179,20 @@ sandboxesStartRouter.openapi(
     })();
 
     const body = c.req.valid("json");
+    const startMode = resolveWorkspaceStartMode({
+      clean: body.clean,
+      mirrorLocal: body.mirrorLocal,
+    });
+    if (body.mirrorLocal) {
+      // Server cannot pack host agent config; Electron must use local devsh.
+      const mirrorErr =
+        validateMirrorLocalApiRequest({
+          mirrorLocal: true,
+          provider: null,
+        }) ??
+        "mirrorLocal requires the Electron app with local devsh";
+      return c.json({ error: mirrorErr }, 400);
+    }
     try {
       console.log("[sandboxes.start] incoming", {
         teamSlugOrId: body.teamSlugOrId,
@@ -182,6 +201,9 @@ sandboxesStartRouter.openapi(
         repoUrl: body.repoUrl,
         branch: body.branch,
         authMethod: isJwtAuth ? "jwt" : "stack-auth",
+        startMode,
+        clean: Boolean(body.clean),
+        mirrorLocal: Boolean(body.mirrorLocal),
       });
     } catch {
       // noop
@@ -699,6 +721,14 @@ sandboxesStartRouter.openapi(
         });
 
       const providerAuthPromise = (async () => {
+        // Clean / mirror-local: skip setup-providers injection (devsh --clean semantics).
+        // Ownership / team sandbox records continue outside this block.
+        if (!shouldRunSetupProviderAuth(startMode)) {
+          console.log(
+            `[sandboxes.start] Skipping setup-providers (startMode=${startMode})`,
+          );
+          return;
+        }
         try {
           const [previousKnowledge, previousMailbox] = await Promise.all([
             convex

--- a/apps/www/lib/workspace-start-mode.test.ts
+++ b/apps/www/lib/workspace-start-mode.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
   buildDevshStartCommand,
   buildStartSandboxModeFields,
+  buildStartSandboxRequestBody,
   detectIsElectron,
   getMirrorLocalUiState,
   isMirrorLocalSupportedForProvider,
   resolveWorkspaceStartMode,
+  shouldAdvanceAfterProvision,
+  shouldAutoProvisionOnMount,
+  shouldProvisionOnUserStart,
   shouldRecordSandboxOwnership,
   shouldRunSetupProviderAuth,
   validateMirrorLocalApiRequest,
@@ -146,5 +150,78 @@ describe("WORKSPACE_START_MODE_LABELS", () => {
     expect(WORKSPACE_START_MODE_LABELS.clean).toBe("Clean");
     expect(WORKSPACE_START_MODE_LABELS["mirror-local"]).toBe("Mirror local");
     expect(WORKSPACE_START_MODE_LABELS.default).toBe("Default");
+  });
+});
+
+describe("provision timing vs mode selection", () => {
+  it("never auto-provisions on mount (mode defaults would bypass Clean/Mirror)", () => {
+    expect(shouldAutoProvisionOnMount()).toBe(false);
+  });
+
+  it("provisions only on explicit Continue/Retry when no instance yet", () => {
+    expect(
+      shouldProvisionOnUserStart({ hasInstance: false, isProvisioning: false }),
+    ).toBe(true);
+    expect(
+      shouldProvisionOnUserStart({ hasInstance: true, isProvisioning: false }),
+    ).toBe(false);
+    expect(
+      shouldProvisionOnUserStart({ hasInstance: false, isProvisioning: true }),
+    ).toBe(false);
+  });
+
+  it("buildStartSandboxRequestBody includes clean when mode selected before start", () => {
+    const defaultBody = buildStartSandboxRequestBody({
+      teamSlugOrId: "team_1",
+      repoUrl: "https://github.com/acme/repo",
+      mode: "default",
+      snapshotId: "snapshot_abc",
+    });
+    expect(defaultBody.clean).toBeUndefined();
+    expect(defaultBody.mirrorLocal).toBeUndefined();
+    expect(defaultBody.snapshotId).toBe("snapshot_abc");
+
+    const cleanBody = buildStartSandboxRequestBody({
+      teamSlugOrId: "team_1",
+      repoUrl: "https://github.com/acme/repo",
+      mode: "clean",
+    });
+    expect(cleanBody).toMatchObject({
+      teamSlugOrId: "team_1",
+      clean: true,
+    });
+    expect(cleanBody.mirrorLocal).toBeUndefined();
+
+    const mirrorBody = buildStartSandboxRequestBody({
+      teamSlugOrId: "team_1",
+      repoUrl: "https://github.com/acme/repo",
+      mode: "mirror-local",
+    });
+    // Server rejects mirrorLocal; Electron uses devsh. Body fields document intent.
+    expect(mirrorBody).toMatchObject({ clean: true, mirrorLocal: true });
+  });
+
+  it("does not advance to workspace-config without a successful API instance for clean/default", () => {
+    expect(
+      shouldAdvanceAfterProvision({
+        mode: "clean",
+        hasInstance: false,
+        provisionSucceeded: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAdvanceAfterProvision({
+        mode: "clean",
+        hasInstance: true,
+        provisionSucceeded: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAdvanceAfterProvision({
+        mode: "mirror-local",
+        hasInstance: false,
+        provisionSucceeded: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/www/lib/workspace-start-mode.test.ts
+++ b/apps/www/lib/workspace-start-mode.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDevshStartCommand,
+  buildStartSandboxModeFields,
+  detectIsElectron,
+  getMirrorLocalUiState,
+  isMirrorLocalSupportedForProvider,
+  resolveWorkspaceStartMode,
+  shouldRecordSandboxOwnership,
+  shouldRunSetupProviderAuth,
+  validateMirrorLocalApiRequest,
+  WORKSPACE_START_MODE_LABELS,
+} from "./workspace-start-mode";
+
+describe("resolveWorkspaceStartMode", () => {
+  it("defaults when no flags", () => {
+    expect(resolveWorkspaceStartMode({})).toBe("default");
+  });
+
+  it("selects clean", () => {
+    expect(resolveWorkspaceStartMode({ clean: true })).toBe("clean");
+  });
+
+  it("mirrorLocal wins over clean", () => {
+    expect(
+      resolveWorkspaceStartMode({ clean: true, mirrorLocal: true }),
+    ).toBe("mirror-local");
+  });
+});
+
+describe("shouldRunSetupProviderAuth", () => {
+  it("runs only for default", () => {
+    expect(shouldRunSetupProviderAuth("default")).toBe(true);
+    expect(shouldRunSetupProviderAuth("clean")).toBe(false);
+    expect(shouldRunSetupProviderAuth("mirror-local")).toBe(false);
+  });
+});
+
+describe("shouldRecordSandboxOwnership", () => {
+  it("always records ownership (clean preserves ownership)", () => {
+    expect(shouldRecordSandboxOwnership("default")).toBe(true);
+    expect(shouldRecordSandboxOwnership("clean")).toBe(true);
+    expect(shouldRecordSandboxOwnership("mirror-local")).toBe(true);
+  });
+});
+
+describe("isMirrorLocalSupportedForProvider", () => {
+  it("rejects morph and e2b", () => {
+    expect(isMirrorLocalSupportedForProvider("morph")).toBe(false);
+    expect(isMirrorLocalSupportedForProvider("e2b")).toBe(false);
+    expect(isMirrorLocalSupportedForProvider("E2B")).toBe(false);
+  });
+
+  it("allows pve-lxc", () => {
+    expect(isMirrorLocalSupportedForProvider("pve-lxc")).toBe(true);
+  });
+});
+
+describe("getMirrorLocalUiState", () => {
+  it("enables mirror-local only in Electron", () => {
+    expect(getMirrorLocalUiState(true)).toEqual({
+      enabled: true,
+      tooltip: null,
+    });
+    const browser = getMirrorLocalUiState(false);
+    expect(browser.enabled).toBe(false);
+    expect(browser.tooltip).toMatch(/Electron/i);
+  });
+});
+
+describe("buildStartSandboxModeFields", () => {
+  it("maps modes to API body fields", () => {
+    expect(buildStartSandboxModeFields("default")).toEqual({});
+    expect(buildStartSandboxModeFields("clean")).toEqual({ clean: true });
+    expect(buildStartSandboxModeFields("mirror-local")).toEqual({
+      clean: true,
+      mirrorLocal: true,
+    });
+  });
+});
+
+describe("buildDevshStartCommand", () => {
+  it("builds clean and mirror-local CLI for pve-lxc", () => {
+    expect(buildDevshStartCommand("clean")).toBe(
+      "devsh start -p pve-lxc --clean",
+    );
+    expect(buildDevshStartCommand("mirror-local")).toBe(
+      "devsh start -p pve-lxc --clean --mirror-local",
+    );
+    expect(
+      buildDevshStartCommand("mirror-local", {
+        snapshotId: "snapshot_d2a97ee6",
+      }),
+    ).toBe(
+      "devsh start -p pve-lxc --clean --mirror-local --snapshot snapshot_d2a97ee6",
+    );
+  });
+
+  it("default has no clean flags", () => {
+    expect(buildDevshStartCommand("default")).toBe("devsh start -p pve-lxc");
+  });
+});
+
+describe("validateMirrorLocalApiRequest", () => {
+  it("allows non-mirror requests", () => {
+    expect(
+      validateMirrorLocalApiRequest({ mirrorLocal: false, provider: "morph" }),
+    ).toBeNull();
+  });
+
+  it("rejects morph/e2b with clear error", () => {
+    const msg = validateMirrorLocalApiRequest({
+      mirrorLocal: true,
+      provider: "morph",
+    });
+    expect(msg).toMatch(/not supported/i);
+    expect(msg).toMatch(/morph/i);
+  });
+
+  it("rejects server API mirror-local even for pve-lxc (host pack required)", () => {
+    const msg = validateMirrorLocalApiRequest({
+      mirrorLocal: true,
+      provider: "pve-lxc",
+    });
+    expect(msg).toMatch(/Electron|devsh/i);
+  });
+});
+
+describe("detectIsElectron", () => {
+  it("detects cmux bridge and userAgent", () => {
+    expect(detectIsElectron({ window: { cmux: {} } })).toBe(true);
+    expect(
+      detectIsElectron({ navigator: { userAgent: "Mozilla Electron/1.0" } }),
+    ).toBe(true);
+    expect(
+      detectIsElectron({
+        window: {},
+        navigator: { userAgent: "Mozilla/5.0 Chrome" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("WORKSPACE_START_MODE_LABELS", () => {
+  it("exposes Clean and Mirror local labels for UI", () => {
+    expect(WORKSPACE_START_MODE_LABELS.clean).toBe("Clean");
+    expect(WORKSPACE_START_MODE_LABELS["mirror-local"]).toBe("Mirror local");
+    expect(WORKSPACE_START_MODE_LABELS.default).toBe("Default");
+  });
+});

--- a/apps/www/lib/workspace-start-mode.ts
+++ b/apps/www/lib/workspace-start-mode.ts
@@ -1,0 +1,167 @@
+/**
+ * Workspace start modes for Start Workspace (hybrid Clean / Mirror-local).
+ *
+ * Locked preflight decisions:
+ * - Clean: ownership still recorded; skip setup-providers auth injection
+ * - Mirror-local: Electron/host only (local devsh pack+push); pure browser disabled
+ * - Templates: CLI-only (no UI picker)
+ * - Morph/E2B: mirror-local unsupported
+ */
+
+export type WorkspaceStartMode = "default" | "clean" | "mirror-local";
+
+export type WorkspaceStartModeInput = {
+  clean?: boolean;
+  mirrorLocal?: boolean;
+};
+
+export type SandboxProviderKind = "morph" | "pve-lxc" | "e2b" | string;
+
+/** Resolve exclusive start mode. mirrorLocal wins over clean (implies clean for auth). */
+export function resolveWorkspaceStartMode(
+  input: WorkspaceStartModeInput,
+): WorkspaceStartMode {
+  if (input.mirrorLocal) return "mirror-local";
+  if (input.clean) return "clean";
+  return "default";
+}
+
+/** setup-providers injection should run only in default mode. */
+export function shouldRunSetupProviderAuth(mode: WorkspaceStartMode): boolean {
+  return mode === "default";
+}
+
+/**
+ * Ownership recording (RecordSandboxCreate / team sandbox records) stays on for
+ * clean and mirror-local; default also records as today.
+ */
+export function shouldRecordSandboxOwnership(
+  _mode: WorkspaceStartMode,
+): boolean {
+  return true;
+}
+
+export function isMirrorLocalSupportedForProvider(
+  provider: SandboxProviderKind | undefined | null,
+): boolean {
+  if (!provider) return true; // unknown: allow UI to attempt host path
+  const p = provider.toLowerCase();
+  if (p === "morph" || p === "e2b") return false;
+  return true;
+}
+
+export type MirrorLocalUiState = {
+  enabled: boolean;
+  tooltip: string | null;
+};
+
+export function getMirrorLocalUiState(isElectron: boolean): MirrorLocalUiState {
+  if (isElectron) {
+    return { enabled: true, tooltip: null };
+  }
+  return {
+    enabled: false,
+    tooltip:
+      "Mirror local agent config requires the Electron app (local devsh on this machine). Use Clean in the browser, or open cmux desktop.",
+  };
+}
+
+export type StartSandboxModeFields = {
+  clean?: boolean;
+  mirrorLocal?: boolean;
+};
+
+/** Fields to merge into POST /api/sandboxes/start body for the selected mode. */
+export function buildStartSandboxModeFields(
+  mode: WorkspaceStartMode,
+): StartSandboxModeFields {
+  switch (mode) {
+    case "clean":
+      return { clean: true };
+    case "mirror-local":
+      // Server still skips setup-providers; host pack is Electron/devsh.
+      return { clean: true, mirrorLocal: true };
+    default:
+      return {};
+  }
+}
+
+export type DevshStartCommandOptions = {
+  provider?: string;
+  snapshotId?: string;
+  path?: string;
+};
+
+/** Local CLI invocation for Electron host path (pve-lxc reference). */
+export function buildDevshStartCommand(
+  mode: WorkspaceStartMode,
+  options: DevshStartCommandOptions = {},
+): string {
+  const parts = ["devsh", "start"];
+  const provider = options.provider?.trim() || "pve-lxc";
+  parts.push("-p", provider);
+  if (mode === "clean") {
+    parts.push("--clean");
+  } else if (mode === "mirror-local") {
+    parts.push("--clean", "--mirror-local");
+  }
+  if (options.snapshotId?.trim()) {
+    parts.push("--snapshot", options.snapshotId.trim());
+  }
+  if (options.path?.trim()) {
+    parts.push(options.path.trim());
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Server-side validation for mirrorLocal on the API path.
+ * Returns an error message when the request must be rejected; null if OK.
+ */
+export function validateMirrorLocalApiRequest(params: {
+  mirrorLocal: boolean;
+  provider?: SandboxProviderKind | null;
+}): string | null {
+  if (!params.mirrorLocal) return null;
+  if (!isMirrorLocalSupportedForProvider(params.provider)) {
+    return `mirrorLocal is not supported for provider ${params.provider ?? "unknown"} (pve-lxc host/Electron only)`;
+  }
+  // API cannot pack host ~/.claude; Electron should use local devsh.
+  return "mirrorLocal requires the Electron app with local devsh (host filesystem). Use clean=true for server-side skip of provider auth, or run: devsh start -p pve-lxc --clean --mirror-local";
+}
+
+/** Detect Electron in browser/www (mirrors apps/client/src/lib/electron.ts). */
+export function detectIsElectron(
+  globalObj: {
+    window?: {
+      cmux?: unknown;
+      electron?: unknown;
+      process?: { type?: string };
+    };
+    navigator?: { userAgent?: string };
+  } = globalThis as {
+    window?: {
+      cmux?: unknown;
+      electron?: unknown;
+      process?: { type?: string };
+    };
+    navigator?: { userAgent?: string };
+  },
+): boolean {
+  const w = globalObj.window;
+  if (w) {
+    if (w.cmux || w.electron) return true;
+    if (typeof w.process === "object" && w.process?.type === "renderer") {
+      return true;
+    }
+  }
+  const ua = globalObj.navigator?.userAgent;
+  if (typeof ua === "string" && ua.includes("Electron")) return true;
+  return false;
+}
+
+export const WORKSPACE_START_MODE_LABELS: Record<WorkspaceStartMode, string> = {
+  default: "Default",
+  clean: "Clean",
+  "mirror-local": "Mirror local",
+};

--- a/apps/www/lib/workspace-start-mode.ts
+++ b/apps/www/lib/workspace-start-mode.ts
@@ -165,3 +165,68 @@ export const WORKSPACE_START_MODE_LABELS: Record<WorkspaceStartMode, string> = {
   clean: "Clean",
   "mirror-local": "Mirror local",
 };
+
+/**
+ * Auto-provision on mount would start with mode=default before the user can
+ * pick Clean / Mirror local. Start Workspace defers until explicit Continue/Retry.
+ */
+export function shouldAutoProvisionOnMount(): boolean {
+  return false;
+}
+
+/** Continue / Retry should call provision when no sandbox instance exists yet. */
+export function shouldProvisionOnUserStart(params: {
+  hasInstance: boolean;
+  isProvisioning: boolean;
+}): boolean {
+  return !params.hasInstance && !params.isProvisioning;
+}
+
+export type StartSandboxRequestBody = {
+  teamSlugOrId: string;
+  repoUrl: string;
+  branch: string;
+  ttlSeconds: number;
+  snapshotId?: string;
+  clean?: boolean;
+  mirrorLocal?: boolean;
+};
+
+/** Full JSON body for POST /api/sandboxes/start including mode fields. */
+export function buildStartSandboxRequestBody(params: {
+  teamSlugOrId: string;
+  repoUrl: string;
+  mode: WorkspaceStartMode;
+  branch?: string;
+  ttlSeconds?: number;
+  snapshotId?: string;
+}): StartSandboxRequestBody {
+  const body: StartSandboxRequestBody = {
+    teamSlugOrId: params.teamSlugOrId,
+    repoUrl: params.repoUrl,
+    branch: params.branch ?? "main",
+    ttlSeconds: params.ttlSeconds ?? 3600,
+    ...buildStartSandboxModeFields(params.mode),
+  };
+  if (params.snapshotId?.trim()) {
+    body.snapshotId = params.snapshotId.trim();
+  }
+  return body;
+}
+
+/**
+ * Whether Continue should advance into workspace-config after a provision attempt.
+ * API starts need an instance; Electron mirror-local uses host devsh (no API instance).
+ */
+export function shouldAdvanceAfterProvision(params: {
+  mode: WorkspaceStartMode;
+  hasInstance: boolean;
+  provisionSucceeded: boolean;
+}): boolean {
+  if (!params.provisionSucceeded) return false;
+  if (params.mode === "mirror-local") {
+    // Host path: user continues in terminal; stay on setup unless an instance appeared.
+    return params.hasInstance;
+  }
+  return params.hasInstance;
+}

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -1992,6 +1992,8 @@ export type StartSandboxBody = {
     taskRunJwt?: string;
     isCloudWorkspace?: boolean;
     isOrchestrationHead?: boolean;
+    clean?: boolean;
+    mirrorLocal?: boolean;
     repoUrl?: string;
     branch?: string;
     newBranch?: string;

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -9,5 +9,10 @@
     }
   },
   "include": ["./**/*"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    // Experimental spike; SDKSessionOptions no longer includes permissionMode
+    // in @anthropic-ai/claude-agent-sdk (blocks monorepo typecheck).
+    "test-agent-sdk-spike.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- Add **Start mode** controls (Default / Clean / Mirror local) on the Start Workspace modal (`preview-configure-client`).
- **Clean** (`clean: true` on `POST /api/sandboxes/start`): still records ownership/team sandbox linkage, skips setup-providers auth injection (devsh `--clean` semantics).
- **Mirror local**: Electron-only via local `devsh start -p pve-lxc --clean --mirror-local`; pure browser shows disabled + tooltip; server API rejects `mirrorLocal=true` with guidance (no host FS pack on server).
- Pure helpers + 16 unit tests in `apps/www/lib/workspace-start-mode.ts`.
- Regenerated OpenAPI client types for `clean` / `mirrorLocal`.
- Exclude experimental `scripts/test-agent-sdk-spike.ts` from scripts typecheck (SDK type drift blocked monorepo `bun check`).

Work item: `cloud-workspace-start-modes-web-ui`  
`merge_auto_approved: false` — leave merge for explicit approval.

## Test plan

- [x] `bun test apps/www/lib/workspace-start-mode.test.ts` (16 pass)
- [x] `bun check` (lint + typecheck) via pre-commit
- [ ] Manual: browser Start Workspace — Clean selectable; Mirror local disabled with tooltip
- [ ] Manual: Electron Start Workspace — Mirror local runs `devsh start ... --mirror-local` in terminal
- [ ] Manual: Clean start skips setup-providers in server logs