### PR TITLE
fix(pve): inject per-clone execd tokens for snapshot smoke

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,6 +64,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Test PVE snapshot scripts
+        run: |
+          bash scripts/test-pve-lxc-token-init.sh
+          bash scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+          uv run python scripts/test-snapshot-pvelxc-results.py
+
       - name: Run devsh Go tests
         run: |
           cd packages/devsh

--- a/configs/systemd/bin/cmux-token-init
+++ b/configs/systemd/bin/cmux-token-init
@@ -13,15 +13,26 @@ LEGACY_BOOT_ID_FILE="/home/user/.token-boot-id"
 
 CURRENT_BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo "unknown")
 
-# Only skip regeneration if ALL required token files exist and boot ID matches
-if [ -f "$BOOT_ID_FILE" ] && [ -f "$AUTH_TOKEN_FILE" ] && [ -f "$VSCODE_TOKEN_FILE" ]; then
-    SAVED_BOOT_ID=$(cat "$BOOT_ID_FILE" 2>/dev/null || echo "")
-    if [ "$CURRENT_BOOT_ID" = "$SAVED_BOOT_ID" ]; then
-        exit 0
-    fi
+AUTH_TOKEN="${CMUX_EXECD_AUTH_TOKEN:-}"
+if [[ -z "$AUTH_TOKEN" && -r /proc/1/environ ]]; then
+  AUTH_TOKEN="$({ tr '\0' '\n' </proc/1/environ | sed -n 's/^CMUX_EXECD_AUTH_TOKEN=//p' | head -n 1; } || true)"
 fi
+if [[ -n "$AUTH_TOKEN" ]]; then
+  [[ "$AUTH_TOKEN" =~ ^[a-f0-9]{64}$ ]] || {
+    echo "cmux-token-init: invalid CMUX_EXECD_AUTH_TOKEN" >&2
+    exit 1
+  }
+else
+  # Only skip regeneration if ALL required token files exist and boot ID matches
+  if [ -f "$BOOT_ID_FILE" ] && [ -f "$AUTH_TOKEN_FILE" ] && [ -f "$VSCODE_TOKEN_FILE" ]; then
+      SAVED_BOOT_ID=$(cat "$BOOT_ID_FILE" 2>/dev/null || echo "")
+      if [ "$CURRENT_BOOT_ID" = "$SAVED_BOOT_ID" ]; then
+          exit 0
+      fi
+  fi
 
-AUTH_TOKEN=$(openssl rand -hex 32)
+  AUTH_TOKEN=$(openssl rand -hex 32)
+fi
 printf "%s" "$AUTH_TOKEN" > "$AUTH_TOKEN_FILE"
 chmod 644 "$AUTH_TOKEN_FILE"
 

--- a/configs/systemd/cmux-execd.service
+++ b/configs/systemd/cmux-execd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Cmux Exec Daemon - HTTP command execution service
-After=network-online.target
+After=network-online.target cmux-token-generator.service
+Requires=cmux-token-generator.service
 Wants=network-online.target
 
 [Service]

--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -806,18 +806,24 @@ func (c *Client) StartInstance(ctx context.Context, opts StartOptions) (*Instanc
 
 		vscodeURL, err := c.buildServiceURL(ctx, 39378, vmid, hostname, domainSuffix, hostname)
 		if err != nil {
+			// Best-effort cleanup: the clone is started and its PVE runtime
+			// env carries the disposable execd token.
+			_ = c.deleteContainer(ctx, vmid)
 			return nil, err
 		}
 		workerURL, err := c.buildServiceURL(ctx, 39376, vmid, hostname, domainSuffix, hostname)
 		if err != nil {
+			_ = c.deleteContainer(ctx, vmid)
 			return nil, err
 		}
 		vncURL, err := c.buildServiceURL(ctx, 39380, vmid, hostname, domainSuffix, hostname)
 		if err != nil {
+			_ = c.deleteContainer(ctx, vmid)
 			return nil, err
 		}
 		xtermURL, err := c.buildServiceURL(ctx, 39383, vmid, hostname, domainSuffix, hostname)
 		if err != nil {
+			_ = c.deleteContainer(ctx, vmid)
 			return nil, err
 		}
 

--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -23,6 +23,9 @@ import (
 const (
 	defaultSnapshotID   = "snapshot_6b744b32"
 	defaultTemplateVMID = 9027
+
+	execTokenEnvVar = "PVE_EXECD_TOKEN_FILE"
+	execTokenEnvKey = "CMUX_EXECD_AUTH_TOKEN"
 )
 
 type SnapshotResolver func(snapshotID string) (templateVMID int, err error)
@@ -60,6 +63,10 @@ type Client struct {
 	// doesn't exist (older containers without cmux-token-init).
 	execTokenMu sync.Mutex
 	execToken   string
+
+	// execRetryBaseDelay is the base backoff between exec attempts; 0 means
+	// the default (2s). Tests set it to 0 to keep retry loops fast.
+	execRetryBaseDelay time.Duration
 }
 
 type Instance struct {
@@ -107,12 +114,14 @@ type pveContainerStatus struct {
 type pveContainerConfig struct {
 	Net0     string `json:"net0,omitempty"`
 	Hostname string `json:"hostname,omitempty"`
+	Env      string `json:"env,omitempty"`
 }
 
 var (
 	reDigits     = regexp.MustCompile(`^\d+$`)
 	reCmuxVmid   = regexp.MustCompile(`^cmux-(\d+)$`)
 	reSnapshotID = regexp.MustCompile(`^snapshot_[a-z0-9]+$`)
+	reExecdToken = regexp.MustCompile(`^[0-9a-f]{64}$`)
 )
 
 func NewClient(cfg Config) (*Client, error) {
@@ -128,14 +137,15 @@ func NewClient(cfg Config) (*Client, error) {
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: !cfg.VerifyTLS}
 
 	return &Client{
-		apiURL:           apiURL,
-		apiToken:         cfg.APIToken,
-		publicDomain:     strings.TrimSpace(cfg.PublicDomain),
-		verifyTLS:        cfg.VerifyTLS,
-		apiHTTP:          &http.Client{Transport: transport, Timeout: 180 * time.Second},
-		execHTTP:         &http.Client{Timeout: 0},
-		snapshotResolver: cfg.SnapshotResolver,
-		node:             strings.TrimSpace(cfg.Node),
+		apiURL:             apiURL,
+		apiToken:           cfg.APIToken,
+		publicDomain:       strings.TrimSpace(cfg.PublicDomain),
+		verifyTLS:          cfg.VerifyTLS,
+		apiHTTP:            &http.Client{Transport: transport, Timeout: 180 * time.Second},
+		execHTTP:           &http.Client{Timeout: 0},
+		snapshotResolver:   cfg.SnapshotResolver,
+		node:               strings.TrimSpace(cfg.Node),
+		execRetryBaseDelay: 2 * time.Second,
 	}, nil
 }
 
@@ -344,6 +354,65 @@ func (c *Client) getContainerConfig(ctx context.Context, vmid int) (pveContainer
 		return pveContainerConfig{}, err
 	}
 	return apiRequest[pveContainerConfig](ctx, c, http.MethodGet, fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/config", node, vmid), nil)
+}
+
+// readExecTokenFile reads the optional execd smoke token from
+// PVE_EXECD_TOKEN_FILE. A blank/unset variable means no token. The trimmed
+// content must be exactly 64 lowercase hex characters; a trailing newline
+// from the token generator is accepted. Errors never include the file path
+// or the token content.
+func readExecTokenFile() (string, error) {
+	tokenFile := strings.TrimSpace(os.Getenv(execTokenEnvVar))
+	if tokenFile == "" {
+		return "", nil
+	}
+	raw, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return "", errors.New("read execd token file failed")
+	}
+	token := strings.TrimSpace(string(raw))
+	if !reExecdToken.MatchString(token) {
+		return "", errors.New("invalid execd token: expected exactly 64 lowercase hex characters")
+	}
+	return token, nil
+}
+
+// upsertRuntimeEnv replaces every CMUX_EXECD_AUTH_TOKEN entry in a
+// NUL-separated PVE runtime-env string with a single entry for token,
+// preserving all other entries exactly once. An empty token removes the
+// entry entirely.
+func upsertRuntimeEnv(env, token string) string {
+	prefix := execTokenEnvKey + "="
+	entries := strings.Split(env, "\x00")
+	out := make([]string, 0, len(entries)+1)
+	for _, entry := range entries {
+		if entry == "" || strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	if token != "" {
+		out = append(out, prefix+token)
+	}
+	return strings.Join(out, "\x00")
+}
+
+// setContainerRuntimeEnv installs the execd smoke token in the container's
+// runtime env via the authenticated PVE config endpoint, preserving all
+// existing entries.
+func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token string) error {
+	cfg, err := c.getContainerConfig(ctx, vmid)
+	if err != nil {
+		return err
+	}
+	node, err := c.getNode(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = c.apiRequestData(ctx, http.MethodPut, fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/config", node, vmid), url.Values{
+		"env": []string{upsertRuntimeEnv(cfg.Env, token)},
+	})
+	return err
 }
 
 func (c *Client) getContainerIP(ctx context.Context, vmid int) (string, error) {
@@ -675,6 +744,13 @@ func (c *Client) StartInstance(ctx context.Context, opts StartOptions) (*Instanc
 	}
 	hostname := instanceID
 
+	// Read/validate the optional execd smoke token before any clone side
+	// effects, so malformed content fails without creating a container.
+	token, err := readExecTokenFile()
+	if err != nil {
+		return nil, err
+	}
+
 	domainSuffix, _ := c.getDomainSuffix(ctx)
 	fqdn := ""
 	if domainSuffix != "" {
@@ -697,6 +773,18 @@ func (c *Client) StartInstance(ctx context.Context, opts StartOptions) (*Instanc
 				continue
 			}
 			return nil, err
+		}
+
+		if token != "" {
+			if err := c.setContainerRuntimeEnv(ctx, vmid, token); err != nil {
+				_ = c.deleteContainer(ctx, vmid)
+				return nil, fmt.Errorf("set container runtime env: %w", err)
+			}
+			// Cache the injected clone token so the immediate timezone call
+			// authenticates with it instead of re-fetching.
+			c.execTokenMu.Lock()
+			c.execToken = token
+			c.execTokenMu.Unlock()
 		}
 
 		if err := c.startContainer(ctx, vmid); err != nil {

--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -65,7 +65,8 @@ type Client struct {
 	execToken   string
 
 	// execRetryBaseDelay is the base backoff between exec attempts; 0 means
-	// the default (2s). Tests set it to 0 to keep retry loops fast.
+	// the default (2s). Tests set a short nonzero delay to keep retry loops
+	// fast.
 	execRetryBaseDelay time.Duration
 }
 
@@ -399,20 +400,23 @@ func upsertRuntimeEnv(env, token string) string {
 
 // setContainerRuntimeEnv installs the execd smoke token in the container's
 // runtime env via the authenticated PVE config endpoint, preserving all
-// existing entries.
+// existing entries. Errors are sanitized: a PVE response body could echo the
+// submitted env (and with it the token), so only fixed messages are returned.
 func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token string) error {
 	cfg, err := c.getContainerConfig(ctx, vmid)
 	if err != nil {
-		return err
+		return errors.New("read container runtime env failed")
 	}
 	node, err := c.getNode(ctx)
 	if err != nil {
-		return err
+		return errors.New("read container runtime env failed")
 	}
-	_, err = c.apiRequestData(ctx, http.MethodPut, fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/config", node, vmid), url.Values{
+	if _, err := c.apiRequestData(ctx, http.MethodPut, fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/config", node, vmid), url.Values{
 		"env": []string{upsertRuntimeEnv(cfg.Env, token)},
-	})
-	return err
+	}); err != nil {
+		return errors.New("update container runtime env failed")
+	}
+	return nil
 }
 
 func (c *Client) getContainerIP(ctx context.Context, vmid int) (string, error) {
@@ -743,6 +747,12 @@ func (c *Client) StartInstance(ctx context.Context, opts StartOptions) (*Instanc
 		instanceID = generated
 	}
 	hostname := instanceID
+
+	// A previous start's injected token must not leak into this instance:
+	// without a token file the cache refills via the SSH/API fallback.
+	c.execTokenMu.Lock()
+	c.execToken = ""
+	c.execTokenMu.Unlock()
 
 	// Read/validate the optional execd smoke token before any clone side
 	// effects, so malformed content fails without creating a container.

--- a/packages/devsh/internal/pvelxc/client_test.go
+++ b/packages/devsh/internal/pvelxc/client_test.go
@@ -1,13 +1,21 @@
 package pvelxc
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/karlorz/devsh/internal/provider"
 )
+
+// testExecdToken is a synthetic 64-character lowercase hex token fixture.
+const testExecdToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 func TestIsPveLxcInstanceID(t *testing.T) {
 	tests := []struct {
@@ -380,5 +388,396 @@ func TestResolveSnapshotFromManifestOrDefaultUsesUpdatedFallback(t *testing.T) {
 	}
 	if templateVMID == 9045 {
 		t.Fatalf("resolveSnapshotFromManifestOrDefault(\"\") unexpectedly returned stale template VMID 9045")
+	}
+}
+
+func TestRuntimeEnvUpsert(t *testing.T) {
+	tests := []struct {
+		name  string
+		env   string
+		token string
+		want  string
+	}{
+		{
+			name:  "empty env appends token",
+			env:   "",
+			token: testExecdToken,
+			want:  "CMUX_EXECD_AUTH_TOKEN=" + testExecdToken,
+		},
+		{
+			name:  "preserves unrelated entries exactly once",
+			env:   "EXISTING=value",
+			token: testExecdToken,
+			want:  "EXISTING=value\x00CMUX_EXECD_AUTH_TOKEN=" + testExecdToken,
+		},
+		{
+			name:  "replaces stale entry instead of duplicating",
+			env:   "EXISTING=value\x00CMUX_EXECD_AUTH_TOKEN=old",
+			token: testExecdToken,
+			want:  "EXISTING=value\x00CMUX_EXECD_AUTH_TOKEN=" + testExecdToken,
+		},
+		{
+			name:  "removes all stale entries before appending",
+			env:   "A=1\x00CMUX_EXECD_AUTH_TOKEN=old\x00B=2\x00CMUX_EXECD_AUTH_TOKEN=older",
+			token: testExecdToken,
+			want:  "A=1\x00B=2\x00CMUX_EXECD_AUTH_TOKEN=" + testExecdToken,
+		},
+		{
+			name:  "empty token removes entry",
+			env:   "A=1\x00CMUX_EXECD_AUTH_TOKEN=old\x00B=2",
+			token: "",
+			want:  "A=1\x00B=2",
+		},
+		{
+			name:  "keeps similarly named keys",
+			env:   "CMUX_EXECD_AUTH_TOKEN_EXTRA=x\x00CMUX_EXECD_AUTH_TOKEN=old",
+			token: testExecdToken,
+			want:  "CMUX_EXECD_AUTH_TOKEN_EXTRA=x\x00CMUX_EXECD_AUTH_TOKEN=" + testExecdToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := upsertRuntimeEnv(tt.env, tt.token)
+			if got != tt.want {
+				t.Errorf("upsertRuntimeEnv(%q, %q) = %q, want %q", tt.env, tt.token, got, tt.want)
+			}
+			if n := strings.Count(got, "CMUX_EXECD_AUTH_TOKEN="); n > 1 {
+				t.Errorf("upsertRuntimeEnv() output has %d CMUX_EXECD_AUTH_TOKEN entries, want at most 1: %q", n, got)
+			}
+		})
+	}
+}
+
+func TestExecdTokenFileReader(t *testing.T) {
+	valid := testExecdToken
+
+	tests := []struct {
+		name    string
+		env     string // used verbatim when usePath is false
+		usePath bool
+		content string
+		write   bool
+		want    string
+		wantErr bool
+	}{
+		{name: "unset or empty", env: ""},
+		{name: "blank value", env: "   "},
+		{name: "valid token with trailing newline", usePath: true, content: valid + "\n", write: true, want: valid},
+		{name: "valid token with trailing CRLF", usePath: true, content: valid + "\r\n", write: true, want: valid},
+		{name: "63 chars rejected", usePath: true, content: valid[:63], write: true, wantErr: true},
+		{name: "65 chars rejected", usePath: true, content: valid + "a", write: true, wantErr: true},
+		{name: "uppercase hex rejected", usePath: true, content: "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", write: true, wantErr: true},
+		{name: "non-hex rejected", usePath: true, content: "g" + valid[1:], write: true, wantErr: true},
+		{name: "embedded newline rejected", usePath: true, content: valid[:32] + "\n" + valid[32:], write: true, wantErr: true},
+		{name: "missing file rejected", usePath: true, write: false, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "smoke-token.txt")
+			if tt.usePath {
+				t.Setenv("PVE_EXECD_TOKEN_FILE", path)
+			} else {
+				t.Setenv("PVE_EXECD_TOKEN_FILE", tt.env)
+			}
+			if tt.write {
+				if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+					t.Fatalf("write token file: %v", err)
+				}
+			}
+
+			got, err := readExecTokenFile()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("readExecTokenFile() error = nil, want error")
+				}
+				if strings.Contains(err.Error(), path) {
+					t.Errorf("readExecTokenFile() error leaks token file path: %v", err)
+				}
+				if tt.content != "" && strings.Contains(err.Error(), strings.TrimSpace(tt.content)) {
+					t.Errorf("readExecTokenFile() error leaks token content: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readExecTokenFile() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("readExecTokenFile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+type startInstanceRecorder struct {
+	mu          sync.Mutex
+	reqs        []string
+	putEnv      string
+	cloneCalls  int
+	putCalls    int
+	configCalls int
+	startCalls  int
+}
+
+func (r *startInstanceRecorder) index(methodPath string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, req := range r.reqs {
+		if req == methodPath {
+			return i
+		}
+	}
+	return -1
+}
+
+// newStartInstanceTestServer serves a minimal PVE API for StartInstance:
+// empty node lists (VMID 200 is free), instant clone/start tasks, and the
+// given config env (JSON-escaped, e.g. "A=1\u0000B=2") on GET config.
+// putStatus != 0 makes the config PUT fail with that status.
+func newStartInstanceTestServer(t *testing.T, configEnvJSON string, putStatus int) (*httptest.Server, *startInstanceRecorder) {
+	t.Helper()
+	rec := &startInstanceRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		rec.mu.Lock()
+		rec.reqs = append(rec.reqs, r.Method+" "+path)
+		rec.mu.Unlock()
+		switch {
+		case strings.HasSuffix(path, "/dns"):
+			_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(path, "/lxc"):
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case strings.HasSuffix(path, "/qemu"):
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case strings.HasSuffix(path, "/clone"):
+			rec.mu.Lock()
+			rec.cloneCalls++
+			rec.mu.Unlock()
+			_, _ = w.Write([]byte(`{"data":"UPID:0"}`))
+		case strings.HasSuffix(path, "/status/current"):
+			_, _ = w.Write([]byte(`{"data":{"status":"stopped","vmid":200}}`))
+		case strings.HasSuffix(path, "/status/start"):
+			rec.mu.Lock()
+			rec.startCalls++
+			rec.mu.Unlock()
+			_, _ = w.Write([]byte(`{"data":"UPID:0"}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(path, "/config"):
+			rec.mu.Lock()
+			rec.configCalls++
+			rec.mu.Unlock()
+			_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200","env":"` + configEnvJSON + `"}}`))
+		case r.Method == http.MethodPut && strings.HasSuffix(path, "/config"):
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("parse PUT config form: %v", err)
+			}
+			rec.mu.Lock()
+			rec.putCalls++
+			rec.putEnv = r.Form.Get("env")
+			rec.mu.Unlock()
+			if putStatus != 0 {
+				w.WriteHeader(putStatus)
+				_, _ = w.Write([]byte(`{"errors":{"env":"rejected"}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":null}`))
+		case r.Method == http.MethodDelete && strings.HasSuffix(path, "/lxc/200"):
+			_, _ = w.Write([]byte(`{"data":"UPID:0"}`))
+		case strings.HasSuffix(path, "/status"):
+			_, _ = w.Write([]byte(`{"data":{"status":"stopped","exitstatus":"OK"}}`))
+		default:
+			t.Errorf("unexpected PVE API request: %s %s", r.Method, path)
+			_, _ = w.Write([]byte(`{"data":null}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+func newStartTestClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	return &Client{
+		apiURL:       srv.URL,
+		apiToken:     "token",
+		publicDomain: "example.com",
+		apiHTTP:      srv.Client(),
+		execHTTP:     &http.Client{Timeout: 0},
+		node:         "test-node",
+	}
+}
+
+func writeExecdTokenFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "smoke-token.txt")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	return path
+}
+
+func TestExecdTokenFileInjectedBeforeCloneStart(t *testing.T) {
+	t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken+"\n"))
+
+	srv, rec := newStartInstanceTestServer(t, "EXISTING=value", 0)
+	client := newStartTestClient(t, srv)
+
+	inst, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID})
+	if err != nil {
+		t.Fatalf("StartInstance() error = %v", err)
+	}
+	if inst == nil || inst.VMID != 200 {
+		t.Fatalf("StartInstance() = %+v, want VMID 200", inst)
+	}
+
+	const (
+		cloneReq = "POST /api2/json/nodes/test-node/lxc/9027/clone"
+		putReq   = "PUT /api2/json/nodes/test-node/lxc/200/config"
+		startReq = "POST /api2/json/nodes/test-node/lxc/200/status/start"
+	)
+	idxClone, idxPut, idxStart := rec.index(cloneReq), rec.index(putReq), rec.index(startReq)
+	if idxClone < 0 {
+		t.Fatalf("clone request not recorded; requests: %v", rec.reqs)
+	}
+	if idxPut < 0 || idxStart < 0 || idxPut > idxStart {
+		t.Fatalf("config PUT must precede start POST; requests: %v", rec.reqs)
+	}
+	if idxPut < idxClone {
+		t.Fatalf("config PUT must follow clone POST; requests: %v", rec.reqs)
+	}
+
+	wantEnv := "EXISTING=value\x00CMUX_EXECD_AUTH_TOKEN=" + testExecdToken
+	if rec.putEnv != wantEnv {
+		t.Errorf("PUT env = %q, want %q", rec.putEnv, wantEnv)
+	}
+	if got := strings.Count(rec.putEnv, "EXISTING=value"); got != 1 {
+		t.Errorf("PUT env preserves EXISTING=value %d times, want exactly 1: %q", got, rec.putEnv)
+	}
+	if got := strings.Count(rec.putEnv, "CMUX_EXECD_AUTH_TOKEN="); got != 1 {
+		t.Errorf("PUT env has %d CMUX_EXECD_AUTH_TOKEN entries, want exactly 1: %q", got, rec.putEnv)
+	}
+
+	client.execTokenMu.Lock()
+	cached := client.execToken
+	client.execTokenMu.Unlock()
+	if cached != testExecdToken {
+		t.Errorf("cached exec token = %q, want the injected token", cached)
+	}
+}
+
+func TestExecdTokenFileReplacesStaleEntry(t *testing.T) {
+	t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken))
+
+	srv, rec := newStartInstanceTestServer(t, "EXISTING=value\\u0000CMUX_EXECD_AUTH_TOKEN=old", 0)
+	client := newStartTestClient(t, srv)
+
+	if _, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID}); err != nil {
+		t.Fatalf("StartInstance() error = %v", err)
+	}
+
+	wantEnv := "EXISTING=value\x00CMUX_EXECD_AUTH_TOKEN=" + testExecdToken
+	if rec.putEnv != wantEnv {
+		t.Errorf("PUT env = %q, want %q", rec.putEnv, wantEnv)
+	}
+	if got := strings.Count(rec.putEnv, "EXISTING=value"); got != 1 {
+		t.Errorf("PUT env preserves EXISTING=value %d times, want exactly 1: %q", got, rec.putEnv)
+	}
+	if got := strings.Count(rec.putEnv, "CMUX_EXECD_AUTH_TOKEN="); got != 1 {
+		t.Errorf("PUT env has %d CMUX_EXECD_AUTH_TOKEN entries, want exactly 1: %q", got, rec.putEnv)
+	}
+}
+
+func TestExecdTokenFileNoUpdateWithoutFile(t *testing.T) {
+	// Unset and empty PVE_EXECD_TOKEN_FILE both mean no injection: the
+	// clone must start without any config update and without seeding the
+	// cached exec token.
+	for _, tc := range []struct {
+		name string
+		env  string
+	}{
+		{name: "unset", env: "unset"},
+		{name: "empty", env: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.env == "unset" {
+				old, had := os.LookupEnv("PVE_EXECD_TOKEN_FILE")
+				os.Unsetenv("PVE_EXECD_TOKEN_FILE")
+				t.Cleanup(func() {
+					if had {
+						os.Setenv("PVE_EXECD_TOKEN_FILE", old)
+					} else {
+						os.Unsetenv("PVE_EXECD_TOKEN_FILE")
+					}
+				})
+			} else {
+				t.Setenv("PVE_EXECD_TOKEN_FILE", "")
+			}
+
+			srv, rec := newStartInstanceTestServer(t, "", 0)
+			client := newStartTestClient(t, srv)
+
+			if _, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID}); err != nil {
+				t.Fatalf("StartInstance() error = %v", err)
+			}
+
+			rec.mu.Lock()
+			putCalls, configCalls := rec.putCalls, rec.configCalls
+			rec.mu.Unlock()
+			if putCalls != 0 {
+				t.Errorf("config PUT calls = %d, want 0 (no token file)", putCalls)
+			}
+			if configCalls != 0 {
+				t.Errorf("config GET calls = %d, want 0 (no token file)", configCalls)
+			}
+
+			client.execTokenMu.Lock()
+			cached := client.execToken
+			client.execTokenMu.Unlock()
+			if cached != "" {
+				t.Errorf("cached exec token = %q, want empty (no injection)", cached)
+			}
+		})
+	}
+}
+
+func TestExecdTokenFileInvalidContentRejectedBeforeStart(t *testing.T) {
+	tokenFile := writeExecdTokenFile(t, "not-a-64-char-hex-token")
+	t.Setenv("PVE_EXECD_TOKEN_FILE", tokenFile)
+
+	srv, rec := newStartInstanceTestServer(t, "", 0)
+	client := newStartTestClient(t, srv)
+
+	if _, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID}); err == nil {
+		t.Fatal("StartInstance() error = nil, want invalid token error")
+	} else {
+		if strings.Contains(err.Error(), tokenFile) {
+			t.Errorf("StartInstance() error leaks token file path: %v", err)
+		}
+		if strings.Contains(err.Error(), "not-a-64-char-hex-token") {
+			t.Errorf("StartInstance() error leaks token content: %v", err)
+		}
+	}
+
+	rec.mu.Lock()
+	cloneCalls, putCalls, startCalls := rec.cloneCalls, rec.putCalls, rec.startCalls
+	rec.mu.Unlock()
+	if cloneCalls != 0 || putCalls != 0 || startCalls != 0 {
+		t.Errorf("requests after invalid token: clone=%d put=%d start=%d, want all 0", cloneCalls, putCalls, startCalls)
+	}
+}
+
+func TestExecdTokenFileInjectionFailureDeletesClone(t *testing.T) {
+	t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken))
+
+	srv, rec := newStartInstanceTestServer(t, "", http.StatusInternalServerError)
+	client := newStartTestClient(t, srv)
+
+	if _, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID}); err == nil {
+		t.Fatal("StartInstance() error = nil, want config injection error")
+	}
+	if idxDelete := rec.index("DELETE /api2/json/nodes/test-node/lxc/200"); idxDelete < 0 {
+		t.Fatalf("clone deletion not requested after injection failure; requests: %v", rec.reqs)
+	}
+	if idxStart := rec.index("POST /api2/json/nodes/test-node/lxc/200/status/start"); idxStart >= 0 {
+		t.Fatalf("start requested despite injection failure; requests: %v", rec.reqs)
 	}
 }

--- a/packages/devsh/internal/pvelxc/client_test.go
+++ b/packages/devsh/internal/pvelxc/client_test.go
@@ -577,7 +577,9 @@ func newStartInstanceTestServer(t *testing.T, configEnvJSON string, putStatus in
 			rec.mu.Unlock()
 			if putStatus != 0 {
 				w.WriteHeader(putStatus)
-				_, _ = w.Write([]byte(`{"errors":{"env":"rejected"}}`))
+				// Deliberately echo the submitted env in the error body so
+				// a leak would surface the token in the returned error.
+				_, _ = w.Write([]byte(`{"errors":{"env":"` + r.Form.Get("env") + `"}}`))
 				return
 			}
 			_, _ = w.Write([]byte(`{"data":null}`))
@@ -655,6 +657,15 @@ func TestExecdTokenFileInjectedBeforeCloneStart(t *testing.T) {
 	if got := strings.Count(rec.putEnv, "CMUX_EXECD_AUTH_TOKEN="); got != 1 {
 		t.Errorf("PUT env has %d CMUX_EXECD_AUTH_TOKEN entries, want exactly 1: %q", got, rec.putEnv)
 	}
+	rec.mu.Lock()
+	configCalls, putCalls := rec.configCalls, rec.putCalls
+	rec.mu.Unlock()
+	if configCalls != 1 {
+		t.Errorf("config GET calls = %d, want exactly 1", configCalls)
+	}
+	if putCalls != 1 {
+		t.Errorf("config PUT calls = %d, want exactly 1", putCalls)
+	}
 
 	client.execTokenMu.Lock()
 	cached := client.execToken
@@ -683,6 +694,15 @@ func TestExecdTokenFileReplacesStaleEntry(t *testing.T) {
 	}
 	if got := strings.Count(rec.putEnv, "CMUX_EXECD_AUTH_TOKEN="); got != 1 {
 		t.Errorf("PUT env has %d CMUX_EXECD_AUTH_TOKEN entries, want exactly 1: %q", got, rec.putEnv)
+	}
+	rec.mu.Lock()
+	configCalls, putCalls := rec.configCalls, rec.putCalls
+	rec.mu.Unlock()
+	if configCalls != 1 {
+		t.Errorf("config GET calls = %d, want exactly 1", configCalls)
+	}
+	if putCalls != 1 {
+		t.Errorf("config PUT calls = %d, want exactly 1", putCalls)
 	}
 }
 
@@ -715,6 +735,12 @@ func TestExecdTokenFileNoUpdateWithoutFile(t *testing.T) {
 			srv, rec := newStartInstanceTestServer(t, "", 0)
 			client := newStartTestClient(t, srv)
 
+			// A prior smoke clone's cached token must be cleared so this
+			// instance falls back to its SSH/API token path.
+			client.execTokenMu.Lock()
+			client.execToken = testExecdToken
+			client.execTokenMu.Unlock()
+
 			if _, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID}); err != nil {
 				t.Fatalf("StartInstance() error = %v", err)
 			}
@@ -733,7 +759,7 @@ func TestExecdTokenFileNoUpdateWithoutFile(t *testing.T) {
 			cached := client.execToken
 			client.execTokenMu.Unlock()
 			if cached != "" {
-				t.Errorf("cached exec token = %q, want empty (no injection)", cached)
+				t.Errorf("cached exec token = %q, want cleared (no injection)", cached)
 			}
 		})
 	}
@@ -773,6 +799,8 @@ func TestExecdTokenFileInjectionFailureDeletesClone(t *testing.T) {
 
 	if _, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID}); err == nil {
 		t.Fatal("StartInstance() error = nil, want config injection error")
+	} else if strings.Contains(err.Error(), testExecdToken) {
+		t.Errorf("StartInstance() error leaks the injected token: %v", err)
 	}
 	if idxDelete := rec.index("DELETE /api2/json/nodes/test-node/lxc/200"); idxDelete < 0 {
 		t.Fatalf("clone deletion not requested after injection failure; requests: %v", rec.reqs)

--- a/packages/devsh/internal/pvelxc/client_test.go
+++ b/packages/devsh/internal/pvelxc/client_test.go
@@ -809,3 +809,59 @@ func TestExecdTokenFileInjectionFailureDeletesClone(t *testing.T) {
 		t.Fatalf("start requested despite injection failure; requests: %v", rec.reqs)
 	}
 }
+
+// TestStartInstanceDeletesCloneWhenServiceURLUnbuildable exercises the
+// post-start cleanup gap: when no public domain, no DNS search suffix, and
+// no container IP are available, buildServiceURL cannot construct the
+// service URLs and StartInstance must still delete the already-started clone
+// (whose PVE runtime env carries the disposable execd token).
+func TestStartInstanceDeletesCloneWhenServiceURLUnbuildable(t *testing.T) {
+	t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken))
+
+	// The httptest server returns an empty DNS search suffix and a container
+	// config without net0 (no IP). The client below leaves publicDomain empty,
+	// so every buildServiceURL call has nothing to build from and must fail.
+	srv, rec := newStartInstanceTestServer(t, "", 0)
+	client := &Client{
+		apiURL:       srv.URL,
+		apiToken:     "token",
+		publicDomain: "",
+		apiHTTP:      srv.Client(),
+		execHTTP:     &http.Client{Timeout: 0},
+		node:         "test-node",
+	}
+
+	inst, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID})
+	if err == nil {
+		t.Fatal("StartInstance() error = nil, want a service-URL build error")
+	}
+	if !strings.Contains(err.Error(), "no public domain") {
+		t.Fatalf("StartInstance() error = %q, want a service-URL build error", err)
+	}
+	if inst != nil {
+		t.Fatalf("StartInstance() returned instance %+v despite error", inst)
+	}
+
+	// Start must have happened before the URL build failure.
+	idxStart := rec.index("POST /api2/json/nodes/test-node/lxc/200/status/start")
+	if idxStart < 0 {
+		t.Fatalf("start request not recorded; requests: %v", rec.reqs)
+	}
+
+	// The already-started, token-bearing clone must be deleted best-effort.
+	idxDelete := rec.index("DELETE /api2/json/nodes/test-node/lxc/200")
+	if idxDelete < 0 {
+		t.Fatalf("clone deletion not requested after service-URL build failure; requests: %v", rec.reqs)
+	}
+	rec.mu.Lock()
+	deleteIdx := -1
+	for i, req := range rec.reqs {
+		if req == "DELETE /api2/json/nodes/test-node/lxc/200" {
+			deleteIdx = i
+		}
+	}
+	rec.mu.Unlock()
+	if deleteIdx <= idxStart {
+		t.Fatalf("DELETE must follow start; DELETE index %d, start index %d; requests: %v", deleteIdx, idxStart, rec.reqs)
+	}
+}

--- a/packages/devsh/internal/pvelxc/exec.go
+++ b/packages/devsh/internal/pvelxc/exec.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -62,26 +61,20 @@ func ShellSingleQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
-// fetchExecToken retrieves the /root/.worker-auth-token from inside the
-// container. When PVE_EXECD_TOKEN_FILE is set, the token is read from that
-// file: CI snapshot runs persist the template's execd token there, because
-// the PVE API has no LXC file-read endpoint and CI runners cannot reach the
-// PVE host over SSH. Otherwise, when PVE_SSH_HOST is set it reads the file
-// via SSH to the PVE host + pct exec; without SSH it falls back to the PVE
-// API file endpoint. The token is cached on the Client after the first
-// successful fetch. Returns "" (no error) when the token file doesn't exist —
-// in that case the execd daemon is in no-auth mode and requests pass through.
+// fetchExecToken retrieves the execd auth token used for exec requests.
+// When PVE_EXECD_TOKEN_FILE is set, the clone-specific smoke token injected
+// by StartInstance is read from that file, so `devsh exec` authenticates
+// with the exact token installed before the clone started. Otherwise, when
+// PVE_SSH_HOST is set it reads /root/.worker-auth-token via SSH to the PVE
+// host + pct exec; without SSH it falls back to the PVE API file endpoint.
+// The token is cached on the Client after the first successful fetch.
 func (c *Client) fetchExecToken(ctx context.Context, vmid int) (string, error) {
-	if tokenFile := os.Getenv("PVE_EXECD_TOKEN_FILE"); tokenFile != "" {
-		raw, err := os.ReadFile(tokenFile)
-		if err != nil {
-			if os.IsNotExist(err) {
-				// No persisted token — execd runs in no-auth mode.
-				return "", nil
-			}
-			return "", fmt.Errorf("fetch exec token from %s: %w", tokenFile, err)
-		}
-		return strings.TrimSpace(string(raw)), nil
+	token, err := readExecTokenFile()
+	if err != nil {
+		return "", err
+	}
+	if token != "" {
+		return token, nil
 	}
 
 	sshHost := SSHHostFromEnv()
@@ -99,7 +92,7 @@ func (c *Client) fetchExecToken(ctx context.Context, vmid int) (string, error) {
 		return "", fmt.Errorf("fetch exec token via SSH+pct: %w", err)
 	}
 
-	token := strings.TrimSpace(string(out))
+	token = strings.TrimSpace(string(out))
 	if token == "" {
 		// Token file doesn't exist in the container — execd is in no-auth mode.
 		return "", nil
@@ -272,7 +265,7 @@ func (c *Client) tryHTTPExec(ctx context.Context, host string, command string, t
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		return nil, nil
+		return nil, fmt.Errorf("request to %s failed: %w", execURL, err)
 	}
 	defer resp.Body.Close()
 
@@ -280,7 +273,7 @@ func (c *Client) tryHTTPExec(ctx context.Context, host string, command string, t
 		return nil, ErrExecUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil
+		return nil, fmt.Errorf("execd at %s returned HTTP %d", execURL, resp.StatusCode)
 	}
 
 	var stdout strings.Builder
@@ -474,7 +467,11 @@ func (c *Client) ExecCommand(ctx context.Context, instanceID string, command str
 	}
 
 	maxRetries := 5
-	baseDelay := 2 * time.Second
+	baseDelay := c.execRetryBaseDelay
+	if baseDelay <= 0 {
+		baseDelay = 2 * time.Second
+	}
+	var lastErr error
 
 	for _, host := range candidates {
 		for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -495,11 +492,16 @@ func (c *Client) ExecCommand(ctx context.Context, instanceID string, command str
 				// 401: invalidate token and retry with a fresh one (once per attempt).
 				if errors.Is(err, ErrExecUnauthorized) && attempt == 1 {
 					c.invalidateExecToken()
+					lastErr = err
 					continue
 				}
+				lastErr = err
 			}
 			if err == nil && result != nil {
 				return result.Stdout, result.Stderr, result.ExitCode, nil
+			}
+			if err == nil {
+				lastErr = fmt.Errorf("execd at %s returned no result", host)
 			}
 
 			if attempt < maxRetries {
@@ -512,6 +514,9 @@ func (c *Client) ExecCommand(ctx context.Context, instanceID string, command str
 		}
 	}
 
+	if lastErr != nil {
+		return "", "", -1, fmt.Errorf("HTTP exec failed for container %d via candidates: %s; last error: %v", vmid, strings.Join(candidates, ", "), lastErr)
+	}
 	return "", "", -1, fmt.Errorf("HTTP exec failed for container %d via candidates: %s", vmid, strings.Join(candidates, ", "))
 }
 

--- a/packages/devsh/internal/pvelxc/exec_test.go
+++ b/packages/devsh/internal/pvelxc/exec_test.go
@@ -48,9 +48,13 @@ func newExecTestClient(t *testing.T, apiHandler http.HandlerFunc, execHandler ht
 		execHTTP: &http.Client{
 			Transport: &rewriteExecTransport{target: targetURL},
 		},
-		node: "test-node",
+		node:               "test-node",
+		execRetryBaseDelay: time.Nanosecond,
 	}
 }
+
+// execTestToken is a synthetic 64-character lowercase hex token fixture.
+const execTestToken = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 
 func newExecReadyTestClient(t *testing.T, execHandler http.HandlerFunc) *Client {
 	t.Helper()
@@ -349,7 +353,7 @@ func TestExecCommandTokenFetchViaAPI(t *testing.T) {
 
 func TestExecCommandTokenFromEnvFile(t *testing.T) {
 	tokenFile := filepath.Join(t.TempDir(), "execd-token.txt")
-	if err := os.WriteFile(tokenFile, []byte("env-file-secret-token\n"), 0o600); err != nil {
+	if err := os.WriteFile(tokenFile, []byte(execTestToken+"\n"), 0o600); err != nil {
 		t.Fatalf("write token file: %v", err)
 	}
 	t.Setenv("PVE_EXECD_TOKEN_FILE", tokenFile)
@@ -399,56 +403,31 @@ func TestExecCommandTokenFromEnvFile(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if gotAuth != "Bearer env-file-secret-token" {
-		t.Errorf("exec Authorization = %q, want %q", gotAuth, "Bearer env-file-secret-token")
+	if gotAuth != "Bearer "+execTestToken {
+		t.Errorf("exec Authorization = %q, want %q", gotAuth, "Bearer "+execTestToken)
 	}
 	if filesCalls != 0 {
 		t.Errorf("files fetch calls = %d, want 0 (env file must bypass the PVE API)", filesCalls)
 	}
 }
 
-func TestExecCommandTokenFromEnvFileMissing(t *testing.T) {
-	// A configured-but-missing env token file means no persisted token was
-	// produced (no-auth execd); the exec must proceed without a token.
+func TestExecdTokenFileMissingRejected(t *testing.T) {
+	// A configured-but-missing token file is a misconfiguration: the exec
+	// cannot authenticate with the injected clone token, so the fetch must
+	// fail without touching SSH or the PVE API.
 	t.Setenv("PVE_EXECD_TOKEN_FILE", filepath.Join(t.TempDir(), "missing-token.txt"))
-
-	var (
-		mu      sync.Mutex
-		gotAuth string
-	)
 
 	client := newExecTestClient(t,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case strings.HasSuffix(r.URL.Path, "/dns"):
-				_, _ = w.Write([]byte(`{"data":{"search":""}}`))
-			case strings.HasSuffix(r.URL.Path, "/config"):
-				_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
-			default:
-				t.Errorf("unexpected PVE API path: %s", r.URL.Path)
-			}
+			t.Errorf("PVE API must not be reached for a missing token file, got %s", r.URL.Path)
 		}),
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			mu.Lock()
-			gotAuth = r.Header.Get("Authorization")
-			mu.Unlock()
-			w.Header().Set("Content-Type", "application/jsonlines")
-			_, _ = w.Write([]byte("{\"type\":\"stdout\",\"data\":\"ok\"}\n{\"type\":\"exit\",\"code\":0}\n"))
+			t.Errorf("exec endpoint must not be reached for a missing token file, got %s", r.URL.Path)
 		}),
 	)
 
-	stdout, _, _, err := client.ExecCommand(context.Background(), "200", "echo ok")
-	if err != nil {
-		t.Fatalf("ExecCommand() error = %v", err)
-	}
-	if stdout != "ok" {
-		t.Errorf("ExecCommand() stdout = %q, want %q", stdout, "ok")
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if gotAuth != "" {
-		t.Errorf("exec Authorization = %q, want empty (no-auth mode)", gotAuth)
+	if _, err := client.fetchExecToken(context.Background(), 200); err == nil {
+		t.Fatal("fetchExecToken() error = nil, want missing-file error")
 	}
 }
 
@@ -541,5 +520,97 @@ func TestFetchExecTokenPrefersSSHWhenHostSet(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "fetch exec token via SSH") {
 		t.Errorf("fetchExecToken() error = %q, want SSH fetch error", err)
+	}
+}
+
+func TestTryHTTPExecReturnsErrorOnNonOKStatus(t *testing.T) {
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/dns"):
+				_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+			case strings.HasSuffix(r.URL.Path, "/config"):
+				_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+			default:
+				t.Errorf("unexpected PVE API path: %s", r.URL.Path)
+			}
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"error":"Bad Gateway"}`))
+		}),
+	)
+
+	_, err := client.tryHTTPExec(context.Background(), "https://port-39375-cmux-200.example.com", "echo ok", 0, "")
+	if err == nil {
+		t.Fatal("tryHTTPExec() error = nil, want HTTP 502 error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 502") {
+		t.Errorf("tryHTTPExec() error = %v, want it to mention HTTP 502", err)
+	}
+}
+
+func TestTryHTTPExecReturnsErrorOnConnectionFailure(t *testing.T) {
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{}}`))
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("exec handler must not be reached")
+		}),
+	)
+
+	// Point the exec transport at a closed listener so the request fails
+	// with a connection error instead of a response.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL, err := url.Parse(dead.URL)
+	if err != nil {
+		t.Fatalf("parse dead server URL: %v", err)
+	}
+	dead.Close()
+	client.execHTTP = &http.Client{Transport: &rewriteExecTransport{target: deadURL}}
+
+	_, err = client.tryHTTPExec(context.Background(), "https://port-39375-cmux-200.example.com", "echo ok", 0, "")
+	if err == nil {
+		t.Fatal("tryHTTPExec() error = nil, want connection error")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("tryHTTPExec() error = %v, want it to mention connection refused", err)
+	}
+}
+
+func TestExecCommandSurfacesLastError(t *testing.T) {
+	// A persistent 401 must surface in the final error (with the fast retry
+	// base delay of 0 set by the test client) instead of a generic message.
+	client := newExecTestClient(t,
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/dns"):
+				_, _ = w.Write([]byte(`{"data":{"search":""}}`))
+			case strings.HasSuffix(r.URL.Path, "/config"):
+				_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200"}}`))
+			case strings.HasSuffix(r.URL.Path, "/files"):
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"data":null}`))
+			default:
+				t.Errorf("unexpected PVE API path: %s", r.URL.Path)
+			}
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"Unauthorized"}`))
+		}),
+	)
+
+	_, _, _, err := client.ExecCommand(context.Background(), "200", "echo ok")
+	if err == nil {
+		t.Fatal("ExecCommand() error = nil, want surfaced last error")
+	}
+	if !strings.Contains(err.Error(), "401 Unauthorized") {
+		t.Errorf("ExecCommand() error = %v, want it to mention 401 Unauthorized", err)
+	}
+	if !strings.Contains(err.Error(), "last error:") {
+		t.Errorf("ExecCommand() error = %v, want it to mention last error", err)
 	}
 }

--- a/scripts/execd/main.go
+++ b/scripts/execd/main.go
@@ -82,6 +82,17 @@ func verifyAuth(r *http.Request) bool {
 	return false
 }
 
+// logAuthState logs whether authentication is enabled or disabled at startup.
+// It must never emit token content, its prefix, a hash, a length, or the token
+// file path — only the enabled/disabled state signal.
+func logAuthState(token string) {
+	if token != "" {
+		log.Printf("auth enabled")
+	} else {
+		log.Printf("auth disabled (no token file found)")
+	}
+}
+
 // authMiddleware wraps a handler with token authentication. When authToken
 // is empty (no token file), requests pass through without auth.
 func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
@@ -357,11 +368,7 @@ func main() {
 	// containers without cmux-token-init), authToken remains "" and the daemon
 	// operates in no-auth mode for backward compatibility.
 	authToken = loadAuthToken()
-	if authToken != "" {
-		log.Printf("auth enabled (token: %s...)", authToken[:8])
-	} else {
-		log.Printf("auth disabled (no token file found)")
-	}
+	logAuthState(authToken)
 
 	port := determinePort(*portFlag)
 	mux := http.NewServeMux()

--- a/scripts/execd/main_test.go
+++ b/scripts/execd/main_test.go
@@ -4,11 +4,13 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -341,6 +343,51 @@ func TestLoadAuthToken_EmptyFile_Skipped(t *testing.T) {
 	token := loadAuthToken()
 	if token != "real-token" {
 		t.Errorf("expected 'real-token' (skip empty), got %q", token)
+	}
+}
+
+// captureLogger redirects the package's standard logger to a buffer and
+// returns a function to read the captured output. It restores the original
+// logger on cleanup.
+func captureLogger(t *testing.T) func() string {
+	t.Helper()
+	orig := log.Writer()
+	origFlag := log.Flags()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		log.SetOutput(orig)
+		log.SetFlags(origFlag)
+	})
+	return func() string { return buf.String() }
+}
+
+func TestLogAuthState_Enabled_DoesNotLeakTokenMaterial(t *testing.T) {
+	synthetic := "supersecret-token-value-42"
+	out := captureLogger(t)
+
+	logAuthState(synthetic)
+
+	logged := strings.TrimSpace(out())
+	if !strings.Contains(logged, "auth enabled") {
+		t.Errorf("expected 'auth enabled' state signal, got %q", logged)
+	}
+	if strings.Contains(logged, synthetic) {
+		t.Errorf("startup log leaked the full auth token: %q", logged)
+	}
+	if strings.Contains(logged, synthetic[:8]) {
+		t.Errorf("startup log leaked the first eight token characters: %q", logged)
+	}
+}
+
+func TestLogAuthState_Disabled_EmitsStateSignal(t *testing.T) {
+	out := captureLogger(t)
+
+	logAuthState("")
+
+	logged := strings.TrimSpace(out())
+	if !strings.Contains(logged, "auth disabled") {
+		t.Errorf("expected 'auth disabled' state signal, got %q", logged)
 	}
 }
 

--- a/scripts/pve/pve-lxc-setup.sh
+++ b/scripts/pve/pve-lxc-setup.sh
@@ -479,14 +479,26 @@ LEGACY_BOOT_ID_FILE="/home/user/.token-boot-id"
 
 CURRENT_BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo "unknown")
 
-if [ -f "$BOOT_ID_FILE" ] && [ -f "$AUTH_TOKEN_FILE" ]; then
-    SAVED_BOOT_ID=$(cat "$BOOT_ID_FILE" 2>/dev/null || echo "")
-    if [ "$CURRENT_BOOT_ID" = "$SAVED_BOOT_ID" ]; then
-        exit 0
-    fi
+AUTH_TOKEN="${CMUX_EXECD_AUTH_TOKEN:-}"
+if [[ -z "$AUTH_TOKEN" && -r /proc/1/environ ]]; then
+  AUTH_TOKEN="$({ tr '\0' '\n' </proc/1/environ | sed -n 's/^CMUX_EXECD_AUTH_TOKEN=//p' | head -n 1; } || true)"
 fi
+if [[ -n "$AUTH_TOKEN" ]]; then
+  [[ "$AUTH_TOKEN" =~ ^[a-f0-9]{64}$ ]] || {
+    echo "cmux-token-init: invalid CMUX_EXECD_AUTH_TOKEN" >&2
+    exit 1
+  }
+else
+  # Only skip regeneration if ALL required token files exist and boot ID matches
+  if [ -f "$BOOT_ID_FILE" ] && [ -f "$AUTH_TOKEN_FILE" ] && [ -f "$VSCODE_TOKEN_FILE" ]; then
+      SAVED_BOOT_ID=$(cat "$BOOT_ID_FILE" 2>/dev/null || echo "")
+      if [ "$CURRENT_BOOT_ID" = "$SAVED_BOOT_ID" ]; then
+          exit 0
+      fi
+  fi
 
-AUTH_TOKEN=$(openssl rand -hex 32)
+  AUTH_TOKEN=$(openssl rand -hex 32)
+fi
 printf "%s" "$AUTH_TOKEN" > "$AUTH_TOKEN_FILE"
 chmod 644 "$AUTH_TOKEN_FILE"
 

--- a/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
@@ -89,10 +89,12 @@ for line in "${snapshot_lines[@]}"; do
   # Generate a fresh disposable execd auth token for this clone and hand its
   # path to devsh via PVE_EXECD_TOKEN_FILE. devsh injects the token into the
   # clone before start and uses it for every HTTP exec probe, so the same
-  # environment value must reach all devsh calls for this clone. The file is
-  # created with mktemp in a temp dir (never under logs/) and removed by the
-  # EXIT cleanup trap. Never print the token or its path.
+  # environment value must reach all devsh calls for this clone. The path is
+  # tracked as soon as mktemp succeeds so the EXIT cleanup trap also covers
+  # failures during chmod or token generation. The file lives in a temp dir
+  # (never under logs/) and is never printed.
   token_file="$(mktemp "${TMPDIR:-/tmp}/cmux-execd-token.${snapshot_id}.XXXXXX")"
+  token_files+=("${token_file}")
   chmod 600 "${token_file}"
   python3 - "${token_file}" <<'PY'
 import secrets
@@ -100,7 +102,6 @@ import sys
 from pathlib import Path
 Path(sys.argv[1]).write_text(secrets.token_hex(32) + "\n", encoding="ascii")
 PY
-  token_files+=("${token_file}")
   export PVE_EXECD_TOKEN_FILE="${token_file}"
 
   echo ""

--- a/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/pve/pve-lxc-snapshot-runtime-smoke.sh
@@ -14,8 +14,6 @@ if [[ ! -f "${results_json}" ]]; then
   exit 2
 fi
 
-results_dir="$(dirname -- "${results_json}")"
-
 if ! command -v devsh >/dev/null 2>&1; then
   echo "ERROR: devsh not found on PATH" >&2
   exit 2
@@ -66,11 +64,21 @@ if [[ ${#snapshot_lines[@]} -eq 0 ]]; then
 fi
 
 active_id=""
+token_files=()
 cleanup() {
   if [[ -n "${active_id}" ]]; then
     devsh delete "${active_id}" >/dev/null 2>&1 || true
   fi
-  rm -f "${results_dir}"/execd-token-*.txt
+  # Remove every disposable execd token file created for this run. The files
+  # live outside logs/ (which is uploaded as a GitHub artifact) and must never
+  # survive any exit path.
+  if (( ${#token_files[@]} > 0 )); then
+    local token_file
+    for token_file in "${token_files[@]}"; do
+      rm -f -- "${token_file}"
+    done
+  fi
+  unset PVE_EXECD_TOKEN_FILE
 }
 trap cleanup EXIT
 
@@ -78,16 +86,22 @@ for line in "${snapshot_lines[@]}"; do
   preset="$(printf '%s' "${line}" | cut -f1)"
   snapshot_id="$(printf '%s' "${line}" | cut -f2)"
 
-  # The snapshot build persists each template's execd auth token next to the
-  # results; clones keep that token until the PVE host reboots. Pass it to
-  # devsh so exec probes carry the Bearer token without SSH or a PVE API
-  # file endpoint (neither is available in CI).
-  token_file="${results_dir}/execd-token-${snapshot_id}.txt"
-  if [[ -f "${token_file}" ]]; then
-    export PVE_EXECD_TOKEN_FILE="${token_file}"
-  else
-    unset PVE_EXECD_TOKEN_FILE
-  fi
+  # Generate a fresh disposable execd auth token for this clone and hand its
+  # path to devsh via PVE_EXECD_TOKEN_FILE. devsh injects the token into the
+  # clone before start and uses it for every HTTP exec probe, so the same
+  # environment value must reach all devsh calls for this clone. The file is
+  # created with mktemp in a temp dir (never under logs/) and removed by the
+  # EXIT cleanup trap. Never print the token or its path.
+  token_file="$(mktemp "${TMPDIR:-/tmp}/cmux-execd-token.${snapshot_id}.XXXXXX")"
+  chmod 600 "${token_file}"
+  python3 - "${token_file}" <<'PY'
+import secrets
+import sys
+from pathlib import Path
+Path(sys.argv[1]).write_text(secrets.token_hex(32) + "\n", encoding="ascii")
+PY
+  token_files+=("${token_file}")
+  export PVE_EXECD_TOKEN_FILE="${token_file}"
 
   echo ""
   echo "=== Runtime smoke: ${preset} (${snapshot_id}) ==="
@@ -113,10 +127,27 @@ for line in "${snapshot_lines[@]}"; do
 
   echo "Instance: ${active_id}"
 
+  # Unauthenticated status-only probe of the public execd hostname. It never
+  # carries auth headers and its failure does not abort the readiness flow;
+  # it only separates tunnel/service reachability (non-200) from
+  # authentication (healthz 200 but /exec 401).
+  if [[ -n "${PVE_PUBLIC_DOMAIN:-}" ]]; then
+    healthz_status="$(
+      curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+        "https://port-39375-${active_id}.${PVE_PUBLIC_DOMAIN}/healthz" 2>/dev/null \
+        || true
+    )"
+  else
+    healthz_status="skipped"
+  fi
+  echo "Healthz status: ${healthz_status}"
+
   echo "Waiting for exec..."
   exec_ready="false"
   saw_401="false"
   saw_token_fetch_fail="false"
+  saw_conn_error="false"
+  saw_edge_error="false"
   deadline=$((SECONDS + 600))
   while (( SECONDS < deadline )); do
     remaining=$((deadline - SECONDS))
@@ -134,6 +165,12 @@ for line in "${snapshot_lines[@]}"; do
     if [[ "${probe_out}" == *"fetch exec token"* ]]; then
       saw_token_fetch_fail="true"
     fi
+    if [[ "${probe_out}" == *"connection refused"* || "${probe_out}" == *"no such host"* || "${probe_out}" == *"i/o timeout"* ]]; then
+      saw_conn_error="true"
+    fi
+    if [[ "${probe_out}" == *"HTTP 502"* || "${probe_out}" == *"HTTP 503"* || "${probe_out}" == *"HTTP 504"* || "${probe_out}" == *"HTTP 524"* ]]; then
+      saw_edge_error="true"
+    fi
 
     remaining=$((deadline - SECONDS))
     if (( remaining <= 0 )); then
@@ -149,7 +186,11 @@ for line in "${snapshot_lines[@]}"; do
     if [[ "${saw_401}" == "true" ]]; then
       echo "exec endpoint returned HTTP 401 (auth) - execd token propagation broken; check execd auth token fetch" >&2
     elif [[ "${saw_token_fetch_fail}" == "true" ]]; then
-      echo "exec probe could not fetch the execd auth token - check snapshot token persistence (execd-token-*.txt) and PVE_EXECD_TOKEN_FILE" >&2
+      echo "exec probe could not fetch the execd auth token - check PVE_EXECD_TOKEN_FILE availability and clone token injection" >&2
+    elif [[ "${saw_edge_error}" == "true" ]]; then
+      echo "execd did not respond (edge/HTTP error) - check cmux-execd startup in the container and cloudflared/tailscale tunnel" >&2
+    elif [[ "${saw_conn_error}" == "true" ]]; then
+      echo "execd connection failed (refused/DNS/timeout) - check cmux-execd startup in the container and network routes" >&2
     else
       echo "exec endpoint unreachable (network) - check cloudflared/tailscale route and cmux-execd startup" >&2
     fi
@@ -197,6 +238,10 @@ for line in "${snapshot_lines[@]}"; do
 
   devsh delete "${active_id}" >/dev/null 2>&1 || true
   active_id=""
+  # The EXIT trap is the safety net for every exit path; dropping the file
+  # here keeps the next iteration free of dangling state.
+  rm -f -- "${token_file}"
+  unset PVE_EXECD_TOKEN_FILE
 done
 
 echo ""

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -1761,7 +1761,6 @@ def _write_results_json(
     base_template_vmid: int,
     ide_provider: str,
     results_payload: list[dict[str, t.Any]],
-    execd_tokens: dict[int, str] | None = None,
 ) -> None:
     payload = {
         "schemaVersion": 1,
@@ -1774,23 +1773,6 @@ def _write_results_json(
     }
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-    # Persist the execd auth token of each built template next to the results
-    # so the runtime smoke test can pass it to devsh via PVE_EXECD_TOKEN_FILE.
-    # Clones of a template keep the template's token while the PVE host stays
-    # booted (boot-id rotation only fires on host reboot), so the token cached
-    # during the build is valid for the smoke containers. The token files are
-    # not part of the results payload and are cleaned up by the smoke script.
-    if execd_tokens:
-        for result in results_payload:
-            template_vmid = result.get("templateVmid")
-            snapshot_id = result.get("snapshotId")
-            if not template_vmid or not snapshot_id:
-                continue
-            token = execd_tokens.get(template_vmid)
-            if token:
-                token_path = out_path.parent / f"execd-token-{snapshot_id}.txt"
-                token_path.write_text(token.strip() + "\n", encoding="utf-8")
 
 
 def _iso_timestamp() -> str:
@@ -6336,7 +6318,6 @@ async def provision_and_snapshot(args: argparse.Namespace) -> None:
             base_template_vmid=args.template_vmid,
             ide_provider=args.ide_provider,
             results_payload=[_serialize_template_result(r) for r in results],
-            execd_tokens=client._execd_auth_tokens,
         )
         console.always(f"Results JSON written: {out_path}")
 
@@ -6593,7 +6574,6 @@ async def run_update_mode(args: argparse.Namespace) -> None:
                 base_template_vmid=args.update_vmid,
                 ide_provider=args.ide_provider,
                 results_payload=[result],
-                execd_tokens=client._execd_auth_tokens,
             )
             console.always(f"Results JSON written: {out_path}")
     finally:

--- a/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
@@ -63,7 +63,7 @@ record_token_state() {
     printf 'path=%s\n' "${PVE_EXECD_TOKEN_FILE:-}"
     if [[ -n "${PVE_EXECD_TOKEN_FILE:-}" && -f "${PVE_EXECD_TOKEN_FILE}" ]]; then
       printf 'exists=yes\n'
-      printf 'content=%s\n' "$(cat "${PVE_EXECD_TOKEN_FILE}")"
+      printf 'content=%s\n' "$(<"${PVE_EXECD_TOKEN_FILE}")"
       printf 'mode=%s\n' "$(stat -c '%a' "${PVE_EXECD_TOKEN_FILE}" 2>/dev/null || stat -f '%Lp' "${PVE_EXECD_TOKEN_FILE}" 2>/dev/null || printf 'unknown')"
     else
       printf 'exists=no\n'
@@ -118,7 +118,18 @@ devsh() {
       echo "pvelxc-deadline"
       ;;
     exec)
-      record_token_state "${DEVSH_EXEC_RECORD:-/dev/null}"
+      # Record the token state at most once per smoke invocation: the record
+      # helper spawns external programs, which must not run on every
+      # readiness probe (real wall time would accrue in SECONDS and skew the
+      # virtual 600-second deadline test).
+      local recorded=0
+      if [[ -f "${DEVSH_EXEC_RECORD_COUNT:-}" ]]; then
+        IFS= read -r recorded <"${DEVSH_EXEC_RECORD_COUNT:-}" || true
+      fi
+      if (( recorded == 0 )); then
+        record_token_state "${DEVSH_EXEC_RECORD:-/dev/null}"
+        printf '%s\n' "$((recorded + 1))" >"${DEVSH_EXEC_RECORD_COUNT:-/dev/null}"
+      fi
 
       local calls=0
       if [[ -f "${DEVSH_CALLS_FILE}" ]]; then
@@ -183,6 +194,7 @@ run_smoke() {
   local results_file="${8:-${tmp_dir}/results.json}"
   local start_count_file="${9:-}"
   local mktemp_record="${10:-}"
+  local exec_record_count="${11:-}"
   (
     cd "${tmp_dir}"
     BASH_ENV="${tmp_dir}/bash_env" \
@@ -194,6 +206,7 @@ run_smoke() {
       DEVSH_HEALTHZ_STATUS="${healthz_status}" \
       DEVSH_START_COUNT_FILE="${start_count_file}" \
       DEVSH_MKTEMP_RECORD="${mktemp_record}" \
+      DEVSH_EXEC_RECORD_COUNT="${exec_record_count}" \
       PVE_PUBLIC_DOMAIN="${public_domain}" \
       bash "${runtime_dir}/pve-lxc-snapshot-runtime-smoke.sh" "${results_file}"
   )
@@ -227,7 +240,8 @@ if [[ "${success_output}" != *"All runtime smoke checks passed"* ]]; then
 fi
 
 calls_file="${tmp_dir}/calls.deadline"
-if deadline_output="$(run_smoke always-fail "${calls_file}" "${tmp_dir}/start.deadline" "${tmp_dir}/exec.deadline" "${tmp_dir}/curl.deadline" 2>&1)"; then
+exec_count_file="${tmp_dir}/exec.deadline.count"
+if deadline_output="$(run_smoke always-fail "${calls_file}" "${tmp_dir}/start.deadline" "${tmp_dir}/exec.deadline" "${tmp_dir}/curl.deadline" "" "" "" "" "" "${exec_count_file}" 2>&1)"; then
   printf '%s\n' "${deadline_output}" >&2
   fail "runtime smoke must fail when readiness never arrives"
 fi
@@ -241,6 +255,13 @@ fi
 deadline_token_path="$(record_field "${tmp_dir}/start.deadline" path)"
 if [[ -z "${deadline_token_path}" || -e "${deadline_token_path}" ]]; then
   fail "temporary token file was not removed after readiness failure"
+fi
+exec_recordings="0"
+if [[ -f "${exec_count_file}" ]]; then
+  IFS= read -r exec_recordings <"${exec_count_file}" || true
+fi
+if [[ "${exec_recordings}" != "1" ]]; then
+  fail "exec token state was recorded ${exec_recordings} times across 200 probes (expected exactly 1)"
 fi
 
 echo "PASS: readiness probes honor the 600-second deadline"
@@ -382,7 +403,8 @@ echo "=== PVE LXC snapshot runtime-smoke cleanup-path tests ==="
 # token array must still remove the temporary file via the EXIT trap.
 calls_file="${tmp_dir}/calls.genfail"
 mktemp_record="${tmp_dir}/mktemp.genfail"
-if genfail_output="$(run_smoke token-gen-fail "${calls_file}" "${tmp_dir}/start.genfail" "${tmp_dir}/exec.genfail" "${tmp_dir}/curl.genfail" "" "" "${tmp_dir}/results.json" "" "${mktemp_record}" 2>&1)"; then
+start_count_file="${tmp_dir}/starts.genfail"
+if genfail_output="$(run_smoke token-gen-fail "${calls_file}" "${tmp_dir}/start.genfail" "${tmp_dir}/exec.genfail" "${tmp_dir}/curl.genfail" "" "" "${tmp_dir}/results.json" "${start_count_file}" "${mktemp_record}" 2>&1)"; then
   printf '%s\n' "${genfail_output}" >&2
   fail "runtime smoke must fail when token generation fails"
 fi
@@ -392,6 +414,18 @@ if [[ -z "${genfail_path}" ]]; then
 fi
 if [[ -e "${genfail_path}" ]]; then
   fail "temporary token file leaked after token generation failure"
+fi
+if [[ -f "${tmp_dir}/start.genfail" ]]; then
+  fail "devsh start was reached despite token generation failure"
+fi
+if [[ -f "${start_count_file}" ]]; then
+  fail "devsh start was invoked despite token generation failure"
+fi
+if [[ "${genfail_output}" == *"Waiting for exec"* ]]; then
+  fail "token generation failure was misreported as a readiness deadline failure"
+fi
+if [[ "${genfail_output}" == *"Runtime smoke"* ]]; then
+  fail "smoke run proceeded past token generation despite the failure"
 fi
 
 echo "PASS: EXIT cleanup covers failures between mktemp and devsh start"

--- a/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
@@ -31,6 +31,13 @@ exit 0
 EOF
 chmod +x "${runtime_dir}/pve-lxc-networkd-diag.sh"
 
+# A stale template token file next to the results JSON. The runtime smoke
+# must ignore it: it generates a fresh disposable token per clone instead of
+# reusing anything found in the artifact directory. Synthetic fixture only.
+STALE_TOKEN="deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+printf '%s\n' "${STALE_TOKEN}" >"${tmp_dir}/execd-token-snapshot-deadline.txt"
+chmod 644 "${tmp_dir}/execd-token-snapshot-deadline.txt"
+
 cat >"${tmp_dir}/bash_env" <<'EOF'
 SECONDS=0
 sleep() {
@@ -44,21 +51,48 @@ timeout() {
   shift
   "$@"
 }
+curl() {
+  printf 'args=%s\n' "$*" >"${DEVSH_CURL_RECORD:-/dev/null}"
+  printf '%s' "${DEVSH_HEALTHZ_STATUS:-200}"
+}
+# Record the PVE_EXECD_TOKEN_FILE state seen by a fake devsh invocation
+# without printing the token itself to the test output.
+record_token_state() {
+  local out_file="$1"
+  {
+    printf 'path=%s\n' "${PVE_EXECD_TOKEN_FILE:-}"
+    if [[ -n "${PVE_EXECD_TOKEN_FILE:-}" && -f "${PVE_EXECD_TOKEN_FILE}" ]]; then
+      printf 'exists=yes\n'
+      printf 'content=%s\n' "$(cat "${PVE_EXECD_TOKEN_FILE}")"
+      printf 'mode=%s\n' "$(stat -c '%a' "${PVE_EXECD_TOKEN_FILE}" 2>/dev/null || stat -f '%Lp' "${PVE_EXECD_TOKEN_FILE}" 2>/dev/null || printf 'unknown')"
+    else
+      printf 'exists=no\n'
+    fi
+  } >"${out_file}"
+}
 devsh() {
   local command_name="${1:-}"
   shift || true
 
   case "${command_name}" in
     start)
+      record_token_state "${DEVSH_START_RECORD:-/dev/null}"
       echo "pvelxc-deadline"
       ;;
     exec)
+      record_token_state "${DEVSH_EXEC_RECORD:-/dev/null}"
+
       local calls=0
       if [[ -f "${DEVSH_CALLS_FILE}" ]]; then
         IFS= read -r calls <"${DEVSH_CALLS_FILE}" || true
       fi
       calls=$((calls + 1))
       printf '%s\n' "${calls}" >"${DEVSH_CALLS_FILE}"
+
+      if [[ "${DEVSH_MODE}" == "ready" ]]; then
+        echo "exec_ready"
+        return 0
+      fi
 
       if [[ "${DEVSH_MODE}" == "fail-then-succeed" && "${calls}" -gt 40 ]]; then
         echo "exec_ready"
@@ -67,6 +101,16 @@ devsh() {
 
       if [[ "${DEVSH_MODE}" == "token-fetch-fail" ]]; then
         echo "Error: failed to execute command: fetch exec token: HTTP 501" >&2
+        return 1
+      fi
+
+      if [[ "${DEVSH_MODE}" == "edge-502" ]]; then
+        echo "Error: failed to execute command: HTTP exec failed for container 227 via candidates: https://port-39375-x.alphasolves.com, http://x.tail715a6.ts.net:39375; last error: execd at https://port-39375-x.alphasolves.com/exec returned HTTP 502" >&2
+        return 1
+      fi
+
+      if [[ "${DEVSH_MODE}" == "conn-refused" ]]; then
+        echo "Error: failed to execute command: HTTP exec failed for container 227 via candidates: https://port-39375-x.alphasolves.com, http://x.tail715a6.ts.net:39375; last error: request to http://x.tail715a6.ts.net:39375/exec failed: Post \"http://x.tail715a6.ts.net:39375/exec\": dial tcp 10.0.0.5:39375: connect: connection refused" >&2
         return 1
       fi
 
@@ -93,19 +137,41 @@ fail() {
 run_smoke() {
   local mode="$1"
   local calls_file="$2"
+  local start_record="$3"
+  local exec_record="$4"
+  local curl_record="$5"
+  local public_domain="${6:-}"
+  local healthz_status="${7:-}"
   (
     cd "${tmp_dir}"
     BASH_ENV="${tmp_dir}/bash_env" \
       DEVSH_MODE="${mode}" \
       DEVSH_CALLS_FILE="${calls_file}" \
+      DEVSH_START_RECORD="${start_record}" \
+      DEVSH_EXEC_RECORD="${exec_record}" \
+      DEVSH_CURL_RECORD="${curl_record}" \
+      DEVSH_HEALTHZ_STATUS="${healthz_status}" \
+      PVE_PUBLIC_DOMAIN="${public_domain}" \
       bash "${runtime_dir}/pve-lxc-snapshot-runtime-smoke.sh" "${tmp_dir}/results.json"
   )
+}
+
+record_field() {
+  local record_file="$1"
+  local field="$2"
+  local value=""
+  if [[ -f "${record_file}" ]]; then
+    value="$(sed -n "s/^${field}=//p" "${record_file}" | head -n 1)"
+  fi
+  printf '%s' "${value}"
 }
 
 echo "=== PVE LXC snapshot runtime-smoke deadline tests ==="
 
 calls_file="${tmp_dir}/calls.success"
-if ! success_output="$(run_smoke fail-then-succeed "${calls_file}" 2>&1)"; then
+start_record="${tmp_dir}/start.success"
+exec_record="${tmp_dir}/exec.success"
+if ! success_output="$(run_smoke fail-then-succeed "${calls_file}" "${start_record}" "${exec_record}" "${tmp_dir}/curl.success" 2>&1)"; then
   printf '%s\n' "${success_output}" >&2
   fail "runtime smoke must accept readiness after more than 40 fast failed probes"
 fi
@@ -118,7 +184,7 @@ if [[ "${success_output}" != *"All runtime smoke checks passed"* ]]; then
 fi
 
 calls_file="${tmp_dir}/calls.deadline"
-if deadline_output="$(run_smoke always-fail "${calls_file}" 2>&1)"; then
+if deadline_output="$(run_smoke always-fail "${calls_file}" "${tmp_dir}/start.deadline" "${tmp_dir}/exec.deadline" "${tmp_dir}/curl.deadline" 2>&1)"; then
   printf '%s\n' "${deadline_output}" >&2
   fail "runtime smoke must fail when readiness never arrives"
 fi
@@ -133,7 +199,7 @@ fi
 echo "PASS: readiness probes honor the 600-second deadline"
 
 calls_file="${tmp_dir}/calls.token"
-if token_output="$(run_smoke token-fetch-fail "${calls_file}" 2>&1)"; then
+if token_output="$(run_smoke token-fetch-fail "${calls_file}" "${tmp_dir}/start.token" "${tmp_dir}/exec.token" "${tmp_dir}/curl.token" 2>&1)"; then
   printf '%s\n' "${token_output}" >&2
   fail "runtime smoke must fail when the execd auth token cannot be fetched"
 fi
@@ -143,5 +209,121 @@ fi
 if [[ "${token_output}" == *"exec endpoint unreachable (network)"* ]]; then
   fail "token-fetch failure was misclassified as a network failure"
 fi
+if [[ "${token_output}" == *"execd-token-"* ]]; then
+  fail "token-fetch diagnostic still references template token persistence"
+fi
 
 echo "PASS: token-fetch failures are classified distinctly from network failures"
+
+calls_file="${tmp_dir}/calls.edge"
+if edge_output="$(run_smoke edge-502 "${calls_file}" "${tmp_dir}/start.edge" "${tmp_dir}/exec.edge" "${tmp_dir}/curl.edge" 2>&1)"; then
+  printf '%s\n' "${edge_output}" >&2
+  fail "runtime smoke must fail when the execd edge returns HTTP 502"
+fi
+if [[ "${edge_output}" != *"execd did not respond (edge/HTTP error)"* ]]; then
+  fail "edge failure lost its diagnostic: ${edge_output}"
+fi
+if [[ "${edge_output}" == *"exec endpoint unreachable (network)"* ]]; then
+  fail "edge failure was misclassified as a network failure"
+fi
+
+echo "PASS: edge/HTTP failures are classified distinctly from network failures"
+
+calls_file="${tmp_dir}/calls.conn"
+if conn_output="$(run_smoke conn-refused "${calls_file}" "${tmp_dir}/start.conn" "${tmp_dir}/exec.conn" "${tmp_dir}/curl.conn" 2>&1)"; then
+  printf '%s\n' "${conn_output}" >&2
+  fail "runtime smoke must fail when the execd connection is refused"
+fi
+if [[ "${conn_output}" != *"execd connection failed (refused/DNS/timeout)"* ]]; then
+  fail "connection failure lost its diagnostic: ${conn_output}"
+fi
+if [[ "${conn_output}" == *"exec endpoint unreachable (network)"* ]]; then
+  fail "connection failure was misclassified as a network failure"
+fi
+
+echo "PASS: connection failures are classified distinctly from network failures"
+
+echo ""
+echo "=== PVE LXC snapshot runtime-smoke disposable-token tests ==="
+
+calls_file="${tmp_dir}/calls.tokenlife"
+start_record="${tmp_dir}/start.tokenlife"
+exec_record="${tmp_dir}/exec.tokenlife"
+curl_record="${tmp_dir}/curl.tokenlife"
+if ! token_output="$(run_smoke ready "${calls_file}" "${start_record}" "${exec_record}" "${curl_record}" "fake.example.com" "200" 2>&1)"; then
+  printf '%s\n' "${token_output}" >&2
+  fail "runtime smoke must pass when the clone is ready"
+fi
+
+start_path="$(record_field "${start_record}" path)"
+start_content="$(record_field "${start_record}" content)"
+start_exists="$(record_field "${start_record}" exists)"
+start_mode="$(record_field "${start_record}" mode)"
+exec_path="$(record_field "${exec_record}" path)"
+exec_content="$(record_field "${exec_record}" content)"
+
+if [[ "${start_exists}" != "yes" ]]; then
+  fail "token file did not exist when devsh start was invoked"
+fi
+if [[ -z "${start_path}" ]]; then
+  fail "token file path was not recorded at devsh start"
+fi
+if [[ "${start_path}" == "${tmp_dir}"/* ]]; then
+  fail "token file was created inside the results directory"
+fi
+if [[ "${start_path}" != /* ]]; then
+  fail "token file path is not absolute"
+fi
+if [[ "${start_path##*/}" != cmux-execd-token.snapshot-deadline.* ]]; then
+  fail "token file path does not match the disposable mktemp pattern"
+fi
+if [[ ! "${start_content}" =~ ^[a-f0-9]{64}$ ]]; then
+  fail "generated token does not match ^[a-f0-9]{64}$"
+fi
+if [[ "${start_content}" == "${STALE_TOKEN}" ]]; then
+  fail "generated token reuses the stale template token instead of a fresh secret"
+fi
+if [[ "${start_mode}" != "600" ]]; then
+  fail "token file mode is not 0600"
+fi
+if [[ "${exec_path}" != "${start_path}" || "${exec_content}" != "${start_content}" ]]; then
+  fail "devsh exec did not see the same token file/content as devsh start"
+fi
+if [[ "${token_output}" != *"Healthz status: 200"* ]]; then
+  fail "healthz status was not reported: ${token_output}"
+fi
+if [[ ! -f "${curl_record}" ]]; then
+  fail "healthz probe never invoked curl"
+fi
+if [[ "$(record_field "${curl_record}" args)" != *"/healthz"* ]]; then
+  fail "healthz probe did not target the /healthz endpoint"
+fi
+if [[ "$(record_field "${curl_record}" args)" != *"https://port-39375-pvelxc-deadline.fake.example.com/healthz"* ]]; then
+  fail "healthz probe did not use the public execd hostname"
+fi
+curl_args="$(record_field "${curl_record}" args)"
+if [[ "${curl_args}" == *"Authorization"* || "${curl_args}" == *"Bearer"* || "${curl_args}" == *"${start_content}"* ]]; then
+  fail "healthz probe carried auth material"
+fi
+if [[ -e "${start_path}" ]]; then
+  fail "token file still exists after the smoke run (EXIT cleanup missing)"
+fi
+if [[ ! -f "${tmp_dir}/execd-token-snapshot-deadline.txt" ]]; then
+  fail "runtime smoke removed the stale template token file instead of ignoring it"
+fi
+
+echo "PASS: each clone gets a fresh disposable 0600 token file cleaned up on exit"
+
+calls_file="${tmp_dir}/calls.skipped"
+if ! skipped_output="$(run_smoke ready "${calls_file}" "${tmp_dir}/start.skipped" "${tmp_dir}/exec.skipped" "${tmp_dir}/curl.skipped" 2>&1)"; then
+  printf '%s\n' "${skipped_output}" >&2
+  fail "runtime smoke must pass when no public domain is configured"
+fi
+if [[ "${skipped_output}" != *"Healthz status: skipped"* ]]; then
+  fail "healthz probe was not skipped without a public domain"
+fi
+if [[ -f "${tmp_dir}/curl.skipped" ]]; then
+  fail "healthz curl was invoked without a public domain"
+fi
+
+echo "PASS: healthz is skipped when no public domain is available"

--- a/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
@@ -39,6 +39,10 @@ printf '%s\n' "${STALE_TOKEN}" >"${tmp_dir}/execd-token-snapshot-deadline.txt"
 chmod 644 "${tmp_dir}/execd-token-snapshot-deadline.txt"
 
 cat >"${tmp_dir}/bash_env" <<'EOF'
+# Unset first so SECONDS is an ordinary variable, not Bash's real-time
+# special one: otherwise a real one-second command sleep accrues wall-clock
+# time and reduces the virtual 600-second probe budget on slow hosts.
+unset SECONDS
 SECONDS=0
 sleep() {
   local duration="${1:-0}"
@@ -178,6 +182,38 @@ EOF
 
 printf '%s\n' '{"results":[{"presetId":"standard","snapshotId":"snapshot-deadline"}]}' >"${tmp_dir}/results.json"
 
+# Focused harness assertion: prove the generated BASH_ENV virtual clock does
+# not accrue real wall time. A real one-second CommandBuiltin sleep must not
+# advance SECONDS; the fake sleep must advance it by exactly its duration.
+clock_focus() {
+  (
+    cd "${tmp_dir}"
+    BASH_ENV="${tmp_dir}/bash_env" bash -s <<'FOCUS_EOF'
+set -euo pipefail
+before="${SECONDS:-0}"
+command sleep 1
+after="${SECONDS:-0}"
+if (( after != before )); then
+  echo "FAIL: real \`command sleep 1\` advanced the virtual clock by $((after - before))s" >&2
+  exit 1
+fi
+sleep 3
+if (( SECONDS != before + 3 )); then
+  echo "FAIL: fake \`sleep 3\` advanced the virtual clock to ${SECONDS}, expected $((before + 3))" >&2
+  exit 1
+fi
+echo "PASS: virtual clock ignores real time; fake sleep advances by exactly three"
+FOCUS_EOF
+  )
+}
+
+# Standalone focus run for TDD: PVE_SMOKE_CLOCK_FOCUS=1 runs only the clock
+# assertion and exits, so the change can be proven red-then-green in isolation.
+if [[ "${PVE_SMOKE_CLOCK_FOCUS:-}" == "1" ]]; then
+  clock_focus || exit 1
+  exit 0
+fi
+
 fail() {
   echo "FAIL: $*" >&2
   exit 1
@@ -223,6 +259,8 @@ record_field() {
 }
 
 echo "=== PVE LXC snapshot runtime-smoke deadline tests ==="
+
+clock_focus
 
 calls_file="${tmp_dir}/calls.success"
 start_record="${tmp_dir}/start.success"

--- a/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
+++ b/scripts/test-pve-lxc-snapshot-runtime-smoke.sh
@@ -70,6 +70,24 @@ record_token_state() {
     fi
   } >"${out_file}"
 }
+# Record the path mktemp returns so cleanup can be asserted even when devsh
+# start is never reached.
+mktemp() {
+  local out
+  out="$(command mktemp "$@")"
+  if [[ -n "${DEVSH_MKTEMP_RECORD:-}" ]]; then
+    printf 'path=%s\n' "${out}" >"${DEVSH_MKTEMP_RECORD}"
+  fi
+  printf '%s\n' "${out}"
+}
+# In-process stand-in that only fails disposable-token generation, proving
+# EXIT cleanup covers failures between mktemp and devsh start.
+python3() {
+  if [[ "${DEVSH_MODE:-}" == "token-gen-fail" && "${2:-}" == *cmux-execd-token* ]]; then
+    return 1
+  fi
+  command python3 "$@"
+}
 devsh() {
   local command_name="${1:-}"
   shift || true
@@ -77,6 +95,26 @@ devsh() {
   case "${command_name}" in
     start)
       record_token_state "${DEVSH_START_RECORD:-/dev/null}"
+
+      local starts=0
+      if [[ -f "${DEVSH_START_COUNT_FILE:-}" ]]; then
+        IFS= read -r starts <"${DEVSH_START_COUNT_FILE}" || true
+      fi
+      starts=$((starts + 1))
+      printf '%s\n' "${starts}" >"${DEVSH_START_COUNT_FILE:-/dev/null}"
+      if [[ -n "${DEVSH_START_RECORD:-}" ]]; then
+        record_token_state "${DEVSH_START_RECORD}.${starts}"
+      fi
+
+      if [[ "${DEVSH_MODE}" == "start-fail" ]]; then
+        echo "devsh start failed" >&2
+        return 1
+      fi
+      if [[ "${DEVSH_MODE}" == "second-start-fails" && "${starts}" -eq 2 ]]; then
+        echo "devsh start failed for second clone" >&2
+        return 1
+      fi
+
       echo "pvelxc-deadline"
       ;;
     exec)
@@ -89,7 +127,7 @@ devsh() {
       calls=$((calls + 1))
       printf '%s\n' "${calls}" >"${DEVSH_CALLS_FILE}"
 
-      if [[ "${DEVSH_MODE}" == "ready" ]]; then
+      if [[ "${DEVSH_MODE}" == "ready" || "${DEVSH_MODE}" == "second-start-fails" ]]; then
         echo "exec_ready"
         return 0
       fi
@@ -105,12 +143,12 @@ devsh() {
       fi
 
       if [[ "${DEVSH_MODE}" == "edge-502" ]]; then
-        echo "Error: failed to execute command: HTTP exec failed for container 227 via candidates: https://port-39375-x.alphasolves.com, http://x.tail715a6.ts.net:39375; last error: execd at https://port-39375-x.alphasolves.com/exec returned HTTP 502" >&2
+        echo "Error: failed to execute command: HTTP exec failed for container 227 via candidates: https://port-39375-x.example.test, http://x.example.test:39375; last error: execd at https://port-39375-x.example.test/exec returned HTTP 502" >&2
         return 1
       fi
 
       if [[ "${DEVSH_MODE}" == "conn-refused" ]]; then
-        echo "Error: failed to execute command: HTTP exec failed for container 227 via candidates: https://port-39375-x.alphasolves.com, http://x.tail715a6.ts.net:39375; last error: request to http://x.tail715a6.ts.net:39375/exec failed: Post \"http://x.tail715a6.ts.net:39375/exec\": dial tcp 10.0.0.5:39375: connect: connection refused" >&2
+        echo "Error: failed to execute command: HTTP exec failed for container 227 via candidates: https://port-39375-x.example.test, http://x.example.test:39375; last error: request to http://x.example.test:39375/exec failed: Post \"http://x.example.test:39375/exec\": dial tcp 192.0.2.10:39375: connect: connection refused" >&2
         return 1
       fi
 
@@ -142,6 +180,9 @@ run_smoke() {
   local curl_record="$5"
   local public_domain="${6:-}"
   local healthz_status="${7:-}"
+  local results_file="${8:-${tmp_dir}/results.json}"
+  local start_count_file="${9:-}"
+  local mktemp_record="${10:-}"
   (
     cd "${tmp_dir}"
     BASH_ENV="${tmp_dir}/bash_env" \
@@ -151,8 +192,10 @@ run_smoke() {
       DEVSH_EXEC_RECORD="${exec_record}" \
       DEVSH_CURL_RECORD="${curl_record}" \
       DEVSH_HEALTHZ_STATUS="${healthz_status}" \
+      DEVSH_START_COUNT_FILE="${start_count_file}" \
+      DEVSH_MKTEMP_RECORD="${mktemp_record}" \
       PVE_PUBLIC_DOMAIN="${public_domain}" \
-      bash "${runtime_dir}/pve-lxc-snapshot-runtime-smoke.sh" "${tmp_dir}/results.json"
+      bash "${runtime_dir}/pve-lxc-snapshot-runtime-smoke.sh" "${results_file}"
   )
 }
 
@@ -194,6 +237,10 @@ if [[ "${deadline_calls}" != "200" ]]; then
 fi
 if [[ "${deadline_output}" != *"exec endpoint unreachable (network)"* ]]; then
   fail "deadline failure lost its network diagnostic"
+fi
+deadline_token_path="$(record_field "${tmp_dir}/start.deadline" path)"
+if [[ -z "${deadline_token_path}" || -e "${deadline_token_path}" ]]; then
+  fail "temporary token file was not removed after readiness failure"
 fi
 
 echo "PASS: readiness probes honor the 600-second deadline"
@@ -327,3 +374,71 @@ if [[ -f "${tmp_dir}/curl.skipped" ]]; then
 fi
 
 echo "PASS: healthz is skipped when no public domain is available"
+
+echo ""
+echo "=== PVE LXC snapshot runtime-smoke cleanup-path tests ==="
+
+# Setup failure: mktemp succeeded but token generation failed. The tracked
+# token array must still remove the temporary file via the EXIT trap.
+calls_file="${tmp_dir}/calls.genfail"
+mktemp_record="${tmp_dir}/mktemp.genfail"
+if genfail_output="$(run_smoke token-gen-fail "${calls_file}" "${tmp_dir}/start.genfail" "${tmp_dir}/exec.genfail" "${tmp_dir}/curl.genfail" "" "" "${tmp_dir}/results.json" "" "${mktemp_record}" 2>&1)"; then
+  printf '%s\n' "${genfail_output}" >&2
+  fail "runtime smoke must fail when token generation fails"
+fi
+genfail_path="$(record_field "${mktemp_record}" path)"
+if [[ -z "${genfail_path}" ]]; then
+  fail "token file path was not recorded at mktemp time"
+fi
+if [[ -e "${genfail_path}" ]]; then
+  fail "temporary token file leaked after token generation failure"
+fi
+
+echo "PASS: EXIT cleanup covers failures between mktemp and devsh start"
+
+# devsh start failure after the token was created.
+calls_file="${tmp_dir}/calls.startfail"
+if startfail_output="$(run_smoke start-fail "${calls_file}" "${tmp_dir}/start.startfail" "${tmp_dir}/exec.startfail" "${tmp_dir}/curl.startfail" 2>&1)"; then
+  printf '%s\n' "${startfail_output}" >&2
+  fail "runtime smoke must fail when devsh start fails"
+fi
+startfail_path="$(record_field "${tmp_dir}/start.startfail" path)"
+if [[ -z "${startfail_path}" || -e "${startfail_path}" ]]; then
+  fail "temporary token file was not removed after devsh start failure"
+fi
+
+echo "PASS: EXIT cleanup removes the token after devsh start failure"
+
+# Two clones: clone 1 succeeds, clone 2 fails at start. The cleanup array
+# must handle the second clone's EXIT path without retaining the first
+# clone's token, and each clone must have had its own fresh token file.
+printf '%s\n' '{"results":[{"presetId":"standard","snapshotId":"snapshot-deadline"},{"presetId":"standard","snapshotId":"snapshot-other"}]}' >"${tmp_dir}/results.two.json"
+calls_file="${tmp_dir}/calls.two"
+start_count_file="${tmp_dir}/starts.two"
+if two_output="$(run_smoke second-start-fails "${calls_file}" "${tmp_dir}/start.two" "${tmp_dir}/exec.two" "${tmp_dir}/curl.two" "" "" "${tmp_dir}/results.two.json" "${start_count_file}" 2>&1)"; then
+  printf '%s\n' "${two_output}" >&2
+  fail "runtime smoke must fail when the second clone's start fails"
+fi
+first_path="$(record_field "${tmp_dir}/start.two.1" path)"
+first_content="$(record_field "${tmp_dir}/start.two.1" content)"
+first_mode="$(record_field "${tmp_dir}/start.two.1" mode)"
+second_path="$(record_field "${tmp_dir}/start.two.2" path)"
+second_content="$(record_field "${tmp_dir}/start.two.2" content)"
+second_mode="$(record_field "${tmp_dir}/start.two.2" mode)"
+if [[ -z "${first_path}" || ! "${first_content}" =~ ^[a-f0-9]{64}$ || "${first_mode}" != "600" ]]; then
+  fail "first clone did not get a fresh 0600 disposable token"
+fi
+if [[ -z "${second_path}" || ! "${second_content}" =~ ^[a-f0-9]{64}$ || "${second_mode}" != "600" ]]; then
+  fail "second clone did not get a fresh 0600 disposable token"
+fi
+if [[ "${first_path}" == "${second_path}" || "${first_content}" == "${second_content}" ]]; then
+  fail "clones did not get independent disposable token files"
+fi
+if [[ -e "${first_path}" || -e "${second_path}" ]]; then
+  fail "a temporary token file survived the two-snapshot run"
+fi
+if [[ "${two_output}" != *"PASS: standard (snapshot-deadline)"* ]]; then
+  fail "first clone did not pass before the second clone failed"
+fi
+
+echo "PASS: two-snapshot EXIT cleanup removes both clones' tokens"

--- a/scripts/test-pve-lxc-token-init.sh
+++ b/scripts/test-pve-lxc-token-init.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Contract test for cmux-token-init token rotation and clone-specific override.
+#
+# Usage: bash scripts/test-pve-lxc-token-init.sh
+#
+# Copies the canonical configs/systemd/bin/cmux-token-init into a temporary
+# fake root (rewriting only its absolute token-file paths into that root),
+# puts controlled cat/openssl executables first in PATH, and verifies:
+#   1. A fresh clone boot ID rotates the token when no override exists.
+#   2. An explicit CMUX_EXECD_AUTH_TOKEN wins over rotation and is mirrored.
+#   3. A matching boot ID with an existing token skips regeneration.
+#   4. The canonical script retains the /proc/1/environ fallback lookup.
+#
+# The live Proxmox `env` integration is exercised by the weekly snapshot
+# smoke clone; this test keeps the generator hermetic.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CANONICAL_SCRIPT="$REPO_ROOT/configs/systemd/bin/cmux-token-init"
+
+# Synthetic 64-hex-char fixtures (never real tokens).
+TEMPLATE_TOKEN="0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e"
+ROTATED_TOKEN="1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f"
+OVERRIDE_TOKEN="abababababababababababababababababababababababababababababababab"
+TEMPLATE_BOOT_ID="template-boot"
+CLONE_BOOT_ID="clone-boot"
+
+FAKE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FAKE_ROOT"' EXIT
+
+mkdir -p "$FAKE_ROOT/bin" "$FAKE_ROOT/root" "$FAKE_ROOT/home/user"
+
+# Controlled executables placed first in PATH.
+cat > "$FAKE_ROOT/bin/cat" <<'EOF'
+#!/bin/bash
+# Controlled cat: returns a fixed boot ID for the kernel boot_id file and
+# delegates everything else to the real cat.
+if [[ "${1:-}" = "/proc/sys/kernel/random/boot_id" ]]; then
+    printf '%s\n' "${FAKE_BOOT_ID:-clone-boot}"
+    exit 0
+fi
+exec /bin/cat "$@"
+EOF
+chmod +x "$FAKE_ROOT/bin/cat"
+
+cat > "$FAKE_ROOT/bin/openssl" <<'EOF'
+#!/bin/bash
+# Controlled openssl: emits a fixed 64-hex token instead of random data.
+printf '%s' "${FAKE_OPENSSL_TOKEN:-1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f}"
+EOF
+chmod +x "$FAKE_ROOT/bin/openssl"
+
+# Copy the canonical script, replacing only its absolute token-file paths.
+sed -e "s|/root/|$FAKE_ROOT/root/|g" -e "s|/home/user/|$FAKE_ROOT/home/user/|g" \
+    "$CANONICAL_SCRIPT" > "$FAKE_ROOT/cmux-token-init"
+chmod +x "$FAKE_ROOT/cmux-token-init"
+
+# Existing template state with boot ID "template-boot".
+seed_template_state() {
+    printf '%s' "$TEMPLATE_TOKEN" > "$FAKE_ROOT/root/.worker-auth-token"
+    printf '%s' "$TEMPLATE_TOKEN" > "$FAKE_ROOT/root/.vscode-token"
+    printf '%s' "$TEMPLATE_BOOT_ID" > "$FAKE_ROOT/root/.token-boot-id"
+    printf '%s' "$TEMPLATE_TOKEN" > "$FAKE_ROOT/home/user/.worker-auth-token"
+    printf '%s' "$TEMPLATE_TOKEN" > "$FAKE_ROOT/home/user/.vscode-token"
+    printf '%s' "$TEMPLATE_BOOT_ID" > "$FAKE_ROOT/home/user/.token-boot-id"
+}
+
+run_token_init() {
+    local boot_id="${1:-$CLONE_BOOT_ID}"
+    local override="${2:-}"
+    (
+        cd "$FAKE_ROOT"
+        export PATH="$FAKE_ROOT/bin:$PATH"
+        export FAKE_BOOT_ID="$boot_id"
+        export FAKE_OPENSSL_TOKEN="$ROTATED_TOKEN"
+        if [[ -n "$override" ]]; then
+            export CMUX_EXECD_AUTH_TOKEN="$override"
+        else
+            unset CMUX_EXECD_AUTH_TOKEN
+        fi
+        "$FAKE_ROOT/cmux-token-init"
+    )
+}
+
+failures=0
+
+assert_file_equals() {
+    local file="$1"
+    local expected="$2"
+    local actual
+    if [[ ! -f "$file" ]]; then
+        echo "FAIL: missing $file (expected: $expected)"
+        failures=$((failures + 1))
+        return
+    fi
+    actual="$(cat "$file")"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "FAIL: $file content mismatch"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        failures=$((failures + 1))
+    else
+        echo "PASS: $file"
+    fi
+}
+
+echo "== [1/4] Clone boot ID rotates token when no override exists =="
+seed_template_state
+run_token_init "$CLONE_BOOT_ID"
+expected="$ROTATED_TOKEN"
+assert_file_equals "$FAKE_ROOT/root/.worker-auth-token" "$expected"
+assert_file_equals "$FAKE_ROOT/root/.vscode-token" "$expected"
+assert_file_equals "$FAKE_ROOT/home/user/.worker-auth-token" "$expected"
+assert_file_equals "$FAKE_ROOT/home/user/.vscode-token" "$expected"
+assert_file_equals "$FAKE_ROOT/root/.token-boot-id" "$CLONE_BOOT_ID"
+
+echo ""
+echo "== [2/4] Explicit CMUX_EXECD_AUTH_TOKEN wins over rotation and is mirrored =="
+seed_template_state
+run_token_init "$CLONE_BOOT_ID" "$OVERRIDE_TOKEN"
+expected="$OVERRIDE_TOKEN"
+assert_file_equals "$FAKE_ROOT/root/.worker-auth-token" "$expected"
+assert_file_equals "$FAKE_ROOT/root/.vscode-token" "$expected"
+assert_file_equals "$FAKE_ROOT/home/user/.worker-auth-token" "$expected"
+assert_file_equals "$FAKE_ROOT/home/user/.vscode-token" "$expected"
+
+echo ""
+echo "== [3/4] Matching boot ID preserves existing tokens when no override exists =="
+seed_template_state
+run_token_init "$TEMPLATE_BOOT_ID"
+expected="$TEMPLATE_TOKEN"
+assert_file_equals "$FAKE_ROOT/root/.worker-auth-token" "$expected"
+assert_file_equals "$FAKE_ROOT/root/.vscode-token" "$expected"
+assert_file_equals "$FAKE_ROOT/home/user/.worker-auth-token" "$expected"
+assert_file_equals "$FAKE_ROOT/home/user/.vscode-token" "$expected"
+
+echo ""
+echo "== [4/4] Canonical script retains the /proc/1/environ fallback lookup =="
+if grep -Fq '/proc/1/environ' "$CANONICAL_SCRIPT"; then
+    echo "PASS: canonical script reads /proc/1/environ"
+else
+    echo "FAIL: canonical script does not read /proc/1/environ"
+    failures=$((failures + 1))
+fi
+
+echo ""
+if [[ "$failures" -gt 0 ]]; then
+    echo "FAILED: $failures assertion(s) failed"
+    exit 1
+fi
+echo "All token-init contract assertions passed."

--- a/scripts/test-snapshot-pvelxc-results.py
+++ b/scripts/test-snapshot-pvelxc-results.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Regression test: snapshot results writing must not persist execd tokens.
+
+The runtime smoke injects a freshly generated disposable execd token per
+clone via PVE_EXECD_TOKEN_FILE; the results writer must never write
+``execd-token-<snapshotId>.txt`` files into the results directory (which is
+uploaded as a GitHub artifact).
+
+Usage: uv run python scripts/test-snapshot-pvelxc-results.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+# Synthetic 64-hex fixture (never a real token).
+SYNTHETIC_TOKEN = "ab" * 32
+
+
+def load_snapshot_pvelxc() -> object:
+    sys.path.insert(0, str(SCRIPT_DIR))
+    spec = importlib.util.spec_from_file_location(
+        "snapshot_pvelxc_results_test", SCRIPT_DIR / "snapshot-pvelxc.py"
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            "could not create import spec for scripts/snapshot-pvelxc.py"
+        )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = load_snapshot_pvelxc()
+WRITE_RESULTS_JSON = MODULE._write_results_json
+
+SAMPLE_RESULTS = [
+    {
+        "presetId": "standard",
+        "snapshotId": "snapshot_abc123",
+        "templateVmid": 9001,
+        "capturedAt": "2026-08-16T00:00:00Z",
+        "node": "pve1",
+        "vcpus": 4,
+        "memoryMib": 8192,
+        "diskSizeMib": 131072,
+    }
+]
+
+
+class ResultsWriterTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _write(self, *, mode: str = "snapshot") -> Path:
+        out_path = self.tmp_path / "results.json"
+        kwargs = dict(
+            out_path=out_path,
+            mode=mode,
+            base_template_vmid=9000,
+            ide_provider="cmux-code",
+            results_payload=SAMPLE_RESULTS,
+        )
+        if "execd_tokens" in inspect.signature(WRITE_RESULTS_JSON).parameters:
+            # Regression guard: if a snapshot-token persistence parameter is
+            # reintroduced, exercise it so the no-token-file assertion below
+            # fails instead of silently passing.
+            kwargs["execd_tokens"] = {9001: SYNTHETIC_TOKEN}
+        WRITE_RESULTS_JSON(**kwargs)
+        return out_path
+
+    def test_results_json_written_without_execd_token_files(self) -> None:
+        out_path = self._write()
+        self.assertTrue(out_path.is_file())
+        self.assertFalse(list(self.tmp_path.glob("execd-token-*.txt")))
+
+    def test_core_result_data_preserved(self) -> None:
+        out_path = self._write()
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+        self.assertEqual(data["schemaVersion"], 1)
+        self.assertEqual(data["mode"], "snapshot")
+        self.assertEqual(data["baseTemplateVmid"], 9000)
+        self.assertEqual(data["ideProvider"], "cmux-code")
+        self.assertIn("generatedAt", data)
+        self.assertEqual(len(data["results"]), 1)
+        result = data["results"][0]
+        self.assertEqual(result["presetId"], "standard")
+        self.assertEqual(result["snapshotId"], "snapshot_abc123")
+        self.assertEqual(result["templateVmid"], 9001)
+        self.assertEqual(result["memoryMib"], 8192)
+        self.assertNotIn("token", result)
+
+    def test_update_mode_results_written_without_execd_token_files(self) -> None:
+        out_path = self._write(mode="update")
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+        self.assertEqual(data["mode"], "update")
+        self.assertEqual(data["results"][0]["presetId"], "standard")
+        self.assertFalse(list(self.tmp_path.glob("execd-token-*.txt")))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Fixes the red **Weekly PVE LXC Snapshot** runtime-smoke failure from [run `31894125424`](https://github.com/karlorz/cmux/actions/runs/31894125424). This supersedes the diagnostics-only approach in #1315; it includes its error-surfacing work and addresses the actual clone authentication failure.

### Root cause

The previous snapshot flow persisted the template's `cmux-execd` token next to `results.json` and reused it for smoke clones. A cloned LXC starts with a fresh boot ID, so `cmux-token-init` correctly rotated the inherited token. The runner then sent the stale template token to `/exec`, which returned HTTP 401.

### What changed

- Generate a fresh 64-character lowercase-hex execd token for each disposable smoke clone, in a mode-`0600` temporary file outside `logs/` and artifacts.
- Inject that token into the clone's Proxmox LXC runtime environment before start, preserving other NUL-separated `env` entries; Proxmox documents this as the format for `lxc.environment.runtime`.
- Make `cmux-token-init` use and validate the injected override while retaining normal boot-ID-based random-token rotation for ordinary clones.
- Reuse the same validated token for post-start `devsh exec` calls, and remove the old `execd-token-*.txt` persistence from snapshot results.
- Delete token-bearing clones on injection, startup, and post-start service-URL failures; remove all temporary token files on smoke-script exit paths.
- Redact execd startup logging so diagnostic artifacts no longer contain an authentication-token prefix.
- Preserve/surface meaningful exec failures: 401 authentication, token fetch/injection, edge HTTP failures, and connection/DNS/timeout failures.
- Make the smoke deadline contract deterministic without changing the production ten-minute deadline, and run the PVE contracts in normal Checks CI without PVE credentials.

## Verification

Passed locally:

- `bash scripts/test-pve-lxc-token-init.sh`
- `bash scripts/test-pve-lxc-snapshot-runtime-smoke.sh`
  - includes the strict 200-probe virtual `600 / 3` deadline assertion
  - also passed three consecutive runs under bounded local CPU pressure
- `uv run --isolated python scripts/test-snapshot-pvelxc-results.py`
- `python3 -m py_compile scripts/snapshot-pvelxc.py`
- `bash -n scripts/pve/pve-lxc-snapshot-runtime-smoke.sh`
- `cd scripts/execd && go vet ./... && go test ./... -count=1`
- `cd packages/devsh && go test ./internal/pvelxc/... -count=1`
- `cd packages/devsh && go test ./... -count=1`
- `bun check` — lint and typecheck pass. Its OpenAPI-generation sub-step reports missing local application environment variables, but the command exits successfully and CI supplies those secrets.
- `git diff --check`

`bun run test` still fails outside this change set, as it does on `origin/main`:

- 32 Convex integration tests require unavailable Stack Auth test credentials.
- Four server tests fail in `src/archiveTask.cmux.test.ts`, `src/utils/server-env.test.ts`, and `src/vscode/CmuxVSCodeInstance.test.ts` due to existing test/mocking behavior.

The branch does not modify `packages/convex`, `apps/server`, or the root `src/` package. The final CI run and a newly dispatched Weekly PVE LXC Snapshot run on `main` after approved merge remain the end-to-end verification gates.
