### PR TITLE
fix: make Antigravity Docker install shell-safe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -920,9 +920,10 @@ RUN /root/.local/bin/cursor-agent --version
 
 # Install agy (Google Antigravity CLI) — no official npm package (the `agy`
 # npm name is an unrelated placeholder), so use the official installer.
-# pipefail makes a failed curl fail the layer instead of piping empty stdin
-# to bash; the --version check then fails fast with the real error.
-RUN set -euo pipefail; curl -fsSL https://antigravity.google/cli/install.sh | bash \
+# Download before executing so curl failures stop the layer under /bin/sh.
+RUN curl -fsSL https://antigravity.google/cli/install.sh -o /tmp/agy-install.sh \
+  && bash /tmp/agy-install.sh \
+  && rm -f /tmp/agy-install.sh \
   && /root/.local/bin/agy --version
 
 # Copy only the built artifacts and runtime dependencies from builder

--- a/apps/server/src/runtime-dockerfile-antigravity.test.ts
+++ b/apps/server/src/runtime-dockerfile-antigravity.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const dockerfilePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "Dockerfile",
+);
+
+describe("worker image Antigravity CLI installation", () => {
+  const dockerfile = readFileSync(dockerfilePath, "utf8");
+
+  it("chains a downloaded installer so curl failure stops the layer under /bin/sh", () => {
+    const installInstruction = dockerfile
+      .match(
+        /^RUN [^\n]*antigravity\.google\/cli\/install\.sh[^\n]*\\\n(?:[^\n]*\\\n)*[^\n]*$/m,
+      )?.[0]
+      .replace(/\\\n\s*/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    expect(
+      installInstruction,
+      "missing dash-compatible Antigravity CLI install instruction",
+    ).toBe(
+      "RUN curl -fsSL https://antigravity.google/cli/install.sh -o /tmp/agy-install.sh && bash /tmp/agy-install.sh && rm -f /tmp/agy-install.sh && /root/.local/bin/agy --version",
+    );
+  });
+});


### PR DESCRIPTION
Fixes the Worker Image build failure seen in run 31303702508 on both linux/amd64 and linux/arm64.

The runtime-base stage uses Docker’s default /bin/sh (dash), so `set -euo pipefail` fails before the Antigravity installer runs. This change downloads the official installer first, executes it with Bash, removes it, and verifies `agy`. It also adds a focused regression test for the exact shell-safe command chain.

Validation:
- `bunx vitest run src/runtime-dockerfile-antigravity.test.ts` (pass)
- pre-commit `bun check` (pass: lint + typecheck)
- full baseline `bun run test` has unrelated pre-existing failures from missing Stack Auth credentials, existing server mocks, and unavailable local Docker daemon

No auto-merge requested.