### PR TITLE
fix(pve): surface exec failure details in snapshot runtime smoke

### DIFF
--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -60,6 +60,10 @@ type Client struct {
 	// doesn't exist (older containers without cmux-token-init).
 	execTokenMu sync.Mutex
 	execToken   string
+
+	// execRetryBaseDelay is the base backoff between exec attempts; 0 means
+	// the default (2s). Tests set it to 0 to keep retry loops fast.
+	execRetryBaseDelay time.Duration
 }
 
 type Instance struct {
@@ -128,14 +132,15 @@ func NewClient(cfg Config) (*Client, error) {
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: !cfg.VerifyTLS}
 
 	return &Client{
-		apiURL:           apiURL,
-		apiToken:         cfg.APIToken,
-		publicDomain:     strings.TrimSpace(cfg.PublicDomain),
-		verifyTLS:        cfg.VerifyTLS,
-		apiHTTP:          &http.Client{Transport: transport, Timeout: 180 * time.Second},
-		execHTTP:         &http.Client{Timeout: 0},
-		snapshotResolver: cfg.SnapshotResolver,
-		node:             strings.TrimSpace(cfg.Node),
+		apiURL:             apiURL,
+		apiToken:           cfg.APIToken,
+		publicDomain:       strings.TrimSpace(cfg.PublicDomain),
+		verifyTLS:          cfg.VerifyTLS,
+		apiHTTP:            &http.Client{Transport: transport, Timeout: 180 * time.Second},
+		execHTTP:           &http.Client{Timeout: 0},
+		snapshotResolver:   cfg.SnapshotResolver,
+		node:               strings.TrimSpace(cfg.Node),
+		execRetryBaseDelay: 2 * time.Second,
 	}, nil
 }
 

--- a/packages/devsh/internal/pvelxc/exec.go
+++ b/packages/devsh/internal/pvelxc/exec.go
@@ -272,7 +272,7 @@ func (c *Client) tryHTTPExec(ctx context.Context, host string, command string, t
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		return nil, nil
+		return nil, fmt.Errorf("request to %s failed: %w", execURL, err)
 	}
 	defer resp.Body.Close()
 
@@ -280,7 +280,7 @@ func (c *Client) tryHTTPExec(ctx context.Context, host string, command string, t
 		return nil, ErrExecUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil
+		return nil, fmt.Errorf("execd at %s returned HTTP %d", execURL, resp.StatusCode)
 	}
 
 	var stdout strings.Builder
@@ -474,7 +474,11 @@ func (c *Client) ExecCommand(ctx context.Context, instanceID string, command str
 	}
 
 	maxRetries := 5
-	baseDelay := 2 * time.Second
+	baseDelay := c.execRetryBaseDelay
+	if baseDelay <= 0 {
+		baseDelay = 2 * time.Second
+	}
+	var lastErr error
 
 	for _, host := range candidates {
 		for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -495,11 +499,16 @@ func (c *Client) ExecCommand(ctx context.Context, instanceID string, command str
 				// 401: invalidate token and retry with a fresh one (once per attempt).
 				if errors.Is(err, ErrExecUnauthorized) && attempt == 1 {
 					c.invalidateExecToken()
+					lastErr = err
 					continue
 				}
+				lastErr = err
 			}
 			if err == nil && result != nil {
 				return result.Stdout, result.Stderr, result.ExitCode, nil
+			}
+			if err == nil {
+				lastErr = fmt.Errorf("execd at %s returned no result", host)
 			}
 
 			if attempt < maxRetries {
@@ -512,6 +521,9 @@ func (c *Client) ExecCommand(ctx context.Context, instanceID string, command str
 		}
 	}
 
+	if lastErr != nil {
+		return "", "", -1, fmt.Errorf("HTTP exec failed for container %d via candidates: %s; last error: %v", vmid, strings.Join(candidates, ", "), lastErr)
+	}
 	return "", "", -1, fmt.Errorf("HTTP exec failed for container %d via candidates: %s", vmid, strings.Join(candidates, ", "))
 }
 

--- a/packages/devsh/internal/pvelxc/exec_test.go
+++ b/packages/devsh/internal/pvelxc/exec_test.go
@@ -48,7 +48,8 @@ func newExecTestClient(t *testing.T, apiHandler http.HandlerFunc, execHandler ht
 		execHTTP: &http.Client{
 			Transport: &rewriteExecTransport{target: targetURL},
 		},
-		node: "test-node",
+		node:               "test-node",
+		execRetryBaseDelay: time.Nanosecond,
 	}
 }
 
@@ -518,6 +519,98 @@ func TestExecCommandRetriesOn401WithFreshTokenViaAPI(t *testing.T) {
 	}
 	if len(auths) != 2 || auths[0] != "Bearer stale-token" || auths[1] != "Bearer fresh-api-token" {
 		t.Errorf("exec Authorization sequence = %q, want [Bearer stale-token Bearer fresh-api-token]", auths)
+	}
+}
+
+func TestTryHTTPExecReturnsErrorOnNonOKStatus(t *testing.T) {
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/dns"):
+				_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+			case strings.HasSuffix(r.URL.Path, "/config"):
+				_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+			default:
+				t.Errorf("unexpected PVE API path: %s", r.URL.Path)
+			}
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"error":"Bad Gateway"}`))
+		}),
+	)
+
+	_, err := client.tryHTTPExec(context.Background(), "https://port-39375-cmux-200.example.com", "echo ok", 0, "")
+	if err == nil {
+		t.Fatal("tryHTTPExec() error = nil, want HTTP 502 error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 502") {
+		t.Errorf("tryHTTPExec() error = %v, want it to mention HTTP 502", err)
+	}
+}
+
+func TestTryHTTPExecReturnsErrorOnConnectionFailure(t *testing.T) {
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{}}`))
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("exec handler must not be reached")
+		}),
+	)
+
+	// Point the exec transport at a closed listener so the request fails
+	// with a connection error instead of a response.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL, err := url.Parse(dead.URL)
+	if err != nil {
+		t.Fatalf("parse dead server URL: %v", err)
+	}
+	dead.Close()
+	client.execHTTP = &http.Client{Transport: &rewriteExecTransport{target: deadURL}}
+
+	_, err = client.tryHTTPExec(context.Background(), "https://port-39375-cmux-200.example.com", "echo ok", 0, "")
+	if err == nil {
+		t.Fatal("tryHTTPExec() error = nil, want connection error")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("tryHTTPExec() error = %v, want it to mention connection refused", err)
+	}
+}
+
+func TestExecCommandSurfacesLastError(t *testing.T) {
+	// A persistent 401 must surface in the final error (with the fast retry
+	// base delay of 0 set by the test client) instead of a generic message.
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/dns"):
+				_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+			case strings.HasSuffix(r.URL.Path, "/config"):
+				_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+			case strings.HasSuffix(r.URL.Path, "/files"):
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"data":null}`))
+			default:
+				t.Errorf("unexpected PVE API path: %s", r.URL.Path)
+			}
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+		}),
+	)
+
+	_, _, _, err := client.ExecCommand(context.Background(), "200", "echo ok")
+	if err == nil {
+		t.Fatal("ExecCommand() error = nil, want surfaced last error")
+	}
+	if !strings.Contains(err.Error(), "401 Unauthorized") {
+		t.Errorf("ExecCommand() error = %v, want it to mention 401 Unauthorized", err)
+	}
+	if !strings.Contains(err.Error(), "last error:") {
+		t.Errorf("ExecCommand() error = %v, want it to mention last error", err)
 	}
 }
 

--- a/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
@@ -117,6 +117,8 @@ for line in "${snapshot_lines[@]}"; do
   exec_ready="false"
   saw_401="false"
   saw_token_fetch_fail="false"
+  saw_conn_error="false"
+  saw_edge_error="false"
   deadline=$((SECONDS + 600))
   while (( SECONDS < deadline )); do
     remaining=$((deadline - SECONDS))
@@ -134,6 +136,12 @@ for line in "${snapshot_lines[@]}"; do
     if [[ "${probe_out}" == *"fetch exec token"* ]]; then
       saw_token_fetch_fail="true"
     fi
+    if [[ "${probe_out}" == *"connection refused"* || "${probe_out}" == *"no such host"* || "${probe_out}" == *"i/o timeout"* ]]; then
+      saw_conn_error="true"
+    fi
+    if [[ "${probe_out}" == *"HTTP 502"* || "${probe_out}" == *"HTTP 503"* || "${probe_out}" == *"HTTP 504"* || "${probe_out}" == *"HTTP 524"* ]]; then
+      saw_edge_error="true"
+    fi
 
     remaining=$((deadline - SECONDS))
     if (( remaining <= 0 )); then
@@ -150,6 +158,10 @@ for line in "${snapshot_lines[@]}"; do
       echo "exec endpoint returned HTTP 401 (auth) - execd token propagation broken; check execd auth token fetch" >&2
     elif [[ "${saw_token_fetch_fail}" == "true" ]]; then
       echo "exec probe could not fetch the execd auth token - check snapshot token persistence (execd-token-*.txt) and PVE_EXECD_TOKEN_FILE" >&2
+    elif [[ "${saw_edge_error}" == "true" ]]; then
+      echo "execd did not respond (edge/HTTP error) - check cmux-execd startup in the container and cloudflared/tailscale tunnel" >&2
+    elif [[ "${saw_conn_error}" == "true" ]]; then
+      echo "execd connection failed (refused/DNS/timeout) - check cmux-execd startup in the container and network routes" >&2
     else
       echo "exec endpoint unreachable (network) - check cloudflared/tailscale route and cmux-execd startup" >&2
     fi

--- a/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
@@ -70,6 +70,16 @@ devsh() {
         return 1
       fi
 
+      if [[ "${DEVSH_MODE}" == "edge-502" ]]; then
+        echo "Error: failed to execute command: HTTP exec failed for container 227 via candidates: https://port-39375-x.alphasolves.com, http://x.tail715a6.ts.net:39375; last error: execd at https://port-39375-x.alphasolves.com/exec returned HTTP 502" >&2
+        return 1
+      fi
+
+      if [[ "${DEVSH_MODE}" == "conn-refused" ]]; then
+        echo "Error: failed to execute command: HTTP exec failed for container 227 via candidates: https://port-39375-x.alphasolves.com, http://x.tail715a6.ts.net:39375; last error: request to http://x.tail715a6.ts.net:39375/exec failed: Post \"http://x.tail715a6.ts.net:39375/exec\": dial tcp 10.0.0.5:39375: connect: connection refused" >&2
+        return 1
+      fi
+
       echo "exec endpoint not ready" >&2
       return 1
       ;;
@@ -145,3 +155,31 @@ if [[ "${token_output}" == *"exec endpoint unreachable (network)"* ]]; then
 fi
 
 echo "PASS: token-fetch failures are classified distinctly from network failures"
+
+calls_file="${tmp_dir}/calls.edge"
+if edge_output="$(run_smoke edge-502 "${calls_file}" 2>&1)"; then
+  printf '%s\n' "${edge_output}" >&2
+  fail "runtime smoke must fail when the execd edge returns HTTP 502"
+fi
+if [[ "${edge_output}" != *"execd did not respond (edge/HTTP error)"* ]]; then
+  fail "edge failure lost its diagnostic: ${edge_output}"
+fi
+if [[ "${edge_output}" == *"exec endpoint unreachable (network)"* ]]; then
+  fail "edge failure was misclassified as a network failure"
+fi
+
+echo "PASS: edge/HTTP failures are classified distinctly from network failures"
+
+calls_file="${tmp_dir}/calls.conn"
+if conn_output="$(run_smoke conn-refused "${calls_file}" 2>&1)"; then
+  printf '%s\n' "${conn_output}" >&2
+  fail "runtime smoke must fail when the execd connection is refused"
+fi
+if [[ "${conn_output}" != *"execd connection failed (refused/DNS/timeout)"* ]]; then
+  fail "connection failure lost its diagnostic: ${conn_output}"
+fi
+if [[ "${conn_output}" == *"exec endpoint unreachable (network)"* ]]; then
+  fail "connection failure was misclassified as a network failure"
+fi
+
+echo "PASS: connection failures are classified distinctly from network failures"


### PR DESCRIPTION
## Problem

Rerun of the Weekly PVE LXC Snapshot (#285, run `31894125424`) after the token-file fix still failed at the runtime smoke stage. Progress: the 501 token-fetch error is gone (the persisted token file was picked up), but every exec probe now fails with a masked error:

```
HTTP exec failed for container 227 via candidates: https://port-39375-pvelxc-b19d5258.alphasolves.com, http://pvelxc-b19d5258.tail715a6.ts.net:39375
```

`tryHTTPExec` swallows connection errors and non-200 statuses as `(nil, nil)`, so the terminal error carries no cause. The smoke script therefore cannot distinguish: token rejected (401), execd never came up (connection refused), or edge unreachable (502/524).

## What this PR does

- **`packages/devsh/internal/pvelxc/exec.go`**: `tryHTTPExec` now returns real errors for connection failures (`request to <url> failed: ...`) and non-200 non-401 statuses (`execd at <url> returned HTTP 502`). `ExecCommand` tracks the last attempt error and appends `last error: ...` to the final message.
- **`packages/devsh/internal/pvelxc/client.go`**: adds `execRetryBaseDelay` (default 2s via `NewClient`) so tests can keep retry loops fast.
- **`scripts/pve/pve-lxc-snapshot-runtime-smoke.sh`**: classifies edge errors (HTTP 502/503/504/524) and connection failures (connection refused / no such host / i/o timeout) distinctly from network unreachability.
- **`scripts/test-pve-lxc-snapshot-runtime-smoke.sh`**: covers the two new classifications.
- **`packages/devsh/internal/pvelxc/exec_test.go`**: three new tests (non-OK status error, connection-refused error, last-error surfacing).

## Verification

- `go test ./internal/pvelxc/...`: 27/27 pass (2.69s)
- `scripts/test-pve-lxc-snapshot-runtime-smoke.sh`: all 4 classification assertions pass
- `bun check` (lint + typecheck): pass
