### PR TITLE
fix(pve): unblock snapshot runtime smoke via persisted execd token file

### DIFF
--- a/packages/devsh/internal/pvelxc/exec.go
+++ b/packages/devsh/internal/pvelxc/exec.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -62,12 +63,27 @@ func ShellSingleQuote(value string) string {
 }
 
 // fetchExecToken retrieves the /root/.worker-auth-token from inside the
-// container. When PVE_SSH_HOST is set it reads the file via SSH to the PVE
-// host + pct exec; otherwise it falls back to the PVE API file endpoint. The
-// token is cached on the Client after the first successful fetch. Returns ""
-// (no error) when the token file doesn't exist — in that case the execd
-// daemon is in no-auth mode and requests pass through.
+// container. When PVE_EXECD_TOKEN_FILE is set, the token is read from that
+// file: CI snapshot runs persist the template's execd token there, because
+// the PVE API has no LXC file-read endpoint and CI runners cannot reach the
+// PVE host over SSH. Otherwise, when PVE_SSH_HOST is set it reads the file
+// via SSH to the PVE host + pct exec; without SSH it falls back to the PVE
+// API file endpoint. The token is cached on the Client after the first
+// successful fetch. Returns "" (no error) when the token file doesn't exist —
+// in that case the execd daemon is in no-auth mode and requests pass through.
 func (c *Client) fetchExecToken(ctx context.Context, vmid int) (string, error) {
+	if tokenFile := os.Getenv("PVE_EXECD_TOKEN_FILE"); tokenFile != "" {
+		raw, err := os.ReadFile(tokenFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// No persisted token — execd runs in no-auth mode.
+				return "", nil
+			}
+			return "", fmt.Errorf("fetch exec token from %s: %w", tokenFile, err)
+		}
+		return strings.TrimSpace(string(raw)), nil
+	}
+
 	sshHost := SSHHostFromEnv()
 	if sshHost == "" {
 		return c.fetchExecTokenViaAPI(ctx, vmid)
@@ -95,7 +111,10 @@ func (c *Client) fetchExecToken(ctx context.Context, vmid int) (string, error) {
 // endpoint (used when PVE_SSH_HOST is not set). The endpoint may return the
 // content JSON-wrapped ({"data":{"content":"..."}}) or as raw file content;
 // both are handled. A 404 means the token file doesn't exist (execd in no-auth
-// mode) and yields "". Other HTTP errors are returned as errors.
+// mode) and yields "". A 501 means the endpoint itself is not implemented on
+// this PVE server, so the token cannot be fetched that way either — treat it
+// like no-auth and attempt the request without a token (the execd will answer
+// 401 if it does require auth). Other HTTP errors are returned as errors.
 func (c *Client) fetchExecTokenViaAPI(ctx context.Context, vmid int) (string, error) {
 	apiCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -115,8 +134,10 @@ func (c *Client) fetchExecTokenViaAPI(ctx context.Context, vmid int) (string, er
 		return "", fmt.Errorf("fetch exec token via PVE API: %w", err)
 	}
 
-	if status == http.StatusNotFound {
-		// Token file doesn't exist in the container — execd is in no-auth mode.
+	if status == http.StatusNotFound || status == http.StatusNotImplemented {
+		// Token file doesn't exist, or the file endpoint is not implemented on
+		// this PVE server — proceed without a token (execd no-auth mode) rather
+		// than failing the exec outright.
 		return "", nil
 	}
 	if status < 200 || status >= 300 {

--- a/packages/devsh/internal/pvelxc/exec_test.go
+++ b/packages/devsh/internal/pvelxc/exec_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -274,6 +276,12 @@ func TestExecCommandTokenFetchViaAPI(t *testing.T) {
 			filesBody:   `{"data":null}`,
 			wantAuth:    "",
 		},
+		{
+			name:        "file endpoint not implemented",
+			filesStatus: http.StatusNotImplemented,
+			filesBody:   `{"data":null}`,
+			wantAuth:    "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -336,6 +344,111 @@ func TestExecCommandTokenFetchViaAPI(t *testing.T) {
 				t.Errorf("files fetch calls = %d, want 1", filesCalls)
 			}
 		})
+	}
+}
+
+func TestExecCommandTokenFromEnvFile(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "execd-token.txt")
+	if err := os.WriteFile(tokenFile, []byte("env-file-secret-token\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	t.Setenv("PVE_EXECD_TOKEN_FILE", tokenFile)
+
+	var (
+		mu         sync.Mutex
+		gotAuth    string
+		filesCalls int
+	)
+
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/dns"):
+				_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+			case strings.HasSuffix(r.URL.Path, "/config"):
+				_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+			case strings.HasSuffix(r.URL.Path, "/files"):
+				mu.Lock()
+				filesCalls++
+				mu.Unlock()
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"data":null}`))
+			default:
+				t.Errorf("unexpected PVE API path: %s", r.URL.Path)
+			}
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			gotAuth = r.Header.Get("Authorization")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/jsonlines")
+			_, _ = w.Write([]byte("{\"type\":\"stdout\",\"data\":\"ok\"}\n{\"type\":\"exit\",\"code\":0}\n"))
+		}),
+	)
+
+	stdout, _, exitCode, err := client.ExecCommand(context.Background(), "200", "echo ok")
+	if err != nil {
+		t.Fatalf("ExecCommand() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("ExecCommand() exitCode = %d, want 0", exitCode)
+	}
+	if stdout != "ok" {
+		t.Errorf("ExecCommand() stdout = %q, want %q", stdout, "ok")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotAuth != "Bearer env-file-secret-token" {
+		t.Errorf("exec Authorization = %q, want %q", gotAuth, "Bearer env-file-secret-token")
+	}
+	if filesCalls != 0 {
+		t.Errorf("files fetch calls = %d, want 0 (env file must bypass the PVE API)", filesCalls)
+	}
+}
+
+func TestExecCommandTokenFromEnvFileMissing(t *testing.T) {
+	// A configured-but-missing env token file means no persisted token was
+	// produced (no-auth execd); the exec must proceed without a token.
+	t.Setenv("PVE_EXECD_TOKEN_FILE", filepath.Join(t.TempDir(), "missing-token.txt"))
+
+	var (
+		mu      sync.Mutex
+		gotAuth string
+	)
+
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/dns"):
+				_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+			case strings.HasSuffix(r.URL.Path, "/config"):
+				_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+			default:
+				t.Errorf("unexpected PVE API path: %s", r.URL.Path)
+			}
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			gotAuth = r.Header.Get("Authorization")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/jsonlines")
+			_, _ = w.Write([]byte("{\"type\":\"stdout\",\"data\":\"ok\"}\n{\"type\":\"exit\",\"code\":0}\n"))
+		}),
+	)
+
+	stdout, _, _, err := client.ExecCommand(context.Background(), "200", "echo ok")
+	if err != nil {
+		t.Fatalf("ExecCommand() error = %v", err)
+	}
+	if stdout != "ok" {
+		t.Errorf("ExecCommand() stdout = %q, want %q", stdout, "ok")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotAuth != "" {
+		t.Errorf("exec Authorization = %q, want empty (no-auth mode)", gotAuth)
 	}
 }
 

--- a/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
@@ -14,6 +14,8 @@ if [[ ! -f "${results_json}" ]]; then
   exit 2
 fi
 
+results_dir="$(dirname -- "${results_json}")"
+
 if ! command -v devsh >/dev/null 2>&1; then
   echo "ERROR: devsh not found on PATH" >&2
   exit 2
@@ -68,12 +70,24 @@ cleanup() {
   if [[ -n "${active_id}" ]]; then
     devsh delete "${active_id}" >/dev/null 2>&1 || true
   fi
+  rm -f "${results_dir}"/execd-token-*.txt
 }
 trap cleanup EXIT
 
 for line in "${snapshot_lines[@]}"; do
   preset="$(printf '%s' "${line}" | cut -f1)"
   snapshot_id="$(printf '%s' "${line}" | cut -f2)"
+
+  # The snapshot build persists each template's execd auth token next to the
+  # results; clones keep that token until the PVE host reboots. Pass it to
+  # devsh so exec probes carry the Bearer token without SSH or a PVE API
+  # file endpoint (neither is available in CI).
+  token_file="${results_dir}/execd-token-${snapshot_id}.txt"
+  if [[ -f "${token_file}" ]]; then
+    export PVE_EXECD_TOKEN_FILE="${token_file}"
+  else
+    unset PVE_EXECD_TOKEN_FILE
+  fi
 
   echo ""
   echo "=== Runtime smoke: ${preset} (${snapshot_id}) ==="
@@ -102,6 +116,7 @@ for line in "${snapshot_lines[@]}"; do
   echo "Waiting for exec..."
   exec_ready="false"
   saw_401="false"
+  saw_token_fetch_fail="false"
   deadline=$((SECONDS + 600))
   while (( SECONDS < deadline )); do
     remaining=$((deadline - SECONDS))
@@ -115,6 +130,9 @@ for line in "${snapshot_lines[@]}"; do
     fi
     if [[ "${probe_out}" == *401* ]]; then
       saw_401="true"
+    fi
+    if [[ "${probe_out}" == *"fetch exec token"* ]]; then
+      saw_token_fetch_fail="true"
     fi
 
     remaining=$((deadline - SECONDS))
@@ -130,6 +148,8 @@ for line in "${snapshot_lines[@]}"; do
   if [[ "${exec_ready}" != "true" ]]; then
     if [[ "${saw_401}" == "true" ]]; then
       echo "exec endpoint returned HTTP 401 (auth) - execd token propagation broken; check execd auth token fetch" >&2
+    elif [[ "${saw_token_fetch_fail}" == "true" ]]; then
+      echo "exec probe could not fetch the execd auth token - check snapshot token persistence (execd-token-*.txt) and PVE_EXECD_TOKEN_FILE" >&2
     else
       echo "exec endpoint unreachable (network) - check cloudflared/tailscale route and cmux-execd startup" >&2
     fi

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -1761,6 +1761,7 @@ def _write_results_json(
     base_template_vmid: int,
     ide_provider: str,
     results_payload: list[dict[str, t.Any]],
+    execd_tokens: dict[int, str] | None = None,
 ) -> None:
     payload = {
         "schemaVersion": 1,
@@ -1773,6 +1774,23 @@ def _write_results_json(
     }
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    # Persist the execd auth token of each built template next to the results
+    # so the runtime smoke test can pass it to devsh via PVE_EXECD_TOKEN_FILE.
+    # Clones of a template keep the template's token while the PVE host stays
+    # booted (boot-id rotation only fires on host reboot), so the token cached
+    # during the build is valid for the smoke containers. The token files are
+    # not part of the results payload and are cleaned up by the smoke script.
+    if execd_tokens:
+        for result in results_payload:
+            template_vmid = result.get("templateVmid")
+            snapshot_id = result.get("snapshotId")
+            if not template_vmid or not snapshot_id:
+                continue
+            token = execd_tokens.get(template_vmid)
+            if token:
+                token_path = out_path.parent / f"execd-token-{snapshot_id}.txt"
+                token_path.write_text(token.strip() + "\n", encoding="utf-8")
 
 
 def _iso_timestamp() -> str:
@@ -6318,6 +6336,7 @@ async def provision_and_snapshot(args: argparse.Namespace) -> None:
             base_template_vmid=args.template_vmid,
             ide_provider=args.ide_provider,
             results_payload=[_serialize_template_result(r) for r in results],
+            execd_tokens=client._execd_auth_tokens,
         )
         console.always(f"Results JSON written: {out_path}")
 
@@ -6574,6 +6593,7 @@ async def run_update_mode(args: argparse.Namespace) -> None:
                 base_template_vmid=args.update_vmid,
                 ide_provider=args.ide_provider,
                 results_payload=[result],
+                execd_tokens=client._execd_auth_tokens,
             )
             console.always(f"Results JSON written: {out_path}")
     finally:

--- a/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
@@ -65,6 +65,11 @@ devsh() {
         return 0
       fi
 
+      if [[ "${DEVSH_MODE}" == "token-fetch-fail" ]]; then
+        echo "Error: failed to execute command: fetch exec token: HTTP 501" >&2
+        return 1
+      fi
+
       echo "exec endpoint not ready" >&2
       return 1
       ;;
@@ -126,3 +131,17 @@ if [[ "${deadline_output}" != *"exec endpoint unreachable (network)"* ]]; then
 fi
 
 echo "PASS: readiness probes honor the 600-second deadline"
+
+calls_file="${tmp_dir}/calls.token"
+if token_output="$(run_smoke token-fetch-fail "${calls_file}" 2>&1)"; then
+  printf '%s\n' "${token_output}" >&2
+  fail "runtime smoke must fail when the execd auth token cannot be fetched"
+fi
+if [[ "${token_output}" != *"could not fetch the execd auth token"* ]]; then
+  fail "token-fetch failure lost its diagnostic: ${token_output}"
+fi
+if [[ "${token_output}" == *"exec endpoint unreachable (network)"* ]]; then
+  fail "token-fetch failure was misclassified as a network failure"
+fi
+
+echo "PASS: token-fetch failures are classified distinctly from network failures"


### PR DESCRIPTION
## Problem

The weekly PVE LXC snapshot run (run `31888430924`) failed at the runtime smoke stage: devsh start succeeded (container `pvelxc-696a09ea`, vmid 227) but every exec probe failed with:

```
failed to set container timezone to Asia/Hong_Kong: fetch exec token: fetch exec token via PVE API: HTTP 501: {"message":"Method 'GET /nodes/karl-ws/lxc/227/files' not implemented","data":null}
```

PVE 8.4.16 does not implement `GET /nodes/{node}/lxc/{vmid}/files`, and CI runners cannot SSH to the PVE host. The smoke script misclassified the failure as a network problem because it only special-cases HTTP 401.

## Root cause

- `fetchExecTokenViaAPI()` (introduced in #1313) relies on the PVE `/files` endpoint, which this PVE server does not implement.
- The build step already knows each template's execd token: `task_restart_execd_early` pre-fetches it and caches it in `client._execd_auth_tokens`.
- The templates have no time namespace on this host, so clones booted on the same host boot keep the snapshot's baked token unchanged — the build-time token is valid for smoke containers.

## Fix

1. **scripts/snapshot-pvelxc.py**: persist each template's execd token to `logs/pve-lxc-snapshot/execd-token-<snapshotId>.txt` next to `results.json` (kept out of the results payload, which is uploaded as an artifact).
2. **packages/devsh/internal/pvelxc/exec.go**: `fetchExecToken` reads `PVE_EXECD_TOKEN_FILE` first (set but missing file → no-auth mode); `fetchExecTokenViaAPI` treats HTTP 501 like 404 as no-auth instead of failing.
3. **scripts/pve/pve-lxc-snapshot-runtime-smoke.sh**: exports `PVE_EXECD_TOKEN_FILE` per preset when the token file exists, classifies token-fetch failures distinctly from network failures, cleans up token files.
4. **scripts/test-pve-lxc-snapshot-runtime-smoke.sh**: covers the token-fetch-failure classification.

## Verification

- `go test ./internal/pvelxc/...`: 24/24 pass (new tests: env-file token, env-file missing, API-501-as-no-auth)
- `bun check` (lint + typecheck): pass
- `scripts/test-pve-lxc-snapshot-runtime-smoke.sh`: both new assertions pass
- Full `bun run test`: 500 pass; 2 pre-existing unrelated failures (`cmux-pty` flaky timing test — passes in isolation; Convex devbox integration timeout)
