### PR TITLE
fix(tests): align codex catalog tests with gpt-5.4 deprecation

### DIFF
--- a/apps/server/src/http-api.test.ts
+++ b/apps/server/src/http-api.test.ts
@@ -417,13 +417,15 @@ describe("HTTP API - apps/server", () => {
         expect(response.status).toBe(200);
         const data = await response.json();
 
-        const gpt54 = data.models.find(
-          (model: { name: string }) => model.name === "codex/gpt-5.4",
+        // gpt-5.4 became hidden/upgradeable after the 2026-07-25 app-server sync;
+        // gpt-5.5 is a visible flagship with the same variant shape.
+        const gpt55 = data.models.find(
+          (model: { name: string }) => model.name === "codex/gpt-5.5",
         );
-        expect(gpt54).toBeDefined();
-        expect(gpt54.defaultVariant).toBe("medium");
+        expect(gpt55).toBeDefined();
+        expect(gpt55.defaultVariant).toBe("medium");
         expect(
-          gpt54.variants.some(
+          gpt55.variants.some(
             (variant: { id: string }) => variant.id === "xhigh",
           ),
         ).toBe(true);

--- a/apps/server/src/utils/providerStatus.test.ts
+++ b/apps/server/src/utils/providerStatus.test.ts
@@ -68,7 +68,7 @@ describe("aggregateByVendor", () => {
     // Use exact agent names from the catalog (flagship models only)
     const statuses: ProviderStatus[] = [
       { name: "claude/opus-4.5", isAvailable: true },
-      { name: "codex/gpt-5.4", isAvailable: true }, // flagship Codex model
+      { name: "codex/gpt-5.5", isAvailable: true }, // flagship Codex model
       { name: "gemini/2.5-flash", isAvailable: false },
     ];
 

--- a/packages/shared/src/agent-catalog.test.ts
+++ b/packages/shared/src/agent-catalog.test.ts
@@ -9,9 +9,11 @@ import { AGENT_CONFIGS, type AgentConfig } from "./agentConfig";
  *    its own authentication flow. User API keys (ANTHROPIC_API_KEY, etc.) are for
  *    direct provider access with custom base URLs, not for OpenCode's routing.
  *
- * 2. Non-flagship Codex models (codex/*): Only flagship models are in static catalog
- *    (gpt-5.4, gpt-5.4-xhigh, gpt-5.4-mini, gpt-5.1-codex-mini). Older/variant models
- *    are auto-discovered via OpenAI API discovery cron.
+ * 2. Non-flagship Codex models (codex/*): Only visible flagships are in the static
+ *    catalog (gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.2).
+ *    gpt-5.4/gpt-5.4-mini became hidden/upgradeable after the 2026-07-25 app-server
+ *    sync and are now runtime-discovered (configs-only). Older/variant models are
+ *    auto-discovered via OpenAI API discovery cron.
  *
  * These models are discovered at runtime via Convex modelDiscovery.
  */
@@ -25,8 +27,6 @@ const CODEX_CATALOG_BASE_MODELS = new Set([
   "codex/gpt-5.6-terra",
   "codex/gpt-5.6-luna",
   "codex/gpt-5.5",
-  "codex/gpt-5.4",
-  "codex/gpt-5.4-mini",
   "codex/gpt-5.2",
 ]);
 

--- a/packages/shared/src/agent-selection.test.ts
+++ b/packages/shared/src/agent-selection.test.ts
@@ -4,14 +4,14 @@ import { resolveAgentSelection } from "./agent-selection";
 describe("resolveAgentSelection", () => {
   it("resolves Codex base models to their default effort without changing the public agent name", () => {
     const resolved = resolveAgentSelection({
-      agentName: "codex/gpt-5.4",
+      agentName: "codex/gpt-5.5",
     });
 
-    expect(resolved.assignedAgentName).toBe("codex/gpt-5.4");
+    expect(resolved.assignedAgentName).toBe("codex/gpt-5.5");
     expect(resolved.selectedVariant).toBe("medium");
-    expect(resolved.agentConfig.name).toBe("codex/gpt-5.4");
+    expect(resolved.agentConfig.name).toBe("codex/gpt-5.5");
     expect(resolved.agentConfig.args).toContain("--model");
-    expect(resolved.agentConfig.args).toContain("gpt-5.4");
+    expect(resolved.agentConfig.args).toContain("gpt-5.5");
     expect(resolved.agentConfig.args).toContain(
       'model_reasoning_effort="medium"',
     );
@@ -19,13 +19,13 @@ describe("resolveAgentSelection", () => {
 
   it("normalizes legacy Codex suffix agent names into base model plus variant", () => {
     const resolved = resolveAgentSelection({
-      agentName: "codex/gpt-5.4-xhigh",
+      agentName: "codex/gpt-5.5-xhigh",
       applyDefaultVariant: false,
     });
 
-    expect(resolved.assignedAgentName).toBe("codex/gpt-5.4");
+    expect(resolved.assignedAgentName).toBe("codex/gpt-5.5");
     expect(resolved.selectedVariant).toBe("xhigh");
-    expect(resolved.agentConfig.name).toBe("codex/gpt-5.4");
+    expect(resolved.agentConfig.name).toBe("codex/gpt-5.5");
   });
 
   it("rejects unsupported Claude effort combinations", () => {

--- a/packages/shared/src/providers/openai/catalog.test.ts
+++ b/packages/shared/src/providers/openai/catalog.test.ts
@@ -36,15 +36,17 @@ describe("CODEX_CATALOG", () => {
     }
   });
 
-  it("includes GPT-5.4 as a model", () => {
-    // Note: app-server catalog uses base name with variants, not suffixes
-    const gpt54 = CODEX_CATALOG.find((e) => e.name === "codex/gpt-5.4");
-    expect(gpt54).toBeDefined();
+  it("includes GPT-5.5 as a visible flagship model", () => {
+    // Note: app-server catalog uses base name with variants, not suffixes.
+    // gpt-5.4/gpt-5.4-mini are hidden/upgradeable after the 2026-07-25 sync;
+    // gpt-5.5 remains a visible flagship.
+    const gpt55 = CODEX_CATALOG.find((e) => e.name === "codex/gpt-5.5");
+    expect(gpt55).toBeDefined();
     // Verify it has xhigh variant
-    expect(gpt54?.variants?.some((v) => v.id === "xhigh")).toBe(true);
+    expect(gpt55?.variants?.some((v) => v.id === "xhigh")).toBe(true);
   });
 
-  it("includes GPT-5.5 as the default model", () => {
+  it("includes GPT-5.5 as the default-tier visible model", () => {
     const gpt55 = CODEX_CATALOG.find((e) => e.name === "codex/gpt-5.5");
     expect(gpt55).toBeDefined();
     expect(gpt55?.displayName).toBe("GPT-5.5");


### PR DESCRIPTION
## Summary

The 2026-07-25 codex app-server catalog sync (bf70f6aef) marked `codex/gpt-5.4` and `codex/gpt-5.4-mini` as `hidden: true` (upgradeable/deprecated upstream), which removed them from `CODEX_VISIBLE_MODELS` → `CODEX_CATALOG` → `AGENT_CATALOG`. Five tests still asserted on `gpt-5.4` as a visible flagship, breaking CI.

## Changes

Migrate the five failing test assertions to `codex/gpt-5.5`, a still-visible flagship with the same variant shape (`defaultVariant: "medium"`, `xhigh` variant present):

- `packages/shared/src/providers/openai/catalog.test.ts` — flagship visibility + xhigh variant
- `packages/shared/src/agent-selection.test.ts` — base model + legacy suffix normalization
- `packages/shared/src/agent-catalog.test.ts` — drop `gpt-5.4`/`gpt-5.4-mini` from `CODEX_CATALOG_BASE_MODELS` so they are correctly classified as runtime-discovered (configs-only)
- `apps/server/src/utils/providerStatus.test.ts` — `aggregateByVendor` multi-vendor test
- `apps/server/src/http-api.test.ts` — static fallback reasoning variants

## Verification

- `bunx vitest run` on all 5 affected files: **pass** (22 + 59 tests)
- `bun run check` (lint + typecheck): **pass**
- Related suites (openai provider, task-class-routing, mcp-preview, provider-registry): **pass**

## Notes

Production code still referencing `codex/gpt-5.4` (`task-class-routing.ts`, `platform-ai.ts`, orchestration presets, UI labels) is intentionally unchanged: those are functional model IDs that work regardless of catalog visibility, and migrating them to the new flagship (`gpt-5.6-sol` / `gpt-5.5`) is a separate product decision beyond fixing CI.

Fixes the CI failure at https://github.com/karlorz/cmux/actions/runs/30152838451