### PR TITLE
fix(sandbox): copy webview dir and resolve ghostty-vt.wasm via module resolution

### DIFF
--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -81,6 +81,7 @@ RUN sed -i 's/"workspace:\*"/"file:..\/shared"/g' package.json && \
     npm install --legacy-peer-deps
 # Copy extension source and build
 COPY packages/vscode-extension/src ./src
+COPY packages/vscode-extension/webview ./webview
 COPY packages/vscode-extension/tsconfig.json ./
 RUN bun run compile && vsce package --allow-missing-repository --no-dependencies --allow-star-activation
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -90,7 +90,7 @@
     "compile": "bun run compile-all",
     "compile-all": "bun run compile-bun && bun run compile-webview",
     "compile-bun": "bun build src/extension.ts --target node --outfile ./out/extension.cjs --external vscode --minify --format cjs",
-    "compile-webview": "bun build webview/ghostty-terminal.ts --outdir ./out/webview --minify && cp webview/ghostty-terminal.css ./out/webview/ && cp ../../node_modules/ghostty-web/ghostty-vt.wasm ./out/webview/",
+    "compile-webview": "bun build webview/ghostty-terminal.ts --outdir ./out/webview --minify && cp webview/ghostty-terminal.css ./out/webview/ && node -e \"require('fs').copyFileSync(require.resolve('ghostty-web/ghostty-vt.wasm'),'out/webview/ghostty-vt.wasm')\"",
     "compile-tsc": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint && npm run compile-tsc",


### PR DESCRIPTION
## Summary

Fixes the CI red on [run 31357351849](https://github.com/karlorz/cmux/actions/runs/31357351849) (Sandbox (Rust) workflow).

The sandbox Docker build (`packages/sandbox/Dockerfile` `ext-builder` stage) failed at `bun run compile-webview` with exit code 1 because of two issues:

### 1. Missing `COPY` for the `webview/` directory

The `ext-builder` stage copies `src` and `tsconfig.json` but never copies the `webview/` directory. The `compile-webview` script runs `bun build webview/ghostty-terminal.ts`, which fails immediately when the entry point is missing. The root `Dockerfile` already copies this directory (line 458); the sandbox Dockerfile was missed when the webview asset pipeline was added in `4a152ceeb`.

**Fix:** Add `COPY packages/vscode-extension/webview ./webview` to the `ext-builder` stage.

### 2. Hardcoded `node_modules` path for `ghostty-vt.wasm`

`compile-webview` hardcoded `../../node_modules/ghostty-web/ghostty-vt.wasm` to locate the WASM file. That path only works when bun hoists to the repo-root `node_modules/` (root Dockerfile). The sandbox `ext-builder` uses `npm install` inside `packages/vscode-extension/`, so the package lands in `packages/vscode-extension/node_modules/ghostty-web/` instead — the hardcoded relative path resolves to `packages/node_modules/...` which doesn't exist.

**Fix:** Replace the hardcoded path with `require.resolve('ghostty-web/ghostty-vt.wasm')`, which works regardless of where the dependency is hoisted (the `ghostty-web` package explicitly exports `./ghostty-vt.wasm` in its `exports` field).

## Verification

- ✅ `bun run compile-webview` — passes locally
- ✅ `bun run compile-all` — passes locally
- ✅ `bun run package` (vsce package) — passes locally, vsix includes `ghostty-vt.wasm`
- ✅ `bun check` (pre-commit hook) — passes
- ✅ `require.resolve('ghostty-web/ghostty-vt.wasm')` resolves correctly from both the package dir and repo root

## Testing

This PR will trigger the `Sandbox (Rust)` workflow on the PR branch (path filter: `packages/sandbox/**`), which is the exact workflow that was red.