### PR TITLE
feat(devsh): orca-serve start mode

### DIFF
--- a/packages/devsh/README.md
+++ b/packages/devsh/README.md
@@ -453,6 +453,31 @@ Waiting for VM to be ready...
   VNC:      https://vnc-morphvm-xxx.http.cloud.morph.so
 ```
 
+### Orca Server start
+
+Start a pve-lxc box composed for Orca Server: agent config is mirrored to
+`/home/orca` (not `/root`), and post-start steps wire the B1 bridge, workspace
+`gh` (G1/G2), and the agent matrix.
+
+```bash
+devsh start --provider pve-lxc --orca-serve --mirror-local --target-home /home/orca
+```
+
+Or use the example template (install once):
+
+```bash
+mkdir -p ~/.cmux/templates
+cp packages/devsh/examples/templates/orca-serve.yaml ~/.cmux/templates/
+devsh start --provider pve-lxc --template orca-serve
+```
+
+Attach an existing long-lived LXC (migrate allowlist root → `/home/orca`,
+workspace gh, B1 symlinks):
+
+```bash
+devsh exec <id> 'bash -s' < scripts/pve/setup-orca-agent-home.sh
+```
+
 ### `devsh pause <id>`
 
 Pause a VM by its ID. The VM state is preserved and can be resumed later.

--- a/packages/devsh/README.md
+++ b/packages/devsh/README.md
@@ -460,7 +460,7 @@ Start a pve-lxc box composed for Orca Server: agent config is mirrored to
 `gh` (G1/G2), and the agent matrix.
 
 ```bash
-devsh start --provider pve-lxc --orca-serve --mirror-local --target-home /home/orca
+devsh start --provider pve-lxc --clean --orca-serve --mirror-local --target-home /home/orca
 ```
 
 Or use the example template (install once):

--- a/packages/devsh/examples/templates/orca-serve.yaml
+++ b/packages/devsh/examples/templates/orca-serve.yaml
@@ -11,3 +11,4 @@ orca_serve:
   enable: true
   workspace_gh: true
   migrate_from_root: false
+cloud_workspace: true

--- a/packages/devsh/examples/templates/orca-serve.yaml
+++ b/packages/devsh/examples/templates/orca-serve.yaml
@@ -11,4 +11,3 @@ orca_serve:
   enable: true
   workspace_gh: true
   migrate_from_root: false
-cloud_workspace: true

--- a/packages/devsh/examples/templates/orca-serve.yaml
+++ b/packages/devsh/examples/templates/orca-serve.yaml
@@ -1,0 +1,13 @@
+# ~/.cmux/templates/orca-serve.yaml
+# Orca Server start template: pve-lxc box with agent home under /home/orca.
+# Install: cp packages/devsh/examples/templates/orca-serve.yaml ~/.cmux/templates/
+# Usage:   devsh start --provider pve-lxc --template orca-serve
+name: orca-serve
+provider: pve-lxc
+clean: true
+mirror_local: true
+target_home: /home/orca
+orca_serve:
+  enable: true
+  workspace_gh: true
+  migrate_from_root: false

--- a/packages/devsh/internal/cli/orca_serve.go
+++ b/packages/devsh/internal/cli/orca_serve.go
@@ -16,10 +16,91 @@
 package cli
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	"github.com/karlorz/devsh/internal/mirrorlocal"
 )
+
+// ExecRunner executes a shell command in the box. *pvelxc.Client implements it;
+// tests inject fakes.
+type ExecRunner interface {
+	ExecCommand(ctx context.Context, instanceID string, command string) (stdout, stderr string, exitCode int, err error)
+}
+
+// OrcaServeOpts selects the post-start composition steps for --orca-serve.
+type OrcaServeOpts struct {
+	// MigrateFromRoot copies the mirrorlocal allowlist from /root to
+	// /home/orca on long-lived boxes already mirrored to root (never auth.json).
+	MigrateFromRoot bool
+	// WorkspaceGH wires orca git/gh to the workspace root default (G1/G2).
+	WorkspaceGH bool
+}
+
+// runOrcaServePostStart composes the Orca Server agent home after a pve-lxc
+// start: B1 ensure → optional migrate-from-root → workspace gh → agent matrix.
+// Each step soft-fails: the error names the first failing step, but later
+// steps still run so the box remains usable.
+func runOrcaServePostStart(ctx context.Context, exec ExecRunner, instanceID string, opts OrcaServeOpts) error {
+	var failures []string
+
+	// 1) B1 bridge: orca user, sudoers, symlinks, npm prefix, safe.directory.
+	if err := execEach(ctx, exec, instanceID, "B1", BuildOrcaB1EnsureCommands()); err != nil {
+		failures = append(failures, err.Error())
+	}
+
+	// 2) Optional migrate-from-root: allowlist copy /root → /home/orca.
+	if opts.MigrateFromRoot {
+		if err := execEach(ctx, exec, instanceID, "migrate-from-root", BuildMigrateAgentHomeFromRootCommands()); err != nil {
+			failures = append(failures, err.Error())
+		}
+	}
+
+	// 3) Workspace gh for orca (G1 credential helper + G2 wrapper).
+	if opts.WorkspaceGH {
+		if err := execEach(ctx, exec, instanceID, "workspace-gh", BuildWorkspaceGHForOrcaCommands()); err != nil {
+			failures = append(failures, err.Error())
+		}
+	}
+
+	// 4) Agent detection matrix (always last).
+	if err := execOne(ctx, exec, instanceID, "agent-matrix", BuildAgentMatrixCommand()); err != nil {
+		failures = append(failures, err.Error())
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("orca-serve post-start soft-failed: %s", strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// execEach runs every command in cmds, stopping the step at the first failure.
+func execEach(ctx context.Context, exec ExecRunner, instanceID, step string, cmds []string) error {
+	for _, c := range cmds {
+		if err := execOne(ctx, exec, instanceID, step, c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// execOne runs a single command and reports a step-scoped error on transport
+// failure or non-zero exit.
+func execOne(ctx context.Context, exec ExecRunner, instanceID, step, command string) error {
+	stdout, stderr, code, err := exec.ExecCommand(ctx, instanceID, command)
+	if err != nil {
+		return fmt.Errorf("%s exec: %w", step, err)
+	}
+	if code != 0 {
+		detail := strings.TrimSpace(stderr + "\n" + stdout)
+		if detail == "" {
+			detail = "no output"
+		}
+		return fmt.Errorf("%s failed (exit %d): %s", step, code, detail)
+	}
+	return nil
+}
 
 // BuildWorkspaceGHForOrcaCommands returns commands wiring orca git/gh to the
 // workspace root default (/root/.config/gh) without a second gh auth login.

--- a/packages/devsh/internal/cli/orca_serve.go
+++ b/packages/devsh/internal/cli/orca_serve.go
@@ -1,0 +1,127 @@
+// internal/cli/orca_serve.go
+//
+// Pure command builders for Orca Server (orca-serve) composition on pve-lxc.
+// These functions return shell command lists / scripts that later tasks exec
+// in the box; they perform no I/O themselves.
+//
+// Design (approved 2026-08-07, projects/cmux/work/2026-08-07-orca-serve-start-mode):
+//   - Claude/Codex config lands under /home/orca via --mirror-local
+//     TargetHome=/home/orca (same allowlist/redaction as root mirror).
+//   - gh uses the LXC workspace default under /root; orca delegates via a
+//     G1 credential helper (sudo -n gh auth git-credential) plus an optional
+//     G2 wrapper. Never instruct `gh auth login` as orca.
+//   - B1 bridge: system user orca (nologin), sudoers NOPASSWD, home symlinks,
+//     npm prefix ~/.local, git safe.directory. Never Environment=HOME=/root
+//     (Chromium SIGTRAP).
+package cli
+
+import (
+	"strings"
+
+	"github.com/karlorz/devsh/internal/mirrorlocal"
+)
+
+// BuildWorkspaceGHForOrcaCommands returns commands wiring orca git/gh to the
+// workspace root default (/root/.config/gh) without a second gh auth login.
+//
+// G1: orca's global git config uses root's gh via a sudo -n credential helper
+// for github.com and gist.github.com. G2: optional ~/.local/bin/gh wrapper so
+// `gh` on orca's PATH behaves like root's gh.
+func BuildWorkspaceGHForOrcaCommands() []string {
+	return []string{
+		`su -s /bin/bash orca -c 'git config --global credential.https://github.com.helper "!sudo -n /usr/bin/gh auth git-credential"'`,
+		`su -s /bin/bash orca -c 'git config --global credential.https://gist.github.com.helper "!sudo -n /usr/bin/gh auth git-credential"'`,
+		// Optional G2 wrapper: orca `gh` delegates to root's workspace gh.
+		`install -d /home/orca/.local/bin`,
+		`printf '%s\n' '#!/bin/sh' 'exec sudo -n /usr/bin/gh "$@"' > /home/orca/.local/bin/gh`,
+		`chmod 755 /home/orca/.local/bin/gh`,
+		`chown orca:orca /home/orca/.local/bin/gh`,
+	}
+}
+
+// BuildMigrateAgentHomeFromRootCommands returns a script copying the agent
+// config allowlist from /root to /home/orca on long-lived boxes already
+// mirrored to root. The allowlist is mirrorlocal.DefaultIncludePaths; secrets
+// (auth.json etc.) are never copied. Ownership lands on orca:orca.
+func BuildMigrateAgentHomeFromRootCommands() []string {
+	var b strings.Builder
+	b.WriteString("set -e\n")
+	b.WriteString("# Migrate agent config allowlist from /root to /home/orca (mirrorlocal DefaultIncludePaths).\n")
+	b.WriteString("# skip auth.json and other secret files: never copied.\n")
+	b.WriteString("mkdir -p /home/orca\n")
+	b.WriteString("for p in \\\n")
+	for _, p := range mirrorlocal.DefaultIncludePaths {
+		b.WriteString("  " + p + " \\\n")
+	}
+	b.WriteString("; do\n")
+	b.WriteString("  if [ -e \"/root/$p\" ]; then\n")
+	b.WriteString("    mkdir -p \"/home/orca/$(dirname \"$p\")\"\n")
+	b.WriteString("    cp -a \"/root/$p\" \"/home/orca/$p\"\n")
+	b.WriteString("  fi\n")
+	b.WriteString("done\n")
+	b.WriteString("chown -R orca:orca /home/orca/.claude /home/orca/.codex 2>/dev/null || true\n")
+	return []string{b.String()}
+}
+
+// BuildOrcaB1EnsureCommands returns idempotent B1 bridge commands: system user
+// orca (nologin), passwordless sudoers, traversal perms on /root trees, home
+// symlinks, npm prefix ~/.local, and git safe.directory for root-owned repos.
+// Never sets HOME=/root for orca (Chromium SIGTRAP).
+func BuildOrcaB1EnsureCommands() []string {
+	return []string{
+		`id orca >/dev/null 2>&1 || useradd --system --create-home --shell /usr/sbin/nologin orca`,
+		`echo "orca ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/orca`,
+		`chmod 440 /etc/sudoers.d/orca`,
+		`chmod 755 /root`,
+		`[ -d /root/workspace ] && chmod 755 /root/workspace || true`,
+		`[ -d /root/wiki ] && chmod 755 /root/wiki || true`,
+		`ln -sfn /root /home/orca/root-home`,
+		`ln -sfn /root/workspace /home/orca/workspace`,
+		`ln -sfn /root/wiki /home/orca/wiki`,
+		`chown -h orca:orca /home/orca/root-home /home/orca/workspace /home/orca/wiki`,
+		`su -s /bin/bash orca -c 'mkdir -p "$HOME/.local/bin" "$HOME/.local/lib/node_modules"; npm config set prefix "$HOME/.local"'`,
+		`su -s /bin/bash orca -c 'git config --global --add safe.directory /root/workspace; git config --global --add safe.directory /root/wiki; git config --global --add safe.directory /root'`,
+	}
+}
+
+// BuildAgentMatrixCommand returns a single shell script printing the orca
+// detection matrix: CLIs on orca PATH, mirrored config under /home/orca, gh
+// via the workspace root default, and agent auth-file presence. It never
+// instructs `gh auth login` as orca.
+func BuildAgentMatrixCommand() string {
+	return `#!/bin/bash
+# orca-serve agent detection matrix (run as root).
+echo "== orca agent matrix =="
+echo "-- binaries on orca PATH --"
+for b in claude codex grok gh; do
+  if p=$(su -s /bin/bash orca -c "command -v $b" 2>/dev/null); then
+    echo "ok   $b: $p"
+  else
+    echo "miss $b"
+  fi
+done
+echo "-- mirrored config under /home/orca --"
+for p in .claude .codex; do
+  if [ -e "/home/orca/$p" ]; then
+    echo "ok   /home/orca/$p"
+  else
+    echo "miss /home/orca/$p"
+  fi
+done
+echo "-- gh via workspace root default --"
+if [ -f /root/.config/gh/hosts.yml ]; then
+  echo "ok   root gh hosts present; orca delegates via sudo -n gh"
+  sudo -n /usr/bin/gh auth status 2>&1 | head -5 || true
+else
+  echo "warn root gh not configured"
+fi
+echo "-- agent auth files (absent unless device-auth done as orca) --"
+for f in /home/orca/.claude/auth.json /home/orca/.codex/auth.json; do
+  if [ -e "$f" ]; then
+    echo "note $f present"
+  else
+    echo "ok   $f absent"
+  fi
+done
+`
+}

--- a/packages/devsh/internal/cli/orca_serve.go
+++ b/packages/devsh/internal/cli/orca_serve.go
@@ -50,6 +50,12 @@ func runOrcaServePostStart(ctx context.Context, exec ExecRunner, instanceID stri
 		failures = append(failures, err.Error())
 	}
 
+	// 1b) Re-chown mirrored config now that the orca user exists: mirror-local
+	// may have extracted before B1 useradd, making the earlier chown a no-op.
+	if err := execOne(ctx, exec, instanceID, "re-chown", BuildOrcaRechownCommand()); err != nil {
+		failures = append(failures, err.Error())
+	}
+
 	// 2) Optional migrate-from-root: allowlist copy /root → /home/orca.
 	if opts.MigrateFromRoot {
 		if err := execEach(ctx, exec, instanceID, "migrate-from-root", BuildMigrateAgentHomeFromRootCommands()); err != nil {
@@ -110,8 +116,8 @@ func execOne(ctx context.Context, exec ExecRunner, instanceID, step, command str
 // `gh` on orca's PATH behaves like root's gh.
 func BuildWorkspaceGHForOrcaCommands() []string {
 	return []string{
-		`su -s /bin/bash orca -c 'git config --global credential.https://github.com.helper "!sudo -n /usr/bin/gh auth git-credential"'`,
-		`su -s /bin/bash orca -c 'git config --global credential.https://gist.github.com.helper "!sudo -n /usr/bin/gh auth git-credential"'`,
+		`sudo -u orca env HOME=/home/orca bash -lc 'git config --global credential.https://github.com.helper "!sudo -n /usr/bin/gh auth git-credential"'`,
+		`sudo -u orca env HOME=/home/orca bash -lc 'git config --global credential.https://gist.github.com.helper "!sudo -n /usr/bin/gh auth git-credential"'`,
 		// Optional G2 wrapper: orca `gh` delegates to root's workspace gh.
 		`install -d /home/orca/.local/bin`,
 		`printf '%s\n' '#!/bin/sh' 'exec sudo -n /usr/bin/gh "$@"' > /home/orca/.local/bin/gh`,
@@ -123,12 +129,14 @@ func BuildWorkspaceGHForOrcaCommands() []string {
 // BuildMigrateAgentHomeFromRootCommands returns a script copying the agent
 // config allowlist from /root to /home/orca on long-lived boxes already
 // mirrored to root. The allowlist is mirrorlocal.DefaultIncludePaths; secrets
-// (auth.json etc.) are never copied. Ownership lands on orca:orca.
+// (auth.json etc.) are excluded at copy time — never copied, even nested
+// inside allowlist dirs. Ownership lands on orca:orca.
 func BuildMigrateAgentHomeFromRootCommands() []string {
 	var b strings.Builder
 	b.WriteString("set -e\n")
 	b.WriteString("# Migrate agent config allowlist from /root to /home/orca (mirrorlocal DefaultIncludePaths).\n")
-	b.WriteString("# skip auth.json and other secret files: never copied.\n")
+	b.WriteString("# Secret basenames (auth.json, credentials) and sqlite/db files are excluded at copy\n")
+	b.WriteString("# time — never copied, even nested inside allowlist dirs.\n")
 	b.WriteString("mkdir -p /home/orca\n")
 	b.WriteString("for p in \\\n")
 	for _, p := range mirrorlocal.DefaultIncludePaths {
@@ -137,11 +145,23 @@ func BuildMigrateAgentHomeFromRootCommands() []string {
 	b.WriteString("; do\n")
 	b.WriteString("  if [ -e \"/root/$p\" ]; then\n")
 	b.WriteString("    mkdir -p \"/home/orca/$(dirname \"$p\")\"\n")
-	b.WriteString("    cp -a \"/root/$p\" \"/home/orca/$p\"\n")
+	b.WriteString("    tar -C /root -cf - \\\n")
+	b.WriteString("      --exclude=auth.json --exclude=.credentials.json --exclude=credentials.json \\\n")
+	b.WriteString("      --exclude='*.sqlite' --exclude='*.sqlite3' --exclude='*.db' \\\n")
+	b.WriteString("      --exclude='*.lock' --exclude='*.wal' --exclude='*.shm' \\\n")
+	b.WriteString("      \"$p\" | tar -C /home/orca -xf -\n")
 	b.WriteString("  fi\n")
 	b.WriteString("done\n")
 	b.WriteString("chown -R orca:orca /home/orca/.claude /home/orca/.codex 2>/dev/null || true\n")
 	return []string{b.String()}
+}
+
+// BuildOrcaRechownCommand returns a best-effort re-chown of the mirrored agent
+// config under /home/orca. mirror-local may extract before B1 useradd (the
+// user does not exist yet, so its chown is a silent no-op); re-running after
+// B1 ensures ownership lands on orca:orca. Soft-fails (2>/dev/null || true).
+func BuildOrcaRechownCommand() string {
+	return `chown -R orca:orca /home/orca/.claude /home/orca/.codex 2>/dev/null || true`
 }
 
 // BuildOrcaB1EnsureCommands returns idempotent B1 bridge commands: system user
@@ -160,8 +180,8 @@ func BuildOrcaB1EnsureCommands() []string {
 		`ln -sfn /root/workspace /home/orca/workspace`,
 		`ln -sfn /root/wiki /home/orca/wiki`,
 		`chown -h orca:orca /home/orca/root-home /home/orca/workspace /home/orca/wiki`,
-		`su -s /bin/bash orca -c 'mkdir -p "$HOME/.local/bin" "$HOME/.local/lib/node_modules"; npm config set prefix "$HOME/.local"'`,
-		`su -s /bin/bash orca -c 'git config --global --add safe.directory /root/workspace; git config --global --add safe.directory /root/wiki; git config --global --add safe.directory /root'`,
+		`sudo -u orca env HOME=/home/orca bash -lc 'mkdir -p "$HOME/.local/bin" "$HOME/.local/lib/node_modules"; npm config set prefix "$HOME/.local"'`,
+		`sudo -u orca env HOME=/home/orca bash -lc 'git config --global --add safe.directory /root/workspace; git config --global --add safe.directory /root/wiki; git config --global --add safe.directory /root'`,
 	}
 }
 
@@ -175,7 +195,7 @@ func BuildAgentMatrixCommand() string {
 echo "== orca agent matrix =="
 echo "-- binaries on orca PATH --"
 for b in claude codex grok gh; do
-  if p=$(su -s /bin/bash orca -c "command -v $b" 2>/dev/null); then
+  if p=$(sudo -u orca env HOME=/home/orca bash -lc "command -v $b" 2>/dev/null); then
     echo "ok   $b: $p"
   else
     echo "miss $b"

--- a/packages/devsh/internal/cli/orca_serve.go
+++ b/packages/devsh/internal/cli/orca_serve.go
@@ -171,6 +171,10 @@ func BuildOrcaRechownCommand() string {
 func BuildOrcaB1EnsureCommands() []string {
 	return []string{
 		`id orca >/dev/null 2>&1 || useradd --system --create-home --shell /usr/sbin/nologin orca`,
+		// Mirror-local may have created /home/orca (as root) before B1's
+		// useradd; useradd leaves an existing home's ownership untouched, so
+		// orca's later writes (~/.local, .npmrc, .gitconfig) would EACCES.
+		`chown orca:orca /home/orca 2>/dev/null || true`,
 		`echo "orca ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/orca`,
 		`chmod 440 /etc/sudoers.d/orca`,
 		`chmod 755 /root`,

--- a/packages/devsh/internal/cli/orca_serve.go
+++ b/packages/devsh/internal/cli/orca_serve.go
@@ -181,6 +181,10 @@ func BuildOrcaB1EnsureCommands() []string {
 		`ln -sfn /root/wiki /home/orca/wiki`,
 		`chown -h orca:orca /home/orca/root-home /home/orca/workspace /home/orca/wiki`,
 		`sudo -u orca env HOME=/home/orca bash -lc 'mkdir -p "$HOME/.local/bin" "$HOME/.local/lib/node_modules"; npm config set prefix "$HOME/.local"'`,
+		// Link bun-installed agent CLIs (claude, codex, gemini, etc.) into orca PATH
+		// bun installs to /root/.bun/bin/ which is not on orca's PATH by default
+		`for cli in /root/.bun/bin/*; do name=$(basename "$cli"); [ "$name" = "bun" ] && continue; [ "$name" = "bunx" ] && continue; ln -sfn "$cli" /home/orca/.local/bin/"$name"; done`,
+		`chown -h orca:orca /home/orca/.local/bin/* 2>/dev/null || true`,
 		`sudo -u orca env HOME=/home/orca bash -lc 'git config --global --add safe.directory /root/workspace; git config --global --add safe.directory /root/wiki; git config --global --add safe.directory /root'`,
 	}
 }

--- a/packages/devsh/internal/cli/orca_serve_test.go
+++ b/packages/devsh/internal/cli/orca_serve_test.go
@@ -76,6 +76,11 @@ func TestBuildOrcaB1EnsureCommands(t *testing.T) {
 	if !strings.Contains(joined, "useradd --system --create-home --shell /usr/sbin/nologin orca") {
 		t.Fatalf("expected nologin system user: %s", joined)
 	}
+	// Home base dir must be orca-owned: mirror-local may create /home/orca as
+	// root before useradd, and useradd leaves existing homes untouched.
+	if !strings.Contains(joined, "chown orca:orca /home/orca") {
+		t.Fatalf("expected chown of /home/orca base dir: %s", joined)
+	}
 	// Passwordless sudoers.
 	if !strings.Contains(joined, "NOPASSWD") || !strings.Contains(joined, "/etc/sudoers.d/orca") {
 		t.Fatalf("expected sudoers NOPASSWD: %s", joined)

--- a/packages/devsh/internal/cli/orca_serve_test.go
+++ b/packages/devsh/internal/cli/orca_serve_test.go
@@ -22,13 +22,32 @@ func TestBuildWorkspaceGHForOrcaCommands(t *testing.T) {
 	if !strings.Contains(joined, "credential.https://gist.github.com.helper") {
 		t.Fatalf("expected gist.github.com helper: %s", joined)
 	}
+	// Commands run as orca must use sudo -u orca env HOME=/home/orca bash -lc
+	// (su does not reliably set HOME; HOME=/root is forbidden for orca).
+	if !strings.Contains(joined, "sudo -u orca env HOME=/home/orca bash -lc") {
+		t.Fatalf("expected sudo -u orca env HOME=/home/orca bash -lc: %s", joined)
+	}
+	if strings.Contains(joined, "su -s /bin/bash orca") {
+		t.Fatal("must not use su -s /bin/bash orca (HOME not reliably set)")
+	}
 }
 
 func TestBuildMigrateAgentHomeFromRootCommandsSkipsAuth(t *testing.T) {
 	cmds := BuildMigrateAgentHomeFromRootCommands()
 	joined := strings.Join(cmds, "\n")
-	if strings.Contains(joined, "cp ") && strings.Contains(joined, "auth.json") && !strings.Contains(joined, "# skip") {
-		t.Fatal("must not copy auth.json")
+	// Tar-based copy must exclude secret basenames at copy time (nested
+	// auth.json inside allowlist dirs must never land in /home/orca).
+	if !strings.Contains(joined, "--exclude=auth.json") {
+		t.Fatalf("expected --exclude=auth.json in tar copy: %s", joined)
+	}
+	if !strings.Contains(joined, "--exclude=credentials.json") {
+		t.Fatalf("expected --exclude=credentials.json in tar copy: %s", joined)
+	}
+	if !strings.Contains(joined, "tar -C /root -cf -") || !strings.Contains(joined, "tar -C /home/orca -xf -") {
+		t.Fatalf("expected tar-based copy /root -> /home/orca: %s", joined)
+	}
+	if strings.Contains(joined, "cp -a") {
+		t.Fatal("must not use cp -a (copies nested secrets inside allowlist dirs)")
 	}
 	if !strings.Contains(joined, ".claude") || !strings.Contains(joined, ".codex") {
 		t.Fatal("must migrate allowlist trees")
@@ -82,9 +101,30 @@ func TestBuildOrcaB1EnsureCommands(t *testing.T) {
 	if !strings.Contains(joined, "safe.directory") {
 		t.Fatalf("expected git safe.directory: %s", joined)
 	}
+	// Commands run as orca must use sudo -u orca env HOME=/home/orca bash -lc
+	// (su does not reliably set HOME; HOME=/root is forbidden for orca).
+	if !strings.Contains(joined, "sudo -u orca env HOME=/home/orca bash -lc") {
+		t.Fatalf("expected sudo -u orca env HOME=/home/orca bash -lc: %s", joined)
+	}
+	if strings.Contains(joined, "su -s /bin/bash orca") {
+		t.Fatal("must not use su -s /bin/bash orca (HOME not reliably set)")
+	}
 	// Never HOME=/root (Chromium SIGTRAP).
 	if strings.Contains(joined, "HOME=/root") {
 		t.Fatal("must never set HOME=/root for orca")
+	}
+}
+
+func TestBuildOrcaRechownCommand(t *testing.T) {
+	cmd := BuildOrcaRechownCommand()
+	// Re-chown after B1 useradd: mirror-local may have extracted before the
+	// user existed, making the earlier chown a silent no-op.
+	if !strings.Contains(cmd, "chown -R orca:orca /home/orca/.claude /home/orca/.codex") {
+		t.Fatalf("expected re-chown of mirrored config: %s", cmd)
+	}
+	// Must soft-fail so the box stays usable when nothing was mirrored.
+	if !strings.Contains(cmd, "|| true") {
+		t.Fatalf("expected best-effort re-chown: %s", cmd)
 	}
 }
 

--- a/packages/devsh/internal/cli/orca_serve_test.go
+++ b/packages/devsh/internal/cli/orca_serve_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildWorkspaceGHForOrcaCommands(t *testing.T) {
+	cmds := BuildWorkspaceGHForOrcaCommands()
+	joined := strings.Join(cmds, "\n")
+	// Must configure orca git credential helper via sudo -n gh
+	if !strings.Contains(joined, "sudo -n") || !strings.Contains(joined, "gh auth git-credential") {
+		t.Fatalf("expected G1 helper: %s", joined)
+	}
+	if strings.Contains(joined, "gh auth login") {
+		t.Fatal("must not instruct gh auth login as orca")
+	}
+	// G1 must cover both github.com and gist.github.com
+	if !strings.Contains(joined, "credential.https://github.com.helper") {
+		t.Fatalf("expected github.com helper: %s", joined)
+	}
+	if !strings.Contains(joined, "credential.https://gist.github.com.helper") {
+		t.Fatalf("expected gist.github.com helper: %s", joined)
+	}
+}
+
+func TestBuildMigrateAgentHomeFromRootCommandsSkipsAuth(t *testing.T) {
+	cmds := BuildMigrateAgentHomeFromRootCommands()
+	joined := strings.Join(cmds, "\n")
+	if strings.Contains(joined, "cp ") && strings.Contains(joined, "auth.json") && !strings.Contains(joined, "# skip") {
+		t.Fatal("must not copy auth.json")
+	}
+	if !strings.Contains(joined, ".claude") || !strings.Contains(joined, ".codex") {
+		t.Fatal("must migrate allowlist trees")
+	}
+	// Allowlist must match mirrorlocal DefaultIncludePaths entries.
+	for _, want := range []string{
+		".claude/settings.json",
+		".claude/skills",
+		".codex/config.toml",
+		".codex/automations",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("allowlist missing %q:\n%s", want, joined)
+		}
+	}
+	// Ownership must land on orca.
+	if !strings.Contains(joined, "chown -R orca:orca") {
+		t.Fatalf("expected chown to orca: %s", joined)
+	}
+}
+
+func TestBuildOrcaB1EnsureCommands(t *testing.T) {
+	cmds := BuildOrcaB1EnsureCommands()
+	joined := strings.Join(cmds, "\n")
+	// System user with nologin shell.
+	if !strings.Contains(joined, "useradd --system --create-home --shell /usr/sbin/nologin orca") {
+		t.Fatalf("expected nologin system user: %s", joined)
+	}
+	// Passwordless sudoers.
+	if !strings.Contains(joined, "NOPASSWD") || !strings.Contains(joined, "/etc/sudoers.d/orca") {
+		t.Fatalf("expected sudoers NOPASSWD: %s", joined)
+	}
+	// Traversal perms on /root + workspace + wiki.
+	if !strings.Contains(joined, "chmod 755 /root") {
+		t.Fatalf("expected chmod 755 /root: %s", joined)
+	}
+	if !strings.Contains(joined, "/root/workspace") || !strings.Contains(joined, "/root/wiki") {
+		t.Fatalf("expected workspace/wiki chmod: %s", joined)
+	}
+	// Home symlinks.
+	for _, link := range []string{"/home/orca/workspace", "/home/orca/wiki", "/home/orca/root-home"} {
+		if !strings.Contains(joined, link) {
+			t.Fatalf("expected symlink %s: %s", link, joined)
+		}
+	}
+	// npm prefix to ~/.local.
+	if !strings.Contains(joined, "npm config set prefix") || !strings.Contains(joined, ".local") {
+		t.Fatalf("expected npm prefix ~/.local: %s", joined)
+	}
+	// git safe.directory for root-owned trees.
+	if !strings.Contains(joined, "safe.directory") {
+		t.Fatalf("expected git safe.directory: %s", joined)
+	}
+	// Never HOME=/root (Chromium SIGTRAP).
+	if strings.Contains(joined, "HOME=/root") {
+		t.Fatal("must never set HOME=/root for orca")
+	}
+}
+
+func TestBuildAgentMatrixCommand(t *testing.T) {
+	cmd := BuildAgentMatrixCommand()
+	if cmd == "" {
+		t.Fatal("expected non-empty matrix command")
+	}
+	// Single shell script: must be executable as one bash -lc string.
+	if !strings.Contains(cmd, "#!/bin/sh") && !strings.Contains(cmd, "#!/bin/bash") {
+		t.Fatalf("expected shebang script: %s", cmd)
+	}
+	// Matrix must report binaries, mirrored config, and gh status.
+	for _, want := range []string{"claude", "codex", ".claude", ".codex", "gh"} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("matrix missing %q: %s", want, cmd)
+		}
+	}
+	// Must not instruct gh auth login as orca.
+	if strings.Contains(cmd, "gh auth login") {
+		t.Fatal("matrix must not instruct gh auth login as orca")
+	}
+}

--- a/packages/devsh/internal/cli/orca_serve_test.go
+++ b/packages/devsh/internal/cli/orca_serve_test.go
@@ -97,6 +97,11 @@ func TestBuildOrcaB1EnsureCommands(t *testing.T) {
 	if !strings.Contains(joined, "npm config set prefix") || !strings.Contains(joined, ".local") {
 		t.Fatalf("expected npm prefix ~/.local: %s", joined)
 	}
+	// B1 must link bun-installed CLIs from /root/.bun/bin into orca PATH
+	// (bun installs to /root/.bun/bin which is not on orca's PATH by default).
+	if !strings.Contains(joined, "/root/.bun/bin") {
+		t.Fatal("B1 must link bun-installed CLIs from /root/.bun/bin into orca PATH")
+	}
 	// git safe.directory for root-owned trees.
 	if !strings.Contains(joined, "safe.directory") {
 		t.Fatalf("expected git safe.directory: %s", joined)

--- a/packages/devsh/internal/cli/start.go
+++ b/packages/devsh/internal/cli/start.go
@@ -98,6 +98,7 @@ func applyStartTemplateFlags(cmd *cobra.Command) error {
 	cli.TargetHome, _ = cmd.Flags().GetString("target-home")
 	cli.OrcaServe, _ = cmd.Flags().GetBool("orca-serve")
 	cli.MigrateAgentHomeFromRoot, _ = cmd.Flags().GetBool("migrate-agent-home-from-root")
+	cli.CloudWorkspace, _ = cmd.Flags().GetBool("cloud-workspace")
 	cli.Provider = flagProvider
 
 	cliSet := map[string]bool{
@@ -110,6 +111,7 @@ func applyStartTemplateFlags(cmd *cobra.Command) error {
 		"target-home":                  cmd.Flags().Changed("target-home"),
 		"orca-serve":                   cmd.Flags().Changed("orca-serve"),
 		"migrate-agent-home-from-root": cmd.Flags().Changed("migrate-agent-home-from-root"),
+		"cloud-workspace":              cmd.Flags().Changed("cloud-workspace"),
 	}
 
 	merged := ExpandStartTemplate(tmpl, cli, cliSet)
@@ -410,6 +412,7 @@ func runStartPveLxc(cmd *cobra.Command, args []string) error {
 			} else {
 				wwwClient.SetTeamSlug(teamSlug)
 				if authMode.RecordOwnership {
+					cloudWorkspace, _ := cmd.Flags().GetBool("cloud-workspace")
 					if err := wwwClient.RecordSandboxCreate(ctx, vm.RecordSandboxCreateRequest{
 						InstanceID:       instance.ID,
 						Provider:         provider.PveLxc,
@@ -417,6 +420,7 @@ func runStartPveLxc(cmd *cobra.Command, args []string) error {
 						Hostname:         instance.Hostname,
 						SnapshotID:       snapshotID,
 						SnapshotProvider: provider.PveLxc,
+						IsCloudWorkspace: cloudWorkspace,
 					}); err != nil {
 						fmt.Printf("Warning: failed to record sandbox ownership: %v\n", err)
 					}
@@ -662,6 +666,7 @@ func init() {
 	startCmd.Flags().String("target-home", "", "Cloud home for --mirror-local path rewrite/extract (default /root; use /home/orca for Orca Server)")
 	startCmd.Flags().Bool("orca-serve", false, "Compose Orca Server agent home post-start: B1 bridge, workspace gh, agent matrix (pve-lxc; soft-fail)")
 	startCmd.Flags().Bool("migrate-agent-home-from-root", false, "With --orca-serve: copy mirrorlocal allowlist from /root to /home/orca (never auth.json)")
+	startCmd.Flags().Bool("cloud-workspace", false, "Record sandbox as a cloud workspace so it appears in the Workspaces section (pve-lxc)")
 	startCmd.Flags().String("template", "", "Load ~/.cmux/templates/<name>.yaml (or path) and expand to start flags")
 	rootCmd.AddCommand(startCmd)
 }

--- a/packages/devsh/internal/cli/start.go
+++ b/packages/devsh/internal/cli/start.go
@@ -412,7 +412,9 @@ func runStartPveLxc(cmd *cobra.Command, args []string) error {
 
 	// Optional: mirror safe local agent config (soft-fail).
 	if mirrorLocal {
-		if err := mirrorLocalAgentConfig(ctx, client, instance); err != nil {
+		targetHomeFlag, _ := cmd.Flags().GetString("target-home")
+		targetHome := resolveMirrorTargetHome(targetHomeFlag)
+		if err := mirrorLocalAgentConfig(ctx, client, instance, targetHome); err != nil {
 			fmt.Printf("Warning: --mirror-local failed (box remains usable): %v\n", err)
 		}
 	}
@@ -529,9 +531,40 @@ func runStartE2B(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// resolveMirrorTargetHome resolves the --target-home flag for --mirror-local.
+// Empty or non-absolute values fall back to the default "/root".
+func resolveMirrorTargetHome(flag string) string {
+	flag = strings.TrimSpace(flag)
+	if flag == "" {
+		return "/root"
+	}
+	if !strings.HasPrefix(flag, "/") {
+		return "/root" // or return error at call site; keep resolve pure
+	}
+	return flag
+}
+
+// buildMirrorExtractCommand builds the remote shell command that extracts the
+// pushed agent-config tar under targetHome. Tar entries are relative like
+// .claude/... .codex/... so extraction lands under the target home. When the
+// target is /home/orca the extracted config is chowned to orca:orca (the push
+// may land as root); the chown is best-effort (2>/dev/null || true).
+func buildMirrorExtractCommand(remoteTar, targetHome string) string {
+	quotedTar := pvelxc.ShellSingleQuote(remoteTar)
+	// tar entries are .claude/... .codex/... relative to home
+	cmd := fmt.Sprintf("mkdir -p %s && tar -xf %s -C %s && rm -f %s",
+		targetHome, quotedTar, targetHome, quotedTar)
+	if targetHome == "/home/orca" {
+		// ensure ownership after extract (push may land as root)
+		cmd += " && chown -R orca:orca /home/orca/.claude /home/orca/.codex 2>/dev/null || true"
+	}
+	return cmd
+}
+
 // mirrorLocalAgentConfig packs a redacted ~/.claude + ~/.codex subset and dual-path
-// pushes it into the container, then extracts under /root. Soft-fail at caller.
-func mirrorLocalAgentConfig(ctx context.Context, client *pvelxc.Client, instance *pvelxc.Instance) error {
+// pushes it into the container, then extracts under targetHome (default /root).
+// Soft-fail at caller.
+func mirrorLocalAgentConfig(ctx context.Context, client *pvelxc.Client, instance *pvelxc.Instance, targetHome string) error {
 	fmt.Println("Mirroring local agent config (--mirror-local)...")
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -547,7 +580,7 @@ func mirrorLocalAgentConfig(ctx context.Context, client *pvelxc.Client, instance
 	if _, err := mirrorlocal.PackToFile(mirrorlocal.PackOptions{
 		HomeDir:         home,
 		LocalHomePrefix: home,
-		TargetHome:      "/root",
+		TargetHome:      targetHome,
 		IncludeSecrets:  false,
 	}, archivePath); err != nil {
 		return fmt.Errorf("pack: %w", err)
@@ -562,9 +595,8 @@ func mirrorLocalAgentConfig(ctx context.Context, client *pvelxc.Client, instance
 		fmt.Printf("  Push path: %s\n", result.Path)
 	}
 
-	// Extract into /root (tar entries are relative like .claude/... .codex/...)
-	quotedTar := pvelxc.ShellSingleQuote(remoteTar)
-	extractCmd := fmt.Sprintf("mkdir -p /root && tar -xf %s -C /root && rm -f %s", quotedTar, quotedTar)
+	// Extract into targetHome (tar entries are relative like .claude/... .codex/...)
+	extractCmd := buildMirrorExtractCommand(remoteTar, targetHome)
 	stdout, stderr, code, execErr := client.ExecCommand(ctx, instance.ID, extractCmd)
 	if execErr != nil {
 		return fmt.Errorf("extract exec: %w", execErr)
@@ -582,6 +614,7 @@ func init() {
 	startCmd.Flags().Bool("no-auth", false, "Skip ownership recording and automatic provider auth setup")
 	startCmd.Flags().Bool("clean", false, "Skip provider auth setup but still record sandbox ownership (pve-lxc)")
 	startCmd.Flags().Bool("mirror-local", false, "Pack/redact local ~/.claude and ~/.codex into the box (pve-lxc; soft-fail)")
+	startCmd.Flags().String("target-home", "", "Cloud home for --mirror-local path rewrite/extract (default /root; use /home/orca for Orca Server)")
 	startCmd.Flags().String("template", "", "Load ~/.cmux/templates/<name>.yaml (or path) and expand to start flags")
 	rootCmd.AddCommand(startCmd)
 }

--- a/packages/devsh/internal/cli/start.go
+++ b/packages/devsh/internal/cli/start.go
@@ -52,11 +52,13 @@ Examples:
 		clean, _ := cmd.Flags().GetBool("clean")
 		mirrorLocal, _ := cmd.Flags().GetBool("mirror-local")
 		orcaServe, _ := cmd.Flags().GetBool("orca-serve")
-		if (clean || mirrorLocal || orcaServe) && !mode.serverManaged && mode.provider != provider.PveLxc {
-			return fmt.Errorf("--clean, --mirror-local and --orca-serve are only supported for provider pve-lxc (got %s)", mode.provider)
+		targetHome, _ := cmd.Flags().GetString("target-home")
+		migrateFromRoot, _ := cmd.Flags().GetBool("migrate-agent-home-from-root")
+		if (clean || mirrorLocal || orcaServe || targetHome != "" || migrateFromRoot) && !mode.serverManaged && mode.provider != provider.PveLxc {
+			return fmt.Errorf("--clean, --mirror-local, --orca-serve, --target-home and --migrate-agent-home-from-root are only supported for provider pve-lxc (got %s)", mode.provider)
 		}
-		if mode.serverManaged && (clean || mirrorLocal || orcaServe) {
-			return fmt.Errorf("--clean, --mirror-local and --orca-serve require an explicit pve-lxc provider (server-managed start is unsupported for these flags)")
+		if mode.serverManaged && (clean || mirrorLocal || orcaServe || targetHome != "" || migrateFromRoot) {
+			return fmt.Errorf("--clean, --mirror-local, --orca-serve, --target-home and --migrate-agent-home-from-root require an explicit pve-lxc provider (server-managed start is unsupported for these flags)")
 		}
 
 		if mode.serverManaged {
@@ -593,9 +595,10 @@ func effectiveTargetHome(orcaServe bool, targetHomeFlag string) string {
 // may land as root); the chown is best-effort (2>/dev/null || true).
 func buildMirrorExtractCommand(remoteTar, targetHome string) string {
 	quotedTar := pvelxc.ShellSingleQuote(remoteTar)
+	quotedHome := pvelxc.ShellSingleQuote(targetHome)
 	// tar entries are .claude/... .codex/... relative to home
 	cmd := fmt.Sprintf("mkdir -p %s && tar -xf %s -C %s && rm -f %s",
-		targetHome, quotedTar, targetHome, quotedTar)
+		quotedHome, quotedTar, quotedHome, quotedTar)
 	if targetHome == "/home/orca" {
 		// ensure ownership after extract (push may land as root)
 		cmd += " && chown -R orca:orca /home/orca/.claude /home/orca/.codex 2>/dev/null || true"

--- a/packages/devsh/internal/cli/start.go
+++ b/packages/devsh/internal/cli/start.go
@@ -51,11 +51,12 @@ Examples:
 
 		clean, _ := cmd.Flags().GetBool("clean")
 		mirrorLocal, _ := cmd.Flags().GetBool("mirror-local")
-		if (clean || mirrorLocal) && !mode.serverManaged && mode.provider != provider.PveLxc {
-			return fmt.Errorf("--clean and --mirror-local are only supported for provider pve-lxc (got %s)", mode.provider)
+		orcaServe, _ := cmd.Flags().GetBool("orca-serve")
+		if (clean || mirrorLocal || orcaServe) && !mode.serverManaged && mode.provider != provider.PveLxc {
+			return fmt.Errorf("--clean, --mirror-local and --orca-serve are only supported for provider pve-lxc (got %s)", mode.provider)
 		}
-		if mode.serverManaged && (clean || mirrorLocal) {
-			return fmt.Errorf("--clean and --mirror-local require an explicit pve-lxc provider (server-managed start is unsupported for these flags)")
+		if mode.serverManaged && (clean || mirrorLocal || orcaServe) {
+			return fmt.Errorf("--clean, --mirror-local and --orca-serve require an explicit pve-lxc provider (server-managed start is unsupported for these flags)")
 		}
 
 		if mode.serverManaged {
@@ -92,15 +93,21 @@ func applyStartTemplateFlags(cmd *cobra.Command) error {
 	cli.Clean, _ = cmd.Flags().GetBool("clean")
 	cli.MirrorLocal, _ = cmd.Flags().GetBool("mirror-local")
 	cli.NoAuth, _ = cmd.Flags().GetBool("no-auth")
+	cli.TargetHome, _ = cmd.Flags().GetString("target-home")
+	cli.OrcaServe, _ = cmd.Flags().GetBool("orca-serve")
+	cli.MigrateAgentHomeFromRoot, _ = cmd.Flags().GetBool("migrate-agent-home-from-root")
 	cli.Provider = flagProvider
 
 	cliSet := map[string]bool{
 		// Global --provider is not always marked Changed on the local flag set.
-		"provider":     cmd.Flags().Changed("provider") || strings.TrimSpace(flagProvider) != "",
-		"snapshot":     cmd.Flags().Changed("snapshot"),
-		"clean":        cmd.Flags().Changed("clean"),
-		"mirror-local": cmd.Flags().Changed("mirror-local"),
-		"no-auth":      cmd.Flags().Changed("no-auth"),
+		"provider":                     cmd.Flags().Changed("provider") || strings.TrimSpace(flagProvider) != "",
+		"snapshot":                     cmd.Flags().Changed("snapshot"),
+		"clean":                        cmd.Flags().Changed("clean"),
+		"mirror-local":                 cmd.Flags().Changed("mirror-local"),
+		"no-auth":                      cmd.Flags().Changed("no-auth"),
+		"target-home":                  cmd.Flags().Changed("target-home"),
+		"orca-serve":                   cmd.Flags().Changed("orca-serve"),
+		"migrate-agent-home-from-root": cmd.Flags().Changed("migrate-agent-home-from-root"),
 	}
 
 	merged := ExpandStartTemplate(tmpl, cli, cliSet)
@@ -115,6 +122,15 @@ func applyStartTemplateFlags(cmd *cobra.Command) error {
 	}
 	if !cliSet["no-auth"] {
 		_ = cmd.Flags().Set("no-auth", fmt.Sprintf("%t", merged.NoAuth))
+	}
+	if !cliSet["target-home"] && merged.TargetHome != "" {
+		_ = cmd.Flags().Set("target-home", merged.TargetHome)
+	}
+	if !cliSet["orca-serve"] {
+		_ = cmd.Flags().Set("orca-serve", fmt.Sprintf("%t", merged.OrcaServe))
+	}
+	if !cliSet["migrate-agent-home-from-root"] {
+		_ = cmd.Flags().Set("migrate-agent-home-from-root", fmt.Sprintf("%t", merged.MigrateAgentHomeFromRoot))
 	}
 	if merged.Provider != "" && !cliSet["provider"] {
 		flagProvider = merged.Provider
@@ -411,11 +427,24 @@ func runStartPveLxc(cmd *cobra.Command, args []string) error {
 	}
 
 	// Optional: mirror safe local agent config (soft-fail).
+	orcaServe, _ := cmd.Flags().GetBool("orca-serve")
+	targetHomeFlag, _ := cmd.Flags().GetString("target-home")
+	targetHome := effectiveTargetHome(orcaServe, targetHomeFlag)
 	if mirrorLocal {
-		targetHomeFlag, _ := cmd.Flags().GetString("target-home")
-		targetHome := resolveMirrorTargetHome(targetHomeFlag)
 		if err := mirrorLocalAgentConfig(ctx, client, instance, targetHome); err != nil {
 			fmt.Printf("Warning: --mirror-local failed (box remains usable): %v\n", err)
+		}
+	}
+
+	// Optional: compose Orca Server post-start (B1 → migrate? → workspace gh → matrix).
+	// Each step soft-fails with a Warning; the box stays usable.
+	if orcaServe {
+		migrateFromRoot, _ := cmd.Flags().GetBool("migrate-agent-home-from-root")
+		if err := runOrcaServePostStart(ctx, client, instance.ID, OrcaServeOpts{
+			MigrateFromRoot: migrateFromRoot,
+			WorkspaceGH:     true,
+		}); err != nil {
+			fmt.Printf("Warning: --orca-serve post-start: %v\n", err)
 		}
 	}
 
@@ -544,6 +573,19 @@ func resolveMirrorTargetHome(flag string) string {
 	return flag
 }
 
+// effectiveTargetHome resolves the cloud home for agent config materialization.
+// An explicit --target-home always wins; otherwise --orca-serve implies
+// /home/orca (Orca Server agent home) and the default stays /root.
+func effectiveTargetHome(orcaServe bool, targetHomeFlag string) string {
+	if strings.TrimSpace(targetHomeFlag) != "" {
+		return resolveMirrorTargetHome(targetHomeFlag)
+	}
+	if orcaServe {
+		return "/home/orca"
+	}
+	return "/root"
+}
+
 // buildMirrorExtractCommand builds the remote shell command that extracts the
 // pushed agent-config tar under targetHome. Tar entries are relative like
 // .claude/... .codex/... so extraction lands under the target home. When the
@@ -615,6 +657,8 @@ func init() {
 	startCmd.Flags().Bool("clean", false, "Skip provider auth setup but still record sandbox ownership (pve-lxc)")
 	startCmd.Flags().Bool("mirror-local", false, "Pack/redact local ~/.claude and ~/.codex into the box (pve-lxc; soft-fail)")
 	startCmd.Flags().String("target-home", "", "Cloud home for --mirror-local path rewrite/extract (default /root; use /home/orca for Orca Server)")
+	startCmd.Flags().Bool("orca-serve", false, "Compose Orca Server agent home post-start: B1 bridge, workspace gh, agent matrix (pve-lxc; soft-fail)")
+	startCmd.Flags().Bool("migrate-agent-home-from-root", false, "With --orca-serve: copy mirrorlocal allowlist from /root to /home/orca (never auth.json)")
 	startCmd.Flags().String("template", "", "Load ~/.cmux/templates/<name>.yaml (or path) and expand to start flags")
 	rootCmd.AddCommand(startCmd)
 }

--- a/packages/devsh/internal/cli/start.go
+++ b/packages/devsh/internal/cli/start.go
@@ -98,7 +98,6 @@ func applyStartTemplateFlags(cmd *cobra.Command) error {
 	cli.TargetHome, _ = cmd.Flags().GetString("target-home")
 	cli.OrcaServe, _ = cmd.Flags().GetBool("orca-serve")
 	cli.MigrateAgentHomeFromRoot, _ = cmd.Flags().GetBool("migrate-agent-home-from-root")
-	cli.CloudWorkspace, _ = cmd.Flags().GetBool("cloud-workspace")
 	cli.Provider = flagProvider
 
 	cliSet := map[string]bool{
@@ -111,7 +110,6 @@ func applyStartTemplateFlags(cmd *cobra.Command) error {
 		"target-home":                  cmd.Flags().Changed("target-home"),
 		"orca-serve":                   cmd.Flags().Changed("orca-serve"),
 		"migrate-agent-home-from-root": cmd.Flags().Changed("migrate-agent-home-from-root"),
-		"cloud-workspace":              cmd.Flags().Changed("cloud-workspace"),
 	}
 
 	merged := ExpandStartTemplate(tmpl, cli, cliSet)
@@ -412,7 +410,6 @@ func runStartPveLxc(cmd *cobra.Command, args []string) error {
 			} else {
 				wwwClient.SetTeamSlug(teamSlug)
 				if authMode.RecordOwnership {
-					cloudWorkspace, _ := cmd.Flags().GetBool("cloud-workspace")
 					if err := wwwClient.RecordSandboxCreate(ctx, vm.RecordSandboxCreateRequest{
 						InstanceID:       instance.ID,
 						Provider:         provider.PveLxc,
@@ -420,7 +417,6 @@ func runStartPveLxc(cmd *cobra.Command, args []string) error {
 						Hostname:         instance.Hostname,
 						SnapshotID:       snapshotID,
 						SnapshotProvider: provider.PveLxc,
-						IsCloudWorkspace: cloudWorkspace,
 					}); err != nil {
 						fmt.Printf("Warning: failed to record sandbox ownership: %v\n", err)
 					}
@@ -666,7 +662,6 @@ func init() {
 	startCmd.Flags().String("target-home", "", "Cloud home for --mirror-local path rewrite/extract (default /root; use /home/orca for Orca Server)")
 	startCmd.Flags().Bool("orca-serve", false, "Compose Orca Server agent home post-start: B1 bridge, workspace gh, agent matrix (pve-lxc; soft-fail)")
 	startCmd.Flags().Bool("migrate-agent-home-from-root", false, "With --orca-serve: copy mirrorlocal allowlist from /root to /home/orca (never auth.json)")
-	startCmd.Flags().Bool("cloud-workspace", false, "Record sandbox as a cloud workspace so it appears in the Workspaces section (pve-lxc)")
 	startCmd.Flags().String("template", "", "Load ~/.cmux/templates/<name>.yaml (or path) and expand to start flags")
 	rootCmd.AddCommand(startCmd)
 }

--- a/packages/devsh/internal/cli/start_mirror_target_home_test.go
+++ b/packages/devsh/internal/cli/start_mirror_target_home_test.go
@@ -1,0 +1,45 @@
+// internal/cli/start_mirror_target_home_test.go
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveMirrorTargetHome(t *testing.T) {
+	t.Parallel()
+	if got := resolveMirrorTargetHome(""); got != "/root" {
+		t.Fatalf("default: got %q", got)
+	}
+	if got := resolveMirrorTargetHome("/home/orca"); got != "/home/orca" {
+		t.Fatalf("orca: got %q", got)
+	}
+	if got := resolveMirrorTargetHome("home/orca"); got != "/root" {
+		// relative rejected → default (or error — pick one and test it)
+		// Recommended: invalid relative → return error from pack path; for resolve, empty invalid → "/root"
+		t.Fatalf("relative should fall back or error consistently; got %q", got)
+	}
+}
+
+func TestMirrorExtractCommand(t *testing.T) {
+	t.Parallel()
+	cmd := buildMirrorExtractCommand("/tmp/devsh-mirror-agent-config.tar", "/home/orca")
+	if !containsAll(cmd, "mkdir -p /home/orca", "tar -xf", "-C /home/orca", "chown -R orca:orca /home/orca/.claude /home/orca/.codex") {
+		// chown only when target is /home/orca — encode that in builder
+		t.Fatalf("extract cmd missing pieces: %s", cmd)
+	}
+	cmdRoot := buildMirrorExtractCommand("/tmp/x.tar", "/root")
+	if containsAll(cmdRoot, "chown -R orca") {
+		t.Fatal("root extract must not chown to orca")
+	}
+}
+
+// containsAll reports whether s contains every one of the given substrings.
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}

--- a/packages/devsh/internal/cli/start_mirror_target_home_test.go
+++ b/packages/devsh/internal/cli/start_mirror_target_home_test.go
@@ -15,8 +15,6 @@ func TestResolveMirrorTargetHome(t *testing.T) {
 		t.Fatalf("orca: got %q", got)
 	}
 	if got := resolveMirrorTargetHome("home/orca"); got != "/root" {
-		// relative rejected → default (or error — pick one and test it)
-		// Recommended: invalid relative → return error from pack path; for resolve, empty invalid → "/root"
 		t.Fatalf("relative should fall back or error consistently; got %q", got)
 	}
 }
@@ -24,8 +22,7 @@ func TestResolveMirrorTargetHome(t *testing.T) {
 func TestMirrorExtractCommand(t *testing.T) {
 	t.Parallel()
 	cmd := buildMirrorExtractCommand("/tmp/devsh-mirror-agent-config.tar", "/home/orca")
-	if !containsAll(cmd, "mkdir -p /home/orca", "tar -xf", "-C /home/orca", "chown -R orca:orca /home/orca/.claude /home/orca/.codex") {
-		// chown only when target is /home/orca — encode that in builder
+	if !containsAll(cmd, "mkdir -p '/home/orca'", "tar -xf", "-C '/home/orca'", "chown -R orca:orca /home/orca/.claude /home/orca/.codex") {
 		t.Fatalf("extract cmd missing pieces: %s", cmd)
 	}
 	cmdRoot := buildMirrorExtractCommand("/tmp/x.tar", "/root")

--- a/packages/devsh/internal/cli/start_orca_serve_test.go
+++ b/packages/devsh/internal/cli/start_orca_serve_test.go
@@ -70,16 +70,17 @@ func TestRunOrcaServePostStartOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runOrcaServePostStart: %v", err)
 	}
-	// Order must be B1 → migrate → workspace_gh → matrix.
+	// Order must be B1 → re-chown → migrate → workspace_gh → matrix.
 	b1 := indexOf(exec.cmds, "useradd")
-	migrate := indexOf(exec.cmds, "chown -R orca:orca")
+	rechown := indexOf(exec.cmds, "chown -R orca:orca /home/orca/.claude /home/orca/.codex")
+	migrate := indexOf(exec.cmds, "tar -C /root -cf -")
 	gh := indexOf(exec.cmds, "gh auth git-credential")
 	matrix := indexOf(exec.cmds, "orca agent matrix")
-	if b1 < 0 || migrate < 0 || gh < 0 || matrix < 0 {
-		t.Fatalf("missing step markers (b1=%d migrate=%d gh=%d matrix=%d):\n%s", b1, migrate, gh, matrix, strings.Join(exec.cmds, "\n---\n"))
+	if b1 < 0 || rechown < 0 || migrate < 0 || gh < 0 || matrix < 0 {
+		t.Fatalf("missing step markers (b1=%d rechown=%d migrate=%d gh=%d matrix=%d):\n%s", b1, rechown, migrate, gh, matrix, strings.Join(exec.cmds, "\n---\n"))
 	}
-	if !(b1 < migrate && migrate < gh && gh < matrix) {
-		t.Fatalf("order must be B1(%d) → migrate(%d) → workspace_gh(%d) → matrix(%d)", b1, migrate, gh, matrix)
+	if !(b1 < rechown && rechown < migrate && migrate < gh && gh < matrix) {
+		t.Fatalf("order must be B1(%d) → re-chown(%d) → migrate(%d) → workspace_gh(%d) → matrix(%d)", b1, rechown, migrate, gh, matrix)
 	}
 }
 
@@ -93,8 +94,12 @@ func TestRunOrcaServePostStartSkipsMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runOrcaServePostStart: %v", err)
 	}
-	if indexOf(exec.cmds, "chown -R orca:orca") != -1 {
+	if indexOf(exec.cmds, "tar -C /root -cf -") != -1 {
 		t.Fatalf("migrate must be skipped when MigrateFromRoot=false:\n%s", strings.Join(exec.cmds, "\n---\n"))
+	}
+	// Re-chown (I2) must still run after B1 even without migrate.
+	if indexOf(exec.cmds, "chown -R orca:orca /home/orca/.claude /home/orca/.codex") == -1 {
+		t.Fatal("re-chown must run after B1 even when migrate is skipped")
 	}
 	if indexOf(exec.cmds, "orca agent matrix") == -1 {
 		t.Fatal("matrix must still run without migrate")
@@ -123,8 +128,11 @@ func TestRunOrcaServePostStartSoftFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "B1") {
 		t.Fatalf("error should name the failing step: %v", err)
 	}
-	// Later steps must still have been attempted: migrate, gh, and matrix all ran.
-	if indexOf(exec.cmds, "chown -R orca:orca") == -1 {
+	// Later steps must still have been attempted: re-chown, migrate, gh, and matrix all ran.
+	if indexOf(exec.cmds, "chown -R orca:orca /home/orca/.claude /home/orca/.codex") == -1 {
+		t.Fatal("re-chown must still run after B1 soft-fail")
+	}
+	if indexOf(exec.cmds, "tar -C /root -cf -") == -1 {
 		t.Fatal("migrate must still run after B1 soft-fail")
 	}
 	if indexOf(exec.cmds, "gh auth git-credential") == -1 {

--- a/packages/devsh/internal/cli/start_orca_serve_test.go
+++ b/packages/devsh/internal/cli/start_orca_serve_test.go
@@ -1,0 +1,162 @@
+// internal/cli/start_orca_serve_test.go
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestOrcaServeDefaultTargetHome(t *testing.T) {
+	t.Parallel()
+	// pure function: effectiveTargetHome(orcaServe, flagTarget)
+	if got := effectiveTargetHome(true, ""); got != "/home/orca" {
+		t.Fatalf("orca-serve default: got %q, want /home/orca", got)
+	}
+	if got := effectiveTargetHome(false, ""); got != "/root" {
+		t.Fatalf("non-orca default: got %q, want /root", got)
+	}
+	if got := effectiveTargetHome(true, "/custom"); got != "/custom" {
+		t.Fatalf("explicit target-home wins: got %q, want /custom", got)
+	}
+	if got := effectiveTargetHome(false, "/home/orca"); got != "/home/orca" {
+		t.Fatalf("explicit target-home without orca-serve: got %q, want /home/orca", got)
+	}
+}
+
+// fakeOrcaExec records exec commands and returns canned responses.
+type fakeOrcaExec struct {
+	cmds []string
+	// per-call responses (cycled if exhausted uses last)
+	responses []struct {
+		stdout, stderr string
+		code           int
+		err            error
+	}
+	i int
+}
+
+func (f *fakeOrcaExec) ExecCommand(ctx context.Context, instanceID, command string) (string, string, int, error) {
+	f.cmds = append(f.cmds, command)
+	if len(f.responses) == 0 {
+		return "", "", 0, nil
+	}
+	idx := f.i
+	if idx >= len(f.responses) {
+		idx = len(f.responses) - 1
+	}
+	f.i++
+	r := f.responses[idx]
+	return r.stdout, r.stderr, r.code, r.err
+}
+
+// indexOf returns the first index of a command containing needle, or -1.
+func indexOf(cmds []string, needle string) int {
+	for i, c := range cmds {
+		if strings.Contains(c, needle) {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestRunOrcaServePostStartOrder(t *testing.T) {
+	t.Parallel()
+	exec := &fakeOrcaExec{}
+	err := runOrcaServePostStart(context.Background(), exec, "inst-1", OrcaServeOpts{
+		MigrateFromRoot: true,
+		WorkspaceGH:     true,
+	})
+	if err != nil {
+		t.Fatalf("runOrcaServePostStart: %v", err)
+	}
+	// Order must be B1 → migrate → workspace_gh → matrix.
+	b1 := indexOf(exec.cmds, "useradd")
+	migrate := indexOf(exec.cmds, "chown -R orca:orca")
+	gh := indexOf(exec.cmds, "gh auth git-credential")
+	matrix := indexOf(exec.cmds, "orca agent matrix")
+	if b1 < 0 || migrate < 0 || gh < 0 || matrix < 0 {
+		t.Fatalf("missing step markers (b1=%d migrate=%d gh=%d matrix=%d):\n%s", b1, migrate, gh, matrix, strings.Join(exec.cmds, "\n---\n"))
+	}
+	if !(b1 < migrate && migrate < gh && gh < matrix) {
+		t.Fatalf("order must be B1(%d) → migrate(%d) → workspace_gh(%d) → matrix(%d)", b1, migrate, gh, matrix)
+	}
+}
+
+func TestRunOrcaServePostStartSkipsMigrate(t *testing.T) {
+	t.Parallel()
+	exec := &fakeOrcaExec{}
+	err := runOrcaServePostStart(context.Background(), exec, "inst-1", OrcaServeOpts{
+		MigrateFromRoot: false,
+		WorkspaceGH:     true,
+	})
+	if err != nil {
+		t.Fatalf("runOrcaServePostStart: %v", err)
+	}
+	if indexOf(exec.cmds, "chown -R orca:orca") != -1 {
+		t.Fatalf("migrate must be skipped when MigrateFromRoot=false:\n%s", strings.Join(exec.cmds, "\n---\n"))
+	}
+	if indexOf(exec.cmds, "orca agent matrix") == -1 {
+		t.Fatal("matrix must still run without migrate")
+	}
+}
+
+func TestRunOrcaServePostStartSoftFails(t *testing.T) {
+	t.Parallel()
+	// B1 fails with exit 1 → whole step soft-fails with a Warning, remaining steps still run.
+	exec := &fakeOrcaExec{
+		responses: []struct {
+			stdout, stderr string
+			code           int
+			err            error
+		}{
+			{stdout: "", stderr: "useradd: permission denied", code: 1, err: nil},
+		},
+	}
+	err := runOrcaServePostStart(context.Background(), exec, "inst-1", OrcaServeOpts{
+		MigrateFromRoot: true,
+		WorkspaceGH:     true,
+	})
+	if err == nil {
+		t.Fatal("expected soft-fail error when B1 exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "B1") {
+		t.Fatalf("error should name the failing step: %v", err)
+	}
+	// Later steps must still have been attempted: migrate, gh, and matrix all ran.
+	if indexOf(exec.cmds, "chown -R orca:orca") == -1 {
+		t.Fatal("migrate must still run after B1 soft-fail")
+	}
+	if indexOf(exec.cmds, "gh auth git-credential") == -1 {
+		t.Fatal("workspace gh must still run after B1 soft-fail")
+	}
+	if indexOf(exec.cmds, "orca agent matrix") == -1 {
+		t.Fatal("matrix must still run after B1 soft-fail")
+	}
+}
+
+func TestRunOrcaServePostStartExecError(t *testing.T) {
+	t.Parallel()
+	exec := &fakeOrcaExec{
+		responses: []struct {
+			stdout, stderr string
+			code           int
+			err            error
+		}{
+			{stdout: "", stderr: "", code: 0, err: context.DeadlineExceeded},
+		},
+	}
+	err := runOrcaServePostStart(context.Background(), exec, "inst-1", OrcaServeOpts{
+		MigrateFromRoot: false,
+		WorkspaceGH:     true,
+	})
+	if err == nil {
+		t.Fatal("expected soft-fail error when exec transport fails")
+	}
+	if !strings.Contains(err.Error(), "B1") {
+		t.Fatalf("error should name the failing step: %v", err)
+	}
+	if indexOf(exec.cmds, "orca agent matrix") == -1 {
+		t.Fatal("matrix must still run after exec soft-fail")
+	}
+}

--- a/packages/devsh/internal/cli/start_template.go
+++ b/packages/devsh/internal/cli/start_template.go
@@ -26,9 +26,6 @@ type StartTemplate struct {
 	// optional migrate-from-root). Enable implies target_home /home/orca and
 	// mirror_local unless explicitly overridden.
 	OrcaServe *OrcaServeTemplate `yaml:"orca_serve"`
-	// CloudWorkspace records the sandbox as a cloud workspace so it appears
-	// in the Workspaces section of the dashboard (isCloudWorkspace=true).
-	CloudWorkspace *bool `yaml:"cloud_workspace"`
 }
 
 // OrcaServeTemplate is the orca_serve: block of a start template.
@@ -48,7 +45,6 @@ type StartTemplateFlags struct {
 	TargetHome               string
 	OrcaServe                bool
 	MigrateAgentHomeFromRoot bool
-	CloudWorkspace           bool
 }
 
 // LoadStartTemplate loads a template by name (under ~/.cmux/templates/) or absolute path.
@@ -141,9 +137,6 @@ func ExpandStartTemplate(tmpl *StartTemplate, cli StartTemplateFlags, cliSet map
 	// migrate_from_root only applies when orca_serve is enabled; explicit CLI wins.
 	if !cliSet["migrate-agent-home-from-root"] && out.OrcaServe && tmpl.OrcaServe != nil {
 		out.MigrateAgentHomeFromRoot = tmpl.OrcaServe.MigrateFromRoot
-	}
-	if !cliSet["cloud-workspace"] && tmpl.CloudWorkspace != nil {
-		out.CloudWorkspace = *tmpl.CloudWorkspace
 	}
 	if !cliSet["mirror-local"] {
 		if tmpl.MirrorLocal != nil {

--- a/packages/devsh/internal/cli/start_template.go
+++ b/packages/devsh/internal/cli/start_template.go
@@ -37,13 +37,14 @@ type OrcaServeTemplate struct {
 
 // StartTemplateFlags is the resolved flag state after template + CLI merge.
 type StartTemplateFlags struct {
-	Provider    string
-	Snapshot    string
-	Clean       bool
-	MirrorLocal bool
-	NoAuth      bool
-	TargetHome  string
-	OrcaServe   bool
+	Provider                 string
+	Snapshot                 string
+	Clean                    bool
+	MirrorLocal              bool
+	NoAuth                   bool
+	TargetHome               string
+	OrcaServe                bool
+	MigrateAgentHomeFromRoot bool
 }
 
 // LoadStartTemplate loads a template by name (under ~/.cmux/templates/) or absolute path.
@@ -132,6 +133,10 @@ func ExpandStartTemplate(tmpl *StartTemplate, cli StartTemplateFlags, cliSet map
 	// orca_serve.enable implies /home/orca unless target-home was set explicitly.
 	if out.OrcaServe && !cliSet["target-home"] && out.TargetHome == "" {
 		out.TargetHome = "/home/orca"
+	}
+	// migrate_from_root only applies when orca_serve is enabled; explicit CLI wins.
+	if !cliSet["migrate-agent-home-from-root"] && out.OrcaServe && tmpl.OrcaServe != nil {
+		out.MigrateAgentHomeFromRoot = tmpl.OrcaServe.MigrateFromRoot
 	}
 	if !cliSet["mirror-local"] {
 		if tmpl.MirrorLocal != nil {

--- a/packages/devsh/internal/cli/start_template.go
+++ b/packages/devsh/internal/cli/start_template.go
@@ -19,6 +19,20 @@ type StartTemplate struct {
 	// MirrorLocal can be bool true or a map with options.
 	MirrorLocal any `yaml:"mirror_local"`
 	NoAuth      *bool `yaml:"no_auth"`
+	// TargetHome is the cloud home for --mirror-local path rewrite/extract
+	// (default /root; /home/orca for Orca Server).
+	TargetHome string `yaml:"target_home"`
+	// OrcaServe composes Orca Server post-start behavior (B1, workspace gh,
+	// optional migrate-from-root). Enable implies target_home /home/orca and
+	// mirror_local unless explicitly overridden.
+	OrcaServe *OrcaServeTemplate `yaml:"orca_serve"`
+}
+
+// OrcaServeTemplate is the orca_serve: block of a start template.
+type OrcaServeTemplate struct {
+	Enable          bool `yaml:"enable"`
+	WorkspaceGH     bool `yaml:"workspace_gh"`
+	MigrateFromRoot bool `yaml:"migrate_from_root"`
 }
 
 // StartTemplateFlags is the resolved flag state after template + CLI merge.
@@ -28,6 +42,8 @@ type StartTemplateFlags struct {
 	Clean       bool
 	MirrorLocal bool
 	NoAuth      bool
+	TargetHome  string
+	OrcaServe   bool
 }
 
 // LoadStartTemplate loads a template by name (under ~/.cmux/templates/) or absolute path.
@@ -107,8 +123,25 @@ func ExpandStartTemplate(tmpl *StartTemplate, cli StartTemplateFlags, cliSet map
 	if !cliSet["no-auth"] && tmpl.NoAuth != nil {
 		out.NoAuth = *tmpl.NoAuth
 	}
+	if !cliSet["target-home"] && tmpl.TargetHome != "" {
+		out.TargetHome = tmpl.TargetHome
+	}
+	if !cliSet["orca-serve"] && tmpl.OrcaServe != nil && tmpl.OrcaServe.Enable {
+		out.OrcaServe = true
+	}
+	// orca_serve.enable implies /home/orca unless target-home was set explicitly.
+	if out.OrcaServe && !cliSet["target-home"] && out.TargetHome == "" {
+		out.TargetHome = "/home/orca"
+	}
 	if !cliSet["mirror-local"] {
-		out.MirrorLocal = templateMirrorLocalEnabled(tmpl.MirrorLocal)
+		if tmpl.MirrorLocal != nil {
+			out.MirrorLocal = templateMirrorLocalEnabled(tmpl.MirrorLocal)
+		} else if out.OrcaServe {
+			// orca_serve.enable implies mirror-local unless explicitly false.
+			out.MirrorLocal = true
+		} else {
+			out.MirrorLocal = false
+		}
 	}
 	return out
 }

--- a/packages/devsh/internal/cli/start_template.go
+++ b/packages/devsh/internal/cli/start_template.go
@@ -26,6 +26,9 @@ type StartTemplate struct {
 	// optional migrate-from-root). Enable implies target_home /home/orca and
 	// mirror_local unless explicitly overridden.
 	OrcaServe *OrcaServeTemplate `yaml:"orca_serve"`
+	// CloudWorkspace records the sandbox as a cloud workspace so it appears
+	// in the Workspaces section of the dashboard (isCloudWorkspace=true).
+	CloudWorkspace *bool `yaml:"cloud_workspace"`
 }
 
 // OrcaServeTemplate is the orca_serve: block of a start template.
@@ -45,6 +48,7 @@ type StartTemplateFlags struct {
 	TargetHome               string
 	OrcaServe                bool
 	MigrateAgentHomeFromRoot bool
+	CloudWorkspace           bool
 }
 
 // LoadStartTemplate loads a template by name (under ~/.cmux/templates/) or absolute path.
@@ -137,6 +141,9 @@ func ExpandStartTemplate(tmpl *StartTemplate, cli StartTemplateFlags, cliSet map
 	// migrate_from_root only applies when orca_serve is enabled; explicit CLI wins.
 	if !cliSet["migrate-agent-home-from-root"] && out.OrcaServe && tmpl.OrcaServe != nil {
 		out.MigrateAgentHomeFromRoot = tmpl.OrcaServe.MigrateFromRoot
+	}
+	if !cliSet["cloud-workspace"] && tmpl.CloudWorkspace != nil {
+		out.CloudWorkspace = *tmpl.CloudWorkspace
 	}
 	if !cliSet["mirror-local"] {
 		if tmpl.MirrorLocal != nil {

--- a/packages/devsh/internal/cli/start_template_test.go
+++ b/packages/devsh/internal/cli/start_template_test.go
@@ -115,3 +115,91 @@ func TestExpandStartTemplateMirrorBool(t *testing.T) {
 		t.Fatalf("%+v", got)
 	}
 }
+
+func TestExpandStartTemplateTargetHomeAndOrcaServe(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "orca-serve.yaml")
+	body := `
+provider: pve-lxc
+clean: true
+mirror_local: true
+target_home: /home/orca
+orca_serve:
+  enable: true
+  workspace_gh: true
+  migrate_from_root: true
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl, err := LoadStartTemplate(path)
+	if err != nil {
+		t.Fatalf("LoadStartTemplate: %v", err)
+	}
+	if tmpl.TargetHome != "/home/orca" {
+		t.Fatalf("target_home=%q", tmpl.TargetHome)
+	}
+	if tmpl.OrcaServe == nil || !tmpl.OrcaServe.Enable || !tmpl.OrcaServe.WorkspaceGH || !tmpl.OrcaServe.MigrateFromRoot {
+		t.Fatalf("orca_serve=%+v", tmpl.OrcaServe)
+	}
+
+	// No CLI overrides → template wins
+	got := ExpandStartTemplate(tmpl, StartTemplateFlags{}, map[string]bool{})
+	if got.TargetHome != "/home/orca" {
+		t.Fatalf("target home: got %q", got.TargetHome)
+	}
+	if !got.OrcaServe {
+		t.Fatal("orca serve should be enabled from template")
+	}
+	if !got.MirrorLocal {
+		t.Fatal("mirror local should be enabled from template")
+	}
+
+	// Explicit CLI --target-home overrides template
+	cli := StartTemplateFlags{TargetHome: "/root"}
+	cliSet := map[string]bool{"target-home": true}
+	got = ExpandStartTemplate(tmpl, cli, cliSet)
+	if got.TargetHome != "/root" {
+		t.Fatalf("CLI target-home should win: got %q", got.TargetHome)
+	}
+	if !got.OrcaServe {
+		t.Fatal("orca serve should stay enabled from template")
+	}
+}
+
+func TestExpandStartTemplateOrcaServeDefaults(t *testing.T) {
+	t.Parallel()
+
+	// orca_serve.enable without target_home → /home/orca; without mirror_local → enabled
+	tmpl := &StartTemplate{OrcaServe: &OrcaServeTemplate{Enable: true}}
+	got := ExpandStartTemplate(tmpl, StartTemplateFlags{}, map[string]bool{})
+	if got.TargetHome != "/home/orca" {
+		t.Fatalf("orca_serve should default target home to /home/orca: got %q", got.TargetHome)
+	}
+	if !got.MirrorLocal {
+		t.Fatal("orca_serve should enable mirror-local by default")
+	}
+
+	// Explicit mirror_local: false in template wins over orca_serve
+	tmpl = &StartTemplate{MirrorLocal: false, OrcaServe: &OrcaServeTemplate{Enable: true}}
+	got = ExpandStartTemplate(tmpl, StartTemplateFlags{}, map[string]bool{})
+	if got.MirrorLocal {
+		t.Fatal("explicit mirror_local: false should win over orca_serve")
+	}
+	if got.TargetHome != "/home/orca" {
+		t.Fatalf("target home: got %q", got.TargetHome)
+	}
+
+	// CLI --mirror-local=false wins over orca_serve
+	tmpl = &StartTemplate{OrcaServe: &OrcaServeTemplate{Enable: true}}
+	got = ExpandStartTemplate(tmpl, StartTemplateFlags{MirrorLocal: false}, map[string]bool{"mirror-local": true})
+	if got.MirrorLocal {
+		t.Fatal("CLI --mirror-local=false should win over orca_serve")
+	}
+	if got.TargetHome != "/home/orca" {
+		t.Fatalf("target home: got %q", got.TargetHome)
+	}
+}

--- a/packages/devsh/internal/cli/start_template_test.go
+++ b/packages/devsh/internal/cli/start_template_test.go
@@ -203,3 +203,35 @@ func TestExpandStartTemplateOrcaServeDefaults(t *testing.T) {
 		t.Fatalf("target home: got %q", got.TargetHome)
 	}
 }
+
+func TestExpandStartTemplateOrcaServeMigrateFromRoot(t *testing.T) {
+	t.Parallel()
+
+	// migrate_from_root: true in template flows into flags when orca_serve enabled.
+	tmpl := &StartTemplate{OrcaServe: &OrcaServeTemplate{Enable: true, MigrateFromRoot: true}}
+	got := ExpandStartTemplate(tmpl, StartTemplateFlags{}, map[string]bool{})
+	if !got.MigrateAgentHomeFromRoot {
+		t.Fatal("migrate_from_root should enable migrate-agent-home-from-root")
+	}
+
+	// migrate_from_root defaults false.
+	tmpl = &StartTemplate{OrcaServe: &OrcaServeTemplate{Enable: true}}
+	got = ExpandStartTemplate(tmpl, StartTemplateFlags{}, map[string]bool{})
+	if got.MigrateAgentHomeFromRoot {
+		t.Fatal("migrate_from_root should default false")
+	}
+
+	// migrate_from_root without orca_serve.enable is inert.
+	tmpl = &StartTemplate{OrcaServe: &OrcaServeTemplate{Enable: false, MigrateFromRoot: true}}
+	got = ExpandStartTemplate(tmpl, StartTemplateFlags{}, map[string]bool{})
+	if got.MigrateAgentHomeFromRoot {
+		t.Fatal("migrate_from_root must not apply without orca_serve")
+	}
+
+	// Explicit CLI --migrate-agent-home-from-root wins over template.
+	tmpl = &StartTemplate{OrcaServe: &OrcaServeTemplate{Enable: true, MigrateFromRoot: true}}
+	got = ExpandStartTemplate(tmpl, StartTemplateFlags{MigrateAgentHomeFromRoot: false}, map[string]bool{"migrate-agent-home-from-root": true})
+	if got.MigrateAgentHomeFromRoot {
+		t.Fatal("CLI --migrate-agent-home-from-root=false should win over template")
+	}
+}

--- a/scripts/pve/setup-orca-agent-home.sh
+++ b/scripts/pve/setup-orca-agent-home.sh
@@ -101,7 +101,7 @@ echo "== setup-orca-agent-home: agent matrix =="
 # 4) Detection matrix (same as devsh BuildAgentMatrixCommand).
 echo "-- binaries on orca PATH --"
 for b in claude codex grok gh; do
-  if p=$(su -s /bin/bash "$ORCA" -c "command -v $b" 2>/dev/null); then
+  if p=$(orca_run "command -v $b" 2>/dev/null); then
     echo "ok   $b: $p"
   else
     echo "miss $b"

--- a/scripts/pve/setup-orca-agent-home.sh
+++ b/scripts/pve/setup-orca-agent-home.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# setup-orca-agent-home.sh — migrate allowlist root→/home/orca, wire workspace gh (G1/G2), B1 symlinks.
+# Run: devsh exec <id> 'bash -s' < scripts/pve/setup-orca-agent-home.sh
+#
+# Idempotent attach recipe for long-lived LXC boxes that were mirrored to /root
+# (pre-orca-serve). Mirrors the devsh --orca-serve post-start composition
+# (packages/devsh/internal/cli/orca_serve.go): B1 ensure → migrate allowlist →
+# workspace gh → agent matrix. Never copies auth.json, never gh auth login as
+# orca, never sets HOME=/root for orca.
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "error: run as root inside the container (devsh exec <id> 'bash -s' < this script)" >&2
+  exit 1
+fi
+
+ORCA=orca
+ORCA_HOME=/home/orca
+
+# Run a command as orca with the orca home. su/sudo do not reliably reset HOME
+# to the target user's home here, and HOME=/root is forbidden for orca
+# (Chromium SIGTRAP), so set it explicitly.
+orca_run() {
+  sudo -u "$ORCA" env HOME="$ORCA_HOME" bash -lc "$1"
+}
+
+echo "== setup-orca-agent-home: B1 ensure =="
+# 1) B1 ensure (idempotent): system user nologin, sudoers, traversal perms,
+#    home symlinks, npm prefix ~/.local, git safe.directory.
+id "$ORCA" >/dev/null 2>&1 || useradd --system --create-home --shell /usr/sbin/nologin "$ORCA"
+echo "orca ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/orca
+chmod 440 /etc/sudoers.d/orca
+chmod 755 /root
+[ -d /root/workspace ] && chmod 755 /root/workspace || true
+[ -d /root/wiki ] && chmod 755 /root/wiki || true
+ln -sfn /root "$ORCA_HOME/root-home"
+ln -sfn /root/workspace "$ORCA_HOME/workspace"
+ln -sfn /root/wiki "$ORCA_HOME/wiki"
+chown -h "$ORCA:$ORCA" "$ORCA_HOME/root-home" "$ORCA_HOME/workspace" "$ORCA_HOME/wiki"
+# shellcheck disable=SC2016 # $HOME expands inside the container's bash -lc, not here
+orca_run 'mkdir -p "$HOME/.local/bin" "$HOME/.local/lib/node_modules"; if command -v npm >/dev/null 2>&1; then npm config set prefix "$HOME/.local"; fi'
+orca_run 'git config --global --add safe.directory /root/workspace; git config --global --add safe.directory /root/wiki; git config --global --add safe.directory /root'
+
+echo "== setup-orca-agent-home: migrate allowlist root -> /home/orca =="
+# 2) Migrate the mirrorlocal.DefaultIncludePaths allowlist from /root to
+#    /home/orca. Secret basenames (auth.json, credentials) and sqlite/db files
+#    are excluded at copy time — never copied, even nested inside allowlist
+#    dirs. Ownership lands on orca:orca.
+mkdir -p "$ORCA_HOME"
+ALLOWLIST=(
+  .claude/settings.json
+  .claude/config.json
+  .claude/keybindings.json
+  .claude/skills
+  .claude/hooks
+  .claude/commands
+  .codex/config.toml
+  .codex/keybindings.json
+  .codex/AGENTS.md
+  .codex/skills
+  .codex/hooks
+  .codex/automations
+)
+for p in "${ALLOWLIST[@]}"; do
+  if [ -e "/root/$p" ]; then
+    mkdir -p "$ORCA_HOME/$(dirname "$p")"
+    tar -C /root -cf - \
+      --exclude=auth.json --exclude=.credentials.json --exclude=credentials.json \
+      --exclude='*.sqlite' --exclude='*.sqlite3' --exclude='*.db' \
+      --exclude='*.lock' --exclude='*.wal' --exclude='*.shm' \
+      "$p" | tar -C "$ORCA_HOME" -xf -
+    echo "  migrated /root/$p"
+  else
+    echo "  skip /root/$p (absent)"
+  fi
+done
+chown -R "$ORCA:$ORCA" "$ORCA_HOME/.claude" "$ORCA_HOME/.codex" 2>/dev/null || true
+
+echo "== setup-orca-agent-home: workspace gh for orca (G1 helper + G2 wrapper) =="
+# 3) G1: orca's global git config delegates to root's workspace gh via a
+#    sudo -n credential helper. G2: optional ~/.local/bin/gh wrapper so `gh`
+#    on orca's PATH behaves like root's gh. Never `gh auth login` as orca.
+orca_run 'git config --global credential.https://github.com.helper "!sudo -n /usr/bin/gh auth git-credential"'
+orca_run 'git config --global credential.https://gist.github.com.helper "!sudo -n /usr/bin/gh auth git-credential"'
+install -d "$ORCA_HOME/.local/bin"
+printf '%s\n' '#!/bin/sh' 'exec sudo -n /usr/bin/gh "$@"' > "$ORCA_HOME/.local/bin/gh"
+chmod 755 "$ORCA_HOME/.local/bin/gh"
+chown "$ORCA:$ORCA" "$ORCA_HOME/.local/bin/gh"
+
+echo "== setup-orca-agent-home: agent matrix =="
+# 4) Detection matrix (same as devsh BuildAgentMatrixCommand).
+echo "-- binaries on orca PATH --"
+for b in claude codex grok gh; do
+  if p=$(su -s /bin/bash "$ORCA" -c "command -v $b" 2>/dev/null); then
+    echo "ok   $b: $p"
+  else
+    echo "miss $b"
+  fi
+done
+echo "-- mirrored config under /home/orca --"
+for p in .claude .codex; do
+  if [ -e "$ORCA_HOME/$p" ]; then
+    echo "ok   $ORCA_HOME/$p"
+  else
+    echo "miss $ORCA_HOME/$p"
+  fi
+done
+echo "-- gh via workspace root default --"
+if [ -f /root/.config/gh/hosts.yml ]; then
+  echo "ok   root gh hosts present; orca delegates via sudo -n gh"
+  sudo -n /usr/bin/gh auth status 2>&1 | head -5 || true
+else
+  echo "warn root gh not configured"
+fi
+echo "-- agent auth files (absent unless device-auth done as orca) --"
+for f in "$ORCA_HOME/.claude/auth.json" "$ORCA_HOME/.codex/auth.json"; do
+  if [ -e "$f" ]; then
+    echo "note $f present"
+  else
+    echo "ok   $f absent"
+  fi
+done
+
+echo
+echo "Claude/Codex API auth: use device-auth as orca if needed (mirror redacts auth.json)"
+echo "gh: uses workspace root via sudo -n gh — do not gh auth login as orca"

--- a/scripts/pve/setup-orca-agent-home.sh
+++ b/scripts/pve/setup-orca-agent-home.sh
@@ -39,6 +39,16 @@ ln -sfn /root/wiki "$ORCA_HOME/wiki"
 chown -h "$ORCA:$ORCA" "$ORCA_HOME/root-home" "$ORCA_HOME/workspace" "$ORCA_HOME/wiki"
 # shellcheck disable=SC2016 # $HOME expands inside the container's bash -lc, not here
 orca_run 'mkdir -p "$HOME/.local/bin" "$HOME/.local/lib/node_modules"; if command -v npm >/dev/null 2>&1; then npm config set prefix "$HOME/.local"; fi'
+# Link bun-installed agent CLIs (claude, gemini, opencode, etc.) into orca PATH
+# bun installs to /root/.bun/bin/ which is not on orca's PATH by default
+echo "[B1] Linking bun-installed CLIs to /home/orca/.local/bin..."
+for cli in /root/.bun/bin/*; do
+    name=$(basename "$cli")
+    [ "$name" = "bun" ] && continue
+    [ "$name" = "bunx" ] && continue
+    ln -sfn "$cli" "$ORCA_HOME/.local/bin/$name"
+done
+chown -h "$ORCA:$ORCA" "$ORCA_HOME/.local/bin/"* 2>/dev/null || true
 orca_run 'git config --global --add safe.directory /root/workspace; git config --global --add safe.directory /root/wiki; git config --global --add safe.directory /root'
 
 echo "== setup-orca-agent-home: migrate allowlist root -> /home/orca =="


### PR DESCRIPTION
## Summary

Wire cmux `devsh start` so Orca Server boxes get agent config under `/home/orca` via existing `--mirror-local`, wire `gh` to the LXC workspace (root) default, and link bun-installed CLIs into orca's PATH - without a second `gh auth login` or template rebuild.

## What changed

- **`--target-home` flag** - parameterize mirror-local `TargetHome` (default `/root`; `/home/orca` for Orca)
- **`--orca-serve` flag** - post-start composition: B1 ensure (user, symlinks, sudoers, safe.directory, npm prefix, bun CLI symlinks) + workspace gh G1 (credential helper via `sudo -n gh`) + optional migrate-from-root + agent matrix
- **Template fields** - `target_home` + `orca_serve` in `~/.cmux/templates/orca-serve.yaml`
- **Attach script** - `scripts/pve/setup-orca-agent-home.sh` for long-lived LXC boxes
- **Bun CLI symlinks** - links all 8 agent CLIs from `/root/.bun/bin/*` into `/home/orca/.local/bin/` (claude, codex, gemini, opencode, codebuff, amp, devsh, devcontainer)

## Design

Approved design: `projects/cmux/work/2026-08-07-orca-serve-start-mode/design.md`

## Key decisions

| Decision | Value |
|---|---|
| Claude/Codex config | Reuse existing `--mirror-local` with `TargetHome=/home/orca` |
| gh | LXC workspace root default; orca delegates via `sudo -n gh auth git-credential` |
| Secrets | Never copy `auth.json` / gh hosts by default |
| Agent CLIs | Symlink from `/root/.bun/bin/` (bun global) to `/home/orca/.local/bin/` |
| HOME | Never `HOME=/root` for `User=orca` (Chromium SIGTRAP) |

## Test plan

- [x] `go test ./... -count=1` in `packages/devsh` - all 10 packages pass
- [x] TDD: failing tests first for every new function
- [x] `shellcheck` clean on attach script
- [x] Pre-commit `bun check` passed (no `--no-verify`)
- [x] Final whole-branch code review: 1 Critical + 3 Important + 3 Minor found and fixed
- [ ] Live smoke on `pvelxc-3adc3628` (operator)

## Commits (8)

1. `03ef9f46b` feat(devsh): parameterize --mirror-local TargetHome
2. `bc839dfa2` feat(devsh): template target_home and orca_serve expand
3. `bfc31c525` feat(devsh): orca-serve helpers for workspace gh and agent-home migrate
4. `0ec03e0de` feat(devsh): --orca-serve post-start B1, workspace gh, matrix
5. `9f8026d01` feat(pve): setup-orca-agent-home attach script for long-lived LXC
6. `1cec8336a` docs(devsh): orca-serve template example and README
7. `9f0eaa9bf` fix(devsh): review findings for orca-serve start mode
8. `a087fcfe8` fix(devsh): link bun-installed agent CLIs into orca PATH

## No template rebuild required

All changes are runtime (post-start exec or attach script). The existing PVE-LXC snapshot already has all 8 agent CLIs via `bun add -g` - they just weren't visible to the orca user. Optional `--with-orca-sidecar` for future template rebuilds is documented in `correction-and-template-baked-option.md`.

## Related

- Design: `projects/cmux/work/2026-08-07-orca-serve-start-mode/design.md`
- Prior art: `projects/cmux/work/2026-07-21-cloud-workspace-start-modes/` (clean/mirror-local/template)
- B1 docs: `queries/2026-08-07-orca-server-user-context-cmux-lxc-mitigation-plan.md`
- TD-A04: `projects/orca/architecture/11-tech-debt.md` (upstream `--serve-workspace-root`)