### PR TITLE
fix(devsh): fall back from stale env refresh tokens

### DIFF
--- a/packages/devsh/internal/auth/auth.go
+++ b/packages/devsh/internal/auth/auth.go
@@ -110,11 +110,11 @@ const (
 	// Development defaults - used when Mode="dev" and no other values provided
 	// These point to local development servers for convenience
 	// ==========================================================================
-	DevProjectID      = "1467bed0-8522-45ee-a8d8-055de324118c"              // Dev Stack Auth project
+	DevProjectID      = "1467bed0-8522-45ee-a8d8-055de324118c"         // Dev Stack Auth project
 	DevPublishableKey = "pck_pt4nwry6sdskews2pxk4g2fbe861ak2zvaf3mqendspa0" // Dev publishable key
-	DevCmuxURL        = "http://localhost:9779"                             // Local dev server
-	DevConvexSiteURL  = "https://famous-camel-162.convex.site"              // Dev Convex deployment
-	DevServerURL      = "http://localhost:9776"                             // Local apps/server socket.io & HTTP API
+	DevCmuxURL        = "http://localhost:9779"                         // Local dev server
+	DevConvexSiteURL  = "https://famous-camel-162.convex.site"          // Dev Convex deployment
+	DevServerURL      = "http://localhost:9776"                         // Local apps/server socket.io & HTTP API
 )
 
 // Build-time configuration variables
@@ -403,27 +403,27 @@ type storedRefreshTokenLoader func() (string, error)
 func getRefreshTokenCredential(loadStoredRefreshToken storedRefreshTokenLoader) (refreshTokenCredential, error) {
 	cfg := GetConfig()
 
-	// 1. Check mode-specific env var first (preferred for CI)
+	// Mode-specific env var takes priority (preferred for CI)
 	modeEnvVar := "DEVSH_PROD_REFRESH_TOKEN"
 	if cfg.IsDev {
 		modeEnvVar = "DEVSH_DEV_REFRESH_TOKEN"
 	}
 
-	// 2. Check generic env vars (legacy support)
+	// Check env vars in priority order: mode-specific first, then generic legacy vars
 	for _, envVar := range []string{modeEnvVar, "DEVSH_REFRESH_TOKEN", "DEVBOX_REFRESH_TOKEN"} {
 		if token := os.Getenv(envVar); token != "" {
 			if err := ValidateRefreshTokenFormat(token); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: %s may be invalid: %v\n", envVar, err)
-				continue
+			} else {
+				return refreshTokenCredential{
+					token:  token,
+					envVar: envVar,
+				}, nil
 			}
-			return refreshTokenCredential{
-				token:  token,
-				envVar: envVar,
-			}, nil
 		}
 	}
 
-	// 3. File-based credentials
+	// File-based credentials
 	storedToken, err := loadStoredRefreshToken()
 	if err != nil {
 		return refreshTokenCredential{}, err
@@ -875,11 +875,10 @@ func getAccessTokenWithStoredRefreshTokenLoader(loadStoredRefreshToken storedRef
 	cfg := GetConfig()
 	client := &http.Client{Timeout: 30 * time.Second}
 	accessToken, statusCode, err := refreshAccessToken(client, cfg, credential.token)
-	if err != nil && statusCode == http.StatusUnauthorized && credential.envVar != "" {
+	if statusCode == http.StatusUnauthorized && credential.envVar != "" {
 		fmt.Fprintf(
 			os.Stderr,
-			"Warning: %s was rejected by Stack Auth with status 401; retrying with stored credentials. Unset %s to remove the stale override.\n",
-			credential.envVar,
+			"Warning: %[1]s was rejected by Stack Auth with status 401; retrying with stored credentials. Unset %[1]s to remove the stale override.\n",
 			credential.envVar,
 		)
 
@@ -897,14 +896,8 @@ func getAccessTokenWithStoredRefreshTokenLoader(loadStoredRefreshToken storedRef
 		return "", err
 	}
 
-	// Parse JWT to get expiry (simple extraction, no verification needed)
-	expiresAt := time.Now().Add(1 * time.Hour).Unix() // Default 1 hour
-	if parts := strings.Split(accessToken, "."); len(parts) == 3 {
-		// Try to parse payload for actual expiry
-		// This is best-effort; we'll use default if it fails
-	}
-
-	// Cache the new access token
+	// Cache the new access token (default 1 hour expiry; JWT exp parsing is best-effort future work)
+	expiresAt := time.Now().Add(1 * time.Hour).Unix()
 	_ = CacheAccessToken(accessToken, expiresAt)
 
 	return accessToken, nil
@@ -930,13 +923,7 @@ func refreshAccessToken(client *http.Client, cfg Config, refreshToken string) (s
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		if _, drainErr := io.Copy(io.Discard, resp.Body); drainErr != nil {
-			return "", resp.StatusCode, fmt.Errorf(
-				"failed to refresh token: status %d; failed to drain response body: %w",
-				resp.StatusCode,
-				drainErr,
-			)
-		}
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return "", resp.StatusCode, fmt.Errorf("failed to refresh token: status %d. Try 'devsh auth login' to re-authenticate", resp.StatusCode)
 	}
 

--- a/packages/devsh/internal/auth/auth.go
+++ b/packages/devsh/internal/auth/auth.go
@@ -110,11 +110,11 @@ const (
 	// Development defaults - used when Mode="dev" and no other values provided
 	// These point to local development servers for convenience
 	// ==========================================================================
-	DevProjectID      = "1467bed0-8522-45ee-a8d8-055de324118c"         // Dev Stack Auth project
+	DevProjectID      = "1467bed0-8522-45ee-a8d8-055de324118c"              // Dev Stack Auth project
 	DevPublishableKey = "pck_pt4nwry6sdskews2pxk4g2fbe861ak2zvaf3mqendspa0" // Dev publishable key
-	DevCmuxURL        = "http://localhost:9779"                         // Local dev server
-	DevConvexSiteURL  = "https://famous-camel-162.convex.site"          // Dev Convex deployment
-	DevServerURL      = "http://localhost:9776"                         // Local apps/server socket.io & HTTP API
+	DevCmuxURL        = "http://localhost:9779"                             // Local dev server
+	DevConvexSiteURL  = "https://famous-camel-162.convex.site"              // Dev Convex deployment
+	DevServerURL      = "http://localhost:9776"                             // Local apps/server socket.io & HTTP API
 )
 
 // Build-time configuration variables
@@ -386,6 +386,21 @@ func StoreRefreshToken(token string) error {
 // 2. Generic env var (DEVSH_REFRESH_TOKEN, DEVBOX_REFRESH_TOKEN)
 // 3. File-based credentials (credentials_dev.json or credentials_prod.json)
 func GetRefreshToken() (string, error) {
+	credential, err := getRefreshTokenCredential(getStoredRefreshToken)
+	if err != nil {
+		return "", err
+	}
+	return credential.token, nil
+}
+
+type refreshTokenCredential struct {
+	token  string
+	envVar string
+}
+
+type storedRefreshTokenLoader func() (string, error)
+
+func getRefreshTokenCredential(loadStoredRefreshToken storedRefreshTokenLoader) (refreshTokenCredential, error) {
 	cfg := GetConfig()
 
 	// 1. Check mode-specific env var first (preferred for CI)
@@ -393,34 +408,32 @@ func GetRefreshToken() (string, error) {
 	if cfg.IsDev {
 		modeEnvVar = "DEVSH_DEV_REFRESH_TOKEN"
 	}
-	if modeToken := os.Getenv(modeEnvVar); modeToken != "" {
-		if err := ValidateRefreshTokenFormat(modeToken); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: %s may be invalid: %v\n", modeEnvVar, err)
-			// Fall through to try other sources
-		} else {
-			return modeToken, nil
-		}
-	}
 
 	// 2. Check generic env vars (legacy support)
-	if devToken := os.Getenv("DEVSH_REFRESH_TOKEN"); devToken != "" {
-		if err := ValidateRefreshTokenFormat(devToken); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: DEVSH_REFRESH_TOKEN may be invalid: %v\n", err)
-			// Fall through to try stored credentials
-		} else {
-			return devToken, nil
-		}
-	}
-	if devToken := os.Getenv("DEVBOX_REFRESH_TOKEN"); devToken != "" {
-		if err := ValidateRefreshTokenFormat(devToken); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: DEVBOX_REFRESH_TOKEN may be invalid: %v\n", err)
-			// Fall through to try stored credentials
-		} else {
-			return devToken, nil
+	for _, envVar := range []string{modeEnvVar, "DEVSH_REFRESH_TOKEN", "DEVBOX_REFRESH_TOKEN"} {
+		if token := os.Getenv(envVar); token != "" {
+			if err := ValidateRefreshTokenFormat(token); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: %s may be invalid: %v\n", envVar, err)
+				continue
+			}
+			return refreshTokenCredential{
+				token:  token,
+				envVar: envVar,
+			}, nil
 		}
 	}
 
 	// 3. File-based credentials
+	storedToken, err := loadStoredRefreshToken()
+	if err != nil {
+		return refreshTokenCredential{}, err
+	}
+	return refreshTokenCredential{
+		token: storedToken,
+	}, nil
+}
+
+func getStoredRefreshToken() (string, error) {
 	if runtime.GOOS == "darwin" {
 		return getFromKeychain()
 	}
@@ -844,25 +857,65 @@ func Logout() error {
 
 // GetAccessToken returns a valid access token, refreshing if necessary
 func GetAccessToken() (string, error) {
+	return getAccessTokenWithStoredRefreshTokenLoader(getStoredRefreshToken)
+}
+
+func getAccessTokenWithStoredRefreshTokenLoader(loadStoredRefreshToken storedRefreshTokenLoader) (string, error) {
 	// Try cached token first (with 60 second buffer)
 	if token, err := GetCachedAccessToken(60); err == nil {
 		return token, nil
 	}
 
 	// Need to refresh
-	refreshToken, err := GetRefreshToken()
+	credential, err := getRefreshTokenCredential(loadStoredRefreshToken)
 	if err != nil {
 		return "", fmt.Errorf("not logged in. Run 'devsh auth login' first")
 	}
 
 	cfg := GetConfig()
 	client := &http.Client{Timeout: 30 * time.Second}
+	accessToken, statusCode, err := refreshAccessToken(client, cfg, credential.token)
+	if err != nil && statusCode == http.StatusUnauthorized && credential.envVar != "" {
+		fmt.Fprintf(
+			os.Stderr,
+			"Warning: %s was rejected by Stack Auth with status 401; retrying with stored credentials. Unset %s to remove the stale override.\n",
+			credential.envVar,
+			credential.envVar,
+		)
 
+		storedToken, storedErr := loadStoredRefreshToken()
+		if storedErr != nil {
+			return "", fmt.Errorf(
+				"refresh token from %s was rejected with status 401 and stored credentials unavailable: %w",
+				credential.envVar,
+				storedErr,
+			)
+		}
+		accessToken, _, err = refreshAccessToken(client, cfg, storedToken)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	// Parse JWT to get expiry (simple extraction, no verification needed)
+	expiresAt := time.Now().Add(1 * time.Hour).Unix() // Default 1 hour
+	if parts := strings.Split(accessToken, "."); len(parts) == 3 {
+		// Try to parse payload for actual expiry
+		// This is best-effort; we'll use default if it fails
+	}
+
+	// Cache the new access token
+	_ = CacheAccessToken(accessToken, expiresAt)
+
+	return accessToken, nil
+}
+
+func refreshAccessToken(client *http.Client, cfg Config, refreshToken string) (string, int, error) {
 	// Refresh the token
 	refreshURL := fmt.Sprintf("%s/api/v1/auth/sessions/current/refresh", cfg.StackAuthURL)
 	req, err := http.NewRequest("POST", refreshURL, nil)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	req.Header.Set("x-stack-project-id", cfg.ProjectID)
@@ -872,30 +925,27 @@ func GetAccessToken() (string, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to refresh token: %w", err)
+		return "", 0, fmt.Errorf("failed to refresh token: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to refresh token: status %d. Try 'devsh auth login' to re-authenticate", resp.StatusCode)
+		if _, drainErr := io.Copy(io.Discard, resp.Body); drainErr != nil {
+			return "", resp.StatusCode, fmt.Errorf(
+				"failed to refresh token: status %d; failed to drain response body: %w",
+				resp.StatusCode,
+				drainErr,
+			)
+		}
+		return "", resp.StatusCode, fmt.Errorf("failed to refresh token: status %d. Try 'devsh auth login' to re-authenticate", resp.StatusCode)
 	}
 
 	var refreshResp RefreshTokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&refreshResp); err != nil {
-		return "", fmt.Errorf("failed to decode refresh response: %w", err)
+		return "", resp.StatusCode, fmt.Errorf("failed to decode refresh response: %w", err)
 	}
 
-	// Parse JWT to get expiry (simple extraction, no verification needed)
-	expiresAt := time.Now().Add(1 * time.Hour).Unix() // Default 1 hour
-	if parts := strings.Split(refreshResp.AccessToken, "."); len(parts) == 3 {
-		// Try to parse payload for actual expiry
-		// This is best-effort; we'll use default if it fails
-	}
-
-	// Cache the new access token
-	_ = CacheAccessToken(refreshResp.AccessToken, expiresAt)
-
-	return refreshResp.AccessToken, nil
+	return refreshResp.AccessToken, resp.StatusCode, nil
 }
 
 // GetUserInfo retrieves the current user's information

--- a/packages/devsh/internal/auth/auth_test.go
+++ b/packages/devsh/internal/auth/auth_test.go
@@ -2,8 +2,15 @@
 package auth
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -286,7 +293,7 @@ func TestConfigValidateMissingProjectID(t *testing.T) {
 	if err == nil {
 		t.Error("expected validation error for missing ProjectID")
 	}
-	if err != nil && !contains(err.Error(), "STACK_PROJECT_ID") {
+	if err != nil && !strings.Contains(err.Error(), "STACK_PROJECT_ID") {
 		t.Errorf("expected error to mention STACK_PROJECT_ID, got: %v", err)
 	}
 }
@@ -302,7 +309,7 @@ func TestConfigValidateMissingPublishableKey(t *testing.T) {
 	if err == nil {
 		t.Error("expected validation error for missing PublishableKey")
 	}
-	if err != nil && !contains(err.Error(), "STACK_PUBLISHABLE_CLIENT_KEY") {
+	if err != nil && !strings.Contains(err.Error(), "STACK_PUBLISHABLE_CLIENT_KEY") {
 		t.Errorf("expected error to mention STACK_PUBLISHABLE_CLIENT_KEY, got: %v", err)
 	}
 }
@@ -318,7 +325,7 @@ func TestConfigValidateMissingCmuxURL(t *testing.T) {
 	if err == nil {
 		t.Error("expected validation error for missing CmuxURL")
 	}
-	if err != nil && !contains(err.Error(), "CMUX_API_URL") {
+	if err != nil && !strings.Contains(err.Error(), "CMUX_API_URL") {
 		t.Errorf("expected error to mention CMUX_API_URL, got: %v", err)
 	}
 }
@@ -334,7 +341,7 @@ func TestConfigValidateMissingConvexSiteURL(t *testing.T) {
 	if err == nil {
 		t.Error("expected validation error for missing ConvexSiteURL")
 	}
-	if err != nil && !contains(err.Error(), "CONVEX_SITE_URL") {
+	if err != nil && !strings.Contains(err.Error(), "CONVEX_SITE_URL") {
 		t.Errorf("expected error to mention CONVEX_SITE_URL, got: %v", err)
 	}
 }
@@ -363,20 +370,334 @@ func TestConfigValidateMultipleMissing(t *testing.T) {
 	}
 	// Should mention multiple missing fields
 	errStr := err.Error()
-	if !contains(errStr, "STACK_PROJECT_ID") {
+	if !strings.Contains(errStr, "STACK_PROJECT_ID") {
 		t.Error("expected error to mention STACK_PROJECT_ID")
 	}
-	if !contains(errStr, "STACK_PUBLISHABLE_CLIENT_KEY") {
+	if !strings.Contains(errStr, "STACK_PUBLISHABLE_CLIENT_KEY") {
 		t.Error("expected error to mention STACK_PUBLISHABLE_CLIENT_KEY")
 	}
 }
 
-// Helper function
-func contains(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+func TestGetAccessTokenUsesEnvironmentRefreshTokenWithoutFallback(t *testing.T) {
+	envToken := "environment-refresh-token-valid"
+	server, requests := newRefreshTokenTestServer(t, map[string]int{
+		envToken: http.StatusOK,
+	})
+	defer server.Close()
+	setAccessTokenTestEnvironment(t, server.URL)
+	t.Setenv("DEVSH_DEV_REFRESH_TOKEN", envToken)
+
+	storedLoads := 0
+	accessToken, err := getAccessTokenWithStoredRefreshTokenLoader(func() (string, error) {
+		storedLoads++
+		return "stored-refresh-token-valid", nil
+	})
+	if err != nil {
+		t.Fatalf("GetAccessToken returned error: %v", err)
 	}
-	return false
+	if accessToken != envToken+"-access" {
+		t.Fatalf("access token = %q, want %q", accessToken, envToken+"-access")
+	}
+	if storedLoads != 0 {
+		t.Fatalf("stored credential loads = %d, want 0", storedLoads)
+	}
+	if got := requests(); len(got) != 1 || got[0] != envToken {
+		t.Fatalf("refresh requests = %q, want [%q]", got, envToken)
+	}
+}
+
+func TestGetRefreshTokenCredentialTracksEnvironmentSource(t *testing.T) {
+	for _, envVar := range []string{
+		"DEVSH_DEV_REFRESH_TOKEN",
+		"DEVSH_REFRESH_TOKEN",
+		"DEVBOX_REFRESH_TOKEN",
+	} {
+		t.Run(envVar, func(t *testing.T) {
+			setAccessTokenTestEnvironment(t, "http://stack-auth.invalid")
+			token := "refresh-token-selected-from-" + envVar
+			t.Setenv(envVar, token)
+
+			credential, err := getRefreshTokenCredential(func() (string, error) {
+				return "", fmt.Errorf("stored credentials should not be loaded")
+			})
+			if err != nil {
+				t.Fatalf("getRefreshTokenCredential returned error: %v", err)
+			}
+			if credential.token != token {
+				t.Fatalf("token = %q, want %q", credential.token, token)
+			}
+			if credential.envVar != envVar {
+				t.Fatalf("env var = %q, want %q", credential.envVar, envVar)
+			}
+		})
+	}
+}
+
+func TestGetAccessTokenFallsBackToStoredCredentialAfterEnvironmentUnauthorized(t *testing.T) {
+	envToken := "environment-refresh-token-stale"
+	genericToken := "generic-refresh-token-not-used"
+	storedToken := "stored-refresh-token-valid"
+	server, requests := newRefreshTokenTestServer(t, map[string]int{
+		envToken:     http.StatusUnauthorized,
+		genericToken: http.StatusOK,
+		storedToken:  http.StatusOK,
+	})
+	defer server.Close()
+	setAccessTokenTestEnvironment(t, server.URL)
+	t.Setenv("DEVSH_DEV_REFRESH_TOKEN", envToken)
+	t.Setenv("DEVSH_REFRESH_TOKEN", genericToken)
+
+	storedLoads := 0
+	var accessToken string
+	var accessErr error
+	stderr := captureStderr(t, func() {
+		accessToken, accessErr = getAccessTokenWithStoredRefreshTokenLoader(func() (string, error) {
+			storedLoads++
+			return storedToken, nil
+		})
+	})
+
+	if accessErr != nil {
+		t.Fatalf("GetAccessToken returned error: %v", accessErr)
+	}
+	if accessToken != storedToken+"-access" {
+		t.Fatalf("access token = %q, want %q", accessToken, storedToken+"-access")
+	}
+	if storedLoads != 1 {
+		t.Fatalf("stored credential loads = %d, want 1", storedLoads)
+	}
+	if got := requests(); len(got) != 2 || got[0] != envToken || got[1] != storedToken {
+		t.Fatalf("refresh requests = %q, want [%q %q]", got, envToken, storedToken)
+	}
+	if !strings.Contains(stderr, "DEVSH_DEV_REFRESH_TOKEN") {
+		t.Fatalf("warning %q does not name DEVSH_DEV_REFRESH_TOKEN", stderr)
+	}
+	if strings.Contains(stderr, envToken) || strings.Contains(stderr, storedToken) {
+		t.Fatalf("warning leaked refresh-token contents: %q", stderr)
+	}
+}
+
+func TestGetAccessTokenDoesNotFallbackForNonUnauthorizedResponse(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			envToken := fmt.Sprintf("environment-refresh-token-%d", status)
+			server, requests := newRefreshTokenTestServer(t, map[string]int{
+				envToken: status,
+			})
+			defer server.Close()
+			setAccessTokenTestEnvironment(t, server.URL)
+			t.Setenv("DEVSH_DEV_REFRESH_TOKEN", envToken)
+
+			storedLoads := 0
+			_, err := getAccessTokenWithStoredRefreshTokenLoader(func() (string, error) {
+				storedLoads++
+				return "stored-refresh-token-valid", nil
+			})
+			if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("status %d", status)) {
+				t.Fatalf("error = %v, want status %d", err, status)
+			}
+			if storedLoads != 0 {
+				t.Fatalf("stored credential loads = %d, want 0", storedLoads)
+			}
+			if got := requests(); len(got) != 1 || got[0] != envToken {
+				t.Fatalf("refresh requests = %q, want [%q]", got, envToken)
+			}
+		})
+	}
+}
+
+func TestGetAccessTokenDoesNotFallbackForMalformedSuccessResponse(t *testing.T) {
+	envToken := "environment-refresh-token-malformed-response"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":`))
+	}))
+	defer server.Close()
+	setAccessTokenTestEnvironment(t, server.URL)
+	t.Setenv("DEVSH_DEV_REFRESH_TOKEN", envToken)
+
+	storedLoads := 0
+	_, err := getAccessTokenWithStoredRefreshTokenLoader(func() (string, error) {
+		storedLoads++
+		return "stored-refresh-token-valid", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to decode refresh response") {
+		t.Fatalf("error = %v, want decode failure", err)
+	}
+	if storedLoads != 0 {
+		t.Fatalf("stored credential loads = %d, want 0", storedLoads)
+	}
+	if requests != 1 {
+		t.Fatalf("refresh requests = %d, want 1", requests)
+	}
+}
+
+func TestGetAccessTokenDoesNotFallbackForTransportFailure(t *testing.T) {
+	envToken := "environment-refresh-token-transport-failure"
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	serverURL := server.URL
+	server.Close()
+	setAccessTokenTestEnvironment(t, serverURL)
+	t.Setenv("DEVSH_DEV_REFRESH_TOKEN", envToken)
+
+	storedLoads := 0
+	_, err := getAccessTokenWithStoredRefreshTokenLoader(func() (string, error) {
+		storedLoads++
+		return "stored-refresh-token-valid", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to refresh token") {
+		t.Fatalf("error = %v, want refresh transport failure", err)
+	}
+	if storedLoads != 0 {
+		t.Fatalf("stored credential loads = %d, want 0", storedLoads)
+	}
+}
+
+func TestGetAccessTokenBoundsUnauthorizedFallback(t *testing.T) {
+	staleEnvToken := "environment-refresh-token-stale"
+	rejectedStoredToken := "stored-refresh-token-rejected"
+	for _, test := range []struct {
+		name         string
+		envToken     string
+		storedToken  string
+		storedErr    error
+		statuses     map[string]int
+		wantRequests []string
+		wantErrors   []string
+	}{
+		{
+			name:         "stored credential is not retried",
+			storedToken:  rejectedStoredToken,
+			statuses:     map[string]int{rejectedStoredToken: http.StatusUnauthorized},
+			wantRequests: []string{rejectedStoredToken},
+			wantErrors:   []string{"status 401"},
+		},
+		{
+			name:         "missing fallback credential stops after environment 401",
+			envToken:     staleEnvToken,
+			storedErr:    fmt.Errorf("token not found in keychain"),
+			statuses:     map[string]int{staleEnvToken: http.StatusUnauthorized},
+			wantRequests: []string{staleEnvToken},
+			wantErrors:   []string{"stored credentials unavailable", "DEVSH_DEV_REFRESH_TOKEN"},
+		},
+		{
+			name:         "rejected fallback credential is tried once",
+			envToken:     staleEnvToken,
+			storedToken:  rejectedStoredToken,
+			statuses:     map[string]int{staleEnvToken: http.StatusUnauthorized, rejectedStoredToken: http.StatusUnauthorized},
+			wantRequests: []string{staleEnvToken, rejectedStoredToken},
+			wantErrors:   []string{"status 401"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, requests := newRefreshTokenTestServer(t, test.statuses)
+			defer server.Close()
+			setAccessTokenTestEnvironment(t, server.URL)
+			if test.envToken != "" {
+				t.Setenv("DEVSH_DEV_REFRESH_TOKEN", test.envToken)
+			}
+
+			storedLoads := 0
+			_, err := getAccessTokenWithStoredRefreshTokenLoader(func() (string, error) {
+				storedLoads++
+				return test.storedToken, test.storedErr
+			})
+			if err == nil {
+				t.Fatal("GetAccessToken returned nil error")
+			}
+			for _, want := range test.wantErrors {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want substring %q", err, want)
+				}
+			}
+			if storedLoads != 1 {
+				t.Fatalf("stored credential loads = %d, want 1", storedLoads)
+			}
+			if got := requests(); !slices.Equal(got, test.wantRequests) {
+				t.Fatalf("refresh requests = %q, want %q", got, test.wantRequests)
+			}
+		})
+	}
+}
+
+func setAccessTokenTestEnvironment(t *testing.T, stackAuthURL string) {
+	t.Helper()
+
+	originalBuildMode := buildMode
+	originalEnvLoaded := envLoaded
+	buildMode = "dev"
+	envLoaded = true
+	t.Cleanup(func() {
+		buildMode = originalBuildMode
+		envLoaded = originalEnvLoaded
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AUTH_API_URL", stackAuthURL)
+	t.Setenv("DEVSH_DEV", "1")
+	t.Setenv("DEVSH_PROD", "")
+	t.Setenv("CMUX_DEVBOX_DEV", "")
+	t.Setenv("CMUX_DEVBOX_PROD", "")
+	t.Setenv("DEVSH_DEV_REFRESH_TOKEN", "")
+	t.Setenv("DEVSH_PROD_REFRESH_TOKEN", "")
+	t.Setenv("DEVSH_REFRESH_TOKEN", "")
+	t.Setenv("DEVBOX_REFRESH_TOKEN", "")
+}
+
+func newRefreshTokenTestServer(t *testing.T, statuses map[string]int) (*httptest.Server, func() []string) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var refreshTokens []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("x-stack-refresh-token")
+		mu.Lock()
+		refreshTokens = append(refreshTokens, token)
+		mu.Unlock()
+
+		status, ok := statuses[token]
+		if !ok {
+			status = http.StatusBadRequest
+		}
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_, _ = fmt.Fprintf(w, `{"access_token":%q}`, token+"-access")
+		}
+	}))
+
+	requests := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), refreshTokens...)
+	}
+	return server, requests
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = original
+	}()
+
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stderr reader: %v", err)
+	}
+	return string(output)
 }


### PR DESCRIPTION
## Summary

- preserve the existing refresh-token source priority and public `GetRefreshToken` API
- track the selected environment variable internally so refresh failures have source context
- on an exact Stack Auth HTTP 401 from an environment token, warn without exposing token contents and retry stored keychain/file credentials exactly once
- avoid fallback for other statuses, transport failures, malformed responses, or an initially stored credential
- drain rejected responses before the bounded retry so the HTTP connection can be reused

## Verification

- `cd packages/devsh && go test ./internal/auth`
- `cd packages/devsh && go test -race ./internal/auth`
- `cd packages/devsh && go test ./...`
- `cd packages/devsh && go vet ./...`
- normal pre-commit hook completed; `bun check` lint and typecheck passed
- repository `bun run test`: the devsh stage passed; unrelated untouched packages reported missing Stack Auth integration credentials and existing mock/timeout failures in Convex, server, shared, and www tests

## Scope notes

- does not change Login, Logout, auth status/config source reporting, Linux credential migration, or downstream API 401 handling
- no auto-merge requested; merge remains explicitly user-approved only