### PR TITLE
fix(pve): unblock snapshot smoke test after execd token auth

### DIFF
--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -183,7 +183,11 @@ func ParseVMID(instanceID string) (int, bool) {
 	return 0, false
 }
 
-func (c *Client) apiRequestData(ctx context.Context, method, path string, params url.Values) (json.RawMessage, error) {
+// apiRequestRaw performs an authenticated PVE API request and returns the raw
+// response body and status code. Unlike apiRequestData it does not enforce a
+// 2xx status or decode the PVE JSON envelope, so callers can handle status
+// codes and raw payloads (e.g. file contents) themselves.
+func (c *Client) apiRequestRaw(ctx context.Context, method, path string, params url.Values) ([]byte, int, error) {
 	reqURL := c.apiURL + path
 	headers := http.Header{}
 	headers.Set("Authorization", "PVEAPIToken="+c.apiToken)
@@ -205,27 +209,35 @@ func (c *Client) apiRequestData(ctx context.Context, method, path string, params
 
 	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	req.Header = headers
 
 	resp, err := c.apiHTTP.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
+		return nil, 0, err
+	}
+	return raw, resp.StatusCode, nil
+}
+
+func (c *Client) apiRequestData(ctx context.Context, method, path string, params url.Values) (json.RawMessage, error) {
+	raw, status, err := c.apiRequestRaw(ctx, method, path, params)
+	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if status < 200 || status >= 300 {
 		msg := strings.TrimSpace(string(raw))
 		if msg == "" {
 			msg = "(empty response)"
 		}
-		return nil, fmt.Errorf("PVE API error %d: %s", resp.StatusCode, msg)
+		return nil, fmt.Errorf("PVE API error %d: %s", status, msg)
 	}
 
 	var env pveEnvelope

--- a/packages/devsh/internal/pvelxc/exec.go
+++ b/packages/devsh/internal/pvelxc/exec.go
@@ -62,14 +62,15 @@ func ShellSingleQuote(value string) string {
 }
 
 // fetchExecToken retrieves the /root/.worker-auth-token from inside the
-// container via SSH to the PVE host + pct exec. The token is cached on the
-// Client after the first successful fetch. Returns "" (no error) when
-// PVE_SSH_HOST is not set — in that case the execd daemon will be in no-auth
-// mode (if the token file doesn't exist) and requests pass through.
+// container. When PVE_SSH_HOST is set it reads the file via SSH to the PVE
+// host + pct exec; otherwise it falls back to the PVE API file endpoint. The
+// token is cached on the Client after the first successful fetch. Returns ""
+// (no error) when the token file doesn't exist — in that case the execd
+// daemon is in no-auth mode and requests pass through.
 func (c *Client) fetchExecToken(ctx context.Context, vmid int) (string, error) {
 	sshHost := SSHHostFromEnv()
 	if sshHost == "" {
-		return "", nil
+		return c.fetchExecTokenViaAPI(ctx, vmid)
 	}
 
 	out, err := exec.CommandContext(ctx, "ssh",
@@ -85,6 +86,59 @@ func (c *Client) fetchExecToken(ctx context.Context, vmid int) (string, error) {
 	token := strings.TrimSpace(string(out))
 	if token == "" {
 		// Token file doesn't exist in the container — execd is in no-auth mode.
+		return "", nil
+	}
+	return token, nil
+}
+
+// fetchExecTokenViaAPI retrieves /root/.worker-auth-token via the PVE API file
+// endpoint (used when PVE_SSH_HOST is not set). The endpoint may return the
+// content JSON-wrapped ({"data":{"content":"..."}}) or as raw file content;
+// both are handled. A 404 means the token file doesn't exist (execd in no-auth
+// mode) and yields "". Other HTTP errors are returned as errors.
+func (c *Client) fetchExecTokenViaAPI(ctx context.Context, vmid int) (string, error) {
+	apiCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	node, err := c.getNode(apiCtx)
+	if err != nil {
+		return "", fmt.Errorf("fetch exec token via PVE API: %w", err)
+	}
+
+	raw, status, err := c.apiRequestRaw(apiCtx, http.MethodGet,
+		fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/files", node, vmid),
+		url.Values{"path": []string{"/root/.worker-auth-token"}})
+	if err != nil {
+		if apiCtx.Err() != nil {
+			return "", apiCtx.Err()
+		}
+		return "", fmt.Errorf("fetch exec token via PVE API: %w", err)
+	}
+
+	if status == http.StatusNotFound {
+		// Token file doesn't exist in the container — execd is in no-auth mode.
+		return "", nil
+	}
+	if status < 200 || status >= 300 {
+		msg := strings.TrimSpace(string(raw))
+		if msg == "" {
+			msg = "(empty response)"
+		}
+		return "", fmt.Errorf("fetch exec token via PVE API: HTTP %d: %s", status, msg)
+	}
+
+	// Try JSON-wrapped content first, then fall back to raw file content.
+	// JSON-looking responses without usable content mean no token.
+	var env struct {
+		Data struct {
+			Content string `json:"content"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &env); err == nil && strings.TrimSpace(env.Data.Content) != "" {
+		return strings.TrimSpace(env.Data.Content), nil
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" || strings.HasPrefix(token, "{") {
 		return "", nil
 	}
 	return token, nil

--- a/packages/devsh/internal/pvelxc/exec_test.go
+++ b/packages/devsh/internal/pvelxc/exec_test.go
@@ -24,21 +24,10 @@ func (t *rewriteExecTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return http.DefaultTransport.RoundTrip(clone)
 }
 
-func newExecReadyTestClient(t *testing.T, execHandler http.HandlerFunc) *Client {
+func newExecTestClient(t *testing.T, apiHandler http.HandlerFunc, execHandler http.HandlerFunc) *Client {
 	t.Helper()
 
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		switch {
-		case strings.HasSuffix(r.URL.Path, "/dns"):
-			_, _ = w.Write([]byte(`{"data":{"search":""}}`))
-		case strings.HasSuffix(r.URL.Path, "/config"):
-			_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
-		default:
-			t.Fatalf("unexpected PVE API path: %s", r.URL.Path)
-		}
-	}))
+	apiServer := httptest.NewServer(apiHandler)
 	t.Cleanup(apiServer.Close)
 
 	execServer := httptest.NewServer(execHandler)
@@ -59,6 +48,27 @@ func newExecReadyTestClient(t *testing.T, execHandler http.HandlerFunc) *Client 
 		},
 		node: "test-node",
 	}
+}
+
+func newExecReadyTestClient(t *testing.T, execHandler http.HandlerFunc) *Client {
+	t.Helper()
+
+	return newExecTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/dns"):
+			_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+		case strings.HasSuffix(r.URL.Path, "/config"):
+			_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+		case strings.HasSuffix(r.URL.Path, "/files"):
+			// Token file absent in the container — execd in no-auth mode.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"data":null}`))
+		default:
+			t.Fatalf("unexpected PVE API path: %s", r.URL.Path)
+		}
+	}), execHandler)
 }
 
 func TestVerifyTimezoneCommand(t *testing.T) {
@@ -191,8 +201,8 @@ func TestExecCommandSendsBearerTokenWhenCached(t *testing.T) {
 
 func TestExecCommandRetriesOn401WithFreshToken(t *testing.T) {
 	var (
-		mu          sync.Mutex
-		callCount   int
+		mu           sync.Mutex
+		callCount    int
 		receivedAuth string
 	)
 
@@ -237,4 +247,186 @@ func TestExecCommandRetriesOn401WithFreshToken(t *testing.T) {
 	}
 	// First call should have sent the stale token.
 	_ = receivedAuth // value is from the last call; we just verify it ran twice.
+}
+
+func TestExecCommandTokenFetchViaAPI(t *testing.T) {
+	tests := []struct {
+		name        string
+		filesStatus int
+		filesBody   string
+		wantAuth    string
+	}{
+		{
+			name:        "json wrapped token",
+			filesStatus: http.StatusOK,
+			filesBody:   `{"data":{"content":"api-secret-token"}}`,
+			wantAuth:    "Bearer api-secret-token",
+		},
+		{
+			name:        "raw content token",
+			filesStatus: http.StatusOK,
+			filesBody:   "raw-secret-token\n",
+			wantAuth:    "Bearer raw-secret-token",
+		},
+		{
+			name:        "token file absent",
+			filesStatus: http.StatusNotFound,
+			filesBody:   `{"data":null}`,
+			wantAuth:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				mu         sync.Mutex
+				gotAuth    string
+				filesCalls int
+			)
+
+			client := newExecTestClient(t,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case strings.HasSuffix(r.URL.Path, "/dns"):
+						_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+					case strings.HasSuffix(r.URL.Path, "/config"):
+						_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+					case strings.HasSuffix(r.URL.Path, "/files"):
+						mu.Lock()
+						filesCalls++
+						mu.Unlock()
+						if got := r.Header.Get("Authorization"); got != "PVEAPIToken=token" {
+							t.Errorf("files request Authorization = %q, want %q", got, "PVEAPIToken=token")
+						}
+						if got := r.URL.Query().Get("path"); got != "/root/.worker-auth-token" {
+							t.Errorf("files request path = %q, want %q", got, "/root/.worker-auth-token")
+						}
+						w.WriteHeader(tt.filesStatus)
+						_, _ = w.Write([]byte(tt.filesBody))
+					default:
+						t.Errorf("unexpected PVE API path: %s", r.URL.Path)
+					}
+				}),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mu.Lock()
+					gotAuth = r.Header.Get("Authorization")
+					mu.Unlock()
+					w.Header().Set("Content-Type", "application/jsonlines")
+					_, _ = w.Write([]byte("{\"type\":\"stdout\",\"data\":\"ok\"}\n{\"type\":\"exit\",\"code\":0}\n"))
+				}),
+			)
+
+			stdout, _, exitCode, err := client.ExecCommand(context.Background(), "200", "echo ok")
+			if err != nil {
+				t.Fatalf("ExecCommand() error = %v", err)
+			}
+			if exitCode != 0 {
+				t.Fatalf("ExecCommand() exitCode = %d, want 0", exitCode)
+			}
+			if stdout != "ok" {
+				t.Errorf("ExecCommand() stdout = %q, want %q", stdout, "ok")
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if gotAuth != tt.wantAuth {
+				t.Errorf("exec Authorization = %q, want %q", gotAuth, tt.wantAuth)
+			}
+			if filesCalls != 1 {
+				t.Errorf("files fetch calls = %d, want 1", filesCalls)
+			}
+		})
+	}
+}
+
+func TestExecCommandRetriesOn401WithFreshTokenViaAPI(t *testing.T) {
+	var (
+		mu         sync.Mutex
+		execCalls  int
+		filesCalls int
+		auths      []string
+	)
+
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/dns"):
+				_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+			case strings.HasSuffix(r.URL.Path, "/config"):
+				_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+			case strings.HasSuffix(r.URL.Path, "/files"):
+				mu.Lock()
+				filesCalls++
+				mu.Unlock()
+				_, _ = w.Write([]byte(`{"data":{"content":"fresh-api-token"}}`))
+			default:
+				t.Errorf("unexpected PVE API path: %s", r.URL.Path)
+			}
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			execCalls++
+			auths = append(auths, r.Header.Get("Authorization"))
+			first := execCalls == 1
+			mu.Unlock()
+
+			if first {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/jsonlines")
+			_, _ = w.Write([]byte("{\"type\":\"stdout\",\"data\":\"ok\"}\n{\"type\":\"exit\",\"code\":0}\n"))
+		}),
+	)
+
+	// Start with a stale token; the 401 should invalidate the cache and
+	// trigger exactly one re-fetch via the PVE API before the retry.
+	client.execToken = "stale-token"
+
+	stdout, _, exitCode, err := client.ExecCommand(context.Background(), "200", "echo ok")
+	if err != nil {
+		t.Fatalf("ExecCommand() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("ExecCommand() exitCode = %d, want 0", exitCode)
+	}
+	if stdout != "ok" {
+		t.Errorf("ExecCommand() stdout = %q, want %q", stdout, "ok")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if execCalls != 2 {
+		t.Errorf("exec calls = %d, want 2 (401 + retry)", execCalls)
+	}
+	if filesCalls != 1 {
+		t.Errorf("files fetch calls = %d, want 1", filesCalls)
+	}
+	if len(auths) != 2 || auths[0] != "Bearer stale-token" || auths[1] != "Bearer fresh-api-token" {
+		t.Errorf("exec Authorization sequence = %q, want [Bearer stale-token Bearer fresh-api-token]", auths)
+	}
+}
+
+func TestFetchExecTokenPrefersSSHWhenHostSet(t *testing.T) {
+	t.Setenv("PVE_SSH_HOST", "127.0.0.1")
+
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("PVE API must not be called when PVE_SSH_HOST is set, got %s", r.URL.Path)
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("exec endpoint must not be called, got %s", r.URL.Path)
+		}),
+	)
+
+	// No sshd on 127.0.0.1 (or no ssh binary): the SSH path must be taken and
+	// must fail with a fetch error rather than touching the PVE API.
+	_, err := client.fetchExecToken(context.Background(), 200)
+	if err == nil {
+		t.Fatal("fetchExecToken() error = nil, want SSH fetch error")
+	}
+	if !strings.Contains(err.Error(), "fetch exec token via SSH") {
+		t.Errorf("fetchExecToken() error = %q, want SSH fetch error", err)
+	}
 }

--- a/scripts/pve/pve-lxc-networkd-diag-inner.sh
+++ b/scripts/pve/pve-lxc-networkd-diag-inner.sh
@@ -72,3 +72,17 @@ echo ""
 
 echo "=== journalctl -u systemd-networkd -n 200 ==="
 journalctl -u systemd-networkd --no-pager -n 200 2>/dev/null || true
+echo ""
+
+echo "=== cmux-execd diagnostics ==="
+systemctl is-active cmux-execd.service cmux-token-generator.service 2>&1 || true
+echo ""
+systemctl status cmux-execd.service --no-pager -n 50 2>&1 || true
+echo ""
+ss -ltnp 2>/dev/null | grep -E '39375|39380' || echo "no 39375/39380 listeners"
+echo ""
+curl -s -o /dev/null -w '%{http_code}\n' --max-time 5 http://127.0.0.1:39375/healthz 2>&1 || true
+echo ""
+ls -la /root/.worker-auth-token 2>/dev/null || echo "token file absent"
+echo ""
+tail -100 /var/log/cmux/cmux-execd.log 2>/dev/null || journalctl -u cmux-execd -n 100 --no-pager 2>/dev/null || echo "no execd logs available"

--- a/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
@@ -101,14 +101,30 @@ for line in "${snapshot_lines[@]}"; do
 
   echo "Waiting for exec..."
   exec_ready="false"
+  saw_401="false"
+  timed_out="false"
+  deadline=$((SECONDS + 600))
   for _ in $(seq 1 40); do
-    if devsh exec "${active_id}" "echo exec_ready" >/dev/null 2>&1; then
+    if probe_out="$(devsh exec "${active_id}" "echo exec_ready" 2>&1)"; then
       exec_ready="true"
+      break
+    fi
+    if [[ "${probe_out}" == *401* ]]; then
+      saw_401="true"
+    fi
+    if (( SECONDS >= deadline )); then
+      # shellcheck disable=SC2034 # deadline-break marker required by Change 4 spec
+      timed_out="true"
       break
     fi
     sleep 3
   done
   if [[ "${exec_ready}" != "true" ]]; then
+    if [[ "${saw_401}" == "true" ]]; then
+      echo "exec endpoint returned HTTP 401 (auth) - execd token propagation broken; check execd auth token fetch" >&2
+    else
+      echo "exec endpoint unreachable (network) - check cloudflared/tailscale route and cmux-execd startup" >&2
+    fi
     echo "ERROR: exec not ready for ${active_id}" >&2
     "${diag}" "${active_id}" "${log_dir}/diag.runtime.${preset}.${snapshot_id}.${active_id}.${timestamp}.txt" || true
     exit 1

--- a/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
@@ -102,22 +102,30 @@ for line in "${snapshot_lines[@]}"; do
   echo "Waiting for exec..."
   exec_ready="false"
   saw_401="false"
-  timed_out="false"
   deadline=$((SECONDS + 600))
-  for _ in $(seq 1 40); do
-    if probe_out="$(devsh exec "${active_id}" "echo exec_ready" 2>&1)"; then
+  while (( SECONDS < deadline )); do
+    remaining=$((deadline - SECONDS))
+    if (( remaining <= 0 )); then
+      break
+    fi
+
+    if probe_out="$(timeout "${remaining}s" devsh exec "${active_id}" "echo exec_ready" 2>&1)"; then
       exec_ready="true"
       break
     fi
     if [[ "${probe_out}" == *401* ]]; then
       saw_401="true"
     fi
-    if (( SECONDS >= deadline )); then
-      # shellcheck disable=SC2034 # deadline-break marker required by Change 4 spec
-      timed_out="true"
+
+    remaining=$((deadline - SECONDS))
+    if (( remaining <= 0 )); then
       break
     fi
-    sleep 3
+    if (( remaining > 3 )); then
+      sleep 3
+    else
+      sleep "${remaining}"
+    fi
   done
   if [[ "${exec_ready}" != "true" ]]; then
     if [[ "${saw_401}" == "true" ]]; then

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -3874,7 +3874,9 @@ async def task_install_agy(ctx: PveTaskContext) -> None:
     cmd = textwrap.dedent(
         """
         set -euo pipefail
-        curl -fsSL https://antigravity.google/cli/install.sh | bash
+        if [ ! -x /root/.local/bin/agy ]; then
+            curl -fsSL https://antigravity.google/cli/install.sh | bash
+        fi
         /root/.local/bin/agy --version
         """
     )
@@ -5635,6 +5637,7 @@ async def _verify_template_artifacts(
         ("/builtins/build/node_modules/path-to-regexp/package.json", "worker path-to-regexp runtime dependency"),
         ("/usr/local/bin/worker-daemon", "Go worker-daemon (SSH/PTY proxy)"),
         ("/usr/local/bin/cmux-token-init", "Auth token generator script"),
+        ("/usr/local/bin/cmux-execd", "cmux-execd HTTP exec daemon binary"),
         (NOVNC_MARKER_FILE, "managed noVNC version marker"),
         (f"{NOVNC_DIR}/vnc.html", "managed noVNC vnc.html"),
         (f"{NOVNC_DIR}/core/rfb.js", "managed noVNC core/rfb.js"),
@@ -5671,6 +5674,29 @@ async def _verify_template_artifacts(
                 console.info(f"[verify] OK: {description}")
         except Exception as e:
             missing.append(f"  - {description}: {path} (check failed: {e})")
+            console.info(f"[verify] ERROR checking {description}: {e}")
+
+    # Verify cmux-execd systemd unit files and state so the template does not
+    # ship with a disabled or dead exec daemon. Unit files may live under
+    # /etc/systemd/system or /usr/lib/systemd/system (wants-symlink enablement).
+    # Both call sites run this before template conversion while the container
+    # is still running, so is-active is valid.
+    systemd_state_checks: list[tuple[str, str]] = [
+        ("test -e /etc/systemd/system/cmux-execd.service -o -e /usr/lib/systemd/system/cmux-execd.service && echo present || echo not-present", "cmux-execd systemd unit file"),
+        ("test -e /etc/systemd/system/cmux-token-generator.service -o -e /usr/lib/systemd/system/cmux-token-generator.service && echo present || echo not-present", "cmux-token-generator systemd unit file"),
+        ("systemctl is-enabled cmux-execd.service 2>/dev/null && echo enabled || echo not-enabled", "cmux-execd systemd unit enabled"),
+        ("systemctl is-active cmux-execd.service 2>/dev/null && echo active || echo not-active", "cmux-execd HTTP exec daemon active"),
+    ]
+    for cmd, description in systemd_state_checks:
+        try:
+            result = await client.aexec_in_container(vmid, cmd, timeout=30, check=False)
+            if result.returncode != 0 or "not-" in result.stdout:
+                missing.append(f"  - {description}")
+                console.info(f"[verify] MISSING: {description}")
+            else:
+                console.info(f"[verify] OK: {description}")
+        except Exception as e:
+            missing.append(f"  - {description} (check failed: {e})")
             console.info(f"[verify] ERROR checking {description}: {e}")
 
     # Check for cmux extension specifically (critical for IDE functionality)

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1637,7 +1637,9 @@ async def task_install_agy(ctx: TaskContext) -> None:
     cmd = textwrap.dedent(
         """
         set -euo pipefail
-        curl -fsSL https://antigravity.google/cli/install.sh | bash
+        if [ ! -x /root/.local/bin/agy ]; then
+            curl -fsSL https://antigravity.google/cli/install.sh | bash
+        fi
         /root/.local/bin/agy --version
         """
     )

--- a/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+source_script="${repo_root}/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh"
+
+if [[ ! -f "${source_script}" ]]; then
+  echo "FAIL: runtime smoke script not found: ${source_script}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf -- "${tmp_dir}"
+}
+trap cleanup EXIT
+
+runtime_dir="${tmp_dir}/runtime"
+bin_dir="${tmp_dir}/bin"
+mkdir -p "${runtime_dir}" "${bin_dir}"
+cp "${source_script}" "${runtime_dir}/pve-lxc-snapshot-runtime-smoke.sh"
+
+cat >"${runtime_dir}/pve-lxc-networkd-verify.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${runtime_dir}/pve-lxc-networkd-verify.sh"
+
+cat >"${runtime_dir}/pve-lxc-networkd-diag.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${runtime_dir}/pve-lxc-networkd-diag.sh"
+
+cat >"${bin_dir}/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+shift
+exec "$@"
+EOF
+chmod +x "${bin_dir}/timeout"
+
+cat >"${bin_dir}/devsh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:-}"
+shift || true
+
+case "${command_name}" in
+  start)
+    echo "pvelxc-deadline"
+    ;;
+  exec)
+    calls=0
+    if [[ -f "${DEVSH_CALLS_FILE}" ]]; then
+      calls="$(<"${DEVSH_CALLS_FILE}")"
+    fi
+    calls=$((calls + 1))
+    printf '%s\n' "${calls}" >"${DEVSH_CALLS_FILE}"
+
+    if [[ "${DEVSH_MODE}" == "fail-then-succeed" && "${calls}" -gt 40 ]]; then
+      echo "exec_ready"
+      exit 0
+    fi
+
+    echo "exec endpoint not ready" >&2
+    exit 1
+    ;;
+  delete)
+    ;;
+  *)
+    echo "unexpected devsh command: ${command_name}" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${bin_dir}/devsh"
+
+cat >"${tmp_dir}/bash_env" <<'EOF'
+SECONDS=0
+sleep() {
+  local duration="${1:-0}"
+  SECONDS=$((SECONDS + duration))
+}
+EOF
+
+printf '%s\n' '{"results":[{"presetId":"standard","snapshotId":"snapshot-deadline"}]}' >"${tmp_dir}/results.json"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+run_smoke() {
+  local mode="$1"
+  local calls_file="$2"
+  (
+    cd "${tmp_dir}"
+    PATH="${bin_dir}:${PATH}" \
+      BASH_ENV="${tmp_dir}/bash_env" \
+      DEVSH_MODE="${mode}" \
+      DEVSH_CALLS_FILE="${calls_file}" \
+      bash "${runtime_dir}/pve-lxc-snapshot-runtime-smoke.sh" "${tmp_dir}/results.json"
+  )
+}
+
+echo "=== PVE LXC snapshot runtime-smoke deadline tests ==="
+
+calls_file="${tmp_dir}/calls.success"
+if ! success_output="$(run_smoke fail-then-succeed "${calls_file}" 2>&1)"; then
+  printf '%s\n' "${success_output}" >&2
+  fail "runtime smoke must accept readiness after more than 40 fast failed probes"
+fi
+success_calls="$(<"${calls_file}")"
+if (( success_calls < 41 )); then
+  fail "expected at least 41 readiness probes, got ${success_calls}"
+fi
+if [[ "${success_output}" != *"All runtime smoke checks passed"* ]]; then
+  fail "success output did not report a passing runtime smoke check"
+fi
+
+calls_file="${tmp_dir}/calls.deadline"
+if deadline_output="$(run_smoke always-fail "${calls_file}" 2>&1)"; then
+  printf '%s\n' "${deadline_output}" >&2
+  fail "runtime smoke must fail when readiness never arrives"
+fi
+deadline_calls="$(<"${calls_file}")"
+if [[ "${deadline_calls}" != "200" ]]; then
+  fail "expected 200 virtual three-second probes before the 600-second deadline, got ${deadline_calls}"
+fi
+if [[ "${deadline_output}" != *"exec endpoint unreachable (network)"* ]]; then
+  fail "deadline failure lost its network diagnostic"
+fi
+
+echo "PASS: readiness probes honor the 600-second deadline"

--- a/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
@@ -16,8 +16,7 @@ cleanup() {
 trap cleanup EXIT
 
 runtime_dir="${tmp_dir}/runtime"
-bin_dir="${tmp_dir}/bin"
-mkdir -p "${runtime_dir}" "${bin_dir}"
+mkdir -p "${runtime_dir}"
 cp "${source_script}" "${runtime_dir}/pve-lxc-snapshot-runtime-smoke.sh"
 
 cat >"${runtime_dir}/pve-lxc-networkd-verify.sh" <<'EOF'
@@ -32,56 +31,50 @@ exit 0
 EOF
 chmod +x "${runtime_dir}/pve-lxc-networkd-diag.sh"
 
-cat >"${bin_dir}/timeout" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-shift
-exec "$@"
-EOF
-chmod +x "${bin_dir}/timeout"
-
-cat >"${bin_dir}/devsh" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-
-command_name="${1:-}"
-shift || true
-
-case "${command_name}" in
-  start)
-    echo "pvelxc-deadline"
-    ;;
-  exec)
-    calls=0
-    if [[ -f "${DEVSH_CALLS_FILE}" ]]; then
-      calls="$(<"${DEVSH_CALLS_FILE}")"
-    fi
-    calls=$((calls + 1))
-    printf '%s\n' "${calls}" >"${DEVSH_CALLS_FILE}"
-
-    if [[ "${DEVSH_MODE}" == "fail-then-succeed" && "${calls}" -gt 40 ]]; then
-      echo "exec_ready"
-      exit 0
-    fi
-
-    echo "exec endpoint not ready" >&2
-    exit 1
-    ;;
-  delete)
-    ;;
-  *)
-    echo "unexpected devsh command: ${command_name}" >&2
-    exit 1
-    ;;
-esac
-EOF
-chmod +x "${bin_dir}/devsh"
-
 cat >"${tmp_dir}/bash_env" <<'EOF'
 SECONDS=0
 sleep() {
   local duration="${1:-0}"
   SECONDS=$((SECONDS + duration))
+}
+# In-process fakes: probes must not spawn real subprocesses, or bash's
+# SECONDS variable accrues wall-clock time and the 600-second deadline
+# fires a probe early on slow machines.
+timeout() {
+  shift
+  "$@"
+}
+devsh() {
+  local command_name="${1:-}"
+  shift || true
+
+  case "${command_name}" in
+    start)
+      echo "pvelxc-deadline"
+      ;;
+    exec)
+      local calls=0
+      if [[ -f "${DEVSH_CALLS_FILE}" ]]; then
+        IFS= read -r calls <"${DEVSH_CALLS_FILE}" || true
+      fi
+      calls=$((calls + 1))
+      printf '%s\n' "${calls}" >"${DEVSH_CALLS_FILE}"
+
+      if [[ "${DEVSH_MODE}" == "fail-then-succeed" && "${calls}" -gt 40 ]]; then
+        echo "exec_ready"
+        return 0
+      fi
+
+      echo "exec endpoint not ready" >&2
+      return 1
+      ;;
+    delete)
+      ;;
+    *)
+      echo "unexpected devsh command: ${command_name}" >&2
+      return 1
+      ;;
+  esac
 }
 EOF
 
@@ -97,8 +90,7 @@ run_smoke() {
   local calls_file="$2"
   (
     cd "${tmp_dir}"
-    PATH="${bin_dir}:${PATH}" \
-      BASH_ENV="${tmp_dir}/bash_env" \
+    BASH_ENV="${tmp_dir}/bash_env" \
       DEVSH_MODE="${mode}" \
       DEVSH_CALLS_FILE="${calls_file}" \
       bash "${runtime_dir}/pve-lxc-snapshot-runtime-smoke.sh" "${tmp_dir}/results.json"


### PR DESCRIPTION
## Problem

The `Weekly PVE LXC Snapshot` CI workflow has been red for 5 consecutive scheduled runs (#283-#287) since PR #1303/#1305 (`c8584bd5f`) added Bearer token auth to `cmux-execd`. The CI smoke test uses `devsh exec`, whose token fetch required `PVE_SSH_HOST` — absent in CI — so every readiness probe hit execd's 401, the test stalled ~30 minutes, then failed.

## Root Cause

1. **Token fetch required SSH** (`PVE_SSH_HOST`): `devsh` had no way to obtain the execd auth token in CI, so all exec probes returned 401.
2. **No readiness deadline**: the runtime smoke script probed a fixed 40 times and then waited on a `sleep 3` loop without a wall-clock cap, so a persistently failing probe could stall the job for ~30 minutes.

## Fix

1. **devsh token fetch via PVE API** (`packages/devsh/internal/pvelxc/`): when `PVE_SSH_HOST` is unset, fetch the execd auth token through the PVE API (`/nodes/{n}/lxc/{id}/files`), mirroring `snapshot-pvelxc.py`. 404 keeps no-auth mode; 401 invalidates and refetches. The SSH path is unchanged.
2. **Snapshot scripts**: guard `install-agy` with an already-installed check so transport retry re-runs never hit the installer's exit-23 path; `snapshot-pvelxc` verifies the `cmux-execd` binary, unit files (either `/etc` or `/usr/lib` location), `is-enabled` and `is-active` before template conversion.
3. **Runtime smoke** (`scripts/pve/pve-lxc-snapshot-runtime-smoke.sh`): 10-minute wall-clock deadline on exec wait, with a decisive 401-auth vs network-failure diagnostic line.
4. **Networkd diag**: capture `cmux-execd` unit state, listeners, healthz, token file, and execd logs so red runs self-diagnose.
5. **Deterministic deadline test** (`scripts/test-pve-lxc-snapshot-runtime-smoke.sh`): fakes run in-process via `BASH_ENV` functions so the virtual `SECONDS` clock cannot accrue real wall-clock time; previously the ~200-probe loop could cross a real second boundary and fail the exact probe-count assertion (199 vs 200) on slow machines.

## Verification

- `scripts/test-pve-lxc-snapshot-runtime-smoke.sh`: 10/10 passes; mutation check confirms the test fails against a broken deadline
- `bun check` (lint + typecheck): passed
