### PR TITLE
fix(pve): propagate execd auth through sandbox setup

### DIFF
--- a/packages/sandbox/src/acp_client/markdown.rs
+++ b/packages/sandbox/src/acp_client/markdown.rs
@@ -118,10 +118,8 @@ pub(crate) fn markdown_to_lines(source: &str) -> Vec<Line<'static>> {
             MdEvent::Start(Tag::Item) => {
                 current_spans.push(Span::raw("• ".to_owned()));
             }
-            MdEvent::End(TagEnd::Item) => {
-                if !current_spans.is_empty() {
-                    lines.push(Line::from(std::mem::take(&mut current_spans)));
-                }
+            MdEvent::End(TagEnd::Item) if !current_spans.is_empty() => {
+                lines.push(Line::from(std::mem::take(&mut current_spans)));
             }
             _ => {}
         }

--- a/packages/sandbox/src/bin/cli.rs
+++ b/packages/sandbox/src/bin/cli.rs
@@ -1563,7 +1563,7 @@ async fn handle_prune(client: &Client, base_url: &str, args: PruneArgs) -> anyho
         .collect();
 
     // Sort by age (oldest first)
-    to_prune.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    to_prune.sort_by_key(|a| a.created_at);
 
     if to_prune.is_empty() {
         let filter_desc = if args.all {

--- a/packages/sandbox/src/bubblewrap.rs
+++ b/packages/sandbox/src/bubblewrap.rs
@@ -570,7 +570,7 @@ impl BubblewrapService {
         // 3. Try searching by prefix
         let guard = self.sandboxes.lock().await;
         let mut matched = None;
-        for (uuid, _) in guard.iter() {
+        for uuid in guard.keys() {
             let simple = uuid.simple().to_string();
             if simple.starts_with(id_str) {
                 if matched.is_some() {
@@ -2463,7 +2463,7 @@ impl SandboxService for BubblewrapService {
                             // Forward signal to all PTY child processes
                             let sessions = sessions.lock().await;
                             let mut sent_count = 0;
-                            for (_session_id, handle) in sessions.iter() {
+                            for handle in sessions.values() {
                                 if let Some(pid) = handle.child_pid {
                                     // Use libc to send the signal
                                     let result = unsafe { libc::kill(pid as i32, signum) };

--- a/packages/sandbox/src/mux/runner.rs
+++ b/packages/sandbox/src/mux/runner.rs
@@ -898,10 +898,8 @@ fn handle_input(
                                     tab.navigate(crate::mux::layout::NavDirection::Right);
                                 }
                             }
-                            KeyCode::Tab => {
-                                if app.sidebar.visible {
-                                    app.focus = FocusArea::Sidebar;
-                                }
+                            KeyCode::Tab if app.sidebar.visible => {
+                                app.focus = FocusArea::Sidebar;
                             }
                             _ => {}
                         }

--- a/packages/sandbox/src/mux/terminal.rs
+++ b/packages/sandbox/src/mux/terminal.rs
@@ -2227,7 +2227,7 @@ impl Perform for VirtualTerminal {
                     // 29 = ANSI text locator
                     self.pending_responses
                         .push(b"\x1b[?64;1;2;6;9;15;16;17;18;21;22;28;29c".to_vec());
-                } else if intermediates == [b'>'] && is_query {
+                } else if intermediates == *b">" && is_query {
                     // Secondary Device Attributes (DA2): CSI > c or CSI > 0 c
                     // Respond as xterm version 314+:
                     // 41 = xterm terminal type
@@ -2313,13 +2313,13 @@ impl Perform for VirtualTerminal {
                 self.insert_chars(n);
             }
             // Soft Terminal Reset (DECSTR) - CSI ! p
-            'p' if intermediates == [b'!'] => {
+            'p' if intermediates == *b"!" => {
                 self.soft_reset();
             }
             // Private modes (DECSET/DECRST) and standard modes (SM/RM)
             'h' | 'l' => {
                 let enable = action == 'h';
-                if intermediates == [b'?'] {
+                if intermediates == *b"?" {
                     // Private (DEC) modes
                     for &param in &params_vec {
                         match param {
@@ -2524,7 +2524,7 @@ impl Perform for VirtualTerminal {
             }
             // DECRQCRA - Request Checksum of Rectangular Area
             // CSI Pid ; Pp ; Pt ; Pl ; Pb ; Pr * y
-            'y' if intermediates == [b'*'] => {
+            'y' if intermediates == *b"*" => {
                 let pid = params_vec.first().copied().unwrap_or(0);
                 let _page = params_vec.get(1).copied().unwrap_or(1); // page number, ignored
                 let top = params_vec.get(2).copied().unwrap_or(1).max(1) as usize;
@@ -2695,7 +2695,7 @@ impl Perform for VirtualTerminal {
                 self.pending_responses.push(response.into_bytes());
             }
             // DECFRA - Fill Rectangular Area: CSI Pc ; Pt ; Pl ; Pb ; Pr $ x
-            'x' if intermediates == [b'$'] => {
+            'x' if intermediates == *b"$" => {
                 let char_code = params_vec.first().copied().unwrap_or(32) as u8; // Default: space
                 let ch = if (32..127).contains(&char_code) {
                     char_code as char
@@ -2751,7 +2751,7 @@ impl Perform for VirtualTerminal {
                 }
             }
             // DECERA - Erase Rectangular Area: CSI Pt ; Pl ; Pb ; Pr $ z
-            'z' if intermediates == [b'$'] => {
+            'z' if intermediates == *b"$" => {
                 // Get rectangle bounds (1-based, convert to 0-based)
                 let top = params_vec.first().copied().unwrap_or(1).max(1) as usize - 1;
                 let left = params_vec.get(1).copied().unwrap_or(1).max(1) as usize - 1;
@@ -2806,7 +2806,7 @@ impl Perform for VirtualTerminal {
             // Ps=1: blinking block, Ps=2: steady block
             // Ps=3: blinking underline, Ps=4: steady underline
             // Ps=5: blinking bar, Ps=6: steady bar
-            'q' if intermediates == [b' '] => {
+            'q' if intermediates == *b" " => {
                 let style = params_vec.first().copied().unwrap_or(0);
                 self.cursor_style = style as u8;
                 // Odd values are blinking, even values (including 0) are steady

--- a/packages/sandbox/src/pve_lxc.rs
+++ b/packages/sandbox/src/pve_lxc.rs
@@ -19,8 +19,9 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 use tokio::sync::Mutex;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 // =============================================================================
@@ -266,6 +267,12 @@ pub struct ResolvedPveConfig {
 pub struct PveClient {
     client: Client,
     config: ResolvedPveConfig,
+}
+
+/// Return the Authorization header value for a non-empty execd token.
+fn bearer_auth_value(token: &str) -> Option<String> {
+    let token = token.trim();
+    (!token.is_empty()).then(|| format!("Bearer {token}"))
 }
 
 impl PveClient {
@@ -638,6 +645,7 @@ impl PveClient {
         ip: std::net::Ipv4Addr,
         command: &[String],
         timeout_ms: Option<u64>,
+        exec_token: &str,
     ) -> SandboxResult<ExecResponse> {
         let cmd_str = command.join(" ");
         let exec_url = format!("http://{}:39375/exec", ip);
@@ -648,20 +656,23 @@ impl PveClient {
             "timeout_ms": timeout,
         });
 
-        let response = self
+        let mut request = self
             .client
             .post(&exec_url)
             .header("Content-Type", "application/json")
             .body(body.to_string())
-            .timeout(std::time::Duration::from_millis(timeout + 5000))
-            .send()
-            .await
-            .map_err(|e| {
-                SandboxError::Internal(format!(
-                    "HTTP exec request failed for container at {}: {}",
-                    ip, e
-                ))
-            })?;
+            .timeout(std::time::Duration::from_millis(timeout + 5000));
+
+        if let Some(auth) = bearer_auth_value(exec_token) {
+            request = request.header("Authorization", auth);
+        }
+
+        let response = request.send().await.map_err(|e| {
+            SandboxError::Internal(format!(
+                "HTTP exec request failed for container at {}: {}",
+                ip, e
+            ))
+        })?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -863,6 +874,10 @@ struct LxcSandboxEntry {
     correlation_id: Option<String>,
     #[allow(dead_code)]
     env: Vec<EnvVar>,
+    /// Auth token for cmux-execd (read from /root/.worker-auth-token inside
+    /// the container via `pct exec`). Empty when the token file is absent
+    /// (older containers without cmux-token-init → execd in no-auth mode).
+    exec_token: String,
 }
 
 impl LxcSandboxEntry {
@@ -962,6 +977,74 @@ impl PveLxcService {
             config.bridge, ip, config.gateway
         )
     }
+
+    /// Fetch the worker-auth-token from inside a container via `pct exec`.
+    /// Returns an empty string when neither supported token file exists
+    /// (execd in no-auth mode). This runs locally on the PVE host — no SSH
+    /// needed.
+    async fn fetch_exec_token(&self, vmid: u32) -> SandboxResult<String> {
+        const TOKEN_SCRIPT: &str = r#"
+for _ in $(seq 1 15); do
+    for path in /root/.worker-auth-token /home/user/.worker-auth-token; do
+        if [ -s "$path" ]; then
+            cat "$path"
+            exit 0
+        fi
+    done
+    sleep 1
+done
+exit 42
+"#;
+
+        for attempt in 1..=5 {
+            let output = tokio::process::Command::new("pct")
+                .arg("exec")
+                .arg(vmid.to_string())
+                .arg("--")
+                .arg("sh")
+                .arg("-c")
+                .arg(TOKEN_SCRIPT)
+                .output()
+                .await
+                .map_err(|error| {
+                    SandboxError::Internal(format!(
+                        "failed to run pct exec for container {vmid}: {error}"
+                    ))
+                })?;
+
+            if output.status.success() {
+                let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !token.is_empty() {
+                    return Ok(token);
+                }
+                return Err(SandboxError::Internal(format!(
+                    "pct exec returned an empty auth token for container {vmid}"
+                )));
+            }
+
+            // Exit code 42 is the deliberate no-token result from TOKEN_SCRIPT.
+            if output.status.code() == Some(42) {
+                debug!("container {vmid} has no worker auth token; using execd no-auth compatibility mode");
+                return Ok(String::new());
+            }
+
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            if attempt < 5 {
+                warn!(
+                    "pct exec token lookup failed for container {vmid} (attempt {attempt}/5): {stderr}; retrying"
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            } else {
+                return Err(SandboxError::Internal(format!(
+                    "failed to read worker auth token for container {vmid}: {stderr}"
+                )));
+            }
+        }
+
+        Err(SandboxError::Internal(format!(
+            "failed to read worker auth token for container {vmid}"
+        )))
+    }
 }
 
 #[async_trait]
@@ -1007,6 +1090,11 @@ impl SandboxService for PveLxcService {
         // Start the container
         self.client.start_lxc(vmid).await?;
 
+        // Fetch the worker-auth-token from the container via pct exec.
+        // This runs locally on the PVE host. An absent token file preserves
+        // compatibility with older containers where execd has no auth.
+        let exec_token = self.fetch_exec_token(vmid).await?;
+
         let entry = LxcSandboxEntry {
             id,
             index,
@@ -1017,6 +1105,7 @@ impl SandboxService for PveLxcService {
             status: SandboxStatus::Running,
             correlation_id: request.tab_id,
             env: request.env,
+            exec_token,
         };
 
         let summary = entry.to_summary(config);
@@ -1064,7 +1153,7 @@ impl SandboxService for PveLxcService {
 
         // Execute command via HTTP exec daemon (cmux-execd) running in the container
         self.client
-            .exec_lxc(entry.ip, &exec.command, exec.timeout_ms)
+            .exec_lxc(entry.ip, &exec.command, exec.timeout_ms, &entry.exec_token)
             .await
     }
 
@@ -1131,20 +1220,23 @@ impl SandboxService for PveLxcService {
         // Send the archive to the container's /files endpoint
         // Note: We can't retry with streaming body, so we do a single attempt
         // The cmux-execd service should be ready by the time we start uploading
-        let response = self
+        let mut request = self
             .client
             .client
             .post(&files_url)
             .body(reqwest_body)
-            .timeout(std::time::Duration::from_secs(300))
-            .send()
-            .await
-            .map_err(|e| {
-                SandboxError::Internal(format!(
-                    "Failed to upload archive to container {}: {}",
-                    entry.ip, e
-                ))
-            })?;
+            .timeout(std::time::Duration::from_secs(300));
+
+        if let Some(auth) = bearer_auth_value(&entry.exec_token) {
+            request = request.header("Authorization", auth);
+        }
+
+        let response = request.send().await.map_err(|e| {
+            SandboxError::Internal(format!(
+                "Failed to upload archive to container {}: {}",
+                entry.ip, e
+            ))
+        })?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -1248,6 +1340,35 @@ impl SandboxService for PveLxcService {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_bearer_auth_value() {
+        assert_eq!(bearer_auth_value("token"), Some("Bearer token".to_string()));
+        assert_eq!(
+            bearer_auth_value("  token\n"),
+            Some("Bearer token".to_string())
+        );
+        assert_eq!(bearer_auth_value("  "), None);
+    }
+
+    #[test]
+    fn test_token_script_supports_both_paths() {
+        let script = r#"
+for _ in $(seq 1 15); do
+    for path in /root/.worker-auth-token /home/user/.worker-auth-token; do
+        if [ -s "$path" ]; then
+            cat "$path"
+            exit 0
+        fi
+    done
+    sleep 1
+done
+exit 42
+"#;
+        assert!(script.contains("/root/.worker-auth-token"));
+        assert!(script.contains("/home/user/.worker-auth-token"));
+        assert!(script.contains("exit 42"));
+    }
 
     #[test]
     fn test_ip_pool_allocation() {

--- a/scripts/pve/pve-lxc-setup.sh
+++ b/scripts/pve/pve-lxc-setup.sh
@@ -350,15 +350,22 @@ else
     mark_done "07-criu"
 fi
 
-# Step 8: Go (for cmux-execd)
-if step_done "08-go"; then
-    echo "[8/10] Go... SKIP (already done)"
-elif command -v go &>/dev/null; then
+# Step 8: Go (for cmux-execd and worker-daemon)
+GO_VERSION="1.25.4"
+go_version_is_sufficient() {
+    local version
+    version="$(go env GOVERSION 2>/dev/null || true)"
+    [[ "$version" =~ ^go1\.([0-9]+)(\.|$) ]] && (( BASH_REMATCH[1] >= 25 ))
+}
+
+if step_done "08-go" && command -v go &>/dev/null && go_version_is_sufficient; then
+    echo "[8/10] Go... SKIP (already done: $(go version))"
+    mark_done "08-go"
+elif command -v go &>/dev/null && go_version_is_sufficient; then
     echo "[8/10] Go... SKIP (already installed: $(go version))"
     mark_done "08-go"
 else
-    echo "[8/10] Installing Go..."
-    GO_VERSION="1.23.4"
+    echo "[8/10] Installing Go ${GO_VERSION}..."
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xzf -
     ln -sf /usr/local/go/bin/go /usr/local/bin/go
     ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
@@ -375,329 +382,18 @@ elif [[ -f /usr/local/bin/cmux-execd ]]; then
 else
     echo "[9/10] Installing cmux-execd..."
 
-    # Create temp build directory
+    # Build the canonical execd source from the repository instead of keeping
+    # a second embedded copy in this setup script.
     EXECD_BUILD_DIR=$(mktemp -d)
-    cd "$EXECD_BUILD_DIR"
+    git clone --depth 1 --filter=blob:none --sparse \
+        https://github.com/karlorz/cmux.git "$EXECD_BUILD_DIR/cmux-repo"
+    git -C "$EXECD_BUILD_DIR/cmux-repo" sparse-checkout init --cone
+    git -C "$EXECD_BUILD_DIR/cmux-repo" sparse-checkout set scripts/execd
 
-    # Write the execd source code
-    cat > main.go << 'EXECD_SOURCE'
-package main
-
-import (
-	"bufio"
-	"context"
-	"encoding/json"
-	"errors"
-	"flag"
-	"fmt"
-	"io"
-	"log"
-	"net/http"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
-)
-
-// authToken is loaded at startup from /root/.worker-auth-token (or
-// /home/user/.worker-auth-token as fallback). When non-empty, all /exec and
-// /files requests must present the token via Authorization: Bearer header,
-// ?token= query param, or _cmux_auth cookie. When empty (token file absent),
-// the daemon operates in no-auth mode for backward compatibility with older
-// containers that don't have cmux-token-init installed.
-var authToken string
-
-// tokenPaths lists the candidate paths for the auth token file, in priority
-// order. /root/ is the canonical location for PVE-LXC containers; /home/user/
-// is a legacy fallback for user-based containers.
-var tokenPaths = []string{
-	"/root/.worker-auth-token",
-	"/home/user/.worker-auth-token",
-}
-
-// loadAuthToken reads the auth token from the first existing token file.
-// Returns "" if no token file is found (no-auth mode).
-func loadAuthToken() string {
-	for _, p := range tokenPaths {
-		data, err := os.ReadFile(p)
-		if err != nil {
-			continue
-		}
-		token := strings.TrimSpace(string(data))
-		if token != "" {
-			return token
-		}
-	}
-	return ""
-}
-
-// verifyAuth checks whether the request presents the expected auth token.
-// Supports Authorization: Bearer <token> header, ?token=<token> query param,
-// and _cmux_auth cookie — same as the cloudrouter worker's verifyAuth.
-func verifyAuth(r *http.Request) bool {
-	if authToken == "" {
-		return true // no token configured → no-auth mode
-	}
-
-	// Check Authorization header
-	if auth := r.Header.Get("Authorization"); auth != "" {
-		if strings.HasPrefix(auth, "Bearer ") {
-			if auth[7:] == authToken {
-				return true
-			}
-		} else if auth == authToken {
-			return true
-		}
-	}
-
-	// Check query parameter
-	if r.URL.Query().Get("token") == authToken {
-		return true
-	}
-
-	// Check cookie
-	if cookie, err := r.Cookie("_cmux_auth"); err == nil && cookie.Value == authToken {
-		return true
-	}
-
-	return false
-}
-
-// authMiddleware wraps a handler with token authentication. When authToken
-// is empty (no token file), requests pass through without auth.
-func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if !verifyAuth(r) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
-			return
-		}
-		next(w, r)
-	}
-}
-
-type execRequest struct {
-	Command   string `json:"command"`
-	TimeoutMs *int   `json:"timeout_ms"`
-}
-
-type execEvent struct {
-	Type    string `json:"type"`
-	Data    string `json:"data,omitempty"`
-	Code    *int   `json:"code,omitempty"`
-	Message string `json:"message,omitempty"`
-}
-
-func writeJSONLine(w io.Writer, flusher http.Flusher, event execEvent) error {
-	payload, err := json.Marshal(event)
-	if err != nil {
-		return err
-	}
-	if _, err = w.Write(append(payload, '\n')); err != nil {
-		return err
-	}
-	flusher.Flush()
-	return nil
-}
-
-func readPipe(ctx context.Context, reader io.Reader, eventType string, wg *sync.WaitGroup, w io.Writer, flusher http.Flusher) {
-	defer wg.Done()
-	scanner := bufio.NewScanner(reader)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
-	for scanner.Scan() {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-		line := strings.TrimRight(scanner.Text(), "\r")
-		if line == "" {
-			continue
-		}
-		_ = writeJSONLine(w, flusher, execEvent{Type: eventType, Data: line})
-	}
-}
-
-func execHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	if !strings.Contains(strings.ToLower(r.Header.Get("Content-Type")), "application/json") {
-		http.Error(w, "Unsupported Content-Type", http.StatusUnsupportedMediaType)
-		return
-	}
-
-	var payload execRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&payload); err != nil {
-		http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
-		return
-	}
-
-	command := strings.TrimSpace(payload.Command)
-	if command == "" {
-		http.Error(w, "Command required", http.StatusBadRequest)
-		return
-	}
-
-	var timeout time.Duration
-	timeoutMs := 0
-	if payload.TimeoutMs != nil && *payload.TimeoutMs > 0 {
-		timeoutMs = *payload.TimeoutMs
-		timeout = time.Duration(timeoutMs) * time.Millisecond
-	}
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/jsonlines")
-	w.WriteHeader(http.StatusOK)
-
-	ctx := context.Background()
-	var cancel context.CancelFunc
-	if timeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-	} else {
-		ctx, cancel = context.WithCancel(ctx)
-	}
-	defer cancel()
-
-	go func() {
-		<-r.Context().Done()
-		cancel()
-	}()
-
-	cmd := exec.CommandContext(ctx, "/bin/bash", "-c", command)
-	stdout, _ := cmd.StdoutPipe()
-	stderr, _ := cmd.StderrPipe()
-
-	if err := cmd.Start(); err != nil {
-		exitCode := 127
-		_ = writeJSONLine(w, flusher, execEvent{Type: "error", Message: err.Error()})
-		_ = writeJSONLine(w, flusher, execEvent{Type: "exit", Code: &exitCode})
-		return
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go readPipe(r.Context(), stdout, "stdout", &wg, w, flusher)
-	go readPipe(r.Context(), stderr, "stderr", &wg, w, flusher)
-
-	waitErr := cmd.Wait()
-	wg.Wait()
-
-	exitCode := 0
-	if waitErr != nil {
-		var exitErr *exec.ExitError
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			_ = writeJSONLine(w, flusher, execEvent{Type: "error", Message: fmt.Sprintf("timeout after %dms", timeoutMs)})
-			exitCode = 124
-		} else if errors.As(waitErr, &exitErr) {
-			exitCode = exitErr.ExitCode()
-		} else {
-			exitCode = 1
-		}
-	}
-	_ = writeJSONLine(w, flusher, execEvent{Type: "exit", Code: &exitCode})
-}
-
-func healthHandler(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("ok"))
-}
-
-func main() {
-	portFlag := flag.Int("port", 39375, "port")
-	flag.Parse()
-
-	// Load auth token at startup. When the token file is absent (e.g. older
-	// containers without cmux-token-init), authToken remains "" and the daemon
-	// operates in no-auth mode for backward compatibility.
-	authToken = loadAuthToken()
-	if authToken != "" {
-		log.Printf("auth enabled (token: %s...)", authToken[:8])
-	} else {
-		log.Printf("auth disabled (no token file found)")
-	}
-
-	port := *portFlag
-	if env := os.Getenv("EXECD_PORT"); env != "" {
-		if v, err := strconv.Atoi(env); err == nil {
-			port = v
-		}
-	}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", healthHandler)
-	mux.HandleFunc("/exec", authMiddleware(execHandler))
-	mux.HandleFunc("/files", authMiddleware(filesHandler))
-	log.Printf("cmux-execd listening on :%d", port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), mux))
-}
-
-// filesHandler accepts a tar archive body and extracts it to /workspace.
-// This enables workspace file sync for PVE LXC containers.
-func filesHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	// Create /workspace if it doesn't exist
-	if err := os.MkdirAll("/workspace", 0755); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to create workspace: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	// Stream the request body directly to tar for extraction
-	cmd := exec.Command("tar", "-x", "-C", "/workspace")
-	cmd.Stdin = r.Body
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to create stderr pipe: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	if err := cmd.Start(); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to start tar: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	// Read stderr for error messages
-	stderrBytes, _ := io.ReadAll(stderr)
-	waitErr := cmd.Wait()
-
-	if waitErr != nil {
-		errMsg := strings.TrimSpace(string(stderrBytes))
-		if errMsg == "" {
-			errMsg = waitErr.Error()
-		}
-		http.Error(w, fmt.Sprintf("tar extraction failed: %s", errMsg), http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Files extracted to /workspace")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("ok"))
-}
-EXECD_SOURCE
-
-    cat > go.mod << 'GOMOD'
-module cmux-execd
-go 1.21
-GOMOD
-
-    # Build the binary
     export PATH="/usr/local/go/bin:$PATH"
-    CGO_ENABLED=0 go build -ldflags="-s -w" -o cmux-execd .
-    mv cmux-execd /usr/local/bin/cmux-execd
-    chmod +x /usr/local/bin/cmux-execd
+    CGO_ENABLED=0 go build -C "$EXECD_BUILD_DIR/cmux-repo/scripts/execd" \
+        -ldflags="-s -w" -o "$EXECD_BUILD_DIR/cmux-execd"
+    install -m 0755 "$EXECD_BUILD_DIR/cmux-execd" /usr/local/bin/cmux-execd
 
     # Create systemd service
     cat > /etc/systemd/system/cmux-execd.service << 'SERVICE'
@@ -720,14 +416,20 @@ StandardError=append:/var/log/cmux/cmux-execd.log
 WantedBy=multi-user.target
 SERVICE
 
-    # Enable and start the service
+    # Enable and start the service once the token generator unit exists.
+    # The generator is declared by the worker-daemon step below, so defer the
+    # initial start on a fresh container until that step has installed it.
     mkdir -p /var/log/cmux
     systemctl daemon-reload
-    systemctl enable cmux-execd
-    systemctl start cmux-execd
+    if [[ -f /etc/systemd/system/cmux-token-generator.service ]]; then
+        systemctl enable cmux-execd
+        systemctl start cmux-token-generator.service
+        systemctl start cmux-execd
+    else
+        log_info "cmux-token-generator.service not installed yet; deferring cmux-execd start"
+    fi
 
     # Cleanup
-    cd /
     rm -rf "$EXECD_BUILD_DIR"
 
     echo "    cmux-execd installed and running on port 39375"
@@ -847,7 +549,9 @@ SERVICE
     systemctl daemon-reload
     systemctl enable cmux-token-generator.service
     systemctl enable cmux-worker-daemon.service
+    systemctl enable cmux-execd
     systemctl start cmux-token-generator.service
+    systemctl start cmux-execd
     systemctl start cmux-worker-daemon.service
 
     cd /

--- a/scripts/pve/pve-lxc-template.sh
+++ b/scripts/pve/pve-lxc-template.sh
@@ -100,22 +100,50 @@ http_exec() {
     hostname=$(get_container_hostname "$vmid")
     local url="https://port-39375-${hostname}.${PVE_PUBLIC_DOMAIN}/exec"
     local json_payload
-    json_payload=$(jq -n --arg cmd "$command" --argjson timeout "$timeout" '{command: $cmd, timeout: $timeout}')
+    json_payload=$(jq -n \
+        --arg cmd "$command" \
+        --argjson timeout_ms "$((timeout * 1000))" \
+        '{command: $cmd, timeout_ms: $timeout_ms}')
+
+    # cmux-token-init runs during the container setup; read the token through
+    # the PVE host's local pct interface and send it to cmux-execd.
+    local auth_token=""
+    if auth_token=$(pct exec "$vmid" -- sh -c '
+        for path in /root/.worker-auth-token /home/user/.worker-auth-token; do
+            if [ -s "$path" ]; then
+                cat "$path"
+                exit 0
+            fi
+        done
+        exit 42
+    ' 2>/dev/null); then
+        auth_token="$(printf '%s' "$auth_token" | tr -d '\r\n')"
+    else
+        auth_token=""
+    fi
+
+    local curl_args=(
+        -sS -X POST "$url"
+        -H "Content-Type: application/json"
+        -d "$json_payload"
+        --max-time "$timeout"
+    )
+    if [[ -n "$auth_token" ]]; then
+        curl_args+=( -H "Authorization: Bearer ${auth_token}" )
+    fi
 
     local result
-    result=$(curl -s -X POST "$url" \
-        -H "Content-Type: application/json" \
-        -d "$json_payload" \
-        --max-time "$timeout" 2>&1) || return 1
+    result=$(curl "${curl_args[@]}" 2>&1) || return 1
 
-    # Parse response
+    # Parse streaming JSON-lines response from cmux-execd.
     local exit_code stdout stderr
-    exit_code=$(echo "$result" | jq -r '.exit_code // 1')
-    stdout=$(echo "$result" | jq -r '.stdout // ""')
-    stderr=$(echo "$result" | jq -r '.stderr // ""')
+    stdout=$(printf '%s\n' "$result" | jq -r 'select(.type == "stdout") | .data // empty' 2>/dev/null | paste -sd '\n' -)
+    stderr=$(printf '%s\n' "$result" | jq -r 'select(.type == "stderr" or .type == "error") | (.data // .message // empty)' 2>/dev/null | paste -sd '\n' -)
+    exit_code=$(printf '%s\n' "$result" | jq -r 'select(.type == "exit") | .code // 1' 2>/dev/null | tail -n 1)
+    [[ "$exit_code" =~ ^-?[0-9]+$ ]] || exit_code=1
 
-    echo "$stdout"
-    [[ -n "$stderr" ]] && echo "$stderr" >&2
+    [[ -n "$stdout" ]] && printf '%s\n' "$stdout"
+    [[ -n "$stderr" ]] && printf '%s\n' "$stderr" >&2
 
     return "$exit_code"
 }
@@ -135,7 +163,8 @@ http_push() {
     local base64_content
     base64_content=$(base64 < "$local_path")
 
-    local decode_cmd="echo '${base64_content}' | base64 -d > ${remote_path}"
+    local decode_cmd
+    decode_cmd=$(printf 'printf %%s %q | base64 -d > %q' "$base64_content" "$remote_path")
     http_exec "$vmid" "$decode_cmd" 60
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1305 / #1303.

This PR closes the remaining code-level auth gaps around `cmux-execd`:

- Adds worker-token retrieval via local `pct exec` to the Rust PVE-LXC sandbox service.
- Sends `Authorization: Bearer` on Rust `/exec` and `/files` requests.
- Retries token lookup while a newly-started container finishes booting; preserves no-auth compatibility only when neither token file exists.
- Removes the duplicated embedded execd source from `scripts/pve/pve-lxc-setup.sh`.
- Builds execd from the canonical `scripts/execd` source using a sparse clone.
- Updates setup to require Go 1.25+, matching `scripts/execd/go.mod`.
- Updates `pve-lxc-template.sh` HTTP setup helpers to retrieve/send the token and parse execd JSON-lines responses.

Operational follow-ups filed separately:

- #1306 — rotate gateway credentials that may have been exposed before the auth fix.
- #1307 — rebuild affected PVE-LXC containers/templates with authenticated execd.

## Verification

- [x] `bash -n scripts/pve/pve-lxc-setup.sh`
- [x] `bash -n scripts/pve/pve-lxc-template.sh`
- [x] `cargo fmt -- --check`
- [x] `cargo test --lib pve_lxc::tests` (6 passed)
- [x] `cargo check --manifest-path packages/sandbox/Cargo.toml`
- [x] `go test ./...` in `scripts/execd`
- [x] `go test ./internal/pvelxc/...` in `packages/devsh`
- [x] `bun check`
- [x] Verified the canonical sparse-clone + `go build -C scripts/execd` command locally

## Notes

`HANDOFF.md` is pre-existing and intentionally not included in this PR.
