### PR TITLE
fix(execd): add token auth to /exec and /files endpoints

### DIFF
--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -54,6 +54,12 @@ type Client struct {
 	dnsMu         sync.Mutex
 	domainSuffix  string
 	domainFetched bool
+
+	// execToken caches the worker-auth-token read from inside the container
+	// via SSH + pct exec. Empty when PVE_SSH_HOST is not set or the token file
+	// doesn't exist (older containers without cmux-token-init).
+	execTokenMu sync.Mutex
+	execToken   string
 }
 
 type Instance struct {

--- a/packages/devsh/internal/pvelxc/exec.go
+++ b/packages/devsh/internal/pvelxc/exec.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -60,6 +61,62 @@ func ShellSingleQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
+// fetchExecToken retrieves the /root/.worker-auth-token from inside the
+// container via SSH to the PVE host + pct exec. The token is cached on the
+// Client after the first successful fetch. Returns "" (no error) when
+// PVE_SSH_HOST is not set — in that case the execd daemon will be in no-auth
+// mode (if the token file doesn't exist) and requests pass through.
+func (c *Client) fetchExecToken(ctx context.Context, vmid int) (string, error) {
+	sshHost := SSHHostFromEnv()
+	if sshHost == "" {
+		return "", nil
+	}
+
+	out, err := exec.CommandContext(ctx, "ssh",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "ConnectTimeout=5",
+		sshHost,
+		fmt.Sprintf("pct exec %d -- cat /root/.worker-auth-token 2>/dev/null || true", vmid),
+	).Output()
+	if err != nil {
+		return "", fmt.Errorf("fetch exec token via SSH+pct: %w", err)
+	}
+
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		// Token file doesn't exist in the container — execd is in no-auth mode.
+		return "", nil
+	}
+	return token, nil
+}
+
+// getExecToken returns the cached exec token, fetching it on first use.
+func (c *Client) getExecToken(ctx context.Context, vmid int) (string, error) {
+	c.execTokenMu.Lock()
+	token := c.execToken
+	c.execTokenMu.Unlock()
+	if token != "" {
+		return token, nil
+	}
+
+	fetched, err := c.fetchExecToken(ctx, vmid)
+	if err != nil {
+		return "", err
+	}
+
+	c.execTokenMu.Lock()
+	c.execToken = fetched
+	c.execTokenMu.Unlock()
+	return fetched, nil
+}
+
+// invalidateExecToken clears the cached token so the next call re-fetches.
+func (c *Client) invalidateExecToken() {
+	c.execTokenMu.Lock()
+	c.execToken = ""
+	c.execTokenMu.Unlock()
+}
+
 func VerifyTimezoneCommand(timezone string) string {
 	return fmt.Sprintf("TZ=%s; date +%%Z", ShellSingleQuote(timezone))
 }
@@ -96,7 +153,11 @@ func (c *Client) VerifyTimezone(ctx context.Context, instanceID string, timezone
 	return &ExecResult{ExitCode: exitCode, Stdout: stdout, Stderr: stderr}, nil
 }
 
-func (c *Client) tryHTTPExec(ctx context.Context, host string, command string, timeout time.Duration) (*ExecResult, error) {
+// ErrExecUnauthorized indicates the execd server returned 401 Unauthorized,
+// signaling the cached token is stale or missing and should be re-fetched.
+var ErrExecUnauthorized = errors.New("execd returned 401 Unauthorized")
+
+func (c *Client) tryHTTPExec(ctx context.Context, host string, command string, timeout time.Duration, token string) (*ExecResult, error) {
 	execURL, err := buildExecURL(host)
 	if err != nil {
 		return nil, err
@@ -127,6 +188,9 @@ func (c *Client) tryHTTPExec(ctx context.Context, host string, command string, t
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	resp, err := c.execHTTP.Do(req)
 	if err != nil {
@@ -137,6 +201,9 @@ func (c *Client) tryHTTPExec(ctx context.Context, host string, command string, t
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrExecUnauthorized
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, nil
 	}
@@ -247,7 +314,7 @@ func (c *Client) WaitForExecReady(ctx context.Context, instanceID string, timeou
 	}
 	defer cancel()
 
-	_, candidates, err := c.resolveExecCandidates(waitCtx, instanceID)
+	vmid, candidates, err := c.resolveExecCandidates(waitCtx, instanceID)
 	if err != nil {
 		return err
 	}
@@ -270,9 +337,22 @@ func (c *Client) WaitForExecReady(ctx context.Context, instanceID string, timeou
 		}
 
 		for _, host := range candidates {
+			token, tokenErr := c.getExecToken(waitCtx, vmid)
+			if tokenErr != nil {
+				lastErr = fmt.Errorf("fetch exec token: %w", tokenErr)
+				continue
+			}
+
 			probeCtx, cancelProbe := context.WithTimeout(waitCtx, probeTimeout)
-			result, probeErr := c.tryHTTPExec(probeCtx, host, execReadyProbeCommand, probeTimeout)
+			result, probeErr := c.tryHTTPExec(probeCtx, host, execReadyProbeCommand, probeTimeout, token)
 			cancelProbe()
+
+			if errors.Is(probeErr, ErrExecUnauthorized) {
+				// Token is stale — invalidate and re-fetch on the next iteration.
+				c.invalidateExecToken()
+				lastErr = fmt.Errorf("probe via %s: 401 Unauthorized (token stale)", host)
+				continue
+			}
 
 			if probeErr != nil {
 				if waitCtx.Err() != nil {
@@ -327,10 +407,20 @@ func (c *Client) ExecCommand(ctx context.Context, instanceID string, command str
 				return "", "", -1, ctx.Err()
 			}
 
-			result, err := c.tryHTTPExec(ctx, host, command, 0)
+			token, tokenErr := c.getExecToken(ctx, vmid)
+			if tokenErr != nil {
+				return "", "", -1, fmt.Errorf("fetch exec token: %w", tokenErr)
+			}
+
+			result, err := c.tryHTTPExec(ctx, host, command, 0, token)
 			if err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return "", "", -1, err
+				}
+				// 401: invalidate token and retry with a fresh one (once per attempt).
+				if errors.Is(err, ErrExecUnauthorized) && attempt == 1 {
+					c.invalidateExecToken()
+					continue
 				}
 			}
 			if err == nil && result != nil {

--- a/packages/devsh/internal/pvelxc/exec_test.go
+++ b/packages/devsh/internal/pvelxc/exec_test.go
@@ -161,3 +161,80 @@ func TestWaitForExecReadyHonorsCancellation(t *testing.T) {
 		t.Fatalf("WaitForExecReady() error = %v, want canceled", err)
 	}
 }
+
+func TestExecCommandSendsBearerTokenWhenCached(t *testing.T) {
+	var receivedAuth string
+
+	client := newExecReadyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/jsonlines")
+		_, _ = w.Write([]byte("{\"type\":\"stdout\",\"data\":\"ok\"}\n{\"type\":\"exit\",\"code\":0}\n"))
+	})
+
+	// Pre-set the cached token so getExecToken doesn't try SSH.
+	client.execToken = "my-secret-token"
+
+	stdout, _, exitCode, err := client.ExecCommand(context.Background(), "200", "echo ok")
+	if err != nil {
+		t.Fatalf("ExecCommand() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("ExecCommand() exitCode = %d, want 0", exitCode)
+	}
+	if stdout != "ok" {
+		t.Errorf("ExecCommand() stdout = %q, want %q", stdout, "ok")
+	}
+	if receivedAuth != "Bearer my-secret-token" {
+		t.Errorf("Authorization header = %q, want %q", receivedAuth, "Bearer my-secret-token")
+	}
+}
+
+func TestExecCommandRetriesOn401WithFreshToken(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		callCount   int
+		receivedAuth string
+	)
+
+	client := newExecReadyTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		receivedAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+
+		// First call: return 401 to simulate stale token.
+		// Second call: return success.
+		if callCount == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/jsonlines")
+		_, _ = w.Write([]byte("{\"type\":\"stdout\",\"data\":\"ok\"}\n{\"type\":\"exit\",\"code\":0}\n"))
+	})
+
+	// Start with a stale token; the 401 should trigger invalidation + re-fetch.
+	// Since PVE_SSH_HOST isn't set, re-fetch returns "" — but the test handler
+	// doesn't check auth, so the second call succeeds regardless.
+	client.execToken = "stale-token"
+
+	stdout, _, exitCode, err := client.ExecCommand(context.Background(), "200", "echo ok")
+	if err != nil {
+		t.Fatalf("ExecCommand() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("ExecCommand() exitCode = %d, want 0", exitCode)
+	}
+	if stdout != "ok" {
+		t.Errorf("ExecCommand() stdout = %q, want %q", stdout, "ok")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (401 + retry), got %d", callCount)
+	}
+	// First call should have sent the stale token.
+	_ = receivedAuth // value is from the last call; we just verify it ran twice.
+}

--- a/scripts/execd/main.go
+++ b/scripts/execd/main.go
@@ -18,6 +18,84 @@ import (
 	"time"
 )
 
+// authToken is loaded at startup from /root/.worker-auth-token (or
+// /home/user/.worker-auth-token as fallback). When non-empty, all /exec and
+// /files requests must present the token via Authorization: Bearer header,
+// ?token= query param, or _cmux_auth cookie. When empty (token file absent),
+// the daemon operates in no-auth mode for backward compatibility with older
+// containers that don't have cmux-token-init installed.
+var authToken string
+
+// tokenPaths lists the candidate paths for the auth token file, in priority
+// order. /root/ is the canonical location for PVE-LXC containers; /home/user/
+// is a legacy fallback for user-based containers.
+var tokenPaths = []string{
+	"/root/.worker-auth-token",
+	"/home/user/.worker-auth-token",
+}
+
+// loadAuthToken reads the auth token from the first existing token file.
+// Returns "" if no token file is found (no-auth mode).
+func loadAuthToken() string {
+	for _, p := range tokenPaths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		token := strings.TrimSpace(string(data))
+		if token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+// verifyAuth checks whether the request presents the expected auth token.
+// Supports Authorization: Bearer <token> header, ?token=<token> query param,
+// and _cmux_auth cookie — same as the cloudrouter worker's verifyAuth.
+func verifyAuth(r *http.Request) bool {
+	if authToken == "" {
+		return true // no token configured → no-auth mode
+	}
+
+	// Check Authorization header
+	if auth := r.Header.Get("Authorization"); auth != "" {
+		if strings.HasPrefix(auth, "Bearer ") {
+			if auth[7:] == authToken {
+				return true
+			}
+		} else if auth == authToken {
+			return true
+		}
+	}
+
+	// Check query parameter
+	if r.URL.Query().Get("token") == authToken {
+		return true
+	}
+
+	// Check cookie
+	if cookie, err := r.Cookie("_cmux_auth"); err == nil && cookie.Value == authToken {
+		return true
+	}
+
+	return false
+}
+
+// authMiddleware wraps a handler with token authentication. When authToken
+// is empty (no token file), requests pass through without auth.
+func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !verifyAuth(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+			return
+		}
+		next(w, r)
+	}
+}
+
 type execRequest struct {
 	Command   string `json:"command"`
 	TimeoutMs *int   `json:"timeout_ms"`
@@ -275,11 +353,21 @@ func main() {
 	portFlag := flag.Int("port", 39375, "port to listen on")
 	flag.Parse()
 
+	// Load auth token at startup. When the token file is absent (e.g. older
+	// containers without cmux-token-init), authToken remains "" and the daemon
+	// operates in no-auth mode for backward compatibility.
+	authToken = loadAuthToken()
+	if authToken != "" {
+		log.Printf("auth enabled (token: %s...)", authToken[:8])
+	} else {
+		log.Printf("auth disabled (no token file found)")
+	}
+
 	port := determinePort(*portFlag)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", healthHandler)
-	mux.HandleFunc("/exec", execHandler)
-	mux.HandleFunc("/files", filesHandler)
+	mux.HandleFunc("/exec", authMiddleware(execHandler))
+	mux.HandleFunc("/files", authMiddleware(filesHandler))
 
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),

--- a/scripts/execd/main_test.go
+++ b/scripts/execd/main_test.go
@@ -120,3 +120,227 @@ func TestHealthHandler(t *testing.T) {
 	}
 }
 
+// --- Auth middleware tests ---
+
+// withAuthToken temporarily sets the package-level authToken for the duration
+// of the test and restores the original value on cleanup.
+func withAuthToken(t *testing.T, token string) {
+	t.Helper()
+	prev := authToken
+	authToken = token
+	t.Cleanup(func() { authToken = prev })
+}
+
+func TestAuthMiddleware_NoTokenConfigured_AllowsAll(t *testing.T) {
+	withAuthToken(t, "") // no-auth mode
+
+	handler := authMiddleware(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("no-auth mode: expected %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestAuthMiddleware_ValidBearerToken_Passes(t *testing.T) {
+	withAuthToken(t, "test-secret-token")
+
+	handler := authMiddleware(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", nil)
+	req.Header.Set("Authorization", "Bearer test-secret-token")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("valid Bearer: expected %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestAuthMiddleware_ValidQueryToken_Passes(t *testing.T) {
+	withAuthToken(t, "test-secret-token")
+
+	handler := authMiddleware(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/exec?token=test-secret-token", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("valid query token: expected %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestAuthMiddleware_ValidCookie_Passes(t *testing.T) {
+	withAuthToken(t, "test-secret-token")
+
+	handler := authMiddleware(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", nil)
+	req.AddCookie(&http.Cookie{Name: "_cmux_auth", Value: "test-secret-token"})
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("valid cookie: expected %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestAuthMiddleware_MissingToken_Returns401(t *testing.T) {
+	withAuthToken(t, "test-secret-token")
+
+	handler := authMiddleware(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("handler should not be called when auth fails")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("missing token: expected %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+}
+
+func TestAuthMiddleware_WrongToken_Returns401(t *testing.T) {
+	withAuthToken(t, "test-secret-token")
+
+	handler := authMiddleware(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("handler should not be called when auth fails")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("wrong token: expected %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+}
+
+func TestAuthMiddleware_RawAuthHeader_Passes(t *testing.T) {
+	withAuthToken(t, "test-secret-token")
+
+	handler := authMiddleware(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/exec", nil)
+	req.Header.Set("Authorization", "test-secret-token")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("raw auth header: expected %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestHealthHandler_NoAuthRequired(t *testing.T) {
+	// /healthz is not wrapped with authMiddleware — it should always return 200
+	withAuthToken(t, "test-secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	healthHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("healthz with auth enabled: expected %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestLoadAuthToken_ReadsFirstExisting(t *testing.T) {
+	// Create temp token files to simulate /root/ and /home/user/ paths
+	tmpDir := t.TempDir()
+	rootToken := filepath.Join(tmpDir, "root-token")
+	userToken := filepath.Join(tmpDir, "user-token")
+
+	if err := os.WriteFile(rootToken, []byte("root-secret\n"), 0644); err != nil {
+		t.Fatalf("write root token: %v", err)
+	}
+	if err := os.WriteFile(userToken, []byte("user-secret\n"), 0644); err != nil {
+		t.Fatalf("write user token: %v", err)
+	}
+
+	// Patch tokenPaths to point to temp files
+	prev := tokenPaths
+	tokenPaths = []string{rootToken, userToken}
+	t.Cleanup(func() { tokenPaths = prev })
+
+	token := loadAuthToken()
+	if token != "root-secret" {
+		t.Errorf("expected 'root-secret' (first path), got %q", token)
+	}
+}
+
+func TestLoadAuthToken_FallsBackToSecondPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	missingPath := filepath.Join(tmpDir, "nonexistent")
+	userToken := filepath.Join(tmpDir, "user-token")
+
+	if err := os.WriteFile(userToken, []byte("user-secret\n"), 0644); err != nil {
+		t.Fatalf("write user token: %v", err)
+	}
+
+	prev := tokenPaths
+	tokenPaths = []string{missingPath, userToken}
+	t.Cleanup(func() { tokenPaths = prev })
+
+	token := loadAuthToken()
+	if token != "user-secret" {
+		t.Errorf("expected 'user-secret' (fallback), got %q", token)
+	}
+}
+
+func TestLoadAuthToken_NoFiles_ReturnsEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	prev := tokenPaths
+	tokenPaths = []string{
+		filepath.Join(tmpDir, "nonexistent-1"),
+		filepath.Join(tmpDir, "nonexistent-2"),
+	}
+	t.Cleanup(func() { tokenPaths = prev })
+
+	token := loadAuthToken()
+	if token != "" {
+		t.Errorf("expected empty token, got %q", token)
+	}
+}
+
+func TestLoadAuthToken_EmptyFile_Skipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	emptyFile := filepath.Join(tmpDir, "empty")
+	goodFile := filepath.Join(tmpDir, "good")
+
+	if err := os.WriteFile(emptyFile, []byte("  \n"), 0644); err != nil {
+		t.Fatalf("write empty token: %v", err)
+	}
+	if err := os.WriteFile(goodFile, []byte("real-token"), 0644); err != nil {
+		t.Fatalf("write good token: %v", err)
+	}
+
+	prev := tokenPaths
+	tokenPaths = []string{emptyFile, goodFile}
+	t.Cleanup(func() { tokenPaths = prev })
+
+	token := loadAuthToken()
+	if token != "real-token" {
+		t.Errorf("expected 'real-token' (skip empty), got %q", token)
+	}
+}
+

--- a/scripts/pve/pve-lxc-setup.sh
+++ b/scripts/pve/pve-lxc-setup.sh
@@ -401,6 +401,84 @@ import (
 	"time"
 )
 
+// authToken is loaded at startup from /root/.worker-auth-token (or
+// /home/user/.worker-auth-token as fallback). When non-empty, all /exec and
+// /files requests must present the token via Authorization: Bearer header,
+// ?token= query param, or _cmux_auth cookie. When empty (token file absent),
+// the daemon operates in no-auth mode for backward compatibility with older
+// containers that don't have cmux-token-init installed.
+var authToken string
+
+// tokenPaths lists the candidate paths for the auth token file, in priority
+// order. /root/ is the canonical location for PVE-LXC containers; /home/user/
+// is a legacy fallback for user-based containers.
+var tokenPaths = []string{
+	"/root/.worker-auth-token",
+	"/home/user/.worker-auth-token",
+}
+
+// loadAuthToken reads the auth token from the first existing token file.
+// Returns "" if no token file is found (no-auth mode).
+func loadAuthToken() string {
+	for _, p := range tokenPaths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		token := strings.TrimSpace(string(data))
+		if token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+// verifyAuth checks whether the request presents the expected auth token.
+// Supports Authorization: Bearer <token> header, ?token=<token> query param,
+// and _cmux_auth cookie — same as the cloudrouter worker's verifyAuth.
+func verifyAuth(r *http.Request) bool {
+	if authToken == "" {
+		return true // no token configured → no-auth mode
+	}
+
+	// Check Authorization header
+	if auth := r.Header.Get("Authorization"); auth != "" {
+		if strings.HasPrefix(auth, "Bearer ") {
+			if auth[7:] == authToken {
+				return true
+			}
+		} else if auth == authToken {
+			return true
+		}
+	}
+
+	// Check query parameter
+	if r.URL.Query().Get("token") == authToken {
+		return true
+	}
+
+	// Check cookie
+	if cookie, err := r.Cookie("_cmux_auth"); err == nil && cookie.Value == authToken {
+		return true
+	}
+
+	return false
+}
+
+// authMiddleware wraps a handler with token authentication. When authToken
+// is empty (no token file), requests pass through without auth.
+func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !verifyAuth(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+			return
+		}
+		next(w, r)
+	}
+}
+
 type execRequest struct {
 	Command   string `json:"command"`
 	TimeoutMs *int   `json:"timeout_ms"`
@@ -530,9 +608,25 @@ func execHandler(w http.ResponseWriter, r *http.Request) {
 	_ = writeJSONLine(w, flusher, execEvent{Type: "exit", Code: &exitCode})
 }
 
+func healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
 func main() {
 	portFlag := flag.Int("port", 39375, "port")
 	flag.Parse()
+
+	// Load auth token at startup. When the token file is absent (e.g. older
+	// containers without cmux-token-init), authToken remains "" and the daemon
+	// operates in no-auth mode for backward compatibility.
+	authToken = loadAuthToken()
+	if authToken != "" {
+		log.Printf("auth enabled (token: %s...)", authToken[:8])
+	} else {
+		log.Printf("auth disabled (no token file found)")
+	}
+
 	port := *portFlag
 	if env := os.Getenv("EXECD_PORT"); env != "" {
 		if v, err := strconv.Atoi(env); err == nil {
@@ -540,10 +634,57 @@ func main() {
 		}
 	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.Write([]byte("ok")) })
-	mux.HandleFunc("/exec", execHandler)
+	mux.HandleFunc("/healthz", healthHandler)
+	mux.HandleFunc("/exec", authMiddleware(execHandler))
+	mux.HandleFunc("/files", authMiddleware(filesHandler))
 	log.Printf("cmux-execd listening on :%d", port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), mux))
+}
+
+// filesHandler accepts a tar archive body and extracts it to /workspace.
+// This enables workspace file sync for PVE LXC containers.
+func filesHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Create /workspace if it doesn't exist
+	if err := os.MkdirAll("/workspace", 0755); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create workspace: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Stream the request body directly to tar for extraction
+	cmd := exec.Command("tar", "-x", "-C", "/workspace")
+	cmd.Stdin = r.Body
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create stderr pipe: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to start tar: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Read stderr for error messages
+	stderrBytes, _ := io.ReadAll(stderr)
+	waitErr := cmd.Wait()
+
+	if waitErr != nil {
+		errMsg := strings.TrimSpace(string(stderrBytes))
+		if errMsg == "" {
+			errMsg = waitErr.Error()
+		}
+		http.Error(w, fmt.Sprintf("tar extraction failed: %s", errMsg), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Files extracted to /workspace")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
 }
 EXECD_SOURCE
 
@@ -562,8 +703,9 @@ GOMOD
     cat > /etc/systemd/system/cmux-execd.service << 'SERVICE'
 [Unit]
 Description=cmux exec daemon - HTTP command execution
-After=network-online.target
+After=network-online.target cmux-token-generator.service
 Wants=network-online.target
+Requires=cmux-token-generator.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary

Fixes #1303

`cmux-execd` (port 39375) had **zero authentication** on its `/exec` and `/files` HTTP endpoints, which are exposed to the internet via Cloudflare tunnel (`https://port-39375-<id>.alphasolves.com`). An unauthenticated peer could run arbitrary root commands and extract files into any container.

## Changes

### `scripts/execd/main.go` (canonical source)
- Added `loadAuthToken()` — reads `/root/.worker-auth-token` or `/home/user/.worker-auth-token` at startup
- Added `verifyAuth(r)` — checks `Authorization: Bearer` header, `?token=` query param, or `_cmux_auth` cookie (same as cloudrouter worker)
- Added `authMiddleware` — wraps `/exec` and `/files` handlers; `/healthz` stays unauthenticated
- **Graceful degradation**: when token file is absent (older containers without `cmux-token-init`), `authToken` is empty and the daemon operates in no-auth mode

### `packages/devsh/internal/pvelxc/exec.go` + `client.go`
- Added `execToken` field (thread-safe via `sync.Mutex`) to cache the worker-auth-token
- Added `fetchExecToken()` — retrieves the token via `ssh root@pve-host "pct exec <vmid> -- cat /root/.worker-auth-token"` (requires `PVE_SSH_HOST`)
- `tryHTTPExec` now sends `Authorization: Bearer <token>` header
- On 401, the cached token is invalidated and re-fetched on the next attempt (stale token recovery)

### `scripts/pve/pve-lxc-setup.sh`
- Synced embedded execd source with canonical `scripts/execd/main.go` (auth code + missing `filesHandler`)
- `cmux-execd.service` now `Requires=cmux-token-generator.service` to ensure token file exists before execd starts

## Test plan

- [x] `go test` in `scripts/execd/` — 15 tests pass (8 new auth tests)
- [x] `go test` in `packages/devsh/internal/pvelxc/` — 33 tests pass (2 new auth integration tests)
- [x] `bun check` — lint + typecheck pass
- [ ] CI: both amd64 and arm64 Docker builds pass
- [ ] Live: rebuild cmux-execd on a PVE-LXC container, verify `/exec` returns 401 without token and 200 with valid Bearer token

## Follow-up (not in this PR)

- The Rust sandbox code (`packages/sandbox/src/pve_lxc.rs`) also calls `/exec` and `/files` without auth. It runs on the PVE host but has no SSH access. With graceful degradation, containers that don't have the token file will keep working. Updating the Rust code for auth requires adding `pct exec` capability to `PveLxcService` — noted as a follow-up.
- Consider rotating gateway API keys on containers that had `/root/.grok/config.toml` exposed while `/exec` was unauthenticated.