### PR TITLE
fix(sandbox): install amp via npm — bun blocks its postinstall

### DIFF
--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -314,8 +314,13 @@ RUN bun add -g \
     @anthropic-ai/claude-code \
     @zed-industries/claude-code-acp \
     @google/gemini-cli \
-    opencode-ai \
-    @sourcegraph/amp && \
+    opencode-ai && \
+  # @sourcegraph/amp declares its bin as a nested path (node_modules/@ampcode/cli/
+  # bin/amp.exe) placed by a postinstall that downloads the platform-specific
+  # native binary. bun blocks that lifecycle script (untrusted) and does not
+  # link the amp bin, so install it via npm which runs the postinstall and
+  # links the binary correctly.
+  npm install -g @sourcegraph/amp && \
   find /usr/local/lib/bun/node_modules -name '*.map' -type f -delete && \
   find /usr/local/lib/bun/node_modules -name '*.ts' ! -name '*.d.ts' -type f -delete && \
   find /usr/local/lib/bun/node_modules -type d -name '__tests__' -exec rm -rf {} + 2>/dev/null || true && \


### PR DESCRIPTION
## Summary

Fixes the remaining red on the Sandbox (Rust) workflow after PR #1310.

### Context

PR #1310 fixed the `ext-builder` build failure. The merge re-ran the workflow on main (run 31455486832), and the image now builds — but the **"Test coding agent CLIs"** step fails on both `linux/amd64` and `linux/arm64`:

```
/bin/bash: line 7: amp: command not found
codex-cli 0.147.0
2.1.227 (Claude Code)
1.18.16
0.54.4
Process completed with exit code 1.
```

`claude`, `codex`, `gemini`, and `opencode` all pass; only `amp` is missing.

### Root cause

`@sourcegraph/amp` declares its bin as a nested path — `node_modules/@ampcode/cli/bin/amp.exe` — whose native binary is placed by a `postinstall` script that downloads a platform-specific package (`@ampcode/cli-linux-x64` / `@ampcode/cli-linux-arm64`). **bun blocks that lifecycle script as untrusted and never links the `amp` bin**, so the command is absent at runtime.

Reproduced locally:
- `bun add -g @sourcegraph/amp` → "Blocked 1 postinstall", bin dir empty, no `amp` command (even with `--trusted`)
- `npm install -g @sourcegraph/amp` → postinstall runs, native binary placed, `amp --version` works

### Fix

`packages/sandbox/Dockerfile`: install `@sourcegraph/amp` via `npm install -g` instead of `bun add -g`. npm runs the postinstall and links the binary correctly. npm's global dir (`/usr/local/lib/node_modules`) is separate from bun's cleanup targets (`/usr/local/lib/bun/node_modules`), so the arch-prune steps don't touch the amp platform binary.

## Verification

- ✅ Local repro of root cause (bun blocks postinstall → no amp bin)
- ✅ Local verification that npm install works and `amp --version` runs
- ✅ `bun check` (pre-commit hook)
- CI will be validated on merge to main (the docker-build job only runs on push/workflow_dispatch; sandbox.yml has no path filter for Dockerfile-only branches, so a workflow_dispatch on this branch may also be used to pre-validate).