### PR TITLE
feat(dashboard): Clean and Mirror local start modes on cloud create

### DIFF
--- a/apps/client/electron/main/bootstrap.ts
+++ b/apps/client/electron/main/bootstrap.ts
@@ -14,6 +14,7 @@ import { app, session } from "electron";
 
 import { clearLogDirectory } from "./log-management/clear-log-directory";
 import { resolveLogFilePath } from "./log-management/log-paths";
+import { resolveElectronPartition } from "./electron-partition";
 import { SENTRY_ELECTRON_DSN } from "../../src/sentry-config";
 
 const APP_ID = "com.karlorz.cmux";
@@ -23,7 +24,10 @@ const APP_NAME = "cmux-next";
 const require = createRequire(import.meta.url);
 (globalThis as typeof globalThis & { require?: typeof require }).require = require;
 
-const PARTITION = "persist:cmux";
+const PARTITION = resolveElectronPartition({
+  isPackaged: app.isPackaged,
+  override: process.env.CMUX_ELECTRON_PARTITION,
+});
 
 try {
   const appDataDir = app.getPath("appData");

--- a/apps/client/electron/main/electron-partition.test.ts
+++ b/apps/client/electron/main/electron-partition.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LEGACY_ELECTRON_PARTITION,
+  resolveElectronPartition,
+} from "./electron-partition";
+
+describe("resolveElectronPartition", () => {
+  it("keeps packaged builds on the existing persistent partition", () => {
+    expect(resolveElectronPartition({ isPackaged: true })).toBe(
+      LEGACY_ELECTRON_PARTITION,
+    );
+  });
+
+  it("isolates development from the installed app partition", () => {
+    expect(resolveElectronPartition({ isPackaged: false })).toBe(
+      "persist:cmux-dev",
+    );
+  });
+
+  it("uses a worktree-specific development partition override", () => {
+    expect(
+      resolveElectronPartition({
+        isPackaged: false,
+        override: "persist:cmux-dev-abc12345",
+      }),
+    ).toBe("persist:cmux-dev-abc12345");
+  });
+
+  it("ignores blank overrides", () => {
+    expect(
+      resolveElectronPartition({ isPackaged: false, override: "   " }),
+    ).toBe("persist:cmux-dev");
+  });
+
+  it("rejects non-persistent overrides", () => {
+    expect(() =>
+      resolveElectronPartition({
+        isPackaged: false,
+        override: "temporary-partition",
+      }),
+    ).toThrow("must start with persist:");
+  });
+});

--- a/apps/client/electron/main/electron-partition.ts
+++ b/apps/client/electron/main/electron-partition.ts
@@ -1,0 +1,24 @@
+export const LEGACY_ELECTRON_PARTITION = "persist:cmux";
+export const DEFAULT_DEV_ELECTRON_PARTITION = "persist:cmux-dev";
+
+export function resolveElectronPartition({
+  isPackaged,
+  override,
+}: {
+  isPackaged: boolean;
+  override?: string;
+}): string {
+  const normalizedOverride = override?.trim();
+  if (normalizedOverride) {
+    if (!normalizedOverride.startsWith("persist:")) {
+      throw new Error(
+        "CMUX_ELECTRON_PARTITION must start with persist:",
+      );
+    }
+    return normalizedOverride;
+  }
+
+  return isPackaged
+    ? LEGACY_ELECTRON_PARTITION
+    : DEFAULT_DEV_ELECTRON_PARTITION;
+}

--- a/apps/client/electron/main/embedded-server.ts
+++ b/apps/client/electron/main/embedded-server.ts
@@ -1,4 +1,5 @@
 import { GitDiffManager } from "@cmux/server/gitDiff";
+import { createMirrorLocalPack } from "@cmux/server/host-config/mirror-local-pack";
 import type { RealtimeServer, RealtimeSocket } from "@cmux/server/realtime";
 import { setupSocketHandlers } from "@cmux/server/socket-handlers";
 import {
@@ -20,7 +21,11 @@ export async function startEmbeddedServer() {
   const ipcRealtimeServer = createIPCRealtimeServer();
 
   // Setup the FULL server socket handlers - this gives us complete parity
-  setupSocketHandlers(ipcRealtimeServer, gitDiffManager, null);
+  setupSocketHandlers(ipcRealtimeServer, gitDiffManager, null, {
+    mirrorLocal: {
+      createPack: () => createMirrorLocalPack(),
+    },
+  });
 
   let vscodeServeHandle: VSCodeServeWebHandle | null = null;
   try {
@@ -33,7 +38,7 @@ export async function startEmbeddedServer() {
   } catch (error) {
     serverLogger.error(
       "Failed to ensure VS Code serve-web in embedded server:",
-      error
+      error,
     );
   }
 

--- a/apps/client/electron/main/index.ts
+++ b/apps/client/electron/main/index.ts
@@ -85,9 +85,16 @@ import {
   type LocalClaudePluginDevLaunchRequest,
   type LocalTerminalTarget,
 } from "../../src/lib/local-claude-plugin-dev";
+import {
+  LEGACY_ELECTRON_PARTITION,
+  resolveElectronPartition,
+} from "./electron-partition";
 
 // Use a cookieable HTTPS origin intercepted locally instead of a custom scheme.
-const PARTITION = "persist:cmux";
+const PARTITION = resolveElectronPartition({
+  isPackaged: app.isPackaged,
+  override: process.env.CMUX_ELECTRON_PARTITION,
+});
 const APP_HOST = "cmux.local";
 const FRAME_BLOCKING_RESPONSE_HEADERS = new Set([
   "x-frame-options",
@@ -143,6 +150,77 @@ const previewWebContentsIds = new Set<number>();
 const altGrActivePreviewContents = new Set<number>();
 let embeddedServerCleanup: (() => Promise<void>) | null = null;
 let autoUpdateIntervalId: ReturnType<typeof setInterval> | null = null;
+
+function getCookieMigrationUrl(cookie: Electron.Cookie): string | null {
+  const domain = cookie.domain?.startsWith(".")
+    ? cookie.domain.slice(1)
+    : cookie.domain;
+  if (!domain) {
+    return null;
+  }
+
+  const scheme = cookie.secure ? "https" : "http";
+  return `${scheme}://${domain}${cookie.path || "/"}`;
+}
+
+async function migrateLegacyDevAuthCookies(
+  targetSession: Electron.Session,
+): Promise<void> {
+  if (app.isPackaged || PARTITION === LEGACY_ELECTRON_PARTITION) {
+    return;
+  }
+
+  try {
+    const targetCookies = await targetSession.cookies.get({});
+    if (
+      targetCookies.some((cookie) =>
+        isStackAuthCookieName(cookie.name, env.NEXT_PUBLIC_STACK_PROJECT_ID),
+      )
+    ) {
+      return;
+    }
+
+    const legacySession = session.fromPartition(LEGACY_ELECTRON_PARTITION);
+    const legacyAuthCookies = (await legacySession.cookies.get({})).filter(
+      (cookie) =>
+        isStackAuthCookieName(cookie.name, env.NEXT_PUBLIC_STACK_PROJECT_ID),
+    );
+
+    let copiedCount = 0;
+    for (const cookie of legacyAuthCookies) {
+      const url = getCookieMigrationUrl(cookie);
+      if (!url) {
+        continue;
+      }
+
+      await targetSession.cookies.set({
+        url,
+        name: cookie.name,
+        value: cookie.value,
+        path: cookie.path,
+        secure: cookie.secure,
+        httpOnly: cookie.httpOnly,
+        sameSite: cookie.sameSite,
+        ...(cookie.hostOnly ? {} : { domain: cookie.domain }),
+        ...(typeof cookie.expirationDate === "number"
+          ? { expirationDate: cookie.expirationDate }
+          : {}),
+      });
+      copiedCount += 1;
+    }
+
+    if (copiedCount > 0) {
+      mainLog("Migrated Stack Auth cookies into isolated development partition", {
+        sourcePartition: LEGACY_ELECTRON_PARTITION,
+        targetPartition: PARTITION,
+        count: copiedCount,
+        names: legacyAuthCookies.map((cookie) => cookie.name),
+      });
+    }
+  } catch (error) {
+    mainWarn("Failed to migrate legacy development auth cookies", error);
+  }
+}
 
 function getTimestamp(): string {
   return new Date().toISOString();
@@ -1721,6 +1799,7 @@ app.whenReady().then(async () => {
   }
 
   const ses = session.fromPartition(PARTITION);
+  await migrateLegacyDevAuthCookies(ses);
   const trustedProxyDomains = buildTrustedProxyDomainSet([
     process.env.PVE_PUBLIC_DOMAIN,
   ]);

--- a/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
+++ b/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
@@ -30,7 +30,7 @@ import {
 import { useNavigate, useRouter } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { Cloud, Loader2, Monitor } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
 type WorkspaceCreationButtonsProps = {
@@ -60,14 +60,10 @@ export function WorkspaceCreationButtons({
   const [isCreatingCloud, setIsCreatingCloud] = useState(false);
   const [workspaceStartMode, setWorkspaceStartMode] =
     useState<WorkspaceStartMode>("default");
-  const mirrorLocalUi = useMemo(
-    () =>
-      getMirrorLocalUiState({
-        isElectron,
-        provider: selectedEnvironmentProvider,
-      }),
-    [selectedEnvironmentProvider],
-  );
+  const mirrorLocalUi = getMirrorLocalUiState({
+    isElectron,
+    provider: selectedEnvironmentProvider,
+  });
 
   const reserveLocalWorkspace = useMutation(api.localWorkspaces.reserve);
   const createTask = useMutation(api.tasks.create);

--- a/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
+++ b/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
@@ -7,6 +7,7 @@ import {
 import { useExpandTasks } from "@/contexts/expand-tasks/ExpandTasksContext";
 import { useSocket } from "@/contexts/socket/use-socket";
 import { useTheme } from "@/components/theme/use-theme";
+import { isElectron } from "@/lib/electron";
 import { preloadTaskRunIframes } from "@/lib/preloadTaskRunIframes";
 import {
   rewriteLocalWorkspaceUrlIfNeeded,
@@ -18,11 +19,19 @@ import type { Id } from "@cmux/convex/dataModel";
 import type {
   CreateLocalWorkspaceResponse,
   CreateCloudWorkspaceResponse,
+  WorkspaceStartMode,
+} from "@cmux/shared";
+import {
+  buildCreateCloudWorkspaceModeFields,
+  buildDevshMirrorLocalCommand,
+  getMirrorLocalUiState,
+  WORKSPACE_START_MODE_LABELS,
+  WORKSPACE_START_MODES,
 } from "@cmux/shared";
 import { useNavigate, useRouter } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { Cloud, Loader2, Monitor } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 type WorkspaceCreationButtonsProps = {
@@ -47,6 +56,13 @@ export function WorkspaceCreationButtons({
   const localServeWeb = useLocalVSCodeServeWebQuery();
   const [isCreatingLocal, setIsCreatingLocal] = useState(false);
   const [isCreatingCloud, setIsCreatingCloud] = useState(false);
+  const [workspaceStartMode, setWorkspaceStartMode] =
+    useState<WorkspaceStartMode>("default");
+  const mirrorLocalUi = useMemo(
+    () => getMirrorLocalUiState(isElectron),
+    // isElectron is a module constant; recompute once per mount
+    [],
+  );
 
   const reserveLocalWorkspace = useMutation(api.localWorkspaces.reserve);
   const createTask = useMutation(api.tasks.create);
@@ -224,6 +240,17 @@ export function WorkspaceCreationButtons({
     // Use resolved environment name from props (falls back to "Unknown Environment" if unavailable)
     const environmentName = selectedEnvironmentName || "Unknown Environment";
 
+    if (
+      workspaceStartMode === "mirror-local" &&
+      !mirrorLocalUi.enabled
+    ) {
+      toast.error(
+        mirrorLocalUi.tooltip ??
+          "Mirror local requires the Electron desktop app.",
+      );
+      return;
+    }
+
     setIsCreatingCloud(true);
 
     try {
@@ -240,6 +267,8 @@ export function WorkspaceCreationButtons({
       // Hint the sidebar to auto-expand this task once it appears
       addTaskToExpand(taskId);
 
+      const modeFields = buildCreateCloudWorkspaceModeFields(workspaceStartMode);
+
       await new Promise<void>((resolve) => {
         socket.emit(
           "create-cloud-workspace",
@@ -248,6 +277,7 @@ export function WorkspaceCreationButtons({
             environmentId,
             taskId,
             theme,
+            ...modeFields,
           },
           async (response: CreateCloudWorkspaceResponse) => {
             try {
@@ -261,7 +291,18 @@ export function WorkspaceCreationButtons({
               const effectiveTaskId = response.taskId ?? taskId;
               const effectiveTaskRunId = response.taskRunId;
 
-              toast.success("Cloud workspace created successfully");
+              if (workspaceStartMode === "mirror-local") {
+                // Host pack is not yet attached to dashboard sandboxes in-process;
+                // soft-fail with explicit CLI guidance (do not claim silent pack success).
+                const cmd = buildDevshMirrorLocalCommand();
+                toast.message("Cloud workspace starting (mirror-local)", {
+                  description: `Agent config pack from this host is not fully wired for dashboard sandboxes yet. For a durable host pack, run: ${cmd}`,
+                });
+              } else if (workspaceStartMode === "clean") {
+                toast.success("Clean cloud workspace created successfully");
+              } else {
+                toast.success("Cloud workspace created successfully");
+              }
 
               if (effectiveTaskId && effectiveTaskRunId) {
                 void router
@@ -296,7 +337,7 @@ export function WorkspaceCreationButtons({
         );
       });
 
-      console.log("Cloud workspace created:", taskId);
+      console.log("Cloud workspace created:", taskId, workspaceStartMode);
     } catch (error) {
       console.error("Error creating cloud workspace:", error);
       toast.error("Failed to create cloud workspace");
@@ -314,6 +355,9 @@ export function WorkspaceCreationButtons({
     theme,
     navigate,
     router,
+    workspaceStartMode,
+    mirrorLocalUi.enabled,
+    mirrorLocalUi.tooltip,
   ]);
 
   const canCreateLocal = selectedProject.length > 0 && !isEnvSelected;
@@ -326,56 +370,110 @@ export function WorkspaceCreationButtons({
   }
 
   return (
-    <div className="flex items-center gap-2 mb-3">
-      {!env.NEXT_PUBLIC_WEB_MODE && (
+    <div className="flex flex-col gap-2 mb-3">
+      <div
+        className="flex flex-wrap items-center gap-2"
+        data-testid="dashboard-workspace-start-mode"
+        role="group"
+        aria-label="Cloud workspace start mode"
+      >
+        <span className="text-[11px] font-medium text-neutral-500 dark:text-neutral-400">
+          Start mode
+        </span>
+        <div className="flex flex-wrap gap-1">
+          {WORKSPACE_START_MODES.map((mode) => {
+            const isMirror = mode === "mirror-local";
+            const disabled = isMirror && !mirrorLocalUi.enabled;
+            const selected = workspaceStartMode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                disabled={disabled}
+                title={
+                  isMirror && mirrorLocalUi.tooltip
+                    ? mirrorLocalUi.tooltip
+                    : undefined
+                }
+                data-testid={`dashboard-workspace-start-mode-${mode}`}
+                aria-pressed={selected}
+                onClick={() => {
+                  if (disabled) return;
+                  setWorkspaceStartMode(mode);
+                }}
+                className={[
+                  "rounded-md border px-2 py-1 text-[11px] font-medium transition",
+                  selected
+                    ? "border-neutral-900 bg-neutral-900 text-white dark:border-neutral-100 dark:bg-neutral-100 dark:text-neutral-900"
+                    : "border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700",
+                  disabled
+                    ? "opacity-50 cursor-not-allowed hover:bg-transparent"
+                    : "",
+                ].join(" ")}
+              >
+                {WORKSPACE_START_MODE_LABELS[mode]}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {!env.NEXT_PUBLIC_WEB_MODE && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={handleCreateLocalWorkspace}
+                disabled={!canCreateLocal || isCreatingLocal}
+                className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium transition-colors rounded-lg bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isCreatingLocal ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <Monitor className="w-3.5 h-3.5" />
+                )}
+                <span>Create Local Workspace</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {!selectedProject.length
+                ? "Select a repository first"
+                : isEnvSelected
+                  ? "Switch to repository mode (not environment)"
+                  : "Create workspace from selected repository"}
+            </TooltipContent>
+          </Tooltip>
+        )}
+
         <Tooltip>
           <TooltipTrigger asChild>
             <button
-              onClick={handleCreateLocalWorkspace}
-              disabled={!canCreateLocal || isCreatingLocal}
+              onClick={handleCreateCloudWorkspace}
+              disabled={!canCreateCloud || isCreatingCloud}
+              data-testid="dashboard-create-cloud-workspace"
               className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium transition-colors rounded-lg bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isCreatingLocal ? (
+              {isCreatingCloud ? (
                 <Loader2 className="w-3.5 h-3.5 animate-spin" />
               ) : (
-                <Monitor className="w-3.5 h-3.5" />
+                <Cloud className="w-4 h-4" />
               )}
-              <span>Create Local Workspace</span>
+              <span>Create Cloud Workspace</span>
             </button>
           </TooltipTrigger>
           <TooltipContent>
             {!selectedProject.length
-              ? "Select a repository first"
-              : isEnvSelected
-                ? "Switch to repository mode (not environment)"
-                : "Create workspace from selected repository"}
+              ? "Select an environment first"
+              : !isEnvSelected
+                ? "Switch to environment mode (not repository)"
+                : workspaceStartMode === "clean"
+                  ? "Create clean workspace (skip provider auth injection)"
+                  : workspaceStartMode === "mirror-local"
+                    ? "Create workspace and skip provider auth; host mirror pack is soft-fail"
+                    : "Create workspace from selected environment"}
           </TooltipContent>
         </Tooltip>
-      )}
-
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            onClick={handleCreateCloudWorkspace}
-            disabled={!canCreateCloud || isCreatingCloud}
-            className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium transition-colors rounded-lg bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 border border-neutral-300 dark:border-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isCreatingCloud ? (
-              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-            ) : (
-              <Cloud className="w-4 h-4" />
-            )}
-            <span>Create Cloud Workspace</span>
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>
-          {!selectedProject.length
-            ? "Select an environment first"
-            : !isEnvSelected
-              ? "Switch to environment mode (not repository)"
-              : "Create workspace from selected environment"}
-        </TooltipContent>
-      </Tooltip>
+      </div>
     </div>
   );
 }

--- a/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
+++ b/apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx
@@ -23,7 +23,6 @@ import type {
 } from "@cmux/shared";
 import {
   buildCreateCloudWorkspaceModeFields,
-  buildDevshMirrorLocalCommand,
   getMirrorLocalUiState,
   WORKSPACE_START_MODE_LABELS,
   WORKSPACE_START_MODES,
@@ -40,6 +39,8 @@ type WorkspaceCreationButtonsProps = {
   isEnvSelected: boolean;
   /** Resolved environment name from environments query (avoids parsing selectedProject) */
   selectedEnvironmentName?: string | null;
+  /** Provider declared by the selected environment. */
+  selectedEnvironmentProvider?: string | null;
 };
 
 export function WorkspaceCreationButtons({
@@ -47,6 +48,7 @@ export function WorkspaceCreationButtons({
   selectedProject,
   isEnvSelected,
   selectedEnvironmentName,
+  selectedEnvironmentProvider,
 }: WorkspaceCreationButtonsProps) {
   const { socket } = useSocket();
   const { addTaskToExpand } = useExpandTasks();
@@ -59,9 +61,12 @@ export function WorkspaceCreationButtons({
   const [workspaceStartMode, setWorkspaceStartMode] =
     useState<WorkspaceStartMode>("default");
   const mirrorLocalUi = useMemo(
-    () => getMirrorLocalUiState(isElectron),
-    // isElectron is a module constant; recompute once per mount
-    [],
+    () =>
+      getMirrorLocalUiState({
+        isElectron,
+        provider: selectedEnvironmentProvider,
+      }),
+    [selectedEnvironmentProvider],
   );
 
   const reserveLocalWorkspace = useMutation(api.localWorkspaces.reserve);
@@ -139,14 +144,14 @@ export function WorkspaceCreationButtons({
               const normalizedWorkspaceUrl = response.workspaceUrl
                 ? rewriteLocalWorkspaceUrlIfNeeded(
                     response.workspaceUrl,
-                    localServeWeb.data?.baseUrl
+                    localServeWeb.data?.baseUrl,
                   )
                 : null;
 
               if (response.workspaceUrl && effectiveTaskRunId) {
                 const proxiedUrl = toProxyWorkspaceUrl(
                   response.workspaceUrl,
-                  localServeWeb.data?.baseUrl
+                  localServeWeb.data?.baseUrl,
                 );
                 if (proxiedUrl) {
                   void preloadTaskRunIframes([
@@ -159,7 +164,7 @@ export function WorkspaceCreationButtons({
               }
 
               toast.success(
-                `Local workspace "${reservation.workspaceName}" created successfully`
+                `Local workspace "${reservation.workspaceName}" created successfully`,
               );
 
               if (effectiveTaskId && effectiveTaskRunId) {
@@ -185,15 +190,12 @@ export function WorkspaceCreationButtons({
                 window.location.assign(normalizedWorkspaceUrl);
               }
             } catch (callbackError) {
-              console.error(
-                "Error creating local workspace:",
-                callbackError
-              );
+              console.error("Error creating local workspace:", callbackError);
               toast.error("Failed to create local workspace");
             } finally {
               resolve();
             }
-          }
+          },
         );
       });
     } catch (error) {
@@ -234,16 +236,13 @@ export function WorkspaceCreationButtons({
     const projectFullName = selectedProject[0];
     const environmentId = projectFullName.replace(
       /^env:/,
-      ""
+      "",
     ) as Id<"environments">;
 
     // Use resolved environment name from props (falls back to "Unknown Environment" if unavailable)
     const environmentName = selectedEnvironmentName || "Unknown Environment";
 
-    if (
-      workspaceStartMode === "mirror-local" &&
-      !mirrorLocalUi.enabled
-    ) {
+    if (workspaceStartMode === "mirror-local" && !mirrorLocalUi.enabled) {
       toast.error(
         mirrorLocalUi.tooltip ??
           "Mirror local requires the Electron desktop app.",
@@ -267,7 +266,8 @@ export function WorkspaceCreationButtons({
       // Hint the sidebar to auto-expand this task once it appears
       addTaskToExpand(taskId);
 
-      const modeFields = buildCreateCloudWorkspaceModeFields(workspaceStartMode);
+      const modeFields =
+        buildCreateCloudWorkspaceModeFields(workspaceStartMode);
 
       await new Promise<void>((resolve) => {
         socket.emit(
@@ -283,7 +283,7 @@ export function WorkspaceCreationButtons({
             try {
               if (!response.success) {
                 toast.error(
-                  response.error || "Failed to create cloud workspace"
+                  response.error || "Failed to create cloud workspace",
                 );
                 return;
               }
@@ -291,16 +291,9 @@ export function WorkspaceCreationButtons({
               const effectiveTaskId = response.taskId ?? taskId;
               const effectiveTaskRunId = response.taskRunId;
 
-              if (workspaceStartMode === "mirror-local") {
-                // Host pack is not yet attached to dashboard sandboxes in-process;
-                // soft-fail with explicit CLI guidance (do not claim silent pack success).
-                const cmd = buildDevshMirrorLocalCommand();
-                toast.message("Cloud workspace starting (mirror-local)", {
-                  description: `Agent config pack from this host is not fully wired for dashboard sandboxes yet. For a durable host pack, run: ${cmd}`,
-                });
-              } else if (workspaceStartMode === "clean") {
+              if (workspaceStartMode === "clean") {
                 toast.success("Clean cloud workspace created successfully");
-              } else {
+              } else if (workspaceStartMode === "default") {
                 toast.success("Cloud workspace created successfully");
               }
 
@@ -325,15 +318,12 @@ export function WorkspaceCreationButtons({
                 });
               }
             } catch (callbackError) {
-              console.error(
-                "Error creating cloud workspace:",
-                callbackError
-              );
+              console.error("Error creating cloud workspace:", callbackError);
               toast.error("Failed to create cloud workspace");
             } finally {
               resolve();
             }
-          }
+          },
         );
       });
 
@@ -469,7 +459,7 @@ export function WorkspaceCreationButtons({
                 : workspaceStartMode === "clean"
                   ? "Create clean workspace (skip provider auth injection)"
                   : workspaceStartMode === "mirror-local"
-                    ? "Create workspace and skip provider auth; host mirror pack is soft-fail"
+                    ? "Create a clean PVE LXC workspace and apply this host's safe agent configuration pack"
                     : "Create workspace from selected environment"}
           </TooltipContent>
         </Tooltip>

--- a/apps/client/src/contexts/socket/electron-socket-provider.tsx
+++ b/apps/client/src/contexts/socket/electron-socket-provider.tsx
@@ -9,6 +9,7 @@ import { stackClientApp } from "../../lib/stack";
 import { authJsonQueryOptions } from "../convex/authJsonQueryOptions";
 import { setGlobalSocket, socketBoot } from "./socket-boot";
 import { ElectronSocketContext } from "./socket-context";
+import { registerMirrorLocalProgressToasts } from "./mirror-local-progress-toasts";
 import type { SocketContextType } from "./types";
 
 export const ElectronSocketProvider: React.FC<React.PropsWithChildren> = ({
@@ -84,6 +85,7 @@ export const ElectronSocketProvider: React.FC<React.PropsWithChildren> = ({
     }
 
     let disposed = false;
+    let unregisterMirrorLocalProgressToasts: (() => void) | undefined;
 
     (async () => {
       const user = await cachedGetUser(stackClientApp);
@@ -139,6 +141,9 @@ export const ElectronSocketProvider: React.FC<React.PropsWithChildren> = ({
         });
       });
 
+      unregisterMirrorLocalProgressToasts =
+        registerMirrorLocalProgressToasts(createdSocket);
+
       // Connect the socket
       createdSocket.connect();
 
@@ -152,6 +157,7 @@ export const ElectronSocketProvider: React.FC<React.PropsWithChildren> = ({
 
     return () => {
       disposed = true;
+      unregisterMirrorLocalProgressToasts?.();
       if (socketRef.current) {
         console.log("[ElectronSocket] Cleaning up IPC socket");
         socketRef.current.disconnect();

--- a/apps/client/src/contexts/socket/mirror-local-progress-toasts.test.ts
+++ b/apps/client/src/contexts/socket/mirror-local-progress-toasts.test.ts
@@ -1,0 +1,68 @@
+import type { MirrorLocalProgress } from "@cmux/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createMirrorLocalProgressToastController } from "./mirror-local-progress-toasts";
+
+function progress(
+  state: MirrorLocalProgress["state"],
+  message: string,
+): MirrorLocalProgress {
+  return {
+    taskRunId: "task-run-1",
+    state,
+    message,
+    fileCount: 3,
+    compressedBytes: 2_048,
+  };
+}
+
+describe("createMirrorLocalProgressToastController", () => {
+  it("updates one loading toast through completion", () => {
+    const toastApi = {
+      loading: vi.fn().mockReturnValue("mirror-toast"),
+      success: vi.fn().mockReturnValue("mirror-toast"),
+      warning: vi.fn().mockReturnValue("mirror-toast"),
+      dismiss: vi.fn(),
+    };
+    const controller = createMirrorLocalProgressToastController(toastApi);
+
+    controller.handle(progress("packing", "Packing…"));
+    controller.handle(progress("uploading", "Uploading…"));
+    controller.handle(progress("applied", "Ready"));
+
+    expect(toastApi.loading).toHaveBeenNthCalledWith(
+      1,
+      "Packing…",
+      expect.objectContaining({ id: undefined, duration: Infinity }),
+    );
+    expect(toastApi.loading).toHaveBeenNthCalledWith(
+      2,
+      "Uploading…",
+      expect.objectContaining({ id: "mirror-toast", duration: Infinity }),
+    );
+    expect(toastApi.success).toHaveBeenCalledWith(
+      "Ready",
+      expect.objectContaining({
+        id: "mirror-toast",
+        description: "3 files · 2 KiB",
+      }),
+    );
+
+    controller.dismissAll();
+    expect(toastApi.dismiss).not.toHaveBeenCalled();
+  });
+
+  it("dismisses an active toast when its socket provider disconnects", () => {
+    const toastApi = {
+      loading: vi.fn().mockReturnValue("mirror-toast"),
+      success: vi.fn().mockReturnValue("mirror-toast"),
+      warning: vi.fn().mockReturnValue("mirror-toast"),
+      dismiss: vi.fn(),
+    };
+    const controller = createMirrorLocalProgressToastController(toastApi);
+
+    controller.handle(progress("packing", "Packing…"));
+    controller.dismissAll();
+
+    expect(toastApi.dismiss).toHaveBeenCalledWith("mirror-toast");
+  });
+});

--- a/apps/client/src/contexts/socket/mirror-local-progress-toasts.ts
+++ b/apps/client/src/contexts/socket/mirror-local-progress-toasts.ts
@@ -1,0 +1,75 @@
+import type { MirrorLocalProgress } from "@cmux/shared";
+import { toast } from "sonner";
+import type { CmuxSocket } from "./types";
+
+type ToastId = ReturnType<typeof toast.loading>;
+
+type MirrorLocalToastApi = {
+  loading: typeof toast.loading;
+  success: typeof toast.success;
+  warning: typeof toast.warning;
+  dismiss: typeof toast.dismiss;
+};
+
+export function createMirrorLocalProgressToastController(
+  toastApi: MirrorLocalToastApi = toast,
+) {
+  const toastIds = new Map<string, ToastId>();
+
+  const handle = (progress: MirrorLocalProgress): void => {
+    const existingId = toastIds.get(progress.taskRunId);
+    const metadata =
+      progress.fileCount !== undefined &&
+      progress.compressedBytes !== undefined
+        ? `${progress.fileCount} files · ${Math.ceil(progress.compressedBytes / 1024)} KiB`
+        : undefined;
+
+    if (
+      progress.state === "packing" ||
+      progress.state === "starting-sandbox" ||
+      progress.state === "uploading" ||
+      progress.state === "applying"
+    ) {
+      const id = toastApi.loading(progress.message, {
+        id: existingId,
+        description: metadata,
+        duration: Infinity,
+      });
+      toastIds.set(progress.taskRunId, id);
+      return;
+    }
+
+    const options = {
+      id: existingId,
+      description: metadata,
+      duration: 8_000,
+    };
+    if (progress.state === "applied") {
+      toastApi.success(progress.message, options);
+    } else {
+      toastApi.warning(progress.message, options);
+    }
+    toastIds.delete(progress.taskRunId);
+  };
+
+  const dismissAll = (): void => {
+    for (const id of toastIds.values()) {
+      toastApi.dismiss(id);
+    }
+    toastIds.clear();
+  };
+
+  return { handle, dismissAll };
+}
+
+export function registerMirrorLocalProgressToasts(
+  socket: CmuxSocket,
+): () => void {
+  const controller = createMirrorLocalProgressToastController();
+  socket.on("mirror-local-progress", controller.handle);
+
+  return () => {
+    socket.off("mirror-local-progress", controller.handle);
+    controller.dismissAll();
+  };
+}

--- a/apps/client/src/contexts/socket/socket-provider.tsx
+++ b/apps/client/src/contexts/socket/socket-provider.tsx
@@ -10,6 +10,7 @@ import { stackClientApp } from "../../lib/stack";
 import { authJsonQueryOptions } from "../convex/authJsonQueryOptions";
 import { setGlobalSocket, socketBoot } from "./socket-boot";
 import { WebSocketContext } from "./socket-context";
+import { registerMirrorLocalProgressToasts } from "./mirror-local-progress-toasts";
 import type { SocketContextType } from "./types";
 import { env } from "@/client-env";
 
@@ -50,6 +51,7 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({
     }
     let disposed = false;
     let createdSocket: SocketContextType["socket"] | null = null;
+    let unregisterMirrorLocalProgressToasts: (() => void) | undefined;
     (async () => {
       // Fetch full auth JSON for server to forward as x-stack-auth
       const user = await cachedGetUser(stackClientApp);
@@ -128,10 +130,13 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({
       newSocket.on("connect_error", handleConnectError);
       newSocket.on("available-editors", handleAvailableEditors);
       newSocket.on("local-repo-not-found", handleLocalRepoNotFound);
+      unregisterMirrorLocalProgressToasts =
+        registerMirrorLocalProgressToasts(newSocket);
     })();
 
     return () => {
       disposed = true;
+      unregisterMirrorLocalProgressToasts?.();
       if (createdSocket) {
         // Remove all listeners before disconnecting to prevent memory leaks
         createdSocket.off("connect");

--- a/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.dashboard.tsx
@@ -9,7 +9,10 @@ import { FileChangeHeatmap } from "@/components/dashboard/FileChangeHeatmap";
 import { SessionActivityCard } from "@/components/dashboard/SessionActivityCard";
 import { SessionTimeline } from "@/components/dashboard/SessionTimeline";
 import { TaskList } from "@/components/dashboard/TaskList";
-import { ErrorBoundary, CompactErrorFallback } from "@/components/ErrorBoundary";
+import {
+  ErrorBoundary,
+  CompactErrorFallback,
+} from "@/components/ErrorBoundary";
 import { WorkspaceCreationButtons } from "@/components/dashboard/WorkspaceCreationButtons";
 import { FloatingPane } from "@/components/floating-pane";
 import { WorkspaceSetupPanel } from "@/components/WorkspaceSetupPanel";
@@ -74,7 +77,7 @@ import { z } from "zod";
 const DashboardInput = lazy(() =>
   import("@/components/dashboard/DashboardInput").then((m) => ({
     default: m.DashboardInput,
-  }))
+  })),
 );
 
 // Skeleton fallback for DashboardInput while loading
@@ -120,7 +123,9 @@ const DEFAULT_AGENT_SELECTIONS = [
   "codex/gpt-5.4-xhigh",
 ]
   .map((agentName) => normalizeStoredAgentSelectionEntry(agentName))
-  .filter((selection): selection is SelectedAgentSelection => selection !== null);
+  .filter(
+    (selection): selection is SelectedAgentSelection => selection !== null,
+  );
 
 const STORED_AGENT_SELECTION_SCHEMA = z.array(
   z.union([
@@ -179,7 +184,9 @@ const parseStoredAgentSelection = (
 
     return result.data
       .map((value) => normalizeStoredAgentSelectionEntry(value))
-      .filter((selection): selection is SelectedAgentSelection => selection !== null);
+      .filter(
+        (selection): selection is SelectedAgentSelection => selection !== null,
+      );
   } catch (error) {
     console.warn("Failed to parse stored agent selection", error);
     return [];
@@ -258,7 +265,7 @@ function DashboardComponent() {
         </div>
       );
     },
-    []
+    [],
   );
 
   useEffect(() => {
@@ -294,7 +301,7 @@ function DashboardComponent() {
       } else {
         dockerPullToastIdRef.current = toast.custom(
           renderDockerPullToast(payload),
-          { duration: Infinity }
+          { duration: Infinity },
         );
       }
     };
@@ -308,12 +315,13 @@ function DashboardComponent() {
   // Lightweight query to check if user is new (has no real tasks) - for onboarding
   // Uses hasRealTasks query which returns early after finding first match
   const hasRealTasksQuery = useQuery(
-    convexQuery(api.tasks.hasRealTasks, { teamSlugOrId })
+    convexQuery(api.tasks.hasRealTasks, { teamSlugOrId }),
   );
 
   const tasksReady = hasRealTasksQuery.isSuccess;
   const hasRealTasks = hasRealTasksQuery.data?.hasRealTasks ?? false;
-  const hasCompletedRealTasks = hasRealTasksQuery.data?.hasCompletedRealTasks ?? false;
+  const hasCompletedRealTasks =
+    hasRealTasksQuery.data?.hasCompletedRealTasks ?? false;
 
   // Auto-start onboarding for new users on the dashboard
   useEffect(() => {
@@ -337,12 +345,7 @@ function DashboardComponent() {
 
     // Start onboarding for new users
     onboarding.startOnboarding();
-  }, [
-    onboarding,
-    tasksReady,
-    hasRealTasks,
-    hasCompletedRealTasks,
-  ]);
+  }, [onboarding, tasksReady, hasRealTasks, hasCompletedRealTasks]);
 
   const [selectedProject, setSelectedProject] = useState<string[]>(() => {
     const stored = localStorage.getItem(`selectedProject-${teamSlugOrId}`);
@@ -356,7 +359,7 @@ function DashboardComponent() {
     // Read from team-scoped key only (legacy keys migrated on component mount)
     const teamScopedKey = `selectedAgents-${teamSlugOrId}`;
     const storedAgents = parseStoredAgentSelection(
-      localStorage.getItem(teamScopedKey)
+      localStorage.getItem(teamScopedKey),
     );
 
     if (storedAgents.length > 0) {
@@ -374,11 +377,13 @@ function DashboardComponent() {
       selectedAgentSelectionsRef.current = selections;
       setSelectedAgentSelectionsState(selections);
     },
-    [setSelectedAgentSelectionsState]
+    [setSelectedAgentSelectionsState],
   );
 
   const [taskDescription, setTaskDescription] = useState<string>("");
-  const [enabledTools, setEnabledTools] = useState<Set<string>>(() => new Set(["context7", "devsh-memory-mcp"]));
+  const [enabledTools, setEnabledTools] = useState<Set<string>>(
+    () => new Set(["context7", "devsh-memory-mcp"]),
+  );
 
   const handleToggleTool = useCallback((toolName: string) => {
     setEnabledTools((prev) => {
@@ -428,7 +433,7 @@ function DashboardComponent() {
       setSelectedProject([val]);
       localStorage.setItem(
         `selectedProject-${teamSlugOrId}`,
-        JSON.stringify([val])
+        JSON.stringify([val]),
       );
       setIsCloudMode(true);
       localStorage.setItem("isCloudMode", JSON.stringify(true));
@@ -443,7 +448,7 @@ function DashboardComponent() {
   // Fetch branches for selected repo
   const isEnvSelected = useMemo(
     () => (selectedProject[0] || "").startsWith("env:"),
-    [selectedProject]
+    [selectedProject],
   );
 
   // Branch search state with debouncing for server-side search
@@ -452,7 +457,8 @@ function DashboardComponent() {
 
   // Immediately use empty string when cleared, otherwise use debounced value
   // This prevents delay when user clears the search
-  const effectiveBranchSearch = branchSearch === "" ? "" : debouncedBranchSearch;
+  const effectiveBranchSearch =
+    branchSearch === "" ? "" : debouncedBranchSearch;
 
   // Branches query - infinite scroll with server-side ordering by recent commits
   // Each search term is cached separately by React Query
@@ -517,7 +523,7 @@ function DashboardComponent() {
   // Extract branch names and default branch from the query
   const branchPages = useMemo(
     () => branchesQuery.data?.pages ?? [],
-    [branchesQuery.data]
+    [branchesQuery.data],
   );
   const branchNames = useMemo(() => {
     const names: string[] = [];
@@ -587,7 +593,7 @@ function DashboardComponent() {
       setSelectedProject(newProjects);
       localStorage.setItem(
         `selectedProject-${teamSlugOrId}`,
-        JSON.stringify(newProjects)
+        JSON.stringify(newProjects),
       );
       if (newProjects[0] !== selectedProject[0]) {
         setSelectedBranch([]);
@@ -598,7 +604,7 @@ function DashboardComponent() {
         localStorage.setItem("isCloudMode", JSON.stringify(true));
       }
     },
-    [selectedProject, teamSlugOrId]
+    [selectedProject, teamSlugOrId],
   );
 
   // Callback for branch selection changes
@@ -614,7 +620,7 @@ function DashboardComponent() {
   });
   const reposByOrg = useMemo(
     () => reposByOrgQuery.data || {},
-    [reposByOrgQuery.data]
+    [reposByOrgQuery.data],
   );
 
   // Team/user visibility is not managed here. Model filtering is done by:
@@ -624,7 +630,7 @@ function DashboardComponent() {
 
   // Fetch available models from Convex (filtered by API keys, includes runtime-discovered models)
   const convexModelsQuery = useQuery(
-    convexQuery(api.models.listAvailable, { teamSlugOrId })
+    convexQuery(api.models.listAvailable, { teamSlugOrId }),
   );
   const convexModels = convexModelsQuery.data ?? null;
 
@@ -653,12 +659,7 @@ function DashboardComponent() {
       .catch((error) => {
         console.error("[Dashboard] Auto-seed failed:", error);
       });
-  }, [
-    convexModels,
-    convexModelsQuery,
-    ensureModelsSeeded,
-    teamSlugOrId,
-  ]);
+  }, [convexModels, convexModelsQuery, ensureModelsSeeded, teamSlugOrId]);
 
   const availableAgentNames = useMemo(() => {
     if (!convexModels) {
@@ -668,7 +669,7 @@ function DashboardComponent() {
     return new Set(
       convexModels
         .filter((entry) => entry.disabled !== true)
-        .map((entry) => entry.name)
+        .map((entry) => entry.name),
     );
   }, [convexModels]);
 
@@ -691,10 +692,10 @@ function DashboardComponent() {
       return selections.filter(
         (selection) =>
           availableAgentNames.has(selection.agentName) &&
-          !isAgentBlockedByProviderStatus(selection.agentName, providerStatus)
+          !isAgentBlockedByProviderStatus(selection.agentName, providerStatus),
       );
     },
-    [availableAgentNames, providerStatus]
+    [availableAgentNames, providerStatus],
   );
 
   const persistAgentSelection = useCallback(
@@ -716,7 +717,7 @@ function DashboardComponent() {
         console.warn("Failed to persist agent selection", error);
       }
     },
-    [defaultAgentSelection, teamSlugOrId]
+    [defaultAgentSelection, teamSlugOrId],
   );
 
   // Keep selected agents aligned with Convex models and user model preferences.
@@ -740,7 +741,11 @@ function DashboardComponent() {
       setSelectedAgentSelections(normalizedSelections);
       persistAgentSelection(normalizedSelections);
     },
-    [normalizeAgentSelection, persistAgentSelection, setSelectedAgentSelections]
+    [
+      normalizeAgentSelection,
+      persistAgentSelection,
+      setSelectedAgentSelections,
+    ],
   );
 
   // Socket-based functions to fetch data from GitHub
@@ -835,7 +840,8 @@ function DashboardComponent() {
         ]);
 
         const optimisticAgentSelections: SelectedAgentSelection[] =
-          args.selectedAgentSelections && args.selectedAgentSelections.length > 0
+          args.selectedAgentSelections &&
+          args.selectedAgentSelections.length > 0
             ? args.selectedAgentSelections
             : (args.selectedAgents ?? []).map((agentName) => ({ agentName }));
 
@@ -928,55 +934,67 @@ function DashboardComponent() {
           }),
         });
         if (!response.ok) {
-          console.error("[prewarm] Failed:", response.status, response.statusText);
+          console.error(
+            "[prewarm] Failed:",
+            response.status,
+            response.statusText,
+          );
         }
       } catch (error) {
         console.error("[prewarm] Network error:", error);
       }
     })();
-  }, [taskDescription, selectedProject, effectiveSelectedBranch, isEnvSelected, isCloudMode, teamSlugOrId]);
+  }, [
+    taskDescription,
+    selectedProject,
+    effectiveSelectedBranch,
+    isEnvSelected,
+    isCloudMode,
+    teamSlugOrId,
+  ]);
 
-  const ensureDockerReadyForLocalTask = useCallback(async (): Promise<boolean> => {
-    if (!socket) {
-      console.error("Cannot verify Docker status: socket not connected");
-      toast.error(
-        "Cannot verify Docker status. Please ensure the server is running."
-      );
-      return false;
-    }
-
-    const status = await new Promise<ProviderStatusResponse | undefined>(
-      (resolve) => {
-        socket.emit("check-provider-status", resolve);
+  const ensureDockerReadyForLocalTask =
+    useCallback(async (): Promise<boolean> => {
+      if (!socket) {
+        console.error("Cannot verify Docker status: socket not connected");
+        toast.error(
+          "Cannot verify Docker status. Please ensure the server is running.",
+        );
+        return false;
       }
-    );
 
-    const isRunning = status?.dockerStatus?.isRunning ?? false;
-    setDockerReady(isRunning);
-
-    if (!isRunning) {
-      toast.error(
-        "Docker isn't running. Install or start Docker Desktop to run local tasks."
+      const status = await new Promise<ProviderStatusResponse | undefined>(
+        (resolve) => {
+          socket.emit("check-provider-status", resolve);
+        },
       );
-      return false;
-    }
 
-    const pullResponse = await new Promise<DockerPullImageResponse>(
-      (resolve) => {
-        socket.emit("docker-pull-image", resolve);
+      const isRunning = status?.dockerStatus?.isRunning ?? false;
+      setDockerReady(isRunning);
+
+      if (!isRunning) {
+        toast.error(
+          "Docker isn't running. Install or start Docker Desktop to run local tasks.",
+        );
+        return false;
       }
-    );
 
-    if (!pullResponse.success) {
-      toast.error(
-        pullResponse.error ??
-          "Docker image is not ready yet. Please try again."
+      const pullResponse = await new Promise<DockerPullImageResponse>(
+        (resolve) => {
+          socket.emit("docker-pull-image", resolve);
+        },
       );
-      return false;
-    }
 
-    return true;
-  }, [setDockerReady, socket]);
+      if (!pullResponse.success) {
+        toast.error(
+          pullResponse.error ??
+            "Docker image is not ready yet. Please try again.",
+        );
+        return false;
+      }
+
+      return true;
+    }, [setDockerReady, socket]);
 
   const handleStartTask = useCallback(async () => {
     if (isStartingTaskRef.current) {
@@ -1048,8 +1066,8 @@ function DashboardComponent() {
               fileName: image.fileName,
               altText: image.altText,
             };
-          }
-        )
+          },
+        ),
       );
 
       // Clear input after successful task creation
@@ -1140,7 +1158,7 @@ function DashboardComponent() {
           // Ralph Mode: keep working until explicit completion signal
           ...(isRalphMode ? { ralphMode: { enabled: true } } : {}),
         },
-        handleStartTaskAck
+        handleStartTaskAck,
       );
       console.log("Task created:", taskId);
     } catch (error) {
@@ -1187,7 +1205,7 @@ function DashboardComponent() {
   // Format repos for multiselect
   // Fetch environments
   const environmentsQuery = useQuery(
-    convexQuery(api.environments.list, { teamSlugOrId })
+    convexQuery(api.environments.list, { teamSlugOrId }),
   );
 
   const projectOptions = useMemo(() => {
@@ -1272,9 +1290,11 @@ function DashboardComponent() {
   const selectedEnvironment = useMemo(() => {
     if (!isEnvSelected || !selectedProject[0]) return null;
     const envId = selectedProject[0].replace(/^env:/, "") as Id<"environments">;
-    return environmentsQuery.data?.find(
-      (environment) => environment._id === envId
-    ) ?? null;
+    return (
+      environmentsQuery.data?.find(
+        (environment) => environment._id === envId,
+      ) ?? null
+    );
   }, [environmentsQuery.data, isEnvSelected, selectedProject]);
 
   const selectedEnvironmentRepos = useMemo(() => {
@@ -1284,6 +1304,10 @@ function DashboardComponent() {
 
   const selectedEnvironmentName = useMemo(() => {
     return selectedEnvironment?.name ?? null;
+  }, [selectedEnvironment]);
+
+  const selectedEnvironmentProvider = useMemo(() => {
+    return selectedEnvironment?.snapshotProvider ?? null;
   }, [selectedEnvironment]);
 
   const workspaceSetupProjects = useMemo(() => {
@@ -1296,7 +1320,10 @@ function DashboardComponent() {
   const shouldShowWorkspaceSetup = workspaceSetupProjects.length > 0;
 
   const shouldShowCloudRepoOnboarding =
-    !!selectedRepoFullName && isCloudMode && !isEnvSelected && !hasDismissedCloudRepoOnboarding;
+    !!selectedRepoFullName &&
+    isCloudMode &&
+    !isEnvSelected &&
+    !hasDismissedCloudRepoOnboarding;
 
   const createEnvironmentSearch = useMemo(() => {
     if (!selectedRepoFullName) return null;
@@ -1332,7 +1359,10 @@ function DashboardComponent() {
     if (isEnvSelected) return; // environment forces cloud mode
     const newMode = !isCloudMode;
     setIsCloudMode(newMode);
-    localStorage.setItem(`isCloudMode-${teamSlugOrId}`, JSON.stringify(newMode));
+    localStorage.setItem(
+      `isCloudMode-${teamSlugOrId}`,
+      JSON.stringify(newMode),
+    );
     // Clean up legacy global key
     localStorage.removeItem("isCloudMode");
   }, [isCloudMode, isEnvSelected, teamSlugOrId]);
@@ -1354,7 +1384,7 @@ function DashboardComponent() {
           setSelectedProject([result.fullName]);
           localStorage.setItem(
             `selectedProject-${teamSlugOrId}`,
-            JSON.stringify([result.fullName])
+            JSON.stringify([result.fullName]),
           );
 
           toast.success(`Added ${result.fullName} to repositories`);
@@ -1375,7 +1405,7 @@ function DashboardComponent() {
         return false; // Don't close dropdown if it's not a valid GitHub URL
       }
     },
-    [addManualRepo, teamSlugOrId, reposByOrgQuery]
+    [addManualRepo, teamSlugOrId, reposByOrgQuery],
   );
 
   // Listen for VSCode spawned events
@@ -1414,7 +1444,7 @@ function DashboardComponent() {
       setSelectedProject([data.repoFullName]);
       localStorage.setItem(
         `selectedProject-${teamSlugOrId}`,
-        JSON.stringify([data.repoFullName])
+        JSON.stringify([data.repoFullName]),
       );
 
       // Set the selected branch
@@ -1522,7 +1552,7 @@ function DashboardComponent() {
 
   const lexicalBranch = useMemo(
     () => effectiveSelectedBranch[0],
-    [effectiveSelectedBranch]
+    [effectiveSelectedBranch],
   );
 
   const canSubmit = useMemo(() => {
@@ -1553,6 +1583,7 @@ function DashboardComponent() {
               selectedProject={selectedProject}
               isEnvSelected={isEnvSelected}
               selectedEnvironmentName={selectedEnvironmentName}
+              selectedEnvironmentProvider={selectedEnvironmentProvider}
             />
 
             <DashboardMainCard
@@ -1583,14 +1614,19 @@ function DashboardComponent() {
               onRalphModeToggle={() => {
                 setIsRalphMode((prev) => {
                   const next = !prev;
-                  localStorage.setItem(`isRalphMode-${teamSlugOrId}`, JSON.stringify(next));
+                  localStorage.setItem(
+                    `isRalphMode-${teamSlugOrId}`,
+                    JSON.stringify(next),
+                  );
                   // Clean up legacy global key
                   localStorage.removeItem("isRalphMode");
                   return next;
                 });
               }}
               isLoadingProjects={reposByOrgQuery.isLoading}
-              isLoadingBranches={branchesQuery.isLoading && effectiveSelectedBranch.length === 0}
+              isLoadingBranches={
+                branchesQuery.isLoading && effectiveSelectedBranch.length === 0
+              }
               teamSlugOrId={teamSlugOrId}
               cloudToggleDisabled={isEnvSelected}
               branchDisabled={isEnvSelected || !selectedProject[0]}
@@ -1623,7 +1659,10 @@ function DashboardComponent() {
                     Set up an environment for {selectedRepoFullName}
                   </p>
                   <p className="text-xs text-green-900/80 dark:text-green-200/80">
-                    Environments let you preconfigure development and maintenance scripts, pre-install packages, and environment variables so cloud workspaces are ready to go the moment they start.
+                    Environments let you preconfigure development and
+                    maintenance scripts, pre-install packages, and environment
+                    variables so cloud workspaces are ready to go the moment
+                    they start.
                   </p>
                   <div className="flex gap-2 justify-end">
                     <button

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
@@ -1,4 +1,5 @@
 import { api } from "@cmux/convex/api";
+import { getMirrorLocalStateFromStatusMessage } from "@cmux/shared";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { convexQuery } from "@convex-dev/react-query";
 import { createFileRoute } from "@tanstack/react-router";
@@ -34,7 +35,7 @@ const paramsSchema = z.object({
 });
 
 export const Route = createFileRoute(
-  "/_layout/$teamSlugOrId/task/$taskId/run/$runId/vscode"
+  "/_layout/$teamSlugOrId/task/$taskId/run/$runId/vscode",
 )({
   component: VSCodeComponent,
   params: {
@@ -58,17 +59,17 @@ export const Route = createFileRoute(
           convexQuery(api.taskRuns.get, {
             teamSlugOrId: opts.params.teamSlugOrId,
             id: opts.params.runId,
-          })
+          }),
         ),
         opts.context.queryClient.ensureQueryData(
-          localVSCodeServeWebQueryOptions()
+          localVSCodeServeWebQueryOptions(),
         ),
       ]);
       if (result) {
         const workspaceUrl = getWorkspaceUrl(
           result.vscode?.workspaceUrl,
           result.vscode?.provider,
-          localServeWeb.baseUrl
+          localServeWeb.baseUrl,
         );
         if (workspaceUrl) {
           await preloadTaskRunIframes([
@@ -93,13 +94,15 @@ function VSCodeComponent() {
   const { socket } = useSocket();
 
   // Query for linked local workspace to trigger sync
-  const linkedLocalWorkspace = useQuery(
-    api.tasks.getLinkedLocalWorkspace,
-    { teamSlugOrId, cloudTaskRunId: taskRunId }
-  );
+  const linkedLocalWorkspace = useQuery(api.tasks.getLinkedLocalWorkspace, {
+    teamSlugOrId,
+    cloudTaskRunId: taskRunId,
+  });
 
   // Query workspace settings for auto-sync preference
-  const workspaceSettings = useQuery(api.workspaceSettings.get, { teamSlugOrId });
+  const workspaceSettings = useQuery(api.workspaceSettings.get, {
+    teamSlugOrId,
+  });
   const autoSyncEnabled = workspaceSettings?.autoSyncEnabled ?? true;
 
   // Trigger sync when viewing a cloud task that has a linked local workspace
@@ -122,16 +125,28 @@ function VSCodeComponent() {
       },
       (response: { success: boolean; error?: string }) => {
         if (!response.success) {
-          console.error("[VSCode route] Failed to trigger sync:", response.error);
+          console.error(
+            "[VSCode route] Failed to trigger sync:",
+            response.error,
+          );
         }
-      }
+      },
     );
-  }, [autoSyncEnabled, socket, linkedLocalWorkspace?.task?.worktreePath, taskRunId]);
+  }, [
+    autoSyncEnabled,
+    socket,
+    linkedLocalWorkspace?.task?.worktreePath,
+    taskRunId,
+  ]);
 
   // Extract stable values from taskRun to avoid re-renders when unrelated fields change
   const rawWorkspaceUrl = taskRun?.vscode?.workspaceUrl;
   const vsCodeProvider = taskRun?.vscode?.provider;
   const vsCodeStatusMessage = taskRun?.vscode?.statusMessage;
+  const mirrorLocalState = getMirrorLocalStateFromStatusMessage(
+    vsCodeStatusMessage,
+  );
+  const isMirrorLocalReady = mirrorLocalState === "applied";
   const taskRunStatus = taskRun?.status;
   const taskRunErrorMessage = taskRun?.errorMessage;
   const localServeWebBaseUrl = localServeWeb.data?.baseUrl;
@@ -141,13 +156,15 @@ function VSCodeComponent() {
 
   // Memoize the workspace URL to prevent unnecessary recalculations
   const workspaceUrl = useMemo(
-    () => getWorkspaceUrl(rawWorkspaceUrl, vsCodeProvider, localServeWebBaseUrl),
-    [rawWorkspaceUrl, vsCodeProvider, localServeWebBaseUrl]
+    () =>
+      getWorkspaceUrl(rawWorkspaceUrl, vsCodeProvider, localServeWebBaseUrl),
+    [rawWorkspaceUrl, vsCodeProvider, localServeWebBaseUrl],
   );
 
   const disablePreflight = useMemo(
-    () => (rawWorkspaceUrl ? shouldUseServerIframePreflight(rawWorkspaceUrl) : false),
-    [rawWorkspaceUrl]
+    () =>
+      rawWorkspaceUrl ? shouldUseServerIframePreflight(rawWorkspaceUrl) : false,
+    [rawWorkspaceUrl],
   );
 
   const persistKey = getTaskRunPersistKey(taskRunId);
@@ -176,7 +193,11 @@ function VSCodeComponent() {
   }, []);
 
   const tryRestoreWorkspaceFocus = useCallback(async (): Promise<boolean> => {
-    if (typeof document === "undefined" || !hasWorkspace || iframeStatus !== "loaded") {
+    if (
+      typeof document === "undefined" ||
+      !hasWorkspace ||
+      iframeStatus !== "loaded"
+    ) {
       return false;
     }
 
@@ -189,10 +210,7 @@ function VSCodeComponent() {
     }
 
     const focused = await isWebviewFocused(currentPersistKey);
-    if (
-      focused ||
-      isInteractiveFocusRetentionElement(document.activeElement)
-    ) {
+    if (focused || isInteractiveFocusRetentionElement(document.activeElement)) {
       return focused;
     }
 
@@ -226,12 +244,9 @@ function VSCodeComponent() {
   }, [workspaceUrl]);
 
   // Stable callback for status changes - setIframeStatus is already stable
-  const handleStatusChange = useCallback(
-    (status: PersistentIframeStatus) => {
-      setIframeStatus(status);
-    },
-    []
-  );
+  const handleStatusChange = useCallback((status: PersistentIframeStatus) => {
+    setIframeStatus(status);
+  }, []);
 
   const handleWorkspaceActivate = useCallback(() => {
     shouldRestoreWorkspaceFocusOnWindowRefocusRef.current = true;
@@ -245,10 +260,10 @@ function VSCodeComponent() {
     (error: Error) => {
       console.error(
         `Failed to load workspace view for task run ${taskRunId}:`,
-        error
+        error,
       );
     },
-    [taskRunId]
+    [taskRunId],
   );
 
   useEffect(() => {
@@ -398,12 +413,18 @@ function VSCodeComponent() {
           void tryRestoreWorkspaceFocus().catch((error) => {
             console.warn(
               `Failed to restore workspace webview focus for task run ${taskRunId}`,
-              error
+              error,
             );
           });
         }, 150);
       }, 10);
-    }, [clearPendingFocusRestore, hasWorkspace, iframeStatus, taskRunId, tryRestoreWorkspaceFocus])
+    }, [
+      clearPendingFocusRestore,
+      hasWorkspace,
+      iframeStatus,
+      taskRunId,
+      tryRestoreWorkspaceFocus,
+    ]),
   );
 
   const loadingFallback = useMemo(
@@ -415,11 +436,11 @@ function VSCodeComponent() {
           loadingDescription={vsCodeStatusMessage}
         />
       ),
-    [isLocalWorkspace, vsCodeStatusMessage]
+    [isLocalWorkspace, vsCodeStatusMessage],
   );
   const errorFallback = useMemo(
     () => <WorkspaceLoadingIndicator variant="vscode" status="error" />,
-    []
+    [],
   );
 
   const isEditorBusy = !hasWorkspace || iframeStatus !== "loaded";
@@ -427,6 +448,18 @@ function VSCodeComponent() {
   return (
     <div className="flex flex-col grow bg-neutral-50 dark:bg-black">
       <div className="flex flex-col grow min-h-0 border-l border-neutral-200 dark:border-neutral-800">
+        {mirrorLocalState && vsCodeStatusMessage ? (
+          <div
+            role="status"
+            className={
+              isMirrorLocalReady
+                ? "border-b border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200"
+                : "border-b border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
+            }
+          >
+            {vsCodeStatusMessage}
+          </div>
+        ) : null}
         <div
           className="flex flex-row grow min-h-0 relative"
           aria-busy={isEditorBusy}

--- a/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
+++ b/apps/client/src/routes/_layout.$teamSlugOrId.task.$taskId.run.$runId.vscode.tsx
@@ -1,5 +1,4 @@
 import { api } from "@cmux/convex/api";
-import { getMirrorLocalStateFromStatusMessage } from "@cmux/shared";
 import { typedZid } from "@cmux/shared/utils/typed-zid";
 import { convexQuery } from "@convex-dev/react-query";
 import { createFileRoute } from "@tanstack/react-router";
@@ -143,10 +142,6 @@ function VSCodeComponent() {
   const rawWorkspaceUrl = taskRun?.vscode?.workspaceUrl;
   const vsCodeProvider = taskRun?.vscode?.provider;
   const vsCodeStatusMessage = taskRun?.vscode?.statusMessage;
-  const mirrorLocalState = getMirrorLocalStateFromStatusMessage(
-    vsCodeStatusMessage,
-  );
-  const isMirrorLocalReady = mirrorLocalState === "applied";
   const taskRunStatus = taskRun?.status;
   const taskRunErrorMessage = taskRun?.errorMessage;
   const localServeWebBaseUrl = localServeWeb.data?.baseUrl;
@@ -448,18 +443,6 @@ function VSCodeComponent() {
   return (
     <div className="flex flex-col grow bg-neutral-50 dark:bg-black">
       <div className="flex flex-col grow min-h-0 border-l border-neutral-200 dark:border-neutral-800">
-        {mirrorLocalState && vsCodeStatusMessage ? (
-          <div
-            role="status"
-            className={
-              isMirrorLocalReady
-                ? "border-b border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200"
-                : "border-b border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200"
-            }
-          >
-            {vsCodeStatusMessage}
-          </div>
-        ) : null}
         <div
           className="flex flex-row grow min-h-0 relative"
           aria-busy={isEditorBusy}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,6 +21,10 @@
       "import": "./src/gitDiff.ts",
       "types": "./src/gitDiff.ts"
     },
+    "./host-config/mirror-local-pack": {
+      "import": "./src/host-config/mirror-local-pack.ts",
+      "types": "./src/host-config/mirror-local-pack.ts"
+    },
     "./realtime": {
       "import": "./src/realtime.ts",
       "types": "./src/realtime.ts"

--- a/apps/server/src/host-config/mirror-local-pack.test.ts
+++ b/apps/server/src/host-config/mirror-local-pack.test.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { x as extractTar } from "tar";
+import { describe, expect, it } from "vitest";
+import {
+  createMirrorLocalPack,
+  MirrorLocalPackError,
+} from "./mirror-local-pack";
+
+async function writeTree(
+  root: string,
+  files: Record<string, string>,
+): Promise<void> {
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const filePath = join(root, relativePath);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, contents, "utf8");
+  }
+}
+
+async function extractPack(archive: Uint8Array): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "cmux-mirror-extract-"));
+  const archivePath = join(root, "pack.tar.gz");
+  const destination = join(root, "out");
+  await mkdir(destination);
+  await writeFile(archivePath, archive);
+  await extractTar({ cwd: destination, file: archivePath, gzip: true });
+  return destination;
+}
+
+describe("createMirrorLocalPack", () => {
+  it("packs only allowlisted config, redacts secrets, rewrites paths, and drops macOS MCP entries", async () => {
+    const home = await mkdtemp(join(tmpdir(), "cmux-mirror-home-"));
+    await writeTree(home, {
+      ".claude/settings.json": JSON.stringify({
+        apiKey: "claude-secret",
+        nested: { access_token: "nested-secret" },
+        notes: `${home}/.claude/skills/demo`,
+        mcpServers: {
+          portable: { command: "npx", args: ["-y", "portable-mcp"] },
+          macOnly: {
+            command: "/Applications/Demo.app/Contents/MacOS/demo",
+            args: [],
+          },
+        },
+      }),
+      ".claude/skills/demo/SKILL.md": `path: ${home}/.claude/skills/demo\n`,
+      ".claude/projects/session.json": "must not ship",
+      ".codex/config.toml": `api_key = "codex-secret"
+
+[projects."${home}"]
+trust_level = "trusted"
+
+[projects."/root"]
+trust_level = "trusted"
+`,
+      ".codex/auth.json": JSON.stringify({ access_token: "oauth-secret" }),
+    });
+
+    const pack = await createMirrorLocalPack({ homeDir: home });
+    const extracted = await extractPack(pack.archive);
+
+    const settings = await readFile(
+      join(extracted, ".claude/settings.json"),
+      "utf8",
+    );
+    expect(settings).not.toContain("claude-secret");
+    expect(settings).not.toContain("nested-secret");
+    expect(settings).not.toContain("/Applications/");
+    expect(settings).not.toContain(home);
+    expect(settings).toContain("/root/.claude/skills/demo");
+    expect(settings).toContain("portable-mcp");
+
+    const config = await readFile(
+      join(extracted, ".codex/config.toml"),
+      "utf8",
+    );
+    expect(config).not.toContain("codex-secret");
+    expect(config).not.toContain(home);
+    expect(config.match(/\[projects\."\/root"\]/g)).toHaveLength(1);
+
+    await expect(
+      readFile(join(extracted, ".codex/auth.json"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      readFile(join(extracted, ".claude/projects/session.json"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+
+    expect(pack.fileCount).toBe(3);
+    expect(pack.compressedBytes).toBe(pack.archive.byteLength);
+    expect(pack.sha256).toBe(
+      createHash("sha256").update(pack.archive).digest("hex"),
+    );
+  });
+
+  it("follows skill directory symlinks only inside approved roots", async () => {
+    const home = await mkdtemp(join(tmpdir(), "cmux-mirror-home-"));
+    const approved = join(home, ".agents", "skills", "demo");
+    await writeTree(home, {
+      ".agents/skills/demo/SKILL.md": "# demo\n",
+    });
+    await mkdir(join(home, ".claude", "skills"), { recursive: true });
+    await symlink(approved, join(home, ".claude", "skills", "demo"));
+
+    const pack = await createMirrorLocalPack({ homeDir: home });
+    const extracted = await extractPack(pack.archive);
+    expect(
+      await readFile(
+        join(extracted, ".claude", "skills", "demo", "SKILL.md"),
+        "utf8",
+      ),
+    ).toBe("# demo\n");
+  });
+
+  it("rejects skill symlinks that escape approved host roots", async () => {
+    const home = await mkdtemp(join(tmpdir(), "cmux-mirror-home-"));
+    const outside = await mkdtemp(join(tmpdir(), "cmux-mirror-outside-"));
+    await writeTree(outside, { "SKILL.md": "# outside\n" });
+    await mkdir(join(home, ".claude", "skills"), { recursive: true });
+    await symlink(outside, join(home, ".claude", "skills", "outside"));
+
+    await expect(
+      createMirrorLocalPack({ homeDir: home }),
+    ).rejects.toMatchObject({
+      code: "unsafe-symlink",
+    } satisfies Partial<MirrorLocalPackError>);
+  });
+
+  it("enforces file-count and per-file limits", async () => {
+    const home = await mkdtemp(join(tmpdir(), "cmux-mirror-home-"));
+    await writeTree(home, {
+      ".claude/skills/a/SKILL.md": "a",
+      ".claude/skills/b/SKILL.md": "b",
+    });
+
+    await expect(
+      createMirrorLocalPack({
+        homeDir: home,
+        limits: { maxFiles: 1 },
+      }),
+    ).rejects.toMatchObject({ code: "file-count-limit" });
+
+    await expect(
+      createMirrorLocalPack({
+        homeDir: home,
+        limits: { maxFileBytes: 0 },
+      }),
+    ).rejects.toMatchObject({ code: "file-size-limit" });
+  });
+
+  it("produces deterministic bytes for unchanged input", async () => {
+    const home = await mkdtemp(join(tmpdir(), "cmux-mirror-home-"));
+    await writeTree(home, {
+      ".claude/settings.json": JSON.stringify({ model: "claude" }),
+      ".codex/config.toml": 'model = "gpt"\n',
+    });
+
+    const first = await createMirrorLocalPack({ homeDir: home });
+    const second = await createMirrorLocalPack({ homeDir: home });
+    expect(second.sha256).toBe(first.sha256);
+    expect(Buffer.from(second.archive)).toEqual(Buffer.from(first.archive));
+  });
+
+  it("returns a valid empty pack when no allowlisted files exist", async () => {
+    const home = await mkdtemp(join(tmpdir(), "cmux-mirror-home-"));
+    const pack = await createMirrorLocalPack({ homeDir: home });
+    expect(pack.fileCount).toBe(0);
+    expect(pack.expandedBytes).toBe(0);
+    expect(pack.compressedBytes).toBeGreaterThan(0);
+  });
+});

--- a/apps/server/src/host-config/mirror-local-pack.test.ts
+++ b/apps/server/src/host-config/mirror-local-pack.test.ts
@@ -114,6 +114,21 @@ trust_level = "trusted"
     ).toBe("# demo\n");
   });
 
+  it("preserves binary skill assets without text transcoding", async () => {
+    const home = await mkdtemp(join(tmpdir(), "cmux-mirror-home-"));
+    const binary = Buffer.from([0x00, 0x80, 0xff, 0x41]);
+    const binaryPath = join(home, ".claude/skills/demo/icon.png");
+    await mkdir(dirname(binaryPath), { recursive: true });
+    await writeFile(binaryPath, binary);
+
+    const pack = await createMirrorLocalPack({ homeDir: home });
+    const extracted = await extractPack(pack.archive);
+
+    expect(
+      await readFile(join(extracted, ".claude/skills/demo/icon.png")),
+    ).toEqual(binary);
+  });
+
   it("rejects skill symlinks that escape approved host roots", async () => {
     const home = await mkdtemp(join(tmpdir(), "cmux-mirror-home-"));
     const outside = await mkdtemp(join(tmpdir(), "cmux-mirror-outside-"));

--- a/apps/server/src/host-config/mirror-local-pack.ts
+++ b/apps/server/src/host-config/mirror-local-pack.ts
@@ -1,0 +1,606 @@
+import { createHash } from "node:crypto";
+import {
+  lstat,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { gzipSync } from "node:zlib";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import { c as createTar } from "tar";
+
+export const MIRROR_LOCAL_POLICY_VERSION = "cmux-mirror-local/v1";
+
+export const MIRROR_LOCAL_DEFAULT_INCLUDE_PATHS = [
+  ".claude/settings.json",
+  ".claude/config.json",
+  ".claude/keybindings.json",
+  ".claude/skills",
+  ".claude/hooks",
+  ".claude/commands",
+  ".codex/config.toml",
+  ".codex/keybindings.json",
+  ".codex/AGENTS.md",
+  ".codex/skills",
+  ".codex/hooks",
+  ".codex/automations",
+] as const;
+
+const SECRET_FILE_BASENAMES = new Set([
+  "auth.json",
+  ".credentials.json",
+  "credentials.json",
+]);
+
+const EXCLUDED_DIRECTORY_NAMES = new Set([
+  "projects",
+  "sessions",
+  "archived_sessions",
+  "cache",
+  "caches",
+  ".tmp",
+  "tmp",
+  "debug",
+  "telemetry",
+  "shell-snapshots",
+  "shell_snapshots",
+  "statsig",
+  "todos",
+  "file-history",
+  "plugins",
+  "backups",
+  "node_modules",
+  ".git",
+]);
+
+const SECRET_JSON_KEYS = new Set([
+  "apiKey",
+  "api_key",
+  "token",
+  "accessToken",
+  "access_token",
+  "refreshToken",
+  "refresh_token",
+  "password",
+  "secret",
+  "clientSecret",
+  "client_secret",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+]);
+
+const SKIPPED_FILE_SUFFIXES = [
+  ".sqlite",
+  ".sqlite3",
+  ".db",
+  ".lock",
+  ".wal",
+  ".shm",
+] as const;
+
+const TEXT_FILE_SUFFIXES = [
+  ".json",
+  ".toml",
+  ".yaml",
+  ".yml",
+  ".md",
+  ".txt",
+  ".sh",
+  ".js",
+  ".ts",
+  ".mjs",
+  ".cjs",
+] as const;
+
+export type MirrorLocalPackLimits = {
+  maxCompressedBytes: number;
+  maxExpandedBytes: number;
+  maxFileBytes: number;
+  maxFiles: number;
+};
+
+export const MIRROR_LOCAL_DEFAULT_LIMITS: MirrorLocalPackLimits = {
+  maxCompressedBytes: 8 * 1024 * 1024,
+  maxExpandedBytes: 64 * 1024 * 1024,
+  maxFileBytes: 2 * 1024 * 1024,
+  maxFiles: 2_000,
+};
+
+export type MirrorLocalPack = {
+  archive: Uint8Array;
+  sha256: string;
+  policyVersion: string;
+  fileCount: number;
+  expandedBytes: number;
+  compressedBytes: number;
+};
+
+export type MirrorLocalPackErrorCode =
+  | "unsafe-include-path"
+  | "unsafe-symlink"
+  | "symlink-cycle"
+  | "file-count-limit"
+  | "file-size-limit"
+  | "expanded-size-limit"
+  | "compressed-size-limit"
+  | "invalid-json";
+
+export class MirrorLocalPackError extends Error {
+  readonly code: MirrorLocalPackErrorCode;
+
+  constructor(code: MirrorLocalPackErrorCode, message: string) {
+    super(message);
+    this.name = "MirrorLocalPackError";
+    this.code = code;
+  }
+}
+
+export type CreateMirrorLocalPackOptions = {
+  homeDir?: string;
+  targetHome?: string;
+  includePaths?: readonly string[];
+  allowedSymlinkRoots?: readonly string[];
+  limits?: Partial<MirrorLocalPackLimits>;
+};
+
+type FileRecord = {
+  archivePath: string;
+  contents: Uint8Array;
+};
+
+function normalizeArchivePath(input: string): string {
+  const withoutTilde = input.startsWith("~/") ? input.slice(2) : input;
+  const normalizedPath = normalize(withoutTilde).split(sep).join("/");
+  if (
+    !normalizedPath ||
+    isAbsolute(withoutTilde) ||
+    normalizedPath === ".." ||
+    normalizedPath.startsWith("../") ||
+    normalizedPath.includes("/../")
+  ) {
+    throw new MirrorLocalPackError(
+      "unsafe-include-path",
+      `Unsafe Mirror local include path: ${input}`,
+    );
+  }
+  return normalizedPath.replace(/^\.\//, "");
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === "" ||
+    (!pathFromRoot.startsWith(`..${sep}`) &&
+      pathFromRoot !== ".." &&
+      !isAbsolute(pathFromRoot))
+  );
+}
+
+function isSkillArchivePath(archivePath: string): boolean {
+  return (
+    archivePath === ".claude/skills" ||
+    archivePath.startsWith(".claude/skills/") ||
+    archivePath === ".codex/skills" ||
+    archivePath.startsWith(".codex/skills/")
+  );
+}
+
+function isTextConfig(fileName: string): boolean {
+  const lower = fileName.toLowerCase();
+  return (
+    TEXT_FILE_SUFFIXES.some((suffix) => lower.endsWith(suffix)) ||
+    lower === "config"
+  );
+}
+
+function redactJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactJsonValue(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    result[key] = SECRET_JSON_KEYS.has(key) ? "" : redactJsonValue(child);
+  }
+  return result;
+}
+
+function isMacOsOnlyMcpServer(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const server = value as Record<string, unknown>;
+  const fields: string[] = [];
+  if (typeof server.command === "string") {
+    fields.push(server.command);
+  }
+  if (Array.isArray(server.args)) {
+    for (const argument of server.args) {
+      if (typeof argument === "string") {
+        fields.push(argument);
+      }
+    }
+  }
+  const joined = fields.join(" ");
+  return [
+    "/Applications/",
+    ".app/Contents/",
+    "/Library/Application Support/",
+    "osascript",
+  ].some((marker) => joined.includes(marker));
+}
+
+function removeMacOsOnlyMcpServers(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const root = value as Record<string, unknown>;
+  for (const key of ["mcpServers", "mcp"]) {
+    const rawServers = root[key];
+    if (
+      !rawServers ||
+      typeof rawServers !== "object" ||
+      Array.isArray(rawServers)
+    ) {
+      continue;
+    }
+    const servers = rawServers as Record<string, unknown>;
+    for (const [name, server] of Object.entries(servers)) {
+      if (isMacOsOnlyMcpServer(server)) {
+        delete servers[name];
+      }
+    }
+  }
+  return root;
+}
+
+function redactTomlSecrets(contents: string): string {
+  return contents
+    .split("\n")
+    .map((line) => {
+      const match = line.match(/^(\s*)([A-Za-z0-9_]+)\s*=/);
+      if (!match || !SECRET_JSON_KEYS.has(match[2] ?? "")) {
+        return line;
+      }
+      return `${match[1] ?? ""}${match[2]} = ""`;
+    })
+    .join("\n");
+}
+
+function dedupeTomlTables(contents: string): string {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  let skipping = false;
+
+  for (const line of contents.split("\n")) {
+    const trimmed = line.trim();
+    const isTable =
+      trimmed.length >= 3 &&
+      trimmed.startsWith("[") &&
+      trimmed.endsWith("]") &&
+      !trimmed.startsWith("[[");
+    if (isTable) {
+      if (seen.has(trimmed)) {
+        skipping = true;
+        continue;
+      }
+      seen.add(trimmed);
+      skipping = false;
+      output.push(line);
+      continue;
+    }
+    if (!skipping) {
+      output.push(line);
+    }
+  }
+  return output.join("\n");
+}
+
+function rewriteHomePaths(
+  contents: string,
+  localHome: string,
+  targetHome: string,
+): string {
+  if (!localHome || localHome === targetHome) {
+    return contents;
+  }
+  return contents.split(localHome).join(targetHome);
+}
+
+function transformFile(
+  archivePath: string,
+  contents: Uint8Array,
+  localHome: string,
+  targetHome: string,
+): Uint8Array {
+  const fileName = basename(archivePath);
+  const lower = fileName.toLowerCase();
+  let text = Buffer.from(contents).toString("utf8");
+
+  if (lower.endsWith(".json")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (error) {
+      throw new MirrorLocalPackError(
+        "invalid-json",
+        `Refusing to mirror invalid JSON config ${archivePath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    parsed = redactJsonValue(parsed);
+    if (
+      fileName === "settings.json" ||
+      fileName === "mcp.json" ||
+      fileName === "claude_desktop_config.json"
+    ) {
+      parsed = removeMacOsOnlyMcpServers(parsed);
+    }
+    text = `${JSON.stringify(parsed, null, 2)}\n`;
+  }
+
+  if (isTextConfig(fileName)) {
+    text = rewriteHomePaths(text, localHome, targetHome);
+  }
+
+  if (lower.endsWith(".toml")) {
+    text = dedupeTomlTables(redactTomlSecrets(text));
+  }
+
+  return Buffer.from(text, "utf8");
+}
+
+function mergeLimits(
+  overrides: Partial<MirrorLocalPackLimits> | undefined,
+): MirrorLocalPackLimits {
+  return {
+    maxCompressedBytes:
+      overrides?.maxCompressedBytes ??
+      MIRROR_LOCAL_DEFAULT_LIMITS.maxCompressedBytes,
+    maxExpandedBytes:
+      overrides?.maxExpandedBytes ??
+      MIRROR_LOCAL_DEFAULT_LIMITS.maxExpandedBytes,
+    maxFileBytes:
+      overrides?.maxFileBytes ?? MIRROR_LOCAL_DEFAULT_LIMITS.maxFileBytes,
+    maxFiles: overrides?.maxFiles ?? MIRROR_LOCAL_DEFAULT_LIMITS.maxFiles,
+  };
+}
+
+async function existingRealPaths(paths: readonly string[]): Promise<string[]> {
+  const resolved: string[] = [];
+  for (const candidate of paths) {
+    try {
+      resolved.push(await realpath(candidate));
+    } catch {
+      // A missing optional skill root cannot be a symlink target.
+    }
+  }
+  return resolved;
+}
+
+export async function createMirrorLocalPack(
+  options: CreateMirrorLocalPackOptions = {},
+): Promise<MirrorLocalPack> {
+  const homeDir = resolve(options.homeDir ?? homedir());
+  const targetHome = options.targetHome ?? "/root";
+  const limits = mergeLimits(options.limits);
+  const includePaths = (
+    options.includePaths ?? MIRROR_LOCAL_DEFAULT_INCLUDE_PATHS
+  ).map(normalizeArchivePath);
+  const allowedSymlinkRoots = await existingRealPaths(
+    options.allowedSymlinkRoots ?? [
+      join(homeDir, ".agents", "skills"),
+      join(homeDir, ".claude", "skills"),
+      join(homeDir, ".codex", "skills"),
+      join(homeDir, ".codex", "plugins", "cache"),
+    ],
+  );
+
+  const records = new Map<string, FileRecord>();
+  let expandedBytes = 0;
+
+  const addFile = async (
+    physicalPath: string,
+    archivePath: string,
+  ): Promise<void> => {
+    const fileName = basename(physicalPath).toLowerCase();
+    if (
+      SECRET_FILE_BASENAMES.has(fileName) ||
+      SKIPPED_FILE_SUFFIXES.some((suffix) => fileName.endsWith(suffix))
+    ) {
+      return;
+    }
+
+    const fileStats = await stat(physicalPath);
+    if (!fileStats.isFile()) {
+      return;
+    }
+    if (fileStats.size > limits.maxFileBytes) {
+      throw new MirrorLocalPackError(
+        "file-size-limit",
+        `Mirror local file exceeds ${limits.maxFileBytes} bytes: ${archivePath}`,
+      );
+    }
+    if (records.size + 1 > limits.maxFiles) {
+      throw new MirrorLocalPackError(
+        "file-count-limit",
+        `Mirror local pack exceeds ${limits.maxFiles} files`,
+      );
+    }
+
+    const rawContents = await readFile(physicalPath);
+    const contents = transformFile(
+      archivePath,
+      rawContents,
+      homeDir,
+      targetHome,
+    );
+    expandedBytes += contents.byteLength;
+    if (expandedBytes > limits.maxExpandedBytes) {
+      throw new MirrorLocalPackError(
+        "expanded-size-limit",
+        `Mirror local pack exceeds ${limits.maxExpandedBytes} expanded bytes`,
+      );
+    }
+    records.set(archivePath, { archivePath, contents });
+  };
+
+  const walk = async (
+    physicalPath: string,
+    archivePath: string,
+    realDirectoryStack: ReadonlySet<string>,
+  ): Promise<void> => {
+    let entryStats;
+    try {
+      entryStats = await lstat(physicalPath);
+    } catch (error) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? error.code
+          : undefined;
+      if (code === "ENOENT" || code === "EACCES") {
+        return;
+      }
+      throw error;
+    }
+
+    if (entryStats.isSymbolicLink()) {
+      if (!isSkillArchivePath(archivePath)) {
+        return;
+      }
+      const target = await realpath(physicalPath);
+      if (!allowedSymlinkRoots.some((root) => isPathInside(root, target))) {
+        throw new MirrorLocalPackError(
+          "unsafe-symlink",
+          `Mirror local skill symlink escapes approved roots: ${archivePath}`,
+        );
+      }
+      const targetStats = await stat(target);
+      if (targetStats.isDirectory()) {
+        if (realDirectoryStack.has(target)) {
+          throw new MirrorLocalPackError(
+            "symlink-cycle",
+            `Mirror local skill symlink cycle detected at ${archivePath}`,
+          );
+        }
+        const nextStack = new Set(realDirectoryStack);
+        nextStack.add(target);
+        const children = await readdir(target, { withFileTypes: true });
+        children.sort((left, right) => left.name.localeCompare(right.name));
+        for (const child of children) {
+          if (child.isDirectory() && EXCLUDED_DIRECTORY_NAMES.has(child.name)) {
+            continue;
+          }
+          await walk(
+            join(target, child.name),
+            `${archivePath}/${child.name}`,
+            nextStack,
+          );
+        }
+        return;
+      }
+      await addFile(target, archivePath);
+      return;
+    }
+
+    if (entryStats.isDirectory()) {
+      const realDirectory = await realpath(physicalPath);
+      if (realDirectoryStack.has(realDirectory)) {
+        throw new MirrorLocalPackError(
+          "symlink-cycle",
+          `Mirror local directory cycle detected at ${archivePath}`,
+        );
+      }
+      const nextStack = new Set(realDirectoryStack);
+      nextStack.add(realDirectory);
+      const children = await readdir(physicalPath, { withFileTypes: true });
+      children.sort((left, right) => left.name.localeCompare(right.name));
+      for (const child of children) {
+        if (child.isDirectory() && EXCLUDED_DIRECTORY_NAMES.has(child.name)) {
+          continue;
+        }
+        await walk(
+          join(physicalPath, child.name),
+          `${archivePath}/${child.name}`,
+          nextStack,
+        );
+      }
+      return;
+    }
+
+    await addFile(physicalPath, archivePath);
+  };
+
+  for (const includePath of includePaths) {
+    await walk(join(homeDir, includePath), includePath, new Set());
+  }
+
+  const tempRoot = await mkdtemp(join(tmpdir(), "cmux-mirror-pack-"));
+  const stagingRoot = join(tempRoot, "staging");
+  const archiveFile = join(tempRoot, "agent-config.tar.gz");
+  try {
+    await mkdir(stagingRoot, { recursive: true });
+    const archiveEntries = [...records.values()].sort((left, right) =>
+      left.archivePath.localeCompare(right.archivePath),
+    );
+    for (const record of archiveEntries) {
+      const destination = join(stagingRoot, record.archivePath);
+      await mkdir(dirname(destination), { recursive: true });
+      await writeFile(destination, record.contents, { mode: 0o600 });
+    }
+
+    let archive: Buffer;
+    if (archiveEntries.length === 0) {
+      // A tar archive ends with two 512-byte zero records. Build that directly
+      // because node-tar rejects an empty input list.
+      archive = gzipSync(Buffer.alloc(1024), { level: 9 });
+    } else {
+      await createTar(
+        {
+          cwd: stagingRoot,
+          file: archiveFile,
+          gzip: { level: 9 },
+          mtime: new Date(0),
+          portable: true,
+          sync: false,
+        },
+        archiveEntries.map((record) => record.archivePath),
+      );
+      archive = await readFile(archiveFile);
+    }
+    if (archive.byteLength > limits.maxCompressedBytes) {
+      throw new MirrorLocalPackError(
+        "compressed-size-limit",
+        `Mirror local pack exceeds ${limits.maxCompressedBytes} compressed bytes`,
+      );
+    }
+
+    return {
+      archive,
+      sha256: createHash("sha256").update(archive).digest("hex"),
+      policyVersion: MIRROR_LOCAL_POLICY_VERSION,
+      fileCount: archiveEntries.length,
+      expandedBytes,
+      compressedBytes: archive.byteLength,
+    };
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}

--- a/apps/server/src/host-config/mirror-local-pack.ts
+++ b/apps/server/src/host-config/mirror-local-pack.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { Stats } from "node:fs";
 import {
   lstat,
   mkdtemp,
@@ -332,6 +333,10 @@ function transformFile(
   targetHome: string,
 ): Uint8Array {
   const fileName = basename(archivePath);
+  if (!isTextConfig(fileName)) {
+    return contents;
+  }
+
   const lower = fileName.toLowerCase();
   let text = Buffer.from(contents).toString("utf8");
 
@@ -419,6 +424,7 @@ export async function createMirrorLocalPack(
   const addFile = async (
     physicalPath: string,
     archivePath: string,
+    fileStats: Stats,
   ): Promise<void> => {
     const fileName = basename(physicalPath).toLowerCase();
     if (
@@ -428,7 +434,6 @@ export async function createMirrorLocalPack(
       return;
     }
 
-    const fileStats = await stat(physicalPath);
     if (!fileStats.isFile()) {
       return;
     }
@@ -516,7 +521,7 @@ export async function createMirrorLocalPack(
         }
         return;
       }
-      await addFile(target, archivePath);
+      await addFile(target, archivePath, targetStats);
       return;
     }
 
@@ -545,7 +550,7 @@ export async function createMirrorLocalPack(
       return;
     }
 
-    await addFile(physicalPath, archivePath);
+    await addFile(physicalPath, archivePath, entryStats);
   };
 
   for (const includePath of includePaths) {

--- a/apps/server/src/host-config/mirror-local-startup.test.ts
+++ b/apps/server/src/host-config/mirror-local-startup.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MirrorLocalPack } from "./mirror-local-pack";
+import {
+  runMirrorLocalStartup,
+  type MirrorLocalHostService,
+} from "./mirror-local-startup";
+
+const pack: MirrorLocalPack = {
+  archive: Buffer.from("pack"),
+  sha256: "b".repeat(64),
+  policyVersion: "cmux-mirror-local/v1",
+  fileCount: 3,
+  expandedBytes: 4,
+  compressedBytes: 4,
+};
+
+describe("runMirrorLocalStartup", () => {
+  it("starts one sandbox and applies the pack to that exact PVE LXC instance", async () => {
+    const startSandbox = vi.fn(async () => ({
+      instanceId: "pvelxc-exact",
+      provider: "pve-lxc",
+    }));
+    const applyPack = vi.fn(
+      async ({
+        onProgress,
+      }: {
+        onProgress: (state: "uploading" | "applying") => void;
+      }) => {
+        onProgress("uploading");
+        onProgress("applying");
+      },
+    );
+    const states: string[] = [];
+
+    const result = await runMirrorLocalStartup({
+      hostService: { createPack: async () => pack },
+      startSandbox,
+      applyPack,
+      onProgress: (progress) => states.push(progress.state),
+    });
+
+    expect(startSandbox).toHaveBeenCalledTimes(1);
+    expect(applyPack).toHaveBeenCalledWith({
+      instanceId: "pvelxc-exact",
+      pack,
+      onProgress: expect.any(Function),
+    });
+    expect(result.state).toBe("applied");
+    expect(states).toEqual([
+      "packing",
+      "starting-sandbox",
+      "uploading",
+      "applying",
+      "applied",
+    ]);
+  });
+
+  it("starts a usable clean sandbox when packing fails", async () => {
+    const hostService: MirrorLocalHostService = {
+      createPack: async () => {
+        throw new Error("host config unreadable");
+      },
+    };
+    const startSandbox = vi.fn(async () => ({
+      instanceId: "pvelxc-clean",
+      provider: "pve-lxc",
+    }));
+    const applyPack = vi.fn(async () => undefined);
+
+    const result = await runMirrorLocalStartup({
+      hostService,
+      startSandbox,
+      applyPack,
+    });
+
+    expect(startSandbox).toHaveBeenCalledTimes(1);
+    expect(applyPack).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      state: "failed",
+      instanceId: "pvelxc-clean",
+      provider: "pve-lxc",
+      errorCode: "pack-failed",
+    });
+  });
+
+  it("does not apply a pack when the actual provider is unsupported", async () => {
+    const applyPack = vi.fn(async () => undefined);
+    const result = await runMirrorLocalStartup({
+      hostService: { createPack: async () => pack },
+      startSandbox: async () => ({
+        instanceId: "morph-123",
+        provider: "morph",
+      }),
+      applyPack,
+    });
+
+    expect(applyPack).not.toHaveBeenCalled();
+    expect(result.state).toBe("unsupported");
+    expect(result.provider).toBe("morph");
+  });
+
+  it("rejects Mirror local before sandbox creation without a trusted host service", async () => {
+    const startSandbox = vi.fn(async () => ({
+      instanceId: "must-not-start",
+      provider: "pve-lxc",
+    }));
+
+    await expect(
+      runMirrorLocalStartup({
+        startSandbox,
+        applyPack: async () => undefined,
+      }),
+    ).rejects.toThrow(/trusted Electron host service/i);
+    expect(startSandbox).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/host-config/mirror-local-startup.ts
+++ b/apps/server/src/host-config/mirror-local-startup.ts
@@ -1,0 +1,162 @@
+import {
+  MIRROR_LOCAL_STATUS_MESSAGES,
+  type MirrorLocalProgress,
+  type MirrorLocalState,
+} from "@cmux/shared";
+import {
+  MirrorLocalPackError,
+  type MirrorLocalPack,
+} from "./mirror-local-pack";
+
+export type MirrorLocalHostService = {
+  createPack(): Promise<MirrorLocalPack>;
+};
+
+export type MirrorLocalSandboxIdentity = {
+  instanceId: string;
+  provider?: string;
+};
+
+export type MirrorLocalStartupOutcome = {
+  state: Extract<
+    MirrorLocalState,
+    "applied" | "empty" | "unsupported" | "failed"
+  >;
+  policyVersion?: string;
+  fileCount?: number;
+  compressedBytes?: number;
+  errorCode?: string;
+  message: string;
+};
+
+type ProgressWithoutTaskRun = Omit<MirrorLocalProgress, "taskRunId">;
+
+export type RunMirrorLocalStartupOptions<
+  TSandbox extends MirrorLocalSandboxIdentity,
+> = {
+  hostService?: MirrorLocalHostService;
+  startSandbox(): Promise<TSandbox>;
+  applyPack(input: {
+    instanceId: string;
+    pack: MirrorLocalPack;
+    onProgress: (state: "uploading" | "applying") => void;
+  }): Promise<void>;
+  onProgress?: (progress: ProgressWithoutTaskRun) => void;
+  onError?: (phase: "packing" | "applying", error: unknown) => void;
+};
+
+function packMetadata(
+  pack: MirrorLocalPack,
+): Pick<
+  ProgressWithoutTaskRun,
+  "policyVersion" | "fileCount" | "compressedBytes"
+> {
+  return {
+    policyVersion: pack.policyVersion,
+    fileCount: pack.fileCount,
+    compressedBytes: pack.compressedBytes,
+  };
+}
+
+export async function runMirrorLocalStartup<
+  TSandbox extends MirrorLocalSandboxIdentity,
+>({
+  hostService,
+  startSandbox,
+  applyPack,
+  onProgress,
+  onError,
+}: RunMirrorLocalStartupOptions<TSandbox>): Promise<
+  TSandbox & MirrorLocalStartupOutcome
+> {
+  if (!hostService) {
+    throw new Error(
+      "Mirror local requires a trusted Electron host service; browser and standalone server requests are not supported.",
+    );
+  }
+
+  onProgress?.({
+    state: "packing",
+    message: MIRROR_LOCAL_STATUS_MESSAGES.packing,
+  });
+
+  let pack: MirrorLocalPack | null = null;
+  let packErrorCode: string | null = null;
+  try {
+    pack = await hostService.createPack();
+  } catch (error) {
+    onError?.("packing", error);
+    packErrorCode =
+      error instanceof MirrorLocalPackError ? error.code : "pack-failed";
+  }
+
+  onProgress?.({
+    state: "starting-sandbox",
+    message: MIRROR_LOCAL_STATUS_MESSAGES["starting-sandbox"],
+    ...(pack ? packMetadata(pack) : {}),
+  });
+  const sandbox = await startSandbox();
+
+  if (!pack) {
+    const outcome: MirrorLocalStartupOutcome = {
+      state: "failed",
+      errorCode: packErrorCode ?? "pack-failed",
+      message: MIRROR_LOCAL_STATUS_MESSAGES.failed,
+    };
+    onProgress?.(outcome);
+    return { ...sandbox, ...outcome };
+  }
+
+  if (pack.fileCount === 0) {
+    const outcome: MirrorLocalStartupOutcome = {
+      state: "empty",
+      ...packMetadata(pack),
+      message: MIRROR_LOCAL_STATUS_MESSAGES.empty,
+    };
+    onProgress?.(outcome);
+    return { ...sandbox, ...outcome };
+  }
+
+  if (sandbox.provider !== "pve-lxc") {
+    const outcome: MirrorLocalStartupOutcome = {
+      state: "unsupported",
+      ...packMetadata(pack),
+      errorCode: "unsupported-provider",
+      message: MIRROR_LOCAL_STATUS_MESSAGES.unsupported,
+    };
+    onProgress?.(outcome);
+    return { ...sandbox, ...outcome };
+  }
+
+  try {
+    await applyPack({
+      instanceId: sandbox.instanceId,
+      pack,
+      onProgress: (state) => {
+        onProgress?.({
+          state,
+          message: MIRROR_LOCAL_STATUS_MESSAGES[state],
+          ...packMetadata(pack),
+        });
+      },
+    });
+  } catch (error) {
+    onError?.("applying", error);
+    const outcome: MirrorLocalStartupOutcome = {
+      state: "failed",
+      ...packMetadata(pack),
+      errorCode: "apply-failed",
+      message: MIRROR_LOCAL_STATUS_MESSAGES.failed,
+    };
+    onProgress?.(outcome);
+    return { ...sandbox, ...outcome };
+  }
+
+  const outcome: MirrorLocalStartupOutcome = {
+    state: "applied",
+    ...packMetadata(pack),
+    message: MIRROR_LOCAL_STATUS_MESSAGES.applied,
+  };
+  onProgress?.(outcome);
+  return { ...sandbox, ...outcome };
+}

--- a/apps/server/src/host-config/pve-mirror-local.test.ts
+++ b/apps/server/src/host-config/pve-mirror-local.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MirrorLocalPack } from "./mirror-local-pack";
+import { applyMirrorLocalPackToPve } from "./pve-mirror-local";
+
+const pack: MirrorLocalPack = {
+  archive: Buffer.from("abcdefghij", "utf8"),
+  sha256: "a".repeat(64),
+  policyVersion: "cmux-mirror-local/v1",
+  fileCount: 2,
+  expandedBytes: 10,
+  compressedBytes: 10,
+};
+
+describe("applyMirrorLocalPackToPve", () => {
+  it("uploads bounded chunks, verifies checksum and paths, extracts under /root, and cleans up", async () => {
+    const commands: string[] = [];
+    const exec = vi.fn(async ({ command }: { command: string }) => {
+      commands.push(command);
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const progress: string[] = [];
+
+    await applyMirrorLocalPackToPve({
+      instanceId: "pvelxc-123",
+      teamSlugOrId: "team-1",
+      pack,
+      exec,
+      chunkSize: 4,
+      remoteNonce: "fixed",
+      onProgress: (state) => progress.push(state),
+    });
+
+    expect(exec).toHaveBeenCalledTimes(6);
+    expect(commands[0]).toContain("umask 077");
+    expect(commands.slice(1, 5)).toHaveLength(4);
+    expect(
+      commands.slice(1, 5).every((command) => command.includes("base64 -d")),
+    ).toBe(true);
+    expect(commands[5]).toContain(pack.sha256);
+    expect(commands[5]).toContain("tar -tzf");
+    expect(commands[5]).toContain("auth.json");
+    expect(commands[5]).toContain("--no-same-owner");
+    expect(commands[5]).toContain("--no-same-permissions");
+    expect(commands[5]).toContain("-C /root");
+    expect(commands[5]).toContain("trap cleanup EXIT");
+    expect(progress).toEqual(["uploading", "applying"]);
+  });
+
+  it("removes the remote archive when an upload chunk fails", async () => {
+    const commands: string[] = [];
+    const exec = vi.fn(async ({ command }: { command: string }) => {
+      commands.push(command);
+      if (commands.length === 2) {
+        return { stdout: "", stderr: "upload failed", exitCode: 17 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+
+    await expect(
+      applyMirrorLocalPackToPve({
+        instanceId: "pvelxc-123",
+        teamSlugOrId: "team-1",
+        pack,
+        exec,
+        chunkSize: 4,
+        remoteNonce: "fixed",
+      }),
+    ).rejects.toThrow(/upload failed/i);
+
+    expect(commands.at(-1)).toContain("rm -f");
+    expect(commands.at(-1)).toContain("cmux-mirror-fixed.tar.gz");
+  });
+});

--- a/apps/server/src/host-config/pve-mirror-local.ts
+++ b/apps/server/src/host-config/pve-mirror-local.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import type { MirrorLocalPack } from "./mirror-local-pack";
+
+const DEFAULT_CHUNK_SIZE = 8 * 1024;
+
+export type PveMirrorLocalExecResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+export type PveMirrorLocalExec = (input: {
+  instanceId: string;
+  teamSlugOrId: string;
+  command: string;
+}) => Promise<PveMirrorLocalExecResult>;
+
+export type PveMirrorLocalApplyProgress = "uploading" | "applying";
+
+export type ApplyMirrorLocalPackToPveOptions = {
+  instanceId: string;
+  teamSlugOrId: string;
+  pack: MirrorLocalPack;
+  exec: PveMirrorLocalExec;
+  chunkSize?: number;
+  remoteNonce?: string;
+  onProgress?: (state: PveMirrorLocalApplyProgress) => void;
+};
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function assertExecSucceeded(
+  result: PveMirrorLocalExecResult,
+  operation: string,
+): void {
+  if (result.exitCode === 0) {
+    return;
+  }
+  const detail = `${result.stderr}\n${result.stdout}`.trim();
+  throw new Error(
+    detail
+      ? `Mirror local ${operation} failed (exit ${result.exitCode}): ${detail}`
+      : `Mirror local ${operation} failed (exit ${result.exitCode})`,
+  );
+}
+
+function chunkString(value: string, chunkSize: number): string[] {
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new Error(
+      "Mirror local upload chunk size must be a positive integer",
+    );
+  }
+  const chunks: string[] = [];
+  for (let offset = 0; offset < value.length; offset += chunkSize) {
+    chunks.push(value.slice(offset, offset + chunkSize));
+  }
+  return chunks;
+}
+
+function buildValidateAndExtractCommand(
+  remoteArchive: string,
+  sha256: string,
+): string {
+  const quotedArchive = shellSingleQuote(remoteArchive);
+  const quotedSha = shellSingleQuote(sha256);
+  return [
+    "set -eu",
+    `archive=${quotedArchive}`,
+    'cleanup() { rm -f "$archive"; }',
+    "trap cleanup EXIT",
+    'actual_sha="$(sha256sum "$archive" | awk \'{print $1}\')"',
+    `[ "$actual_sha" = ${quotedSha} ]`,
+    'tar -tzf "$archive" | while IFS= read -r entry; do',
+    '  case "$entry" in /*|../*|*/../*|*/..) echo "unsafe archive path: $entry" >&2; exit 20;; esac',
+    '  base="${entry##*/}"',
+    '  case "$base" in auth.json|.credentials.json|credentials.json) echo "credential file rejected: $entry" >&2; exit 21;; esac',
+    "done",
+    'tar -tvzf "$archive" | awk \'substr($1,1,1) != "-" && substr($1,1,1) != "d" { exit 22 }\'',
+    "mkdir -p /root",
+    'tar -xzf "$archive" -C /root --no-same-owner --no-same-permissions',
+  ].join("\n");
+}
+
+export async function applyMirrorLocalPackToPve({
+  instanceId,
+  teamSlugOrId,
+  pack,
+  exec,
+  chunkSize = DEFAULT_CHUNK_SIZE,
+  remoteNonce = randomUUID(),
+  onProgress,
+}: ApplyMirrorLocalPackToPveOptions): Promise<void> {
+  const remoteArchive = `/tmp/cmux-mirror-${remoteNonce}.tar.gz`;
+  const quotedArchive = shellSingleQuote(remoteArchive);
+  let applied = false;
+
+  try {
+    onProgress?.("uploading");
+    assertExecSucceeded(
+      await exec({
+        instanceId,
+        teamSlugOrId,
+        command: `umask 077 && : > ${quotedArchive}`,
+      }),
+      "upload initialization",
+    );
+
+    const encoded = Buffer.from(pack.archive).toString("base64");
+    for (const chunk of chunkString(encoded, chunkSize)) {
+      assertExecSucceeded(
+        await exec({
+          instanceId,
+          teamSlugOrId,
+          command: `printf '%s' ${shellSingleQuote(chunk)} | base64 -d >> ${quotedArchive}`,
+        }),
+        "upload",
+      );
+    }
+
+    onProgress?.("applying");
+    assertExecSucceeded(
+      await exec({
+        instanceId,
+        teamSlugOrId,
+        command: buildValidateAndExtractCommand(remoteArchive, pack.sha256),
+      }),
+      "apply",
+    );
+    applied = true;
+  } finally {
+    if (!applied) {
+      assertExecSucceeded(
+        await exec({
+          instanceId,
+          teamSlugOrId,
+          command: `rm -f ${quotedArchive}`,
+        }),
+        "cleanup",
+      );
+    }
+  }
+}

--- a/apps/server/src/host-config/pve-mirror-local.ts
+++ b/apps/server/src/host-config/pve-mirror-local.ts
@@ -46,17 +46,12 @@ function assertExecSucceeded(
   );
 }
 
-function chunkString(value: string, chunkSize: number): string[] {
+function assertValidChunkSize(chunkSize: number): void {
   if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
     throw new Error(
       "Mirror local upload chunk size must be a positive integer",
     );
   }
-  const chunks: string[] = [];
-  for (let offset = 0; offset < value.length; offset += chunkSize) {
-    chunks.push(value.slice(offset, offset + chunkSize));
-  }
-  return chunks;
 }
 
 function buildValidateAndExtractCommand(
@@ -92,6 +87,7 @@ export async function applyMirrorLocalPackToPve({
   remoteNonce = randomUUID(),
   onProgress,
 }: ApplyMirrorLocalPackToPveOptions): Promise<void> {
+  assertValidChunkSize(chunkSize);
   const remoteArchive = `/tmp/cmux-mirror-${remoteNonce}.tar.gz`;
   const quotedArchive = shellSingleQuote(remoteArchive);
   let applied = false;
@@ -108,7 +104,8 @@ export async function applyMirrorLocalPackToPve({
     );
 
     const encoded = Buffer.from(pack.archive).toString("base64");
-    for (const chunk of chunkString(encoded, chunkSize)) {
+    for (let offset = 0; offset < encoded.length; offset += chunkSize) {
+      const chunk = encoded.slice(offset, offset + chunkSize);
       assertExecSucceeded(
         await exec({
           instanceId,

--- a/apps/server/src/http-api.test.ts
+++ b/apps/server/src/http-api.test.ts
@@ -138,6 +138,32 @@ async function withLocalHttpApiServer<T>(
 }
 
 describe("HTTP API - apps/server", () => {
+  describe("POST /api/create-cloud-workspace", () => {
+    it("rejects Mirror local without a trusted Electron host service", async () => {
+      await withLocalHttpApiServer(async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/api/create-cloud-workspace`, {
+          method: "POST",
+          headers: {
+            authorization: "Bearer test-token",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            teamSlugOrId: "team-1",
+            taskId: "task-1",
+            environmentId: "environment-1",
+            clean: true,
+            mirrorLocal: true,
+          }),
+        });
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+          error: expect.stringMatching(/Electron embedded server/i),
+        });
+      });
+    });
+  });
+
   describe("Orchestration filtering helpers", () => {
     it("matches a single-task local flow by task id", () => {
       const orchestrationId = "orch_task_local_123";

--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -598,6 +598,14 @@ async function handleCreateCloudWorkspace(
     return;
   }
 
+  if (mirrorLocal) {
+    jsonResponse(res, 400, {
+      error:
+        "Mirror local is available only through the Electron embedded server with a trusted host configuration service.",
+    });
+    return;
+  }
+
   serverLogger.info("[http-api] POST /api/create-cloud-workspace", {
     taskId,
     environmentId,

--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -535,6 +535,8 @@ interface CreateCloudWorkspaceRequest {
   projectFullName?: string;
   repoUrl?: string;
   theme?: "dark" | "light" | "system";
+  clean?: boolean;
+  mirrorLocal?: boolean;
 }
 
 interface CreateCloudWorkspaceResponse {
@@ -571,8 +573,15 @@ async function handleCreateCloudWorkspace(
     return;
   }
 
-  const { teamSlugOrId, taskId, environmentId, projectFullName, repoUrl } =
-    body;
+  const {
+    teamSlugOrId,
+    taskId,
+    environmentId,
+    projectFullName,
+    repoUrl,
+    clean,
+    mirrorLocal,
+  } = body;
 
   if (!teamSlugOrId || !taskId) {
     jsonResponse(res, 400, {
@@ -593,6 +602,8 @@ async function handleCreateCloudWorkspace(
     taskId,
     environmentId,
     projectFullName,
+    clean: Boolean(clean),
+    mirrorLocal: Boolean(mirrorLocal),
   });
 
   // Hoist taskRunId outside runWithAuth to handle failures properly
@@ -652,6 +663,11 @@ async function handleCreateCloudWorkspace(
           : `[create-cloud-workspace] Starting sandbox for repo ${projectFullName}`,
       );
 
+      const { buildSandboxesStartModeFields } = await import("@cmux/shared");
+      const modeFields = buildSandboxesStartModeFields({
+        clean,
+        mirrorLocal,
+      });
       const startRes = await postApiSandboxesStart({
         client: getWwwClient(),
         body: {
@@ -665,6 +681,7 @@ async function handleCreateCloudWorkspace(
           taskRunJwt,
           isCloudWorkspace: true,
           isOrchestrationHead: true,
+          ...modeFields,
           ...(environmentId ? { environmentId } : { projectFullName, repoUrl }),
         },
       });

--- a/apps/server/src/http-api.ts
+++ b/apps/server/src/http-api.ts
@@ -17,6 +17,10 @@ import {
   DEFAULT_TASK_LIST_LIMIT,
   ORCHESTRATION_STATUSES,
 } from "@cmux/convex/orchestrationQueries";
+import {
+  buildSandboxesStartModeFields,
+  type TaskClass,
+} from "@cmux/shared";
 import { AGENT_CONFIGS } from "@cmux/shared/agentConfig";
 import { DEFAULT_CLAUDE_AGENT_NAME } from "@cmux/shared/providers/anthropic/models";
 import {
@@ -44,8 +48,6 @@ import { extractSandboxStartError } from "./utils/sandboxErrors";
 import { env } from "./utils/server-env";
 import { getResponseErrorMessage } from "./utils/httpError";
 import { buildTaskRunCreateArgs } from "./utils/taskRunCreateArgs";
-
-import type { TaskClass } from "@cmux/shared";
 
 interface StartTaskRequest {
   // Required fields
@@ -671,7 +673,6 @@ async function handleCreateCloudWorkspace(
           : `[create-cloud-workspace] Starting sandbox for repo ${projectFullName}`,
       );
 
-      const { buildSandboxesStartModeFields } = await import("@cmux/shared");
       const modeFields = buildSandboxesStartModeFields({
         clean,
         mirrorLocal,

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -22,6 +22,7 @@ import {
   type TriggerLocalCloudSyncResponse,
   type AvailableEditors,
   type FileInfo,
+  buildSandboxesStartModeFields,
   isLoopbackHostname,
   LOCAL_VSCODE_PLACEHOLDER_ORIGIN,
   MIRROR_LOCAL_STATUS_MESSAGES,
@@ -2398,8 +2399,6 @@ export function setupSocketHandlers(
             { clean: Boolean(clean), mirrorLocal: Boolean(mirrorLocal) },
           );
 
-          const { buildSandboxesStartModeFields } =
-            await import("@cmux/shared");
           const modeFields = buildSandboxesStartModeFields({
             clean,
             mirrorLocal,

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -2250,6 +2250,8 @@ export function setupSocketHandlers(
           projectFullName,
           repoUrl,
           taskId: providedTaskId,
+          clean,
+          mirrorLocal,
         } = parsed.data;
         const teamSlugOrId = requestedTeamSlugOrId || safeTeam;
 
@@ -2317,8 +2319,15 @@ export function setupSocketHandlers(
           serverLogger.info(
             environmentId
               ? `[create-cloud-workspace] Starting Morph sandbox for environment ${environmentId}`
-              : `[create-cloud-workspace] Starting Morph sandbox for repo ${projectFullName}`
+              : `[create-cloud-workspace] Starting Morph sandbox for repo ${projectFullName}`,
+            { clean: Boolean(clean), mirrorLocal: Boolean(mirrorLocal) },
           );
+
+          const { buildSandboxesStartModeFields } = await import("@cmux/shared");
+          const modeFields = buildSandboxesStartModeFields({
+            clean,
+            mirrorLocal,
+          });
 
           const startRes = await postApiSandboxesStart({
             client: getWwwClient(),
@@ -2333,6 +2342,7 @@ export function setupSocketHandlers(
               taskRunJwt,
               isCloudWorkspace: true,
               isOrchestrationHead: true,
+              ...modeFields,
               ...(environmentId
                 ? { environmentId }
                 : { projectFullName, repoUrl }),

--- a/apps/server/src/socket-handlers.ts
+++ b/apps/server/src/socket-handlers.ts
@@ -24,7 +24,9 @@ import {
   type FileInfo,
   isLoopbackHostname,
   LOCAL_VSCODE_PLACEHOLDER_ORIGIN,
+  MIRROR_LOCAL_STATUS_MESSAGES,
   type IframePreflightResult,
+  type MirrorLocalProgress,
 } from "@cmux/shared";
 import {
   type PullRequestActionResult,
@@ -44,6 +46,11 @@ import { resumeContainersForRuns, stopContainersForRuns } from "./archiveTask";
 import { execWithEnv } from "./execWithEnv";
 import { getGitDiff } from "./diffs/gitDiff";
 import { GitDiffManager } from "./gitDiff";
+import {
+  runMirrorLocalStartup,
+  type MirrorLocalHostService,
+} from "./host-config/mirror-local-startup";
+import { applyMirrorLocalPackToPve } from "./host-config/pve-mirror-local";
 import { getRustTime } from "./native/core";
 import type { RealtimeServer } from "./realtime";
 import { RepositoryManager } from "./repositoryManager";
@@ -139,7 +146,7 @@ const providerStatusInflight = new Map<
 >();
 
 function getCachedProviderStatus(
-  teamSlugOrId: string
+  teamSlugOrId: string,
 ): ProviderStatusCacheEntry["data"] | null {
   const entry = providerStatusCache.get(teamSlugOrId);
   if (!entry) return null;
@@ -152,7 +159,7 @@ function getCachedProviderStatus(
 
 function setCachedProviderStatus(
   teamSlugOrId: string,
-  data: ProviderStatusCacheEntry["data"]
+  data: ProviderStatusCacheEntry["data"],
 ): void {
   // Evict expired entries if cache is at capacity
   if (providerStatusCache.size >= PROVIDER_STATUS_CACHE_MAX_SIZE) {
@@ -216,7 +223,10 @@ function sleep(ms: number): Promise<void> {
 function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return "0B";
   const units = ["B", "KB", "MB", "GB", "TB"];
-  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
   const value = bytes / Math.pow(1024, exponent);
   return `${value.toFixed(value >= 10 ? 1 : 2)}${units[exponent]}`;
 }
@@ -241,7 +251,9 @@ function collectWorktreePaths(nodes: unknown): string[] {
   return Array.from(paths);
 }
 
-function sanitizeShellPath(candidate: string | undefined | null): string | null {
+function sanitizeShellPath(
+  candidate: string | undefined | null,
+): string | null {
   if (!candidate) {
     return null;
   }
@@ -287,10 +299,7 @@ function getUserLoginShell(): string {
   return "cmd.exe";
 }
 
-function buildLoginShellArgs(
-  shellPath: string,
-  command: string
-): string[] {
+function buildLoginShellArgs(shellPath: string, command: string): string[] {
   if (isWindows) {
     const normalized = shellPath.toLowerCase();
     if (normalized.includes("powershell") || normalized.includes("pwsh")) {
@@ -338,7 +347,7 @@ const IframePreflightRequestSchema = z.object({
 
 function buildServeWebWorkspaceUrl(
   baseUrl: string,
-  folderPath: string
+  folderPath: string,
 ): string {
   const workspaceUrl = new URL(baseUrl);
   workspaceUrl.searchParams.set("folder", folderPath);
@@ -381,7 +390,10 @@ function buildPrDescription({
 export function setupSocketHandlers(
   rt: RealtimeServer,
   gitDiffManager: GitDiffManager,
-  defaultRepo?: GitRepoInfo | null
+  defaultRepo?: GitRepoInfo | null,
+  hostServices?: {
+    mirrorLocal?: MirrorLocalHostService;
+  },
 ) {
   let hasRefreshedGithub = false;
   let dockerEventsStarted = false;
@@ -444,7 +456,7 @@ export function setupSocketHandlers(
       "iframe-preflight",
       async (
         rawData: unknown,
-        callback: (result: IframePreflightResult) => void
+        callback: (result: IframePreflightResult) => void,
       ) => {
         const respond = (result: IframePreflightResult) => {
           callback(result);
@@ -521,7 +533,7 @@ export function setupSocketHandlers(
             error: message,
           });
         }
-      }
+      },
     );
 
     // Send default repo info to newly connected client if available
@@ -533,7 +545,7 @@ export function setupSocketHandlers(
       };
       serverLogger.info(
         `Sending default-repo to new client ${socket.id}:`,
-        defaultRepoData
+        defaultRepoData,
       );
       socket.emit("default-repo", defaultRepoData);
     }
@@ -563,7 +575,7 @@ export function setupSocketHandlers(
       runWithAuth(initialToken, initialAuthJson, () => {
         if (!initialTeam) {
           serverLogger.warn(
-            "No team provided on socket handshake; skipping initial GitHub refresh"
+            "No team provided on socket handshake; skipping initial GitHub refresh",
           );
           return;
         }
@@ -577,14 +589,14 @@ export function setupSocketHandlers(
         dockerEventsStarted = true;
         runWithAuth(initialToken, initialAuthJson, () => {
           serverLogger.info(
-            "Starting Docker container state sync after authenticated connect"
+            "Starting Docker container state sync after authenticated connect",
           );
           DockerVSCodeInstance.startContainerStateSync();
         });
       }
     } else if (!initialToken) {
       serverLogger.info(
-        "Skipping initial GitHub refresh: no auth token on connect"
+        "Skipping initial GitHub refresh: no auth token on connect",
       );
     }
 
@@ -598,7 +610,7 @@ export function setupSocketHandlers(
           !parsed.originPathOverride
         ) {
           throw new Error(
-            "repoFullName, repoUrl, or originPathOverride is required"
+            "repoFullName, repoUrl, or originPathOverride is required",
           );
         }
 
@@ -617,7 +629,7 @@ export function setupSocketHandlers(
               } catch (error) {
                 serverLogger.warn(
                   "Failed to fetch GitHub OAuth token for git-diff:",
-                  error
+                  error,
                 );
               }
             }
@@ -636,7 +648,7 @@ export function setupSocketHandlers(
               authToken,
               forceRefresh: parsed.forceRefresh,
             });
-          }
+          },
         );
 
         if (parsed.originPathOverride) {
@@ -650,7 +662,7 @@ export function setupSocketHandlers(
             });
           } catch (e) {
             serverLogger.warn(
-              `Failed to start watcher for ${parsed.originPathOverride}: ${String(e)}`
+              `Failed to start watcher for ${parsed.originPathOverride}: ${String(e)}`,
             );
           }
         }
@@ -742,7 +754,10 @@ export function setupSocketHandlers(
 
         socket.emit("available-editors", availability);
       } catch (error) {
-        serverLogger.error("[socket] Failed to detect available editors", error);
+        serverLogger.error(
+          "[socket] Failed to detect available editors",
+          error,
+        );
       }
     })();
 
@@ -751,7 +766,7 @@ export function setupSocketHandlers(
       if (!taskDataParseResult.success) {
         serverLogger.error(
           "Task data failed schema validation:",
-          taskDataParseResult.error
+          taskDataParseResult.error,
         );
         callback({
           taskId: data.taskId,
@@ -767,7 +782,8 @@ export function setupSocketHandlers(
         if (env.NEXT_PUBLIC_WEB_MODE && !taskData.isCloudMode) {
           callback({
             taskId,
-            error: "Local mode is not available in the web version. Please use Cloud mode.",
+            error:
+              "Local mode is not available in the web version. Please use Cloud mode.",
           });
           return;
         }
@@ -775,7 +791,7 @@ export function setupSocketHandlers(
         // For local mode, ensure Docker is running and image is available before attempting to spawn
         if (!taskData.isCloudMode) {
           const updateTaskRunStatusMessage = async (
-            message: string | undefined
+            message: string | undefined,
           ): Promise<void> => {
             if (!taskData.taskRunIds || taskData.taskRunIds.length === 0) {
               return;
@@ -787,21 +803,20 @@ export function setupSocketHandlers(
                     teamSlugOrId: safeTeam,
                     id: taskRunId,
                     statusMessage: message,
-                  })
-                )
+                  }),
+                ),
               );
             } catch (error) {
               serverLogger.warn(
                 "[start-task] Failed to update VSCode status message",
-                error
+                error,
               );
             }
           };
 
           try {
-            const { checkDockerStatus } = await import(
-              "@cmux/shared/providers/common/check-docker"
-            );
+            const { checkDockerStatus } =
+              await import("@cmux/shared/providers/common/check-docker");
             const docker = await checkDockerStatus();
             if (!docker.isRunning) {
               callback({
@@ -822,7 +837,7 @@ export function setupSocketHandlers(
 
             if (docker.workerImage?.isPulling) {
               serverLogger.info(
-                `Docker image "${imageName}" is currently being pulled, waiting for completion...`
+                `Docker image "${imageName}" is currently being pulled, waiting for completion...`,
               );
               rt.emit("docker-pull-progress", {
                 imageName,
@@ -830,7 +845,7 @@ export function setupSocketHandlers(
                 phase: "waiting",
               });
               await updateTaskRunStatusMessage(
-                `Waiting for Docker image pull: ${imageName}`
+                `Waiting for Docker image pull: ${imageName}`,
               );
 
               const deadline = Date.now() + DOCKER_PULL_TIMEOUT_MS;
@@ -843,10 +858,13 @@ export function setupSocketHandlers(
                   break;
                 } catch (error) {
                   const now = Date.now();
-                  if (now - lastStatusUpdate > DOCKER_PULL_PROGRESS_THROTTLE_MS) {
+                  if (
+                    now - lastStatusUpdate >
+                    DOCKER_PULL_PROGRESS_THROTTLE_MS
+                  ) {
                     lastStatusUpdate = now;
                     await updateTaskRunStatusMessage(
-                      `Waiting for Docker image pull: ${imageName}`
+                      `Waiting for Docker image pull: ${imageName}`,
                     );
                   }
                   await sleep(2_000);
@@ -865,7 +883,7 @@ export function setupSocketHandlers(
 
             if (!docker.workerImage?.isAvailable || shouldForcePull) {
               serverLogger.info(
-                `Ensuring Docker image "${imageName}" is pulled before starting task`
+                `Ensuring Docker image "${imageName}" is pulled before starting task`,
               );
               rt.emit("docker-pull-progress", {
                 imageName,
@@ -873,7 +891,7 @@ export function setupSocketHandlers(
                 phase: "pulling",
               });
               await updateTaskRunStatusMessage(
-                `Pulling Docker image: ${imageName}`
+                `Pulling Docker image: ${imageName}`,
               );
 
               try {
@@ -891,8 +909,8 @@ export function setupSocketHandlers(
                   const timeoutId = setTimeout(() => {
                     reject(
                       new Error(
-                        `Docker pull timed out after ${DOCKER_PULL_TIMEOUT_MS / 1000 / 60} minutes`
-                      )
+                        `Docker pull timed out after ${DOCKER_PULL_TIMEOUT_MS / 1000 / 60} minutes`,
+                      ),
                     );
                   }, DOCKER_PULL_TIMEOUT_MS);
 
@@ -921,7 +939,7 @@ export function setupSocketHandlers(
                         const previous = layerStats.get(event.id);
                         const current = Math.max(
                           previous?.current ?? 0,
-                          event.progressDetail.current
+                          event.progressDetail.current,
                         );
                         layerStats.set(event.id, {
                           current,
@@ -933,12 +951,17 @@ export function setupSocketHandlers(
                       let aggregateTotal = 0;
                       for (const layer of layerStats.values()) {
                         aggregateTotal += layer.total;
-                        aggregateCurrent += Math.min(layer.current, layer.total);
+                        aggregateCurrent += Math.min(
+                          layer.current,
+                          layer.total,
+                        );
                       }
 
                       let percent =
                         aggregateTotal > 0
-                          ? Math.round((aggregateCurrent / aggregateTotal) * 100)
+                          ? Math.round(
+                              (aggregateCurrent / aggregateTotal) * 100,
+                            )
                           : undefined;
                       if (percent !== undefined && percent >= 100) {
                         percent = 99;
@@ -950,7 +973,7 @@ export function setupSocketHandlers(
                       const aggregateProgress =
                         aggregateTotal > 0
                           ? `${formatBytes(aggregateCurrent)}/${formatBytes(
-                              aggregateTotal
+                              aggregateTotal,
                             )}`
                           : "";
 
@@ -959,7 +982,8 @@ export function setupSocketHandlers(
                         (safePercent !== undefined &&
                           safePercent !== lastAggregatePercent) ||
                         aggregateProgress !== lastAggregateProgress ||
-                        now - lastProgressUpdate > DOCKER_PULL_PROGRESS_THROTTLE_MS;
+                        now - lastProgressUpdate >
+                          DOCKER_PULL_PROGRESS_THROTTLE_MS;
 
                       if (shouldEmit) {
                         lastStatus = event.status;
@@ -977,15 +1001,16 @@ export function setupSocketHandlers(
                           id: event.id,
                           current:
                             aggregateTotal > 0 ? aggregateCurrent : undefined,
-                          total: aggregateTotal > 0 ? aggregateTotal : undefined,
+                          total:
+                            aggregateTotal > 0 ? aggregateTotal : undefined,
                           percent: safePercent,
                           phase: "pulling",
                         });
                         void updateTaskRunStatusMessage(
-                          `Pulling Docker image: ${event.status}${event.id ? ` (${event.id})` : ""}`
+                          `Pulling Docker image: ${event.status}${event.id ? ` (${event.id})` : ""}`,
                         );
                       }
-                    }
+                    },
                   );
                 });
 
@@ -997,12 +1022,12 @@ export function setupSocketHandlers(
                   phase: "complete",
                 });
                 serverLogger.info(
-                  `Successfully pulled Docker image: ${imageName}`
+                  `Successfully pulled Docker image: ${imageName}`,
                 );
               } catch (pullError) {
                 serverLogger.error(
                   "[start-task] Error auto-pulling Docker image:",
-                  pullError
+                  pullError,
                 );
                 rt.emit("docker-pull-progress", {
                   imageName,
@@ -1031,7 +1056,7 @@ export function setupSocketHandlers(
           } catch (e) {
             serverLogger.error(
               "[start-task] Failed to verify Docker status",
-              e
+              e,
             );
             callback({
               taskId,
@@ -1057,7 +1082,7 @@ export function setupSocketHandlers(
             // Fetch workspace settings for branchPrefix
             const workspaceSettings = await getConvex().query(
               api.workspaceSettings.get,
-              { teamSlugOrId: safeTeam }
+              { teamSlugOrId: safeTeam },
             );
             // Use configured prefix, or default if not set (undefined/null)
             // Empty string is valid and means no prefix
@@ -1071,10 +1096,10 @@ export function setupSocketHandlers(
             const branchNames = generateBranchNamesFromDescription(
               taskData.taskDescription,
               agentCount,
-              branchPrefix
+              branchPrefix,
             );
             serverLogger.info(
-              `[Server] Generated ${branchNames.length} deterministic branch names instantly`
+              `[Server] Generated ${branchNames.length} deterministic branch names instantly`,
             );
 
             // Fire-and-forget: generate AI PR title asynchronously
@@ -1084,7 +1109,7 @@ export function setupSocketHandlers(
                 const prInfo = await generatePRInfoAndBranchNames(
                   taskData.taskDescription,
                   agentCount,
-                  safeTeam
+                  safeTeam,
                 );
                 await getConvex().mutation(api.tasks.setPullRequestTitle, {
                   teamSlugOrId: safeTeam,
@@ -1092,12 +1117,12 @@ export function setupSocketHandlers(
                   pullRequestTitle: prInfo.prTitle,
                 });
                 serverLogger.info(
-                  `[Server] AI-generated PR title saved: "${prInfo.prTitle}"`
+                  `[Server] AI-generated PR title saved: "${prInfo.prTitle}"`,
                 );
               } catch (e) {
                 serverLogger.error(
                   `[Server] Failed generating PR title (non-blocking):`,
-                  e
+                  e,
                 );
               }
             })();
@@ -1120,12 +1145,12 @@ export function setupSocketHandlers(
                 environmentId: taskData.environmentId,
                 ralphModeOptions: taskData.ralphMode,
               },
-              safeTeam
+              safeTeam,
             );
 
             // Check if at least one agent spawned successfully
             const successfulAgents = agentResults.filter(
-              (result) => result.success
+              (result) => result.success,
             );
             if (successfulAgents.length === 0) {
               const errors = agentResults
@@ -1134,7 +1159,7 @@ export function setupSocketHandlers(
                 .join("; ");
               serverLogger.error(
                 `Failed to spawn any agents for task ${taskId}:`,
-                errors
+                errors,
               );
               rt.emit("task-failed", {
                 taskId,
@@ -1147,16 +1172,16 @@ export function setupSocketHandlers(
             agentResults.forEach((result) => {
               if (result.success) {
                 serverLogger.info(
-                  `Successfully spawned ${result.agentName} with terminal ${result.terminalId}`
+                  `Successfully spawned ${result.agentName} with terminal ${result.terminalId}`,
                 );
                 if (result.vscodeUrl) {
                   serverLogger.info(
-                    `VSCode URL for ${result.agentName}: ${result.vscodeUrl}`
+                    `VSCode URL for ${result.agentName}: ${result.vscodeUrl}`,
                   );
                 }
               } else {
                 serverLogger.error(
-                  `Failed to spawn ${result.agentName}: ${result.error}`
+                  `Failed to spawn ${result.agentName}: ${result.error}`,
                 );
               }
             });
@@ -1178,7 +1203,7 @@ export function setupSocketHandlers(
                 instanceId: primaryAgent.terminalId,
                 url: primaryAgent.vscodeUrl.replace(
                   "/?folder=/root/workspace",
-                  ""
+                  "",
                 ),
                 workspaceUrl: primaryAgent.vscodeUrl,
                 provider: taskData.isCloudMode ? "morph" : "docker",
@@ -1194,12 +1219,12 @@ export function setupSocketHandlers(
                     workspacePath: primaryAgent.worktreePath,
                     filePath: changedPath,
                   });
-                }
+                },
               );
             } catch (error) {
               serverLogger.warn(
                 "Could not set up file watching for workspace:",
-                error
+                error,
               );
               // Continue without file watching
             }
@@ -1223,7 +1248,10 @@ export function setupSocketHandlers(
     socket.on(
       "get-local-vscode-serve-web-origin",
       (
-        callback?: (response: { baseUrl: string | null; port: number | null }) => void
+        callback?: (response: {
+          baseUrl: string | null;
+          port: number | null;
+        }) => void,
       ) => {
         if (!callback) {
           return;
@@ -1241,14 +1269,14 @@ export function setupSocketHandlers(
         } catch (error) {
           serverLogger.error(
             "Failed to handle get-local-vscode-serve-web-origin:",
-            error
+            error,
           );
           callback({
             baseUrl: null,
             port: null,
           });
         }
-      }
+      },
     );
 
     // Handler to check VS Code availability and optionally refresh detection
@@ -1263,7 +1291,7 @@ export function setupSocketHandlers(
           source: string | null;
           suggestions: string[];
           errors: string[];
-        }) => void
+        }) => void,
       ) => {
         if (!callback) {
           return;
@@ -1276,7 +1304,9 @@ export function setupSocketHandlers(
             executablePath: null,
             variant: null,
             source: null,
-            suggestions: ["Local workspaces are not available in the web version."],
+            suggestions: [
+              "Local workspaces are not available in the web version.",
+            ],
             errors: [],
           });
           return;
@@ -1318,24 +1348,27 @@ export function setupSocketHandlers(
             executablePath: null,
             variant: null,
             source: null,
-            suggestions: ["An error occurred while checking VS Code availability."],
+            suggestions: [
+              "An error occurred while checking VS Code availability.",
+            ],
             errors: [getErrorMessage(error)],
           });
         }
-      }
+      },
     );
 
     socket.on(
       "create-local-workspace",
       async (
         rawData,
-        callback: (response: CreateLocalWorkspaceResponse) => void
+        callback: (response: CreateLocalWorkspaceResponse) => void,
       ) => {
         // In web mode, local workspaces are not supported
         if (env.NEXT_PUBLIC_WEB_MODE) {
           callback({
             success: false,
-            error: "Local workspaces are not available in the web version. Please use Cloud mode.",
+            error:
+              "Local workspaces are not available in the web version. Please use Cloud mode.",
           });
           return;
         }
@@ -1344,7 +1377,7 @@ export function setupSocketHandlers(
         if (!parsed.success) {
           serverLogger.error(
             "Invalid create-local-workspace payload:",
-            parsed.error
+            parsed.error,
           );
           callback({
             success: false,
@@ -1404,14 +1437,15 @@ export function setupSocketHandlers(
                     searchedLocations: detectionResult.searchedLocations.length,
                     errors: detectionResult.errors,
                   }
-                : {}
+                : {},
             );
 
             // Build user-friendly error message with suggestions
             let errorMessage =
               "VS Code is not available. Local workspaces require VS Code to be installed.";
             if (suggestions.length > 0) {
-              errorMessage += "\n\nTo fix this:\n• " + suggestions.slice(0, 3).join("\n• ");
+              errorMessage +=
+                "\n\nTo fix this:\n• " + suggestions.slice(0, 3).join("\n• ");
             }
 
             callback({
@@ -1433,8 +1467,7 @@ export function setupSocketHandlers(
         let workspaceConfig: WorkspaceConfigResponse | null = null;
         if (projectFullName) {
           try {
-            const { getApiWorkspaceConfigs } =
-              await getWwwOpenApiModule();
+            const { getApiWorkspaceConfigs } = await getWwwOpenApiModule();
             const response = await getApiWorkspaceConfigs({
               client: getWwwClient(),
               query: {
@@ -1449,7 +1482,7 @@ export function setupSocketHandlers(
               {
                 projectFullName,
                 error,
-              }
+              },
             );
           }
         }
@@ -1476,7 +1509,7 @@ export function setupSocketHandlers(
                 repoUrl,
                 branch,
                 linkedFromCloudTaskRunId,
-              }
+              },
             );
             taskId = reservation.taskId;
             taskRunId = reservation.taskRunId;
@@ -1501,26 +1534,32 @@ export function setupSocketHandlers(
           // Use Codex-style worktree path: ~/.cmux/worktrees/{shortId}/{repoName}/
           // This integrates with VSCode's Source Control view
           const effectiveRepoUrl =
-            repoUrl ?? (projectFullName ? `https://github.com/${projectFullName}.git` : "");
+            repoUrl ??
+            (projectFullName
+              ? `https://github.com/${projectFullName}.git`
+              : "");
 
           // Look up custom source repo mapping from settings (P1 fix)
           let mappedLocalRepoPath: string | undefined;
           if (projectFullName) {
             try {
-              const mapping = await convex.query(api.sourceRepoMappings.getByProject, {
-                teamSlugOrId,
-                projectFullName,
-              });
+              const mapping = await convex.query(
+                api.sourceRepoMappings.getByProject,
+                {
+                  teamSlugOrId,
+                  projectFullName,
+                },
+              );
               if (mapping?.localRepoPath) {
                 mappedLocalRepoPath = mapping.localRepoPath;
                 serverLogger.info(
-                  `[create-local-workspace] Using mapped local repo path: ${mappedLocalRepoPath}`
+                  `[create-local-workspace] Using mapped local repo path: ${mappedLocalRepoPath}`,
                 );
               }
             } catch (mappingError) {
               serverLogger.warn(
                 "[create-local-workspace] Failed to lookup source repo mapping:",
-                mappingError
+                mappingError,
               );
             }
           }
@@ -1532,7 +1571,7 @@ export function setupSocketHandlers(
               localRepoPath: mappedLocalRepoPath,
               projectFullName: projectFullName ?? undefined,
             },
-            teamSlugOrId
+            teamSlugOrId,
           );
 
           const resolvedWorkspacePath = worktreeInfo.worktreePath;
@@ -1570,7 +1609,7 @@ export function setupSocketHandlers(
                   {
                     projectFullName,
                     error,
-                  }
+                  },
                 );
                 parsedEnvVars = {};
               }
@@ -1582,7 +1621,7 @@ export function setupSocketHandlers(
                   mode: 0o600,
                 });
                 serverLogger.info(
-                  `[create-local-workspace] Wrote env vars to ${envFile}`
+                  `[create-local-workspace] Wrote env vars to ${envFile}`,
                 );
 
                 // Add .env to .git/info/exclude so it doesn't show in git status
@@ -1592,7 +1631,7 @@ export function setupSocketHandlers(
                     resolvedWorkspacePath,
                     ".git",
                     "info",
-                    "exclude"
+                    "exclude",
                   );
                   // For worktrees, .git is a file pointing to the main repo's .git dir
                   // Check if .git is a file (worktree) or directory (regular repo)
@@ -1605,7 +1644,11 @@ export function setupSocketHandlers(
                     const gitContent = await fs.readFile(gitPath, "utf8");
                     const gitdirMatch = gitContent.match(/^gitdir:\s*(.+)$/m);
                     if (gitdirMatch) {
-                      excludePath = path.join(gitdirMatch[1].trim(), "info", "exclude");
+                      excludePath = path.join(
+                        gitdirMatch[1].trim(),
+                        "info",
+                        "exclude",
+                      );
                     } else {
                       excludePath = gitExcludeFile;
                     }
@@ -1614,14 +1657,19 @@ export function setupSocketHandlers(
                   }
 
                   // Ensure info directory exists
-                  await fs.mkdir(path.dirname(excludePath), { recursive: true });
+                  await fs.mkdir(path.dirname(excludePath), {
+                    recursive: true,
+                  });
 
                   // Read existing exclude file or create empty
                   let existingExclude = "";
                   try {
                     existingExclude = await fs.readFile(excludePath, "utf8");
                   } catch (e) {
-                    serverLogger.debug(`Git exclude file doesn't exist at ${excludePath}:`, e);
+                    serverLogger.debug(
+                      `Git exclude file doesn't exist at ${excludePath}:`,
+                      e,
+                    );
                   }
 
                   // Add .env if not already excluded
@@ -1629,13 +1677,13 @@ export function setupSocketHandlers(
                     const newExclude = existingExclude.trimEnd() + "\n.env\n";
                     await fs.writeFile(excludePath, newExclude, "utf8");
                     serverLogger.info(
-                      `[create-local-workspace] Added .env to git exclude: ${excludePath}`
+                      `[create-local-workspace] Added .env to git exclude: ${excludePath}`,
                     );
                   }
                 } catch (excludeError) {
                   serverLogger.warn(
                     "[create-local-workspace] Failed to add .env to git exclude",
-                    { error: excludeError }
+                    { error: excludeError },
                   );
                 }
               } catch (error) {
@@ -1644,7 +1692,7 @@ export function setupSocketHandlers(
                   {
                     projectFullName,
                     error,
-                  }
+                  },
                 );
               }
             }
@@ -1654,7 +1702,7 @@ export function setupSocketHandlers(
 
           // Run maintenance script asynchronously in background (doesn't block VSCode loading)
           const runMaintenanceScriptAsync = (
-            parsedEnvVars: Record<string, string>
+            parsedEnvVars: Record<string, string>,
           ) => {
             if (!workspaceConfig || !taskRunId) {
               return;
@@ -1673,11 +1721,11 @@ export function setupSocketHandlers(
               const loginShell = getUserLoginShell();
               const shellArgs = buildLoginShellArgs(
                 loginShell,
-                maintenancePayload
+                maintenancePayload,
               );
 
               serverLogger.info(
-                `[create-local-workspace] Running local maintenance script for ${workspaceName} in background (shell: ${loginShell})`
+                `[create-local-workspace] Running local maintenance script for ${workspaceName} in background (shell: ${loginShell})`,
               );
 
               try {
@@ -1696,16 +1744,13 @@ export function setupSocketHandlers(
                   devError: undefined,
                 });
                 serverLogger.info(
-                  `[create-local-workspace] Maintenance script completed successfully for ${workspaceName}`
+                  `[create-local-workspace] Maintenance script completed successfully for ${workspaceName}`,
                 );
               } catch (error) {
                 const execErr = isExecError(error) ? error : null;
                 const stderr = execErr?.stderr?.trim() ?? "";
                 const stdout = execErr?.stdout?.trim() ?? "";
-                const baseMessage =
-                  stderr ||
-                  stdout ||
-                  (getErrorMessage(error));
+                const baseMessage = stderr || stdout || getErrorMessage(error);
 
                 const maintenanceErrorMessage = baseMessage
                   ? `Maintenance script failed: ${baseMessage}`
@@ -1713,7 +1758,7 @@ export function setupSocketHandlers(
 
                 serverLogger.error(
                   `[create-local-workspace] ${maintenanceErrorMessage}`,
-                  error
+                  error,
                 );
 
                 await convex.mutation(api.taskRuns.updateEnvironmentError, {
@@ -1727,7 +1772,7 @@ export function setupSocketHandlers(
           };
 
           const normalizeBranchName = (
-            value?: string | null
+            value?: string | null,
           ): string | null => {
             if (!value) {
               return null;
@@ -1740,10 +1785,7 @@ export function setupSocketHandlers(
               .replace(/^refs\/heads\//, "")
               .replace(/^refs\/remotes\/origin\//, "")
               .replace(/^origin\//, "");
-            const sanitized = withoutPrefix.replace(
-              /[^a-zA-Z0-9._/-]/g,
-              "-"
-            );
+            const sanitized = withoutPrefix.replace(/[^a-zA-Z0-9._/-]/g, "-");
             return sanitized || null;
           };
 
@@ -1755,14 +1797,14 @@ export function setupSocketHandlers(
                 { cwd },
                 (error) => {
                   resolve(!error);
-                }
+                },
               );
             });
 
           const ensureBaseBranchRefs = async (
             repoPath: string,
             baseBranchName: string,
-            headBranchName?: string | null
+            headBranchName?: string | null,
           ) => {
             if (headBranchName && baseBranchName === headBranchName) {
               return;
@@ -1776,12 +1818,12 @@ export function setupSocketHandlers(
                 await execFileAsync(
                   "git",
                   ["fetch", "origin", `${baseBranchName}:${remoteRef}`],
-                  { cwd: repoPath }
+                  { cwd: repoPath },
                 );
               } catch (error) {
                 serverLogger.warn(
                   `[create-local-workspace] Failed to fetch base branch ${baseBranchName}`,
-                  error
+                  error,
                 );
               }
             }
@@ -1794,12 +1836,12 @@ export function setupSocketHandlers(
                   await execFileAsync(
                     "git",
                     ["branch", baseBranchName, `origin/${baseBranchName}`],
-                    { cwd: repoPath }
+                    { cwd: repoPath },
                   );
                 } catch (error) {
                   serverLogger.warn(
                     `[create-local-workspace] Failed to create local base branch ${baseBranchName}`,
-                    error
+                    error,
                   );
                 }
               }
@@ -1827,7 +1869,7 @@ export function setupSocketHandlers(
           } catch (error) {
             serverLogger.warn(
               `Unable to update worktree path for task ${taskId}:`,
-              error
+              error,
             );
           }
 
@@ -1861,19 +1903,22 @@ export function setupSocketHandlers(
           responded = true;
 
           // Codex-style: Create worktree from existing local repo
-          if (worktreeInfo.mode === "codex-style" && worktreeInfo.sourceRepoPath) {
+          if (
+            worktreeInfo.mode === "codex-style" &&
+            worktreeInfo.sourceRepoPath
+          ) {
             const repoMgr = RepositoryManager.getInstance();
             const sourceRepo = worktreeInfo.sourceRepoPath;
 
             // Fetch latest from origin
             try {
               serverLogger.info(
-                `[create-local-workspace] Fetching latest from origin in ${sourceRepo}`
+                `[create-local-workspace] Fetching latest from origin in ${sourceRepo}`,
               );
               await repoMgr.fetchLatest(sourceRepo, branch);
             } catch (fetchErr) {
               serverLogger.warn(
-                `[create-local-workspace] Failed to fetch latest: ${fetchErr}`
+                `[create-local-workspace] Failed to fetch latest: ${fetchErr}`,
               );
             }
 
@@ -1885,7 +1930,7 @@ export function setupSocketHandlers(
 
             // Create worktree from local repo
             serverLogger.info(
-              `[create-local-workspace] Creating worktree at ${resolvedWorkspacePath} from ${sourceRepo} on branch ${worktreeBranch}`
+              `[create-local-workspace] Creating worktree at ${resolvedWorkspacePath} from ${sourceRepo} on branch ${worktreeBranch}`,
             );
 
             try {
@@ -1896,11 +1941,14 @@ export function setupSocketHandlers(
                 await execFileAsync(
                   "git",
                   ["rev-parse", "--verify", worktreeBranch],
-                  { cwd: sourceRepo }
+                  { cwd: sourceRepo },
                 );
                 branchExists = true;
               } catch (e) {
-                serverLogger.debug(`Branch ${worktreeBranch} doesn't exist locally:`, e);
+                serverLogger.debug(
+                  `Branch ${worktreeBranch} doesn't exist locally:`,
+                  e,
+                );
               }
 
               if (branchExists) {
@@ -1908,36 +1956,49 @@ export function setupSocketHandlers(
                 await execFileAsync(
                   "git",
                   ["worktree", "add", resolvedWorkspacePath, worktreeBranch],
-                  { cwd: sourceRepo }
+                  { cwd: sourceRepo },
                 );
                 serverLogger.info(
-                  `[create-local-workspace] Created worktree using existing branch ${worktreeBranch}`
+                  `[create-local-workspace] Created worktree using existing branch ${worktreeBranch}`,
                 );
               } else {
                 // Branch doesn't exist locally, create it tracking the remote
                 await execFileAsync(
                   "git",
-                  ["worktree", "add", "-b", worktreeBranch, resolvedWorkspacePath, `origin/${worktreeBranch}`],
-                  { cwd: sourceRepo }
+                  [
+                    "worktree",
+                    "add",
+                    "-b",
+                    worktreeBranch,
+                    resolvedWorkspacePath,
+                    `origin/${worktreeBranch}`,
+                  ],
+                  { cwd: sourceRepo },
                 );
                 serverLogger.info(
-                  `[create-local-workspace] Created worktree with new branch ${worktreeBranch} tracking origin/${worktreeBranch}`
+                  `[create-local-workspace] Created worktree with new branch ${worktreeBranch} tracking origin/${worktreeBranch}`,
                 );
               }
             } catch (error) {
               // If that fails, try detached HEAD as fallback
               const execErr = isExecError(error) ? error : null;
               serverLogger.warn(
-                `[create-local-workspace] Failed to create worktree with branch, trying detached: ${execErr?.stderr || error}`
+                `[create-local-workspace] Failed to create worktree with branch, trying detached: ${execErr?.stderr || error}`,
               );
               try {
                 await execFileAsync(
                   "git",
-                  ["worktree", "add", "--detach", resolvedWorkspacePath, `origin/${worktreeBranch}`],
-                  { cwd: sourceRepo }
+                  [
+                    "worktree",
+                    "add",
+                    "--detach",
+                    resolvedWorkspacePath,
+                    `origin/${worktreeBranch}`,
+                  ],
+                  { cwd: sourceRepo },
                 );
                 serverLogger.info(
-                  `[create-local-workspace] Created worktree in detached HEAD state at origin/${worktreeBranch}`
+                  `[create-local-workspace] Created worktree in detached HEAD state at origin/${worktreeBranch}`,
                 );
               } catch (detachErr) {
                 if (cleanupWorkspace) {
@@ -1945,24 +2006,22 @@ export function setupSocketHandlers(
                 }
                 const detachExecErr = isExecError(detachErr) ? detachErr : null;
                 throw new Error(
-                  `Failed to create worktree: ${detachExecErr?.stderr || detachErr}`
+                  `Failed to create worktree: ${detachExecErr?.stderr || detachErr}`,
                 );
               }
             }
 
             // Verify worktree was created
             try {
-              await execFileAsync(
-                "git",
-                ["rev-parse", "--verify", "HEAD"],
-                { cwd: resolvedWorkspacePath }
-              );
+              await execFileAsync("git", ["rev-parse", "--verify", "HEAD"], {
+                cwd: resolvedWorkspacePath,
+              });
             } catch (verifyErr) {
               if (cleanupWorkspace) {
                 await cleanupWorkspace();
               }
               throw new Error(
-                `Worktree creation failed: ${verifyErr instanceof Error ? verifyErr.message : "Unknown error"}`
+                `Worktree creation failed: ${verifyErr instanceof Error ? verifyErr.message : "Unknown error"}`,
               );
             }
           } else if (repoUrl) {
@@ -1986,18 +2045,14 @@ export function setupSocketHandlers(
                 execErr?.stderr?.trim() ||
                 (error instanceof Error ? error.message : "Git clone failed");
               throw new Error(
-                message ? `Git clone failed: ${message}` : "Git clone failed"
+                message ? `Git clone failed: ${message}` : "Git clone failed",
               );
             }
 
             try {
-              await execFileAsync(
-                "git",
-                ["rev-parse", "--verify", "HEAD"],
-                {
-                  cwd: resolvedWorkspacePath,
-                }
-              );
+              await execFileAsync("git", ["rev-parse", "--verify", "HEAD"], {
+                cwd: resolvedWorkspacePath,
+              });
             } catch (error) {
               if (cleanupWorkspace) {
                 await cleanupWorkspace();
@@ -2005,7 +2060,7 @@ export function setupSocketHandlers(
               throw new Error(
                 error instanceof Error
                   ? `Git clone failed to produce a checkout: ${error.message}`
-                  : "Git clone failed to produce a checkout"
+                  : "Git clone failed to produce a checkout",
               );
             }
 
@@ -2015,12 +2070,12 @@ export function setupSocketHandlers(
               try {
                 const repoMgr = RepositoryManager.getInstance();
                 baseBranchName = await repoMgr.getDefaultBranch(
-                  resolvedWorkspacePath
+                  resolvedWorkspacePath,
                 );
               } catch (error) {
                 serverLogger.warn(
                   "[create-local-workspace] Failed to detect default base branch",
-                  error
+                  error,
                 );
               }
             }
@@ -2028,7 +2083,7 @@ export function setupSocketHandlers(
               await ensureBaseBranchRefs(
                 resolvedWorkspacePath,
                 baseBranchName,
-                normalizedHeadBranch
+                normalizedHeadBranch,
               );
             }
           } else {
@@ -2042,7 +2097,7 @@ export function setupSocketHandlers(
                 (error as NodeJS.ErrnoException).code === "EEXIST"
               ) {
                 throw new Error(
-                  `Workspace directory already exists: ${workspacePath}`
+                  `Workspace directory already exists: ${workspacePath}`,
                 );
               }
               throw error;
@@ -2066,7 +2121,11 @@ export function setupSocketHandlers(
             await convex.mutation(api.worktreeRegistry.register, {
               teamSlugOrId,
               worktreePath: resolvedWorkspacePath,
-              sourceRepoPath: worktreeInfo.sourceRepoPath || repoUrl || projectFullName || "local",
+              sourceRepoPath:
+                worktreeInfo.sourceRepoPath ||
+                repoUrl ||
+                projectFullName ||
+                "local",
               projectFullName: projectFullName || "local",
               branchName: branch || "main",
               shortId: worktreeInfo.shortId || workspaceName || "local",
@@ -2074,12 +2133,12 @@ export function setupSocketHandlers(
               taskRunId,
             });
             serverLogger.info(
-              `[create-local-workspace] Registered worktree in registry: ${resolvedWorkspacePath}`
+              `[create-local-workspace] Registered worktree in registry: ${resolvedWorkspacePath}`,
             );
           } catch (regError) {
             serverLogger.warn(
               `[create-local-workspace] Failed to register worktree in registry:`,
-              regError
+              regError,
             );
           }
 
@@ -2106,12 +2165,12 @@ export function setupSocketHandlers(
                   workspacePath: resolvedWorkspacePath,
                   filePath: changedPath,
                 });
-              }
+              },
             );
           } catch (error) {
             serverLogger.warn(
               "Could not set up file watching for workspace:",
-              error
+              error,
             );
           }
 
@@ -2120,7 +2179,9 @@ export function setupSocketHandlers(
             // we need to first download all existing cloud changes before
             // starting the local-to-cloud sync. Otherwise, the local-to-cloud
             // sync would overwrite the cloud changes with the fresh git clone.
-            const cloudInstance = VSCodeInstance.getInstance(linkedFromCloudTaskRunId);
+            const cloudInstance = VSCodeInstance.getInstance(
+              linkedFromCloudTaskRunId,
+            );
             if (cloudInstance && cloudInstance.isWorkerConnected()) {
               try {
                 const workerSocket = cloudInstance.getWorkerSocket();
@@ -2139,16 +2200,16 @@ export function setupSocketHandlers(
                     { taskRunId: linkedFromCloudTaskRunId },
                     (result: { filesSent: number }) => {
                       serverLogger.info(
-                        `[create-local-workspace] Full cloud sync completed: ${result.filesSent} files received from cloud`
+                        `[create-local-workspace] Full cloud sync completed: ${result.filesSent} files received from cloud`,
                       );
                       resolve();
-                    }
+                    },
                   );
 
                   // Timeout after 30 seconds in case of issues
                   setTimeout(() => {
                     serverLogger.warn(
-                      "[create-local-workspace] Full cloud sync timed out after 30s"
+                      "[create-local-workspace] Full cloud sync timed out after 30s",
                     );
                     resolve();
                   }, 30000);
@@ -2156,12 +2217,12 @@ export function setupSocketHandlers(
               } catch (error) {
                 serverLogger.warn(
                   "[create-local-workspace] Failed to perform initial cloud sync, starting local-to-cloud sync anyway",
-                  error
+                  error,
                 );
               }
             } else {
               serverLogger.info(
-                "[create-local-workspace] Cloud worker not connected, skipping initial cloud download"
+                "[create-local-workspace] Cloud worker not connected, skipping initial cloud download",
               );
             }
 
@@ -2193,7 +2254,7 @@ export function setupSocketHandlers(
             } catch (failError) {
               serverLogger.error(
                 "Failed to mark task run as failed:",
-                failError
+                failError,
               );
             }
             try {
@@ -2206,7 +2267,7 @@ export function setupSocketHandlers(
             } catch (statusError) {
               serverLogger.warn(
                 "Failed to update VS Code status after failure:",
-                statusError
+                statusError,
               );
             }
           }
@@ -2217,25 +2278,25 @@ export function setupSocketHandlers(
             } catch (cleanupError) {
               serverLogger.warn(
                 "Failed to clean up workspace after error:",
-                cleanupError
+                cleanupError,
               );
             }
           }
         }
-      }
+      },
     );
 
     socket.on(
       "create-cloud-workspace",
       async (
         rawData,
-        callback: (response: CreateCloudWorkspaceResponse) => void
+        callback: (response: CreateCloudWorkspaceResponse) => void,
       ) => {
         const parsed = CreateCloudWorkspaceSchema.safeParse(rawData);
         if (!parsed.success) {
           serverLogger.error(
             "Invalid create-cloud-workspace payload:",
-            parsed.error
+            parsed.error,
           );
           callback({
             success: false,
@@ -2254,6 +2315,15 @@ export function setupSocketHandlers(
           mirrorLocal,
         } = parsed.data;
         const teamSlugOrId = requestedTeamSlugOrId || safeTeam;
+
+        if (mirrorLocal && !hostServices?.mirrorLocal) {
+          callback({
+            success: false,
+            error:
+              "Mirror local requires the Electron desktop app with a trusted host configuration service.",
+          });
+          return;
+        }
 
         const convex = getConvex();
         const taskId: Id<"tasks"> | undefined = providedTaskId;
@@ -2278,11 +2348,12 @@ export function setupSocketHandlers(
               isOrchestrationHead: true,
             }),
           );
-          taskRunId = taskRunResult.taskRunId;
+          const activeTaskRunId = taskRunResult.taskRunId;
+          taskRunId = activeTaskRunId;
           const taskRunJwt = taskRunResult.jwt;
 
           serverLogger.info(
-            `[create-cloud-workspace] Created taskRun ${taskRunId} for task ${taskId}`
+            `[create-cloud-workspace] Created taskRun ${taskRunId} for task ${taskId}`,
           );
 
           // Update initial VSCode status
@@ -2290,8 +2361,11 @@ export function setupSocketHandlers(
             teamSlugOrId,
             id: taskRunId,
             vscode: {
-              provider: "morph",
+              provider: mirrorLocal ? "pve-lxc" : "morph",
               status: "starting",
+              statusMessage: mirrorLocal
+                ? MIRROR_LOCAL_STATUS_MESSAGES.packing
+                : undefined,
               startedAt: now,
             },
           });
@@ -2310,49 +2384,128 @@ export function setupSocketHandlers(
           });
           responded = true;
 
-          // Spawn Morph instance via www API
           const {
             postApiSandboxesStart,
             postApiSandboxesByIdPublishDevcontainer,
+            postApiPveLxcInstancesByInstanceIdExec,
           } = await getWwwOpenApiModule();
+          const wwwClient = getWwwClient();
 
           serverLogger.info(
             environmentId
-              ? `[create-cloud-workspace] Starting Morph sandbox for environment ${environmentId}`
-              : `[create-cloud-workspace] Starting Morph sandbox for repo ${projectFullName}`,
+              ? `[create-cloud-workspace] Starting sandbox for environment ${environmentId}`
+              : `[create-cloud-workspace] Starting sandbox for repo ${projectFullName}`,
             { clean: Boolean(clean), mirrorLocal: Boolean(mirrorLocal) },
           );
 
-          const { buildSandboxesStartModeFields } = await import("@cmux/shared");
+          const { buildSandboxesStartModeFields } =
+            await import("@cmux/shared");
           const modeFields = buildSandboxesStartModeFields({
             clean,
             mirrorLocal,
           });
 
-          const startRes = await postApiSandboxesStart({
-            client: getWwwClient(),
-            body: {
-              teamSlugOrId,
-              ttlSeconds: 60 * 60,
-              metadata: {
-                instance: `cmux-workspace-${taskRunId}`,
-                agentName: "cloud-workspace",
+          const startSandbox = async () => {
+            const startRes = await postApiSandboxesStart({
+              client: wwwClient,
+              body: {
+                teamSlugOrId,
+                ttlSeconds: 60 * 60,
+                metadata: {
+                  instance: `cmux-workspace-${activeTaskRunId}`,
+                  agentName: "cloud-workspace",
+                },
+                taskRunId: activeTaskRunId,
+                taskRunJwt,
+                isCloudWorkspace: true,
+                isOrchestrationHead: true,
+                ...modeFields,
+                ...(environmentId
+                  ? { environmentId }
+                  : { projectFullName, repoUrl }),
               },
-              taskRunId,
-              taskRunJwt,
-              isCloudWorkspace: true,
-              isOrchestrationHead: true,
-              ...modeFields,
-              ...(environmentId
-                ? { environmentId }
-                : { projectFullName, repoUrl }),
-            },
-          });
+            });
 
-          const data = startRes.data;
-          if (!data) {
-            const errorMessage = extractSandboxStartError(startRes);
-            throw new Error(errorMessage);
+            if (!startRes.data) {
+              const errorMessage = extractSandboxStartError(startRes);
+              throw new Error(errorMessage);
+            }
+            return startRes.data;
+          };
+
+          let mirrorProgressPersistence = Promise.resolve();
+          const reportMirrorProgress = (
+            progress: Omit<MirrorLocalProgress, "taskRunId">,
+          ) => {
+            const event: MirrorLocalProgress = {
+              taskRunId: activeTaskRunId,
+              ...progress,
+            };
+            socket.emit("mirror-local-progress", event);
+            mirrorProgressPersistence = mirrorProgressPersistence
+              .then(async () => {
+                await convex.mutation(api.taskRuns.updateVSCodeStatusMessage, {
+                  teamSlugOrId,
+                  id: activeTaskRunId,
+                  statusMessage: progress.message,
+                });
+              })
+              .catch((error) => {
+                serverLogger.warn(
+                  `[create-cloud-workspace] Failed to persist Mirror local progress for ${activeTaskRunId}`,
+                  error,
+                );
+              });
+          };
+
+          let data: Awaited<ReturnType<typeof startSandbox>>;
+          let mirrorStatusMessage: string | undefined;
+          if (mirrorLocal) {
+            const mirrorResult = await runMirrorLocalStartup({
+              hostService: hostServices?.mirrorLocal,
+              startSandbox,
+              applyPack: async ({ instanceId, pack, onProgress }) => {
+                await applyMirrorLocalPackToPve({
+                  instanceId,
+                  teamSlugOrId,
+                  pack,
+                  onProgress,
+                  exec: async ({ command }) => {
+                    const execRes =
+                      await postApiPveLxcInstancesByInstanceIdExec({
+                        client: wwwClient,
+                        path: { instanceId },
+                        body: { teamSlugOrId, command, timeoutSeconds: 120 },
+                      });
+                    if (!execRes.data) {
+                      throw new Error(
+                        getErrorMessage(
+                          execRes.error,
+                          "PVE LXC command execution failed",
+                        ),
+                      );
+                    }
+                    return {
+                      stdout: execRes.data.stdout,
+                      stderr: execRes.data.stderr,
+                      exitCode: execRes.data.exit_code,
+                    };
+                  },
+                });
+              },
+              onProgress: reportMirrorProgress,
+              onError: (phase, error) => {
+                serverLogger.error(
+                  `[create-cloud-workspace] Mirror local ${phase} failed for ${activeTaskRunId}`,
+                  error,
+                );
+              },
+            });
+            data = mirrorResult;
+            mirrorStatusMessage = mirrorResult.message;
+            await mirrorProgressPersistence;
+          } else {
+            data = await startSandbox();
           }
 
           const sandboxId = data.instanceId;
@@ -2363,13 +2516,13 @@ export function setupSocketHandlers(
           const workspaceUrl = `${vscodeBaseUrl}?folder=/root/workspace`;
 
           serverLogger.info(
-            `[create-cloud-workspace] Sandbox started: ${sandboxId}, VSCode URL: ${workspaceUrl}`
+            `[create-cloud-workspace] Sandbox started: ${sandboxId}, VSCode URL: ${workspaceUrl}`,
           );
 
           // For cloud workspaces, update VSCode instance immediately with the URL
           // No need to wait for VSCode readiness - the frontend will handle loading states
           serverLogger.info(
-            `[create-cloud-workspace] Updating VSCode instance with URL (no readiness check)`
+            `[create-cloud-workspace] Updating VSCode instance with URL (no readiness check)`,
           );
 
           // Update taskRun with actual VSCode info immediately
@@ -2384,6 +2537,7 @@ export function setupSocketHandlers(
               workspaceUrl,
               vncUrl,
               xtermUrl,
+              statusMessage: mirrorStatusMessage,
               startedAt: now,
             },
           });
@@ -2402,17 +2556,17 @@ export function setupSocketHandlers(
 
           try {
             await postApiSandboxesByIdPublishDevcontainer({
-              client: getWwwClient(),
+              client: wwwClient,
               path: { id: sandboxId },
               body: { teamSlugOrId, taskRunId },
             });
             serverLogger.info(
-              `[create-cloud-workspace] Published forwarded ports for taskRun ${taskRunId}`
+              `[create-cloud-workspace] Published forwarded ports for taskRun ${taskRunId}`,
             );
           } catch (publishError) {
             serverLogger.warn(
               `[create-cloud-workspace] Failed to publish forwarded ports for taskRun ${taskRunId} (non-fatal)`,
-              publishError
+              publishError,
             );
           }
 
@@ -2429,7 +2583,7 @@ export function setupSocketHandlers(
           serverLogger.info(
             environmentId
               ? `Cloud workspace created successfully: ${taskId} for environment ${environmentId}`
-              : `Cloud workspace created successfully: ${taskId} for repo ${projectFullName}`
+              : `Cloud workspace created successfully: ${taskId} for repo ${projectFullName}`,
           );
         } catch (error) {
           serverLogger.error("Error creating cloud workspace:", error);
@@ -2453,7 +2607,7 @@ export function setupSocketHandlers(
             } catch (failError) {
               serverLogger.error(
                 "Failed to mark task run as failed:",
-                failError
+                failError,
               );
             }
             try {
@@ -2466,12 +2620,12 @@ export function setupSocketHandlers(
             } catch (statusError) {
               serverLogger.warn(
                 "Failed to update VS Code status after failure:",
-                statusError
+                statusError,
               );
             }
           }
         }
-      }
+      },
     );
 
     // Sync PR state (non-destructive): query GitHub and update Convex
@@ -2525,7 +2679,7 @@ export function setupSocketHandlers(
         const repoFullNames = await collectRepoFullNamesForRun(
           run,
           task,
-          safeTeam
+          safeTeam,
         );
         if (repoFullNames.length === 0) {
           callback({
@@ -2538,8 +2692,8 @@ export function setupSocketHandlers(
 
         const existingByRepo = new Map(
           (run.pullRequests ?? []).map(
-            (record) => [record.repoFullName, record] as const
-          )
+            (record) => [record.repoFullName, record] as const,
+          ),
         );
 
         const results = await Promise.all(
@@ -2573,8 +2727,7 @@ export function setupSocketHandlers(
 
               return toPullRequestActionResult(repoFullName, detail);
             } catch (error) {
-              const message =
-                getErrorMessage(error);
+              const message = getErrorMessage(error);
               return {
                 repoFullName,
                 url: undefined,
@@ -2584,7 +2737,7 @@ export function setupSocketHandlers(
                 error: message,
               } satisfies PullRequestActionResult;
             }
-          })
+          }),
         );
 
         const persisted = await persistPullRequestResults({
@@ -2651,26 +2804,26 @@ export function setupSocketHandlers(
           const updatedRecords: StoredPullRequestInfo[] =
             existingRecords.length > 0
               ? existingRecords.map((record) =>
-                record.repoFullName === repoFullName
-                  ? {
-                    ...record,
+                  record.repoFullName === repoFullName
+                    ? {
+                        ...record,
+                        state: "merged",
+                        isDraft: false,
+                      }
+                    : record,
+                )
+              : [
+                  {
+                    repoFullName,
+                    url:
+                      run.pullRequestUrl && run.pullRequestUrl !== "pending"
+                        ? run.pullRequestUrl
+                        : undefined,
+                    number: run.pullRequestNumber ?? undefined,
                     state: "merged",
                     isDraft: false,
-                  }
-                  : record
-              )
-              : [
-                {
-                  repoFullName,
-                  url:
-                    run.pullRequestUrl && run.pullRequestUrl !== "pending"
-                      ? run.pullRequestUrl
-                      : undefined,
-                  number: run.pullRequestNumber ?? undefined,
-                  state: "merged",
-                  isDraft: false,
-                },
-              ];
+                  },
+                ];
 
           await getConvex().mutation(api.taskRuns.updatePullRequestState, {
             teamSlugOrId: safeTeam,
@@ -2738,14 +2891,22 @@ export function setupSocketHandlers(
           found: number;
           registered: number;
           error?: string;
-        }) => void
+        }) => void,
       ) => {
         // Guard callback in case client didn't provide one
         const safeCallback =
           typeof callback === "function"
             ? callback
-            : (response: { success: boolean; found: number; registered: number; error?: string }) => {
-                serverLogger.info("[scan-worktrees] No callback provided, result:", response);
+            : (response: {
+                success: boolean;
+                found: number;
+                registered: number;
+                error?: string;
+              }) => {
+                serverLogger.info(
+                  "[scan-worktrees] No callback provided, result:",
+                  response,
+                );
               };
 
         const teamSlugOrId = data.teamSlugOrId || safeTeam;
@@ -2770,7 +2931,10 @@ export function setupSocketHandlers(
           try {
             await fs.access(worktreeBasePath);
           } catch (e) {
-            serverLogger.debug(`Worktree base path doesn't exist at ${worktreeBasePath}:`, e);
+            serverLogger.debug(
+              `Worktree base path doesn't exist at ${worktreeBasePath}:`,
+              e,
+            );
             safeCallback({ success: true, found: 0, registered: 0 });
             return;
           }
@@ -2813,7 +2977,11 @@ export function setupSocketHandlers(
               await fs.access(directGitPath);
               // This shortId dir is itself a worktree
               found++;
-              await registerWorktree(shortIdPath, shortIdDir.name, shortIdDir.name);
+              await registerWorktree(
+                shortIdPath,
+                shortIdDir.name,
+                shortIdDir.name,
+              );
               continue;
             } catch (e) {
               serverLogger.debug(`${shortIdPath} is not a direct worktree:`, e);
@@ -2822,7 +2990,9 @@ export function setupSocketHandlers(
             // Read subdirectories (repo name dirs)
             let repoEntries;
             try {
-              repoEntries = await fs.readdir(shortIdPath, { withFileTypes: true });
+              repoEntries = await fs.readdir(shortIdPath, {
+                withFileTypes: true,
+              });
             } catch (e) {
               serverLogger.debug(`Failed to read directory ${shortIdPath}:`, e);
               continue;
@@ -2842,14 +3012,18 @@ export function setupSocketHandlers(
               }
 
               found++;
-              await registerWorktree(worktreePath, shortIdDir.name, repoEntry.name);
+              await registerWorktree(
+                worktreePath,
+                shortIdDir.name,
+                repoEntry.name,
+              );
             }
           }
 
           async function registerWorktree(
             worktreePath: string,
             shortId: string,
-            repoName: string
+            repoName: string,
           ) {
             // Try to get branch name
             let branchName = "unknown";
@@ -2857,11 +3031,14 @@ export function setupSocketHandlers(
               const { stdout } = await execFileAsync(
                 "git",
                 ["branch", "--show-current"],
-                { cwd: worktreePath }
+                { cwd: worktreePath },
               );
               branchName = stdout.trim() || "unknown";
             } catch (e) {
-              serverLogger.debug(`Failed to get branch name for ${worktreePath}:`, e);
+              serverLogger.debug(
+                `Failed to get branch name for ${worktreePath}:`,
+                e,
+              );
             }
 
             // Try to get remote URL for source repo path (sanitized)
@@ -2871,19 +3048,22 @@ export function setupSocketHandlers(
               const { stdout } = await execFileAsync(
                 "git",
                 ["config", "--get", "remote.origin.url"],
-                { cwd: worktreePath }
+                { cwd: worktreePath },
               );
               const rawUrl = stdout.trim();
               sourceRepoPath = sanitizeGitUrl(rawUrl);
               // Extract owner/repo from URL (fixed regex to handle dots in repo names)
               const match = rawUrl.match(
-                /(?:github\.com[:/])([^/]+\/[^/]+?)(?:\.git)?$/
+                /(?:github\.com[:/])([^/]+\/[^/]+?)(?:\.git)?$/,
               );
               if (match) {
                 projectFullName = match[1].replace(/\.git$/, "");
               }
             } catch (e) {
-              serverLogger.debug(`Failed to get remote URL for ${worktreePath}:`, e);
+              serverLogger.debug(
+                `Failed to get remote URL for ${worktreePath}:`,
+                e,
+              );
             }
 
             // Register the worktree
@@ -2899,19 +3079,22 @@ export function setupSocketHandlers(
               });
               registered++;
               serverLogger.info(
-                `[scan-worktrees] Registered existing worktree: ${worktreePath}`
+                `[scan-worktrees] Registered existing worktree: ${worktreePath}`,
               );
             } catch (regError) {
               serverLogger.warn(
                 `[scan-worktrees] Failed to register worktree ${worktreePath}:`,
-                regError
+                regError,
               );
             }
           }
 
           safeCallback({ success: true, found, registered });
         } catch (error) {
-          serverLogger.error("[scan-worktrees] Error scanning worktrees:", error);
+          serverLogger.error(
+            "[scan-worktrees] Error scanning worktrees:",
+            error,
+          );
           safeCallback({
             success: false,
             found: 0,
@@ -2919,7 +3102,7 @@ export function setupSocketHandlers(
             error: getErrorMessage(error),
           });
         }
-      }
+      },
     );
 
     // Delete a worktree from filesystem and registry
@@ -2927,14 +3110,17 @@ export function setupSocketHandlers(
       "delete-worktree",
       async (
         data: { teamSlugOrId: string; worktreePath: string },
-        callback: (response: { success: boolean; error?: string }) => void
+        callback: (response: { success: boolean; error?: string }) => void,
       ) => {
         // Guard callback in case client didn't provide one
         const safeCallback =
           typeof callback === "function"
             ? callback
             : (response: { success: boolean; error?: string }) => {
-                serverLogger.info("[delete-worktree] No callback provided, result:", response);
+                serverLogger.info(
+                  "[delete-worktree] No callback provided, result:",
+                  response,
+                );
               };
 
         const { teamSlugOrId: teamId, worktreePath } = data;
@@ -2960,26 +3146,39 @@ export function setupSocketHandlers(
           if (settings?.codexWorktreePathPattern) {
             // codexWorktreePathPattern is a base path (not a template with placeholders)
             // ShortId and repoName are appended automatically during worktree creation
-            const customPattern = settings.codexWorktreePathPattern.replace(/\/+$/, ""); // Remove trailing slashes
-            const resolvedCustomPath = path.resolve(customPattern.replace(/^~/, homeDir));
-            if (resolvedCustomPath && !allowedPrefixes.includes(resolvedCustomPath)) {
+            const customPattern = settings.codexWorktreePathPattern.replace(
+              /\/+$/,
+              "",
+            ); // Remove trailing slashes
+            const resolvedCustomPath = path.resolve(
+              customPattern.replace(/^~/, homeDir),
+            );
+            if (
+              resolvedCustomPath &&
+              !allowedPrefixes.includes(resolvedCustomPath)
+            ) {
               allowedPrefixes.push(resolvedCustomPath);
             }
           }
         } catch (settingsError) {
-          serverLogger.warn("[delete-worktree] Failed to fetch workspace settings for custom path:", settingsError);
+          serverLogger.warn(
+            "[delete-worktree] Failed to fetch workspace settings for custom path:",
+            settingsError,
+          );
         }
 
         const normalizedPath = path.resolve(worktreePath);
         // P1 fix: Proper path boundary check to prevent overmatch
         // e.g., /home/user/cmuxFoo should NOT match /home/user/cmux prefix
-        const isAllowed = allowedPrefixes.some((prefix) =>
-          normalizedPath === prefix || normalizedPath.startsWith(prefix + path.sep)
+        const isAllowed = allowedPrefixes.some(
+          (prefix) =>
+            normalizedPath === prefix ||
+            normalizedPath.startsWith(prefix + path.sep),
         );
 
         if (!isAllowed) {
           serverLogger.warn(
-            `[delete-worktree] Rejected deletion of path outside allowed directories: ${worktreePath}`
+            `[delete-worktree] Rejected deletion of path outside allowed directories: ${worktreePath}`,
           );
           safeCallback({
             success: false,
@@ -2996,7 +3195,7 @@ export function setupSocketHandlers(
             // Path doesn't exist, just remove from registry
             serverLogger.debug(`[delete-worktree] Path doesn't exist:`, e);
             serverLogger.info(
-              `[delete-worktree] Path doesn't exist, removing from registry only: ${worktreePath}`
+              `[delete-worktree] Path doesn't exist, removing from registry only: ${worktreePath}`,
             );
             await getConvex().mutation(api.worktreeRegistry.remove, {
               teamSlugOrId: resolvedTeamId,
@@ -3015,19 +3214,25 @@ export function setupSocketHandlers(
               const gitdirMatch = gitContent.match(/gitdir:\s*(.+)/);
               if (gitdirMatch) {
                 // This is a proper git worktree, try to remove it via git
-                const parentGitDir = gitdirMatch[1].trim().replace(/\/worktrees\/[^/]+$/, "");
+                const parentGitDir = gitdirMatch[1]
+                  .trim()
+                  .replace(/\/worktrees\/[^/]+$/, "");
                 const parentRepoPath = path.dirname(parentGitDir);
 
                 try {
-                  await execFileAsync("git", ["worktree", "remove", "--force", normalizedPath], {
-                    cwd: parentRepoPath,
-                  });
+                  await execFileAsync(
+                    "git",
+                    ["worktree", "remove", "--force", normalizedPath],
+                    {
+                      cwd: parentRepoPath,
+                    },
+                  );
                   serverLogger.info(
-                    `[delete-worktree] Removed git worktree via git command: ${worktreePath}`
+                    `[delete-worktree] Removed git worktree via git command: ${worktreePath}`,
                   );
                 } catch (gitError) {
                   serverLogger.warn(
-                    `[delete-worktree] git worktree remove failed, falling back to rm: ${gitError}`
+                    `[delete-worktree] git worktree remove failed, falling back to rm: ${gitError}`,
                   );
                   // Fall back to manual deletion
                   await fs.rm(normalizedPath, { recursive: true, force: true });
@@ -3036,26 +3241,36 @@ export function setupSocketHandlers(
             }
           } catch (e) {
             // .git is a directory (regular clone) or doesn't exist, just delete the folder
-            serverLogger.debug(`[delete-worktree] .git is not a file, deleting folder directly:`, e);
+            serverLogger.debug(
+              `[delete-worktree] .git is not a file, deleting folder directly:`,
+              e,
+            );
             await fs.rm(normalizedPath, { recursive: true, force: true });
             serverLogger.info(
-              `[delete-worktree] Deleted worktree folder: ${worktreePath}`
+              `[delete-worktree] Deleted worktree folder: ${worktreePath}`,
             );
           }
 
           // Also check if parent shortId directory is now empty and remove it
           const parentDir = path.dirname(normalizedPath);
-          if (allowedPrefixes.some((prefix) => parentDir.startsWith(prefix) && parentDir !== prefix)) {
+          if (
+            allowedPrefixes.some(
+              (prefix) => parentDir.startsWith(prefix) && parentDir !== prefix,
+            )
+          ) {
             try {
               const remaining = await fs.readdir(parentDir);
               if (remaining.length === 0) {
                 await fs.rmdir(parentDir);
                 serverLogger.info(
-                  `[delete-worktree] Removed empty parent directory: ${parentDir}`
+                  `[delete-worktree] Removed empty parent directory: ${parentDir}`,
                 );
               }
             } catch (e) {
-              serverLogger.debug(`[delete-worktree] Failed to clean up parent directory ${parentDir}:`, e);
+              serverLogger.debug(
+                `[delete-worktree] Failed to clean up parent directory ${parentDir}:`,
+                e,
+              );
             }
           }
 
@@ -3065,16 +3280,21 @@ export function setupSocketHandlers(
             worktreePath,
           });
 
-          serverLogger.info(`[delete-worktree] Successfully deleted worktree: ${worktreePath}`);
+          serverLogger.info(
+            `[delete-worktree] Successfully deleted worktree: ${worktreePath}`,
+          );
           safeCallback({ success: true });
         } catch (error) {
-          serverLogger.error("[delete-worktree] Error deleting worktree:", error);
+          serverLogger.error(
+            "[delete-worktree] Error deleting worktree:",
+            error,
+          );
           safeCallback({
             success: false,
             error: getErrorMessage(error),
           });
         }
-      }
+      },
     );
 
     // Validate worktree paths exist on filesystem
@@ -3087,12 +3307,10 @@ export function setupSocketHandlers(
           validPaths: string[];
           invalidPaths: string[];
           error?: string;
-        }) => void
+        }) => void,
       ) => {
         const safeCallback =
-          typeof callback === "function"
-            ? callback
-            : () => {};
+          typeof callback === "function" ? callback : () => {};
 
         const { worktreePaths } = data;
         const validPaths: string[] = [];
@@ -3103,7 +3321,10 @@ export function setupSocketHandlers(
             await fs.access(worktreePath);
             validPaths.push(worktreePath);
           } catch (e) {
-            serverLogger.debug(`[validate-worktrees] Path doesn't exist: ${worktreePath}:`, e);
+            serverLogger.debug(
+              `[validate-worktrees] Path doesn't exist: ${worktreePath}:`,
+              e,
+            );
             invalidPaths.push(worktreePath);
           }
         }
@@ -3113,7 +3334,7 @@ export function setupSocketHandlers(
           validPaths,
           invalidPaths,
         });
-      }
+      },
     );
 
     // Clean up a task's worktreePath if it doesn't exist on filesystem
@@ -3121,12 +3342,10 @@ export function setupSocketHandlers(
       "cleanup-stale-workspace",
       async (
         data: { teamSlugOrId: string; taskId: string },
-        callback: (response: { success: boolean; error?: string }) => void
+        callback: (response: { success: boolean; error?: string }) => void,
       ) => {
         const safeCallback =
-          typeof callback === "function"
-            ? callback
-            : () => {};
+          typeof callback === "function" ? callback : () => {};
 
         const { teamSlugOrId: teamId, taskId } = data;
         const resolvedTeamId = teamId || safeTeam;
@@ -3143,7 +3362,9 @@ export function setupSocketHandlers(
             id: taskId as Id<"tasks">,
             worktreePath: undefined,
           });
-          serverLogger.info(`[cleanup-stale-workspace] Cleared worktreePath for task ${taskId}`);
+          serverLogger.info(
+            `[cleanup-stale-workspace] Cleared worktreePath for task ${taskId}`,
+          );
           safeCallback({ success: true });
         } catch (error) {
           serverLogger.error("[cleanup-stale-workspace] Error:", error);
@@ -3152,13 +3373,16 @@ export function setupSocketHandlers(
             error: getErrorMessage(error),
           });
         }
-      }
+      },
     );
 
     socket.on("open-in-editor", async (data, callback) => {
       // In web mode, opening local editors is not supported
       if (env.NEXT_PUBLIC_WEB_MODE) {
-        callback?.({ success: false, error: "Opening local editors is not available in the web version." });
+        callback?.({
+          success: false,
+          error: "Opening local editors is not available in the web version.",
+        });
         return;
       }
 
@@ -3218,7 +3442,10 @@ export function setupSocketHandlers(
             throw new Error(`Unknown editor: ${editor}`);
         }
 
-        serverLogger.info(`Opening ${filePath} in ${editor} with command:`, command);
+        serverLogger.info(
+          `Opening ${filePath} in ${editor} with command:`,
+          command,
+        );
 
         const childProcess = spawn(command[0], command.slice(1), {
           detached: true,
@@ -3252,8 +3479,7 @@ export function setupSocketHandlers(
         }, 200);
       } catch (error) {
         serverLogger.error("Error opening editor:", error);
-        const errorMessage =
-          getErrorMessage(error);
+        const errorMessage = getErrorMessage(error);
         socket.emit("open-in-editor-error", { error: errorMessage });
         // Send error callback
         if (callback) {
@@ -3291,7 +3517,7 @@ export function setupSocketHandlers(
 
         async function walkDir(
           dir: string,
-          baseDir: string
+          baseDir: string,
         ): Promise<FileInfo[]> {
           const files: FileInfo[] = [];
 
@@ -3305,7 +3531,7 @@ export function setupSocketHandlers(
               const shouldIgnore = ignoredPatterns.some(
                 (ignorePattern) =>
                   minimatch(relativePath, ignorePattern) ||
-                  minimatch(fullPath, ignorePattern)
+                  minimatch(fullPath, ignorePattern),
               );
 
               if (shouldIgnore) continue;
@@ -3353,7 +3579,7 @@ export function setupSocketHandlers(
             targetRepoUrl,
             safeTeam,
             undefined,
-            repoFullName
+            repoFullName,
           );
 
           // Codex-style mode requires an existing local repo
@@ -3362,7 +3588,7 @@ export function setupSocketHandlers(
             const repoDisplayName = repoFullName || targetRepoUrl;
             serverLogger.warn(
               `[create-local-workspace] No local repository found for ${repoDisplayName}. ` +
-                `Please add a source repo mapping in Settings > Worktrees, or clone the repository locally first.`
+                `Please add a source repo mapping in Settings > Worktrees, or clone the repository locally first.`,
             );
             // Emit event to frontend so it can show a notification/toast
             socket.emit("local-repo-not-found", {
@@ -3374,13 +3600,16 @@ export function setupSocketHandlers(
 
           // Codex-style: originPath points to existing local repo, just fetch latest
           serverLogger.info(
-            `[create-local-workspace] Using existing local repo at ${projectPaths.originPath}`
+            `[create-local-workspace] Using existing local repo at ${projectPaths.originPath}`,
           );
           try {
-            await repoManager.fetchLatest(projectPaths.originPath, branchOverride);
+            await repoManager.fetchLatest(
+              projectPaths.originPath,
+              branchOverride,
+            );
           } catch (fetchErr) {
             serverLogger.warn(
-              `[create-local-workspace] Failed to fetch latest: ${fetchErr}`
+              `[create-local-workspace] Failed to fetch latest: ${fetchErr}`,
             );
           }
 
@@ -3401,14 +3630,14 @@ export function setupSocketHandlers(
             serverLogger.error(
               "Origin directory does not exist:",
               worktreeInfo.originPath,
-              e
+              e,
             );
             return [];
           }
 
           let fileList = await walkDir(
             worktreeInfo.originPath,
-            worktreeInfo.originPath
+            worktreeInfo.originPath,
           );
 
           if (pattern) {
@@ -3481,7 +3710,7 @@ export function setupSocketHandlers(
             } catch (error) {
               serverLogger.error(
                 `Failed to list files for environment repo ${repoFullName}:`,
-                error
+                error,
               );
             }
           }
@@ -3535,7 +3764,7 @@ export function setupSocketHandlers(
           execWithEnv("whoami").then((r) => r.stdout),
           execWithEnv("echo $HOME").then((r) => r.stdout),
           execWithEnv('ls -la ~/.config/gh/ || echo "No gh config"').then(
-            (r) => r.stdout
+            (r) => r.stdout,
           ),
         ]);
 
@@ -3587,14 +3816,14 @@ export function setupSocketHandlers(
           runWithAuthToken(initialToken, () =>
             refreshGitHubData({ teamSlugOrId }).catch((error) => {
               serverLogger.error("Background refresh failed:", error);
-            })
+            }),
           );
           return;
         }
 
         // If no repos exist, do a full fetch
         await runWithAuthToken(initialToken, () =>
-          refreshGitHubData({ teamSlugOrId })
+          refreshGitHubData({ teamSlugOrId }),
         );
         const reposByOrg = await getConvex().query(api.github.getReposByOrg, {
           teamSlugOrId,
@@ -3604,8 +3833,7 @@ export function setupSocketHandlers(
         serverLogger.error("Error fetching repos:", error);
         callback({
           success: false,
-          error: `Failed to fetch GitHub repos: ${getErrorMessage(error)
-            }`,
+          error: `Failed to fetch GitHub repos: ${getErrorMessage(error)}`,
         });
       }
     });
@@ -3677,12 +3905,12 @@ Please address the issue mentioned in the comment above.`;
               "codex/gpt-5.1-codex-high",
             ],
           },
-          safeTeam
+          safeTeam,
         );
 
         // Check if at least one agent spawned successfully
         const successfulAgents = agentResults.filter(
-          (result) => result.success
+          (result) => result.success,
         );
 
         if (successfulAgents.length === 0) {
@@ -3726,7 +3954,7 @@ Please address the issue mentioned in the comment above.`;
       }
     });
 
-// Create a draft PR for a crowned run: commits, pushes, then creates a draft PR
+    // Create a draft PR for a crowned run: commits, pushes, then creates a draft PR
     socket.on("github-create-draft-pr", async (data, callback) => {
       try {
         const { taskRunId } = GitHubCreateDraftPrSchema.parse(data);
@@ -3788,7 +4016,7 @@ Please address the issue mentioned in the comment above.`;
         const repoFullNames = await collectRepoFullNamesForRun(
           run,
           task,
-          safeTeam
+          safeTeam,
         );
         if (repoFullNames.length === 0) {
           callback({
@@ -3812,8 +4040,8 @@ Please address the issue mentioned in the comment above.`;
 
         const existingByRepo = new Map(
           (run.pullRequests ?? []).map(
-            (record) => [record.repoFullName, record] as const
-          )
+            (record) => [record.repoFullName, record] as const,
+          ),
         );
 
         const results = await Promise.all(
@@ -3844,7 +4072,7 @@ Please address the issue mentioned in the comment above.`;
                   truncatedTitle,
                   branchName,
                   baseBranch,
-                  body
+                  body,
                 );
                 // Fetch PR detail for additional metadata; fall back to created info if fetch fails
                 detail =
@@ -3852,7 +4080,7 @@ Please address the issue mentioned in the comment above.`;
                     githubToken,
                     owner,
                     repo,
-                    created.number
+                    created.number,
                   ).catch(() => null)) ??
                   ({
                     ...created,
@@ -3862,8 +4090,7 @@ Please address the issue mentioned in the comment above.`;
 
               return toPullRequestActionResult(repoFullName, detail);
             } catch (error) {
-              const message =
-                getErrorMessage(error);
+              const message = getErrorMessage(error);
               return {
                 repoFullName,
                 url: undefined,
@@ -3873,7 +4100,7 @@ Please address the issue mentioned in the comment above.`;
                 error: message,
               } satisfies PullRequestActionResult;
             }
-          })
+          }),
         );
 
         const persisted = await persistPullRequestResults({
@@ -3921,7 +4148,7 @@ Please address the issue mentioned in the comment above.`;
           statusPromise = runWithAuthToken(currentAuthToken, () =>
             env.NEXT_PUBLIC_WEB_MODE
               ? checkAllProvidersStatusWebMode({ teamSlugOrId: safeTeam })
-              : checkAllProvidersStatus({ teamSlugOrId: safeTeam })
+              : checkAllProvidersStatus({ teamSlugOrId: safeTeam }),
           );
           providerStatusInflight.set(safeTeam, statusPromise);
           statusPromise.finally(() => providerStatusInflight.delete(safeTeam));
@@ -3953,9 +4180,8 @@ Please address the issue mentioned in the comment above.`;
       }
 
       try {
-        const { checkDockerStatus } = await import(
-          "@cmux/shared/providers/common/check-docker"
-        );
+        const { checkDockerStatus } =
+          await import("@cmux/shared/providers/common/check-docker");
         const docker = await checkDockerStatus();
 
         if (!docker.isRunning) {
@@ -3992,7 +4218,10 @@ Please address the issue mentioned in the comment above.`;
               callback({ success: true, imageName });
               return;
             } catch (e) {
-              serverLogger.debug(`[docker-pull-image] Image not yet available, retrying:`, e);
+              serverLogger.debug(
+                `[docker-pull-image] Image not yet available, retrying:`,
+                e,
+              );
               await sleep(2_000);
             }
           }
@@ -4026,7 +4255,10 @@ Please address the issue mentioned in the comment above.`;
         let lastStatus = "";
         let lastAggregatePercent = -1;
         let lastAggregateProgress = "";
-        const layerStats = new Map<string, { current: number; total: number }>();
+        const layerStats = new Map<
+          string,
+          { current: number; total: number }
+        >();
 
         // Wait for the pull to complete
         await new Promise<void>((resolve, reject) => {
@@ -4054,7 +4286,7 @@ Please address the issue mentioned in the comment above.`;
                 const previous = layerStats.get(event.id);
                 const current = Math.max(
                   previous?.current ?? 0,
-                  event.progressDetail.current
+                  event.progressDetail.current,
                 );
                 layerStats.set(event.id, {
                   current,
@@ -4083,7 +4315,7 @@ Please address the issue mentioned in the comment above.`;
               const aggregateProgress =
                 aggregateTotal > 0
                   ? `${formatBytes(aggregateCurrent)}/${formatBytes(
-                      aggregateTotal
+                      aggregateTotal,
                     )}`
                   : "";
 
@@ -4114,7 +4346,7 @@ Please address the issue mentioned in the comment above.`;
                   phase: "pulling",
                 });
               }
-            }
+            },
           );
         });
 
@@ -4135,8 +4367,7 @@ Please address the issue mentioned in the comment above.`;
           status: "Pull failed",
           phase: "error",
         });
-        const errorMessage =
-          getErrorMessage(error);
+        const errorMessage = getErrorMessage(error);
 
         // Provide user-friendly error messages
         let userFriendlyError: string;
@@ -4183,7 +4414,7 @@ Please address the issue mentioned in the comment above.`;
         const results = await runWithAuth(
           currentAuthToken,
           currentAuthHeaderJson,
-          async () => stopContainersForRuns(taskId, safeTeam)
+          async () => stopContainersForRuns(taskId, safeTeam),
         );
 
         try {
@@ -4198,13 +4429,13 @@ Please address the issue mentioned in the comment above.`;
               localCloudSyncManager.stopSync(worktreePath);
             }
             serverLogger.info(
-              `Stopped git diff watchers for archived task ${taskId}: ${worktreePaths.join(", ")}`
+              `Stopped git diff watchers for archived task ${taskId}: ${worktreePaths.join(", ")}`,
             );
           }
         } catch (error) {
           serverLogger.error(
             `Failed to clean up git diff watchers for archived task ${taskId}:`,
-            error
+            error,
           );
         }
 
@@ -4214,11 +4445,11 @@ Please address the issue mentioned in the comment above.`;
 
         if (failed > 0) {
           serverLogger.warn(
-            `Archived task ${taskId}: ${successful} containers stopped, ${failed} failed`
+            `Archived task ${taskId}: ${successful} containers stopped, ${failed} failed`,
           );
         } else {
           serverLogger.info(
-            `Successfully archived task ${taskId}: all ${successful} containers stopped`
+            `Successfully archived task ${taskId}: all ${successful} containers stopped`,
           );
         }
 
@@ -4240,7 +4471,7 @@ Please address the issue mentioned in the comment above.`;
         const results = await runWithAuth(
           currentAuthToken,
           currentAuthHeaderJson,
-          async () => resumeContainersForRuns(taskId, safeTeam)
+          async () => resumeContainersForRuns(taskId, safeTeam),
         );
 
         // Log summary
@@ -4249,11 +4480,11 @@ Please address the issue mentioned in the comment above.`;
 
         if (failed > 0) {
           serverLogger.warn(
-            `Unarchived task ${taskId}: ${successful} containers resumed, ${failed} failed`
+            `Unarchived task ${taskId}: ${successful} containers resumed, ${failed} failed`,
           );
         } else {
           serverLogger.info(
-            `Successfully unarchived task ${taskId}: all ${successful} containers resumed`
+            `Successfully unarchived task ${taskId}: all ${successful} containers resumed`,
           );
         }
 
@@ -4270,7 +4501,7 @@ Please address the issue mentioned in the comment above.`;
     socket.on("trigger-local-cloud-sync", async (data, callback) => {
       serverLogger.info(
         `[trigger-local-cloud-sync] RECEIVED event:`,
-        JSON.stringify(data)
+        JSON.stringify(data),
       );
       try {
         const parsed = TriggerLocalCloudSyncSchema.safeParse(data);
@@ -4299,7 +4530,7 @@ Please address the issue mentioned in the comment above.`;
         const normalizedPath = path.resolve(localWorkspacePath);
         if (normalizedPath.includes("/../") || normalizedPath.endsWith("/..")) {
           serverLogger.warn(
-            `[trigger-local-cloud-sync] Path traversal attempt: ${localWorkspacePath}`
+            `[trigger-local-cloud-sync] Path traversal attempt: ${localWorkspacePath}`,
           );
           const response: TriggerLocalCloudSyncResponse = {
             success: false,
@@ -4310,7 +4541,7 @@ Please address the issue mentioned in the comment above.`;
         }
 
         serverLogger.info(
-          `[trigger-local-cloud-sync] Manual sync requested: ${localWorkspacePath} -> ${cloudTaskRunId}`
+          `[trigger-local-cloud-sync] Manual sync requested: ${localWorkspacePath} -> ${cloudTaskRunId}`,
         );
 
         // Check if sync session exists (use original path for lookup)
@@ -4320,7 +4551,7 @@ Please address the issue mentioned in the comment above.`;
         // This handles server restarts where VSCodeInstance is lost but cloud workspace is still running
         const existingInstance = VSCodeInstance.getInstance(cloudTaskRunId);
         serverLogger.debug(
-          `[trigger-local-cloud-sync] Reconnect check: existingInstance=${!!existingInstance}, workerConnected=${existingInstance?.isWorkerConnected() ?? "N/A"}`
+          `[trigger-local-cloud-sync] Reconnect check: existingInstance=${!!existingInstance}, workerConnected=${existingInstance?.isWorkerConnected() ?? "N/A"}`,
         );
         if (!existingInstance || !existingInstance.isWorkerConnected()) {
           // Query task run to get worker URL for reconnection
@@ -4331,7 +4562,7 @@ Please address the issue mentioned in the comment above.`;
 
           if (!taskRun) {
             serverLogger.warn(
-              `[trigger-local-cloud-sync] Task run not found or unauthorized: ${cloudTaskRunId}`
+              `[trigger-local-cloud-sync] Task run not found or unauthorized: ${cloudTaskRunId}`,
             );
             const response: TriggerLocalCloudSyncResponse = {
               success: false,
@@ -4347,14 +4578,10 @@ Please address the issue mentioned in the comment above.`;
 
           // For Morph instances, derive worker URL from VSCode URL if not stored
           // VSCode is on port 39378, worker is on port 39377
-          if (
-            !workerUrl &&
-            vscodeUrl &&
-            taskRun.vscode?.provider === "morph"
-          ) {
+          if (!workerUrl && vscodeUrl && taskRun.vscode?.provider === "morph") {
             workerUrl = vscodeUrl.replace("port-39378", "port-39377");
             serverLogger.info(
-              `[trigger-local-cloud-sync] Derived worker URL from VSCode URL: ${workerUrl}`
+              `[trigger-local-cloud-sync] Derived worker URL from VSCode URL: ${workerUrl}`,
             );
           }
 
@@ -4364,7 +4591,7 @@ Please address the issue mentioned in the comment above.`;
             taskRun.vscode?.provider !== "docker"
           ) {
             serverLogger.info(
-              `[trigger-local-cloud-sync] No VSCodeInstance or worker disconnected, attempting to reconnect to worker at ${workerUrl}`
+              `[trigger-local-cloud-sync] No VSCodeInstance or worker disconnected, attempting to reconnect to worker at ${workerUrl}`,
             );
             try {
               const reconnectedInstance = await CmuxVSCodeInstance.reconnect({
@@ -4377,7 +4604,7 @@ Please address the issue mentioned in the comment above.`;
                 sandboxId: taskRun.vscode?.containerName,
               });
               serverLogger.info(
-                `[trigger-local-cloud-sync] Successfully reconnected to cloud workspace`
+                `[trigger-local-cloud-sync] Successfully reconnected to cloud workspace`,
               );
 
               // Start file watch and cloud sync after reconnecting
@@ -4385,7 +4612,7 @@ Please address the issue mentioned in the comment above.`;
               reconnectedInstance.startFileWatch("/root/workspace");
               reconnectedInstance.startCloudSync();
               serverLogger.info(
-                `[trigger-local-cloud-sync] Started file watch and cloud sync for reconnected instance`
+                `[trigger-local-cloud-sync] Started file watch and cloud sync for reconnected instance`,
               );
 
               // Set up sync-files event handler for cloud-to-local sync
@@ -4394,15 +4621,15 @@ Please address the issue mentioned in the comment above.`;
                 async (data: WorkerSyncFiles) => {
                   serverLogger.info(
                     `[trigger-local-cloud-sync] Sync files received after reconnect:`,
-                    { fileCount: data.files.length, taskRunId: data.taskRunId }
+                    { fileCount: data.files.length, taskRunId: data.taskRunId },
                   );
                   await localCloudSyncManager.handleCloudSync(data);
-                }
+                },
               );
             } catch (reconnectError) {
               serverLogger.warn(
                 `[trigger-local-cloud-sync] Failed to reconnect to worker, will use lazy sync`,
-                reconnectError
+                reconnectError,
               );
               // Continue anyway - lazy sync will handle it when worker becomes available
             }
@@ -4425,9 +4652,12 @@ Please address the issue mentioned in the comment above.`;
             // Directory doesn't exist yet, wait and retry
             if (waited === 0) {
               serverLogger.info(
-                `[trigger-local-cloud-sync] Waiting for directory to exist: ${normalizedPath}`
+                `[trigger-local-cloud-sync] Waiting for directory to exist: ${normalizedPath}`,
               );
-              serverLogger.debug(`[trigger-local-cloud-sync] Initial access error:`, e);
+              serverLogger.debug(
+                `[trigger-local-cloud-sync] Initial access error:`,
+                e,
+              );
             }
             await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
             waited += pollIntervalMs;
@@ -4436,7 +4666,7 @@ Please address the issue mentioned in the comment above.`;
 
         if (!dirExists) {
           serverLogger.warn(
-            `[trigger-local-cloud-sync] Directory still doesn't exist after ${maxWaitMs}ms: ${normalizedPath}`
+            `[trigger-local-cloud-sync] Directory still doesn't exist after ${maxWaitMs}ms: ${normalizedPath}`,
           );
           const response: TriggerLocalCloudSyncResponse = {
             success: false,
@@ -4448,14 +4678,14 @@ Please address the issue mentioned in the comment above.`;
 
         if (waited > 0) {
           serverLogger.info(
-            `[trigger-local-cloud-sync] Directory exists after ${waited}ms: ${normalizedPath}`
+            `[trigger-local-cloud-sync] Directory exists after ${waited}ms: ${normalizedPath}`,
           );
         }
 
         if (!status.found) {
           // Start a new sync session if none exists
           serverLogger.info(
-            `[trigger-local-cloud-sync] No existing session, starting new sync`
+            `[trigger-local-cloud-sync] No existing session, starting new sync`,
           );
           await localCloudSyncManager.startSync({
             localWorkspacePath,

--- a/apps/www/lib/routes/sandboxes-routes/_helpers.ts
+++ b/apps/www/lib/routes/sandboxes-routes/_helpers.ts
@@ -726,6 +726,16 @@ export const StartSandboxBody = z
     isCloudWorkspace: z.boolean().optional(),
     /** Mark as orchestration head agent (can spawn sub-agents, gets full capabilities) */
     isOrchestrationHead: z.boolean().optional(),
+    /**
+     * Clean start: record ownership as usual but skip setup-providers auth injection
+     * (devsh --clean / dashboard Clean mode).
+     */
+    clean: z.boolean().optional(),
+    /**
+     * Mirror local intent. Server cannot pack host ~/.claude; dashboard Electron
+     * handles host pack. When true, treat like clean for setup-providers skip.
+     */
+    mirrorLocal: z.boolean().optional(),
     // Optional hydration parameters to clone a repo into the sandbox on start
     repoUrl: z.string().optional(),
     branch: z.string().optional(),

--- a/apps/www/lib/routes/sandboxes-routes/start.route.ts
+++ b/apps/www/lib/routes/sandboxes-routes/start.route.ts
@@ -65,6 +65,10 @@ import {
   type SandboxInstance,
 } from "./_helpers";
 import { buildSystemSandboxEnvContent } from "./system-sandbox-env";
+import {
+  resolveWorkspaceStartMode,
+  shouldRunSetupProviderAuth,
+} from "@cmux/shared";
 
 export const sandboxesStartRouter = new OpenAPIHono();
 
@@ -174,6 +178,10 @@ sandboxesStartRouter.openapi(
     })();
 
     const body = c.req.valid("json");
+    const startMode = resolveWorkspaceStartMode({
+      clean: body.clean,
+      mirrorLocal: body.mirrorLocal,
+    });
     try {
       console.log("[sandboxes.start] incoming", {
         teamSlugOrId: body.teamSlugOrId,
@@ -182,6 +190,9 @@ sandboxesStartRouter.openapi(
         repoUrl: body.repoUrl,
         branch: body.branch,
         authMethod: isJwtAuth ? "jwt" : "stack-auth",
+        startMode,
+        clean: Boolean(body.clean),
+        mirrorLocal: Boolean(body.mirrorLocal),
       });
     } catch {
       // noop
@@ -699,6 +710,14 @@ sandboxesStartRouter.openapi(
         });
 
       const providerAuthPromise = (async () => {
+        // Clean / mirror-local: skip setup-providers (devsh --clean semantics).
+        // Ownership / team sandbox records continue outside this block.
+        if (!shouldRunSetupProviderAuth(startMode)) {
+          console.log(
+            `[sandboxes.start] Skipping setup-providers (startMode=${startMode})`,
+          );
+          return;
+        }
         try {
           const [previousKnowledge, previousMailbox] = await Promise.all([
             convex

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "dotenv -e ../../.env -- next dev --port 9779",
+    "dev:webpack": "dotenv -e ../../.env -- next dev --port 9779 --webpack",
     "prebuild": "bun run generate-openapi-client",
     "build": "./scripts/build.sh",
     "start": "next start",

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -1,7 +1,7 @@
 # cmux CLI Guide
 
 > **Primary CLI**: `devsh` is the primary operator CLI for cmux.
-> **Last Updated**: 2026-03-24
+> **Last Updated**: 2026-07-22
 
 ## Quick Start
 
@@ -21,6 +21,9 @@ devsh start -p pve-lxc
 # List running sandboxes
 devsh ls
 ```
+
+For **Clean** / **Mirror local** start modes (CLI + team dashboard), see
+[Cloud workspace start modes](./CLOUD_WORKSPACE_START_MODES.md).
 
 ## CLI Surfaces
 
@@ -55,6 +58,11 @@ devsh start -p pve-lxc    # PVE-LXC (fastest, cheapest)
 devsh start -p e2b        # E2B (managed pause/resume)
 devsh start -p morph      # Morph (fallback)
 
+# Start modes (pve-lxc reference; see docs/CLOUD_WORKSPACE_START_MODES.md)
+devsh start -p pve-lxc --clean
+devsh start -p pve-lxc --clean --mirror-local
+devsh start -p pve-lxc --template <name>   # CLI-only templates under ~/.cmux/templates
+
 # List sandboxes
 devsh ls
 devsh list
@@ -71,6 +79,19 @@ devsh resume <id>
 # Execute command in sandbox
 devsh exec <id> "command"
 ```
+
+**Start modes (summary):**
+
+| Flag | Meaning |
+|------|---------|
+| (none) | Default: setup-providers auth injection as today |
+| `--clean` | Skip setup-providers auth injection; ownership still recorded |
+| `--mirror-local` | Clean + pack redacted host `~/.claude` / `~/.codex` (host FS; durable path) |
+
+In the **desktop app team dashboard**, the same Default / Clean / Mirror local
+choices appear as a segmented control above **Create Cloud Workspace**
+(environment still required). Mirror local is Electron-only in the UI.
+Do **not** use preview.new `/preview` for these modes.
 
 ### Task Orchestration
 

--- a/docs/CLOUD_WORKSPACE_START_MODES.md
+++ b/docs/CLOUD_WORKSPACE_START_MODES.md
@@ -1,7 +1,7 @@
 # Cloud workspace start modes
 
-> **Last updated:** 2026-07-22  
-> **Primary UI entry:** Team dashboard (`/$teamSlugOrId/dashboard`)  
+> **Last updated:** 2026-07-22
+> **Primary UI entry:** Team dashboard (`/$teamSlugOrId/dashboard`)
 > **Not the entry:** preview.new `/preview` (PR screenshot product)
 
 Operators can start cloud workspaces in three modes: **Default**, **Clean**, and **Mirror local**. Modes exist on both the **team dashboard** (app) and the **devsh CLI**. Dashboard and CLI share backend semantics where applicable; full host filesystem pack for mirror is CLI/Electron-only.

--- a/docs/CLOUD_WORKSPACE_START_MODES.md
+++ b/docs/CLOUD_WORKSPACE_START_MODES.md
@@ -1,0 +1,77 @@
+# Cloud workspace start modes
+
+> **Last updated:** 2026-07-22  
+> **Primary UI entry:** Team dashboard (`/$teamSlugOrId/dashboard`)  
+> **Not the entry:** preview.new `/preview` (PR screenshot product)
+
+Operators can start cloud workspaces in three modes: **Default**, **Clean**, and **Mirror local**. Modes exist on both the **team dashboard** (app) and the **devsh CLI**. Dashboard and CLI share backend semantics where applicable; full host filesystem pack for mirror is CLI/Electron-only.
+
+## Primary product path (dashboard)
+
+1. Open the **team dashboard** in the desktop app (Electron) or web client.
+2. Select an **environment** (cloud create still requires an environment — not a bare repo).
+3. Choose **Start mode**: Default | Clean | Mirror local.
+4. Click **Create Cloud Workspace**.
+
+| Mode | Behavior |
+|------|----------|
+| **Default** | Existing start: setup-providers auth injection runs as today. |
+| **Clean** | Ownership / team sandbox linkage still recorded; **setup-providers auth injection skipped** (`clean: true` on `POST /api/sandboxes/start`). |
+| **Mirror local** | Implies clean for auth. **Enabled only in Electron.** Packs redacted local agent config (`~/.claude` / `~/.codex` allowlist) via host path when available; otherwise soft-fails with clear toast + CLI guidance. Disabled in pure browser with tooltip. |
+
+### Wiring (implementation)
+
+- UI: `apps/client/src/components/dashboard/WorkspaceCreationButtons.tsx`
+- Socket/HTTP: `create-cloud-workspace` accepts `clean` / `mirrorLocal` (`packages/shared` schema)
+- Server forwards `clean` into sandboxes start; start route skips setup-providers when mode is clean/mirror-local
+- Shared helpers: `@cmux/shared` `workspace-start-mode`
+
+### What is not the entry
+
+- `http://localhost:9779/preview` — **Screenshot previews for GitHub PRs** (preview.new), not team cloud create.
+- Bare `/preview/configure` without `?repo=` — 404 by design.
+
+## CLI path (authoritative for host pack)
+
+```bash
+# Default
+devsh start -p pve-lxc
+
+# Clean: skip provider auth injection; keep ownership
+devsh start -p pve-lxc --clean
+
+# Mirror local: clean + pack redacted host agent config into the box
+devsh start -p pve-lxc --clean --mirror-local
+
+# Templates (CLI-only in v1 — no dashboard picker)
+devsh start -p pve-lxc --template <name>
+# Recipes: ~/.cmux/templates/*.yaml
+```
+
+Prefer **pve-lxc** for mirror-local. Morph/E2B: mirror unsupported; use Clean if applicable or CLI docs for provider limits.
+
+## Limits and known soft-fails
+
+| Topic | Status |
+|-------|--------|
+| Environment required on dashboard cloud create | Yes |
+| Template picker in dashboard | No (CLI only) |
+| Browser pack of `~/.claude` | No (Electron/host only) |
+| Dashboard mirror host pack | Soft-fail + `devsh … --mirror-local` guidance if pack not fully attached to dashboard sandboxes |
+| Secrets / OAuth copy | Off by default (redacted allowlist) |
+| Auto-merge of feature PR | **No** — human approval (`merge_auto_approved: false`) |
+
+## Research notes (2026-07-22)
+
+Supporting research used **grok-search** as the primary web tool:
+
+- Clean LXC workspaces should avoid baking credentials into templates; apply non-secret config after start.
+- Selective agent-config mirror beats full home sync for security and reproducibility.
+- Dashboard vs CLI should document **semantic parity**, with CLI preferred for automation and durable host pack.
+
+Vault: `projects/cmux/requirements/2026-07-22-deep-research-cloud-workspace-start-modes-dashboard.md`
+
+## Related PRs
+
+- Dashboard start modes: PR #1272 (`feat/cloud-workspace-start-modes-dashboard`) — **leave merge for human approval**
+- Preview-surface experiment: PR #1271 — not the dashboard product entry

--- a/packages/pve-lxc-client/src/exec-command-log.test.ts
+++ b/packages/pve-lxc-client/src/exec-command-log.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatExecCommandForLog } from "./exec-command-log";
+
+describe("formatExecCommandForLog", () => {
+  it("redacts Mirror local upload payloads", () => {
+    const command =
+      "printf '%s' 'sensitive-base64-payload' | base64 -d >> '/tmp/cmux-mirror-fixed.tar.gz'";
+
+    expect(formatExecCommandForLog(command)).toBe(
+      "[redacted Mirror local upload chunk]",
+    );
+    expect(formatExecCommandForLog(command)).not.toContain("sensitive-base64");
+  });
+
+  it("preserves the existing command truncation behavior", () => {
+    expect(formatExecCommandForLog("echo ready")).toBe("echo ready");
+    expect(formatExecCommandForLog("x".repeat(101))).toBe(
+      `${"x".repeat(100)}...`,
+    );
+  });
+});

--- a/packages/pve-lxc-client/src/exec-command-log.ts
+++ b/packages/pve-lxc-client/src/exec-command-log.ts
@@ -1,0 +1,12 @@
+const MAX_LOGGED_COMMAND_LENGTH = 100;
+const MIRROR_UPLOAD_COMMAND =
+  /\|\s*base64 -d >> ['"]?\/tmp\/cmux-mirror-[^\s'"]+\.tar\.gz/;
+
+export function formatExecCommandForLog(command: string): string {
+  if (MIRROR_UPLOAD_COMMAND.test(command)) {
+    return "[redacted Mirror local upload chunk]";
+  }
+  return command.length > MAX_LOGGED_COMMAND_LENGTH
+    ? `${command.slice(0, MAX_LOGGED_COMMAND_LENGTH)}...`
+    : command;
+}

--- a/packages/pve-lxc-client/src/index.ts
+++ b/packages/pve-lxc-client/src/index.ts
@@ -8,6 +8,7 @@
 
 import { Agent, fetch as undiciFetch } from "undici";
 import crypto from "node:crypto";
+import { formatExecCommandForLog } from "./exec-command-log";
 
 /**
  * Configuration for PveLxcClient.
@@ -812,10 +813,9 @@ export class PveLxcClient {
         const httpResult = await this.httpExec(host, command, options?.timeoutMs);
 
         if (httpResult) {
-          // Log command execution (truncate long commands for readability)
-          const truncatedCmd = command.length > 100 ? `${command.slice(0, 100)}...` : command;
+          const commandForLog = formatExecCommandForLog(command);
           console.log(
-            `[PveLxcClient] Exec completed (exit=${httpResult.exit_code}): ${truncatedCmd}`
+            `[PveLxcClient] Exec completed (exit=${httpResult.exit_code}): ${commandForLog}`
           );
           if (attempt > 1) {
             console.log(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from "./run-control-types";
 export * from "./local-run-artifacts";
 export * from "./codeReview/callback-schemas";
 export * from "./socket-schemas";
+export * from "./workspace-start-mode";
 export * from "./terminal-config";
 export * from "./verifyTaskRunToken";
 export * from "./utils/normalize-origin";

--- a/packages/shared/src/socket-schemas.test.ts
+++ b/packages/shared/src/socket-schemas.test.ts
@@ -235,6 +235,31 @@ describe("socket-schemas", () => {
       });
       expect(result.success).toBe(false);
     });
+
+    it("accepts clean and mirrorLocal flags for dashboard start modes", () => {
+      const clean = CreateCloudWorkspaceSchema.safeParse({
+        teamSlugOrId: "team-123",
+        environmentId: "k57hmn7abc123def456ghi789",
+        clean: true,
+      });
+      expect(clean.success).toBe(true);
+      if (clean.success) {
+        expect(clean.data.clean).toBe(true);
+        expect(clean.data.mirrorLocal).toBeUndefined();
+      }
+
+      const mirror = CreateCloudWorkspaceSchema.safeParse({
+        teamSlugOrId: "team-123",
+        environmentId: "k57hmn7abc123def456ghi789",
+        clean: true,
+        mirrorLocal: true,
+      });
+      expect(mirror.success).toBe(true);
+      if (mirror.success) {
+        expect(mirror.data.mirrorLocal).toBe(true);
+        expect(mirror.data.clean).toBe(true);
+      }
+    });
   });
 
   describe("AuthenticateSchema", () => {

--- a/packages/shared/src/socket-schemas.test.ts
+++ b/packages/shared/src/socket-schemas.test.ts
@@ -7,6 +7,7 @@ import {
   StartTaskSchema,
   CreateLocalWorkspaceSchema,
   CreateCloudWorkspaceSchema,
+  MirrorLocalProgressSchema,
   AuthenticateSchema,
   TerminalCreatedSchema,
   TerminalOutputSchema,
@@ -259,6 +260,31 @@ describe("socket-schemas", () => {
         expect(mirror.data.mirrorLocal).toBe(true);
         expect(mirror.data.clean).toBe(true);
       }
+    });
+  });
+
+  describe("MirrorLocalProgressSchema", () => {
+    it("accepts sanitized lifecycle metadata", () => {
+      expect(
+        MirrorLocalProgressSchema.parse({
+          taskRunId: "run-123",
+          state: "applied",
+          message: "Mirror local workspace ready",
+          policyVersion: "cmux-mirror-local/v1",
+          fileCount: 12,
+          compressedBytes: 4096,
+        }),
+      ).toMatchObject({ state: "applied", fileCount: 12 });
+    });
+
+    it("rejects unknown lifecycle states", () => {
+      expect(
+        MirrorLocalProgressSchema.safeParse({
+          taskRunId: "run-123",
+          state: "copying-secrets",
+          message: "unsafe",
+        }).success,
+      ).toBe(false);
     });
   });
 
@@ -600,7 +626,10 @@ describe("socket-schemas", () => {
       const result = ProviderStatusSchema.safeParse({
         name: "docker",
         isAvailable: false,
-        missingRequirements: ["Docker is not running", "Docker image not found"],
+        missingRequirements: [
+          "Docker is not running",
+          "Docker image not found",
+        ],
       });
       expect(result.success).toBe(true);
     });

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -1,5 +1,6 @@
 import type { Id } from "@cmux/convex/dataModel";
 import { z } from "zod";
+import { MIRROR_LOCAL_STATES } from "./workspace-start-mode";
 import { typedZid } from "./utils/typed-zid";
 import { RUNTIME_PROVIDERS } from "./provider-types";
 import type {
@@ -52,7 +53,7 @@ export const StartTaskSchema = z.object({
         src: z.string(),
         fileName: z.string().optional(),
         altText: z.string(),
-      })
+      }),
     )
     .optional(),
   theme: z.enum(["dark", "light", "system"]).optional(),
@@ -114,7 +115,7 @@ export const CreateCloudWorkspaceSchema = z
   })
   .refine(
     (value) => Boolean(value.environmentId || value.projectFullName),
-    "Either environmentId or projectFullName is required"
+    "Either environmentId or projectFullName is required",
   );
 
 export const CreateCloudWorkspaceResponseSchema = z.object({
@@ -287,7 +288,7 @@ export const ListFilesRequestSchema = z
   })
   .refine(
     (value) => Boolean(value.repoPath || value.environmentId),
-    "repoPath or environmentId is required"
+    "repoPath or environmentId is required",
   );
 
 export const FileInfoSchema = z.object({
@@ -320,6 +321,15 @@ export const VSCodeSpawnedSchema = z.object({
   provider: z.enum(RUNTIME_PROVIDERS),
 });
 
+export const MirrorLocalProgressSchema = z.object({
+  taskRunId: z.string(),
+  state: z.enum(MIRROR_LOCAL_STATES),
+  message: z.string(),
+  policyVersion: z.string().optional(),
+  fileCount: z.number().int().nonnegative().optional(),
+  compressedBytes: z.number().int().nonnegative().optional(),
+  errorCode: z.string().optional(),
+});
 
 // GitHub events
 export const GitHubFetchReposSchema = z.object({
@@ -344,8 +354,8 @@ export const GitHubReposResponseSchema = z.object({
         z.object({
           fullName: z.string(),
           name: z.string(),
-        })
-      )
+        }),
+      ),
     )
     .optional(),
   error: z.string().optional(),
@@ -530,6 +540,7 @@ export type ListFilesRequest = z.infer<typeof ListFilesRequestSchema>;
 export type FileInfo = z.infer<typeof FileInfoSchema>;
 export type ListFilesResponse = z.infer<typeof ListFilesResponseSchema>;
 export type VSCodeSpawned = z.infer<typeof VSCodeSpawnedSchema>;
+export type MirrorLocalProgress = z.infer<typeof MirrorLocalProgressSchema>;
 export type GitHubBranch = z.infer<typeof GitHubBranchSchema>;
 export type GitHubReposResponse = z.infer<typeof GitHubReposResponseSchema>;
 export type GitHubAuthResponse = z.infer<typeof GitHubAuthResponseSchema>;
@@ -560,20 +571,20 @@ export type DefaultRepo = z.infer<typeof DefaultRepoSchema>;
 export interface ClientToServerEvents {
   authenticate: (
     data: Authenticate,
-    callback?: (response?: { ok: boolean; error?: string }) => void
+    callback?: (response?: { ok: boolean; error?: string }) => void,
   ) => void;
   // Terminal operations
   "start-task": (
     data: StartTask,
-    callback: (response: TaskAcknowledged | TaskStarted | TaskError) => void
+    callback: (response: TaskAcknowledged | TaskStarted | TaskError) => void,
   ) => void;
   "create-local-workspace": (
     data: CreateLocalWorkspace,
-    callback: (response: CreateLocalWorkspaceResponse) => void
+    callback: (response: CreateLocalWorkspaceResponse) => void,
   ) => void;
   "create-cloud-workspace": (
     data: CreateCloudWorkspace,
-    callback: (response: CreateCloudWorkspaceResponse) => void
+    callback: (response: CreateCloudWorkspaceResponse) => void,
   ) => void;
   "git-status": (data: GitStatusRequest) => void;
   "git-diff": (
@@ -581,29 +592,29 @@ export interface ClientToServerEvents {
     callback: (
       response:
         | { ok: true; diffs: import("./diff-types.js").ReplaceDiffEntry[] }
-        | { ok: false; error: string; diffs: [] }
-    ) => void
+        | { ok: false; error: string; diffs: [] },
+    ) => void,
   ) => void;
   "git-full-diff": (data: GitFullDiffRequest) => void;
   "open-in-editor": (
     data: OpenInEditor,
-    callback: (response: OpenInEditorResponse) => void
+    callback: (response: OpenInEditorResponse) => void,
   ) => void;
   "list-files": (
     data: ListFilesRequest,
     callback: (
       response:
         | { ok: true; files: FileInfo[] }
-        | { ok: false; files: FileInfo[]; error: string }
-    ) => void
+        | { ok: false; files: FileInfo[]; error: string },
+    ) => void,
   ) => void;
   // GitHub operations
   "github-test-auth": (
-    callback: (response: GitHubAuthResponse) => void
+    callback: (response: GitHubAuthResponse) => void,
   ) => void;
   "github-fetch-repos": (
     data: GitHubFetchRepos,
-    callback: (response: GitHubReposResponse) => void
+    callback: (response: GitHubReposResponse) => void,
   ) => void;
   // Create a draft pull request for a given task run
   "github-create-draft-pr": (
@@ -613,7 +624,7 @@ export interface ClientToServerEvents {
       results: PullRequestActionResult[];
       aggregate: AggregatePullRequestSummary;
       error?: string;
-    }) => void
+    }) => void,
   ) => void;
   // Sync PR state with GitHub and update Convex
   "github-sync-pr-state": (
@@ -623,7 +634,7 @@ export interface ClientToServerEvents {
       results: PullRequestActionResult[];
       aggregate: AggregatePullRequestSummary;
       error?: string;
-    }) => void
+    }) => void,
   ) => void;
   // Merge branch directly
   "github-merge-branch": (
@@ -633,26 +644,29 @@ export interface ClientToServerEvents {
       merged?: boolean;
       commitSha?: string;
       error?: string;
-    }) => void
+    }) => void,
   ) => void;
   // Rust N-API test: returns current time
   "rust-get-time": (
     callback: (
-      response: { ok: true; time: string } | { ok: false; error: string }
-    ) => void
+      response: { ok: true; time: string } | { ok: false; error: string },
+    ) => void,
   ) => void;
   "iframe-preflight": (
     data: { url: string },
-    callback: (response: IframePreflightResult) => void
+    callback: (response: IframePreflightResult) => void,
   ) => void;
   "check-provider-status": (
-    callback: (response: ProviderStatusResponse) => void
+    callback: (response: ProviderStatusResponse) => void,
   ) => void;
   "docker-pull-image": (
-    callback: (response: DockerPullImageResponse) => void
+    callback: (response: DockerPullImageResponse) => void,
   ) => void;
   "get-local-vscode-serve-web-origin": (
-    callback: (response: { baseUrl: string | null; port: number | null }) => void
+    callback: (response: {
+      baseUrl: string | null;
+      port: number | null;
+    }) => void,
   ) => void;
   "check-vscode-availability": (
     data: { refresh?: boolean } | undefined,
@@ -663,15 +677,15 @@ export interface ClientToServerEvents {
       source: string | null;
       suggestions: string[];
       errors: string[];
-    }) => void
+    }) => void,
   ) => void;
   "archive-task": (
     data: ArchiveTask,
-    callback: (response: { success: boolean; error?: string }) => void
+    callback: (response: { success: boolean; error?: string }) => void,
   ) => void;
   "unarchive-task": (
     data: ArchiveTask,
-    callback: (response: { success: boolean; error?: string }) => void
+    callback: (response: { success: boolean; error?: string }) => void,
   ) => void;
   "spawn-from-comment": (
     data: SpawnFromComment,
@@ -683,12 +697,12 @@ export interface ClientToServerEvents {
       terminalId?: string;
       vscodeUrl?: string;
       error?: string;
-    }) => void
+    }) => void,
   ) => void;
   // Trigger local-to-cloud file sync
   "trigger-local-cloud-sync": (
     data: TriggerLocalCloudSync,
-    callback: (response: TriggerLocalCloudSyncResponse) => void
+    callback: (response: TriggerLocalCloudSyncResponse) => void,
   ) => void;
   // Scan filesystem for existing worktrees and register them
   "scan-worktrees": (
@@ -698,15 +712,12 @@ export interface ClientToServerEvents {
       found: number;
       registered: number;
       error?: string;
-    }) => void
+    }) => void,
   ) => void;
   // Delete a worktree from filesystem and registry
   "delete-worktree": (
     data: { teamSlugOrId: string; worktreePath: string },
-    callback: (response: {
-      success: boolean;
-      error?: string;
-    }) => void
+    callback: (response: { success: boolean; error?: string }) => void,
   ) => void;
   // Validate worktree paths and clean up stale entries
   "validate-worktrees": (
@@ -716,15 +727,12 @@ export interface ClientToServerEvents {
       validPaths: string[];
       invalidPaths: string[];
       error?: string;
-    }) => void
+    }) => void,
   ) => void;
   // Clean up a task's worktreePath if it doesn't exist
   "cleanup-stale-workspace": (
     data: { teamSlugOrId: string; taskId: string },
-    callback: (response: {
-      success: boolean;
-      error?: string;
-    }) => void
+    callback: (response: { success: boolean; error?: string }) => void,
   ) => void;
 }
 
@@ -739,6 +747,7 @@ export interface ServerToClientEvents {
   "git-full-diff-response": (data: GitFullDiffResponse) => void;
   "open-in-editor-error": (data: OpenInEditorError) => void;
   "vscode-spawned": (data: VSCodeSpawned) => void;
+  "mirror-local-progress": (data: MirrorLocalProgress) => void;
   "default-repo": (data: DefaultRepo) => void;
   "available-editors": (data: AvailableEditors) => void;
   "task-started": (data: TaskStarted) => void;

--- a/packages/shared/src/socket-schemas.ts
+++ b/packages/shared/src/socket-schemas.ts
@@ -101,6 +101,16 @@ export const CreateCloudWorkspaceSchema = z
     taskId: typedZid("tasks").optional(),
     taskRunId: typedZid("taskRuns").optional(),
     theme: z.enum(["dark", "light", "system"]).optional(),
+    /**
+     * Clean start: skip setup-providers auth injection; ownership still recorded.
+     * Maps to POST /api/sandboxes/start clean=true.
+     */
+    clean: z.boolean().optional(),
+    /**
+     * Mirror local agent config. Implies clean for auth. Host pack is Electron-only;
+     * server forwards clean and may soft-fail pack with client guidance.
+     */
+    mirrorLocal: z.boolean().optional(),
   })
   .refine(
     (value) => Boolean(value.environmentId || value.projectFullName),

--- a/packages/shared/src/workspace-start-mode.test.ts
+++ b/packages/shared/src/workspace-start-mode.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCreateCloudWorkspaceModeFields,
+  buildDevshMirrorLocalCommand,
+  buildSandboxesStartModeFields,
+  getMirrorLocalUiState,
+  resolveWorkspaceStartMode,
+  shouldRecordSandboxOwnership,
+  shouldRunSetupProviderAuth,
+  WORKSPACE_START_MODE_LABELS,
+  WORKSPACE_START_MODES,
+} from "./workspace-start-mode";
+
+describe("resolveWorkspaceStartMode", () => {
+  it("defaults when no flags", () => {
+    expect(resolveWorkspaceStartMode({})).toBe("default");
+  });
+
+  it("selects clean", () => {
+    expect(resolveWorkspaceStartMode({ clean: true })).toBe("clean");
+  });
+
+  it("mirrorLocal wins over clean", () => {
+    expect(
+      resolveWorkspaceStartMode({ clean: true, mirrorLocal: true }),
+    ).toBe("mirror-local");
+  });
+});
+
+describe("shouldRunSetupProviderAuth", () => {
+  it("runs only for default", () => {
+    expect(shouldRunSetupProviderAuth("default")).toBe(true);
+    expect(shouldRunSetupProviderAuth("clean")).toBe(false);
+    expect(shouldRunSetupProviderAuth("mirror-local")).toBe(false);
+  });
+});
+
+describe("shouldRecordSandboxOwnership", () => {
+  it("always records", () => {
+    expect(shouldRecordSandboxOwnership("default")).toBe(true);
+    expect(shouldRecordSandboxOwnership("clean")).toBe(true);
+    expect(shouldRecordSandboxOwnership("mirror-local")).toBe(true);
+  });
+});
+
+describe("getMirrorLocalUiState", () => {
+  it("enables only in Electron", () => {
+    expect(getMirrorLocalUiState(true)).toEqual({
+      enabled: true,
+      tooltip: null,
+    });
+    const browser = getMirrorLocalUiState(false);
+    expect(browser.enabled).toBe(false);
+    expect(browser.tooltip).toMatch(/Electron/i);
+  });
+});
+
+describe("buildCreateCloudWorkspaceModeFields", () => {
+  it("maps modes for socket emit", () => {
+    expect(buildCreateCloudWorkspaceModeFields("default")).toEqual({});
+    expect(buildCreateCloudWorkspaceModeFields("clean")).toEqual({
+      clean: true,
+    });
+    expect(buildCreateCloudWorkspaceModeFields("mirror-local")).toEqual({
+      clean: true,
+      mirrorLocal: true,
+    });
+  });
+});
+
+describe("buildSandboxesStartModeFields", () => {
+  it("forwards clean for clean and mirror-local; default empty", () => {
+    expect(buildSandboxesStartModeFields({})).toEqual({});
+    expect(buildSandboxesStartModeFields({ clean: true })).toEqual({
+      clean: true,
+    });
+    // mirror implies clean on sandboxes start (server cannot pack host FS)
+    expect(buildSandboxesStartModeFields({ mirrorLocal: true })).toEqual({
+      clean: true,
+    });
+  });
+});
+
+describe("labels and modes for dashboard UI", () => {
+  it("exposes Default Clean Mirror local", () => {
+    expect(WORKSPACE_START_MODES).toEqual([
+      "default",
+      "clean",
+      "mirror-local",
+    ]);
+    expect(WORKSPACE_START_MODE_LABELS.default).toBe("Default");
+    expect(WORKSPACE_START_MODE_LABELS.clean).toBe("Clean");
+    expect(WORKSPACE_START_MODE_LABELS["mirror-local"]).toBe("Mirror local");
+  });
+});
+
+describe("buildDevshMirrorLocalCommand", () => {
+  it("builds host CLI for soft-fail guidance", () => {
+    expect(buildDevshMirrorLocalCommand()).toBe(
+      "devsh start -p pve-lxc --clean --mirror-local",
+    );
+  });
+});

--- a/packages/shared/src/workspace-start-mode.test.ts
+++ b/packages/shared/src/workspace-start-mode.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCreateCloudWorkspaceModeFields,
   buildSandboxesStartModeFields,
-  getMirrorLocalStateFromStatusMessage,
   getMirrorLocalUiState,
-  MIRROR_LOCAL_STATUS_MESSAGES,
   resolveWorkspaceStartMode,
   shouldRecordSandboxOwnership,
   shouldRunSetupProviderAuth,
@@ -116,16 +114,5 @@ describe("labels and modes for dashboard UI", () => {
     expect(WORKSPACE_START_MODE_LABELS.default).toBe("Default");
     expect(WORKSPACE_START_MODE_LABELS.clean).toBe("Clean");
     expect(WORKSPACE_START_MODE_LABELS["mirror-local"]).toBe("Mirror local");
-  });
-});
-
-describe("Mirror local status messages", () => {
-  it("round-trips persisted messages to structured states", () => {
-    expect(
-      getMirrorLocalStateFromStatusMessage(
-        MIRROR_LOCAL_STATUS_MESSAGES.applied,
-      ),
-    ).toBe("applied");
-    expect(getMirrorLocalStateFromStatusMessage("Unrelated status")).toBeNull();
   });
 });

--- a/packages/shared/src/workspace-start-mode.test.ts
+++ b/packages/shared/src/workspace-start-mode.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCreateCloudWorkspaceModeFields,
-  buildDevshMirrorLocalCommand,
   buildSandboxesStartModeFields,
+  getMirrorLocalStateFromStatusMessage,
   getMirrorLocalUiState,
+  MIRROR_LOCAL_STATUS_MESSAGES,
   resolveWorkspaceStartMode,
   shouldRecordSandboxOwnership,
   shouldRunSetupProviderAuth,
@@ -21,9 +22,9 @@ describe("resolveWorkspaceStartMode", () => {
   });
 
   it("mirrorLocal wins over clean", () => {
-    expect(
-      resolveWorkspaceStartMode({ clean: true, mirrorLocal: true }),
-    ).toBe("mirror-local");
+    expect(resolveWorkspaceStartMode({ clean: true, mirrorLocal: true })).toBe(
+      "mirror-local",
+    );
   });
 });
 
@@ -44,14 +45,42 @@ describe("shouldRecordSandboxOwnership", () => {
 });
 
 describe("getMirrorLocalUiState", () => {
-  it("enables only in Electron", () => {
-    expect(getMirrorLocalUiState(true)).toEqual({
+  it("enables only in Electron for a PVE LXC environment", () => {
+    expect(
+      getMirrorLocalUiState({ isElectron: true, provider: "pve-lxc" }),
+    ).toEqual({
       enabled: true,
       tooltip: null,
     });
-    const browser = getMirrorLocalUiState(false);
+
+    const browser = getMirrorLocalUiState({
+      isElectron: false,
+      provider: "pve-lxc",
+    });
     expect(browser.enabled).toBe(false);
     expect(browser.tooltip).toMatch(/Electron/i);
+  });
+
+  it.each(["morph", "pve-vm", "e2b"])(
+    "disables unsupported provider %s",
+    (provider) => {
+      const state = getMirrorLocalUiState({
+        isElectron: true,
+        provider,
+      });
+      expect(state.enabled).toBe(false);
+      expect(state.tooltip).toContain("PVE LXC");
+      expect(state.tooltip).toContain(provider);
+    },
+  );
+
+  it("disables Mirror local until the environment provider is known", () => {
+    const state = getMirrorLocalUiState({
+      isElectron: true,
+      provider: null,
+    });
+    expect(state.enabled).toBe(false);
+    expect(state.tooltip).toMatch(/select.*PVE LXC/i);
   });
 });
 
@@ -83,21 +112,20 @@ describe("buildSandboxesStartModeFields", () => {
 
 describe("labels and modes for dashboard UI", () => {
   it("exposes Default Clean Mirror local", () => {
-    expect(WORKSPACE_START_MODES).toEqual([
-      "default",
-      "clean",
-      "mirror-local",
-    ]);
+    expect(WORKSPACE_START_MODES).toEqual(["default", "clean", "mirror-local"]);
     expect(WORKSPACE_START_MODE_LABELS.default).toBe("Default");
     expect(WORKSPACE_START_MODE_LABELS.clean).toBe("Clean");
     expect(WORKSPACE_START_MODE_LABELS["mirror-local"]).toBe("Mirror local");
   });
 });
 
-describe("buildDevshMirrorLocalCommand", () => {
-  it("builds host CLI for soft-fail guidance", () => {
-    expect(buildDevshMirrorLocalCommand()).toBe(
-      "devsh start -p pve-lxc --clean --mirror-local",
-    );
+describe("Mirror local status messages", () => {
+  it("round-trips persisted messages to structured states", () => {
+    expect(
+      getMirrorLocalStateFromStatusMessage(
+        MIRROR_LOCAL_STATUS_MESSAGES.applied,
+      ),
+    ).toBe("applied");
+    expect(getMirrorLocalStateFromStatusMessage("Unrelated status")).toBeNull();
   });
 });

--- a/packages/shared/src/workspace-start-mode.ts
+++ b/packages/shared/src/workspace-start-mode.ts
@@ -33,20 +33,6 @@ export const MIRROR_LOCAL_STATUS_MESSAGES: Record<MirrorLocalState, string> = {
     "Workspace started, but local agent configuration could not be mirrored. The workspace is usable as a Clean workspace.",
 };
 
-export function getMirrorLocalStateFromStatusMessage(
-  message: string | null | undefined,
-): MirrorLocalState | null {
-  if (!message) {
-    return null;
-  }
-  for (const state of MIRROR_LOCAL_STATES) {
-    if (MIRROR_LOCAL_STATUS_MESSAGES[state] === message) {
-      return state;
-    }
-  }
-  return null;
-}
-
 export type WorkspaceStartModeInput = {
   clean?: boolean;
   mirrorLocal?: boolean;

--- a/packages/shared/src/workspace-start-mode.ts
+++ b/packages/shared/src/workspace-start-mode.ts
@@ -6,6 +6,47 @@
 
 export type WorkspaceStartMode = "default" | "clean" | "mirror-local";
 
+export const MIRROR_LOCAL_STATES = [
+  "packing",
+  "starting-sandbox",
+  "uploading",
+  "applying",
+  "applied",
+  "empty",
+  "unsupported",
+  "failed",
+] as const;
+
+export type MirrorLocalState = (typeof MIRROR_LOCAL_STATES)[number];
+
+export const MIRROR_LOCAL_STATUS_MESSAGES: Record<MirrorLocalState, string> = {
+  packing: "Packing local agent configuration…",
+  "starting-sandbox": "Starting PVE LXC workspace…",
+  uploading: "Uploading agent configuration…",
+  applying: "Applying agent configuration…",
+  applied: "Mirror local workspace ready",
+  empty:
+    "Workspace started clean; no allowlisted local agent configuration was found.",
+  unsupported:
+    "Workspace started clean; Mirror local supports PVE LXC sandboxes only.",
+  failed:
+    "Workspace started, but local agent configuration could not be mirrored. The workspace is usable as a Clean workspace.",
+};
+
+export function getMirrorLocalStateFromStatusMessage(
+  message: string | null | undefined,
+): MirrorLocalState | null {
+  if (!message) {
+    return null;
+  }
+  for (const state of MIRROR_LOCAL_STATES) {
+    if (MIRROR_LOCAL_STATUS_MESSAGES[state] === message) {
+      return state;
+    }
+  }
+  return null;
+}
+
 export type WorkspaceStartModeInput = {
   clean?: boolean;
   mirrorLocal?: boolean;
@@ -36,14 +77,38 @@ export type MirrorLocalUiState = {
   tooltip: string | null;
 };
 
-export function getMirrorLocalUiState(isElectron: boolean): MirrorLocalUiState {
-  if (isElectron) {
+export type MirrorLocalUiStateInput = {
+  isElectron: boolean;
+  provider?: string | null;
+};
+
+export function getMirrorLocalUiState({
+  isElectron,
+  provider,
+}: MirrorLocalUiStateInput): MirrorLocalUiState {
+  if (!isElectron) {
+    return {
+      enabled: false,
+      tooltip:
+        "Mirror local agent config requires the Electron app (host filesystem). Use Clean in the browser, or open the desktop app.",
+    };
+  }
+
+  if (!provider) {
+    return {
+      enabled: false,
+      tooltip:
+        "Select a PVE LXC environment to use Mirror local in the Electron app.",
+    };
+  }
+
+  if (provider === "pve-lxc") {
     return { enabled: true, tooltip: null };
   }
+
   return {
     enabled: false,
-    tooltip:
-      "Mirror local agent config requires the Electron app (host filesystem). Use Clean in the browser, or open the desktop app.",
+    tooltip: `Mirror local currently supports PVE LXC environments only (selected provider: ${provider}).`,
   };
 }
 
@@ -70,26 +135,14 @@ export function buildCreateCloudWorkspaceModeFields(
 }
 
 /** Sandboxes start body fields derived from create-cloud-workspace flags. */
-export function buildSandboxesStartModeFields(
-  input: WorkspaceStartModeInput,
-): { clean?: boolean } {
+export function buildSandboxesStartModeFields(input: WorkspaceStartModeInput): {
+  clean?: boolean;
+} {
   const mode = resolveWorkspaceStartMode(input);
   if (mode === "default") return {};
   // Server API never packs host FS; mirrorLocal is client/host only.
   // Always forward clean when clean or mirror-local.
   return { clean: true };
-}
-
-export function buildDevshMirrorLocalCommand(options?: {
-  provider?: string;
-  snapshotId?: string;
-}): string {
-  const provider = options?.provider?.trim() || "pve-lxc";
-  const parts = ["devsh", "start", "-p", provider, "--clean", "--mirror-local"];
-  if (options?.snapshotId?.trim()) {
-    parts.push("--snapshot", options.snapshotId.trim());
-  }
-  return parts.join(" ");
 }
 
 export const WORKSPACE_START_MODE_LABELS: Record<WorkspaceStartMode, string> = {

--- a/packages/shared/src/workspace-start-mode.ts
+++ b/packages/shared/src/workspace-start-mode.ts
@@ -1,0 +1,105 @@
+/**
+ * Cloud workspace start modes for team dashboard create-cloud-workspace.
+ * Clean: skip setup-providers auth; keep ownership.
+ * Mirror-local: implies clean; host pack only (Electron); browser disabled.
+ */
+
+export type WorkspaceStartMode = "default" | "clean" | "mirror-local";
+
+export type WorkspaceStartModeInput = {
+  clean?: boolean;
+  mirrorLocal?: boolean;
+};
+
+/** Resolve exclusive start mode. mirrorLocal wins over clean. */
+export function resolveWorkspaceStartMode(
+  input: WorkspaceStartModeInput,
+): WorkspaceStartMode {
+  if (input.mirrorLocal) return "mirror-local";
+  if (input.clean) return "clean";
+  return "default";
+}
+
+/** setup-providers injection runs only in default mode. */
+export function shouldRunSetupProviderAuth(mode: WorkspaceStartMode): boolean {
+  return mode === "default";
+}
+
+export function shouldRecordSandboxOwnership(
+  _mode: WorkspaceStartMode,
+): boolean {
+  return true;
+}
+
+export type MirrorLocalUiState = {
+  enabled: boolean;
+  tooltip: string | null;
+};
+
+export function getMirrorLocalUiState(isElectron: boolean): MirrorLocalUiState {
+  if (isElectron) {
+    return { enabled: true, tooltip: null };
+  }
+  return {
+    enabled: false,
+    tooltip:
+      "Mirror local agent config requires the Electron app (host filesystem). Use Clean in the browser, or open the desktop app.",
+  };
+}
+
+export type CreateCloudWorkspaceModeFields = {
+  clean?: boolean;
+  mirrorLocal?: boolean;
+};
+
+/**
+ * Fields to merge into create-cloud-workspace emit / sandboxes start body.
+ * mirror-local implies clean for auth skip; pack is host-side.
+ */
+export function buildCreateCloudWorkspaceModeFields(
+  mode: WorkspaceStartMode,
+): CreateCloudWorkspaceModeFields {
+  switch (mode) {
+    case "clean":
+      return { clean: true };
+    case "mirror-local":
+      return { clean: true, mirrorLocal: true };
+    default:
+      return {};
+  }
+}
+
+/** Sandboxes start body fields derived from create-cloud-workspace flags. */
+export function buildSandboxesStartModeFields(
+  input: WorkspaceStartModeInput,
+): { clean?: boolean } {
+  const mode = resolveWorkspaceStartMode(input);
+  if (mode === "default") return {};
+  // Server API never packs host FS; mirrorLocal is client/host only.
+  // Always forward clean when clean or mirror-local.
+  return { clean: true };
+}
+
+export function buildDevshMirrorLocalCommand(options?: {
+  provider?: string;
+  snapshotId?: string;
+}): string {
+  const provider = options?.provider?.trim() || "pve-lxc";
+  const parts = ["devsh", "start", "-p", provider, "--clean", "--mirror-local"];
+  if (options?.snapshotId?.trim()) {
+    parts.push("--snapshot", options.snapshotId.trim());
+  }
+  return parts.join(" ");
+}
+
+export const WORKSPACE_START_MODE_LABELS: Record<WorkspaceStartMode, string> = {
+  default: "Default",
+  clean: "Clean",
+  "mirror-local": "Mirror local",
+};
+
+export const WORKSPACE_START_MODES: readonly WorkspaceStartMode[] = [
+  "default",
+  "clean",
+  "mirror-local",
+] as const;

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -1992,6 +1992,10 @@ export type StartSandboxBody = {
     taskRunJwt?: string;
     isCloudWorkspace?: boolean;
     isOrchestrationHead?: boolean;
+    /** Skip setup-providers auth injection; ownership still recorded. */
+    clean?: boolean;
+    /** Host mirror intent; server treats like clean for auth. Pack is host-side. */
+    mirrorLocal?: boolean;
     repoUrl?: string;
     branch?: string;
     newBranch?: string;

--- a/packages/www-openapi-client/src/client/types.gen.ts
+++ b/packages/www-openapi-client/src/client/types.gen.ts
@@ -1992,9 +1992,7 @@ export type StartSandboxBody = {
     taskRunJwt?: string;
     isCloudWorkspace?: boolean;
     isOrchestrationHead?: boolean;
-    /** Skip setup-providers auth injection; ownership still recorded. */
     clean?: boolean;
-    /** Host mirror intent; server treats like clean for auth. Pack is host-side. */
     mirrorLocal?: boolean;
     repoUrl?: string;
     branch?: string;

--- a/scripts/dev-www-startup.test.ts
+++ b/scripts/dev-www-startup.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+describe("local WWW startup", () => {
+  it("defines a Webpack dev command for linked worktrees", () => {
+    const packageJson: unknown = JSON.parse(
+      readFileSync(resolve(repoRoot, "apps/www/package.json"), "utf8"),
+    );
+
+    expect(isRecord(packageJson)).toBe(true);
+    if (!isRecord(packageJson)) {
+      return;
+    }
+
+    const scripts = packageJson.scripts;
+    expect(isRecord(scripts)).toBe(true);
+    if (!isRecord(scripts)) {
+      return;
+    }
+
+    expect(scripts["dev:webpack"]).toBe(
+      "dotenv -e ../../.env -- next dev --port 9779 --webpack",
+    );
+  });
+
+  it("uses the Webpack command from the local stack orchestrator", () => {
+    const devScript = readFileSync(resolve(repoRoot, "scripts/dev.sh"), "utf8");
+
+    expect(devScript).toContain(
+      'bun run dev:webpack 2>&1 | tee "$LOG_DIR/www.log"',
+    );
+  });
+});

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -683,9 +683,10 @@ echo -e "${GREEN}Starting frontend on port 5173...${NC}"
 CLIENT_PID=$!
 check_process $CLIENT_PID "Frontend Client"
 
-# Start the www app
+# Start the www app. Webpack avoids Next's Turbopack package-root resolution
+# failure when this repository is running from a linked worktree.
 echo -e "${GREEN}Starting www app on port 9779...${NC}"
-(cd "$APP_DIR/apps/www" && exec bash -c 'trap "pkill -9 -P $$ 2>/dev/null || true" EXIT; bun run dev 2>&1 | tee "$LOG_DIR/www.log" | prefix_output "WWW" "$GREEN"') </dev/null &
+(cd "$APP_DIR/apps/www" && exec bash -c 'trap "pkill -9 -P $$ 2>/dev/null || true" EXIT; bun run dev:webpack 2>&1 | tee "$LOG_DIR/www.log" | prefix_output "WWW" "$GREEN"') </dev/null &
 WWW_PID=$!
 check_process $WWW_PID "WWW App"
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -18,6 +18,7 @@
 # Environment variables:
 #   SKIP_DOCKER_BUILD       Set to "false" to build Docker image (default: true)
 #   SKIP_CONVEX             Set to "false" to run Convex (default: true)
+#   CMUX_ELECTRON_PARTITION Override the persistent Electron partition used in dev
 #
 # Examples:
 #   ./scripts/dev.sh                          # Start without Docker build
@@ -328,6 +329,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 export SKIP_DOCKER_BUILD
+
+if [ "$RUN_ELECTRON" = "true" ]; then
+    export CMUX_ELECTRON_PARTITION="${CMUX_ELECTRON_PARTITION:-persist:cmux-dev-${PROJECT_HASH}}"
+fi
 
 # Set the worker image name for local development
 # This overrides the default (docker.io/lawrencecchen/cmux:latest) to use the locally-built image
@@ -735,6 +740,7 @@ if [ "$SKIP_CONVEX" != "true" ]; then
 fi
 if [ "$RUN_ELECTRON" = "true" ]; then
     echo -e "${BLUE}Electron app is starting...${NC}"
+    echo -e "${BLUE}Electron partition: $CMUX_ELECTRON_PARTITION${NC}"
     if [ "$ELECTRON_DEBUG" = "true" ]; then
         echo -e "${BLUE}Chrome DevTools: chrome://inspect or http://localhost:$ELECTRON_DEBUG_PORT${NC}"
     fi

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -9,5 +9,8 @@
     }
   },
   "include": ["./**/*"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "test-agent-sdk-spike.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- Team **dashboard** (`WorkspaceCreationButtons`) gains **Default | Clean | Mirror local** segmented control for cloud workspace create (environment still required).
- Socket + HTTP `create-cloud-workspace` accept `clean` / `mirrorLocal` and forward **`clean: true`** into `POST /api/sandboxes/start` so setup-providers is skipped while ownership remains.
- Pure helpers live in `@cmux/shared` (`workspace-start-mode.ts`) with unit tests; Mirror is **Electron-gated** (browser disabled + tooltip); host pack soft-fails with explicit `devsh` guidance (no silent browser pack).
- Leaves PR #1271 (preview surface) open; this is the **dashboard** product entry.

Work item: `cloud-workspace-start-modes-dashboard`  
`merge_auto_approved: false` — leave merge for explicit approval.

## Test plan

- [x] `bun test packages/shared/src/workspace-start-mode.test.ts packages/shared/src/socket-schemas.test.ts` (68 pass)
- [x] `bun check` via pre-commit
- [ ] Manual: Electron dashboard → env selected → Clean create → skip setup-providers in logs
- [ ] Manual: browser → Mirror disabled; Clean works
- [ ] Optional: Electron mirror soft-fail toast with CLI command