### PR TITLE
fix(devsh): surface PVE status and version hint on env injection failure

### DIFF
--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -403,7 +403,7 @@ func upsertRuntimeEnv(env, token string) string {
 // existing entries. Errors are sanitized: a PVE response body could echo the
 // submitted env (and with it the token), so only fixed messages plus the HTTP
 // status code are returned. A 400 means PVE rejected the env parameter
-// itself: the LXC runtime env option only exists on PVE 9.0+ (pve-container
+// itself: the LXC runtime env option only exists on PVE 9.1+ (pve-container
 // 6.0.15+), so PVE 8.x hosts always fail this way.
 func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token string) error {
 	cfg, err := c.getContainerConfig(ctx, vmid)
@@ -421,7 +421,7 @@ func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token str
 		return errors.New("update container runtime env failed")
 	}
 	if status == http.StatusBadRequest {
-		return errors.New("update container runtime env failed: PVE rejected the env parameter (HTTP 400); the LXC runtime env option requires PVE 9.0+ (pve-container 6.0.15+)")
+		return errors.New("update container runtime env failed: PVE rejected the env parameter (HTTP 400); the LXC runtime env option requires PVE 9.1+ (pve-container 6.0.15+)")
 	}
 	if status < 200 || status >= 300 {
 		return fmt.Errorf("update container runtime env failed (HTTP %d)", status)

--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -402,9 +402,9 @@ func upsertRuntimeEnv(env, token string) string {
 // runtime env via the authenticated PVE config endpoint, preserving all
 // existing entries. Errors are sanitized: a PVE response body could echo the
 // submitted env (and with it the token), so only fixed messages plus the HTTP
-// status code are returned. A 400 means PVE rejected the env parameter
-// itself: the LXC runtime env option only exists on PVE 9.1+ (pve-container
-// 6.0.15+), so PVE 8.x hosts always fail this way.
+// status code are returned. A 400 may mean that the PVE version does not
+// support the env parameter: the LXC runtime env option requires PVE 9.1+
+// (pve-container 6.0.15+).
 func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token string) error {
 	cfg, err := c.getContainerConfig(ctx, vmid)
 	if err != nil {
@@ -421,7 +421,7 @@ func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token str
 		return errors.New("update container runtime env failed")
 	}
 	if status == http.StatusBadRequest {
-		return errors.New("update container runtime env failed: PVE rejected the env parameter (HTTP 400); the LXC runtime env option requires PVE 9.1+ (pve-container 6.0.15+)")
+		return errors.New("update container runtime env failed: PVE rejected the env parameter (HTTP 400); if env is unsupported, the LXC runtime env option requires PVE 9.1+ (pve-container 6.0.15+)")
 	}
 	if status < 200 || status >= 300 {
 		return fmt.Errorf("update container runtime env failed (HTTP %d)", status)

--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -401,7 +401,10 @@ func upsertRuntimeEnv(env, token string) string {
 // setContainerRuntimeEnv installs the execd smoke token in the container's
 // runtime env via the authenticated PVE config endpoint, preserving all
 // existing entries. Errors are sanitized: a PVE response body could echo the
-// submitted env (and with it the token), so only fixed messages are returned.
+// submitted env (and with it the token), so only fixed messages plus the HTTP
+// status code are returned. A 400 means PVE rejected the env parameter
+// itself: the LXC runtime env option only exists on PVE 9.0+ (pve-container
+// 6.0.15+), so PVE 8.x hosts always fail this way.
 func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token string) error {
 	cfg, err := c.getContainerConfig(ctx, vmid)
 	if err != nil {
@@ -411,10 +414,17 @@ func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token str
 	if err != nil {
 		return errors.New("read container runtime env failed")
 	}
-	if _, err := c.apiRequestData(ctx, http.MethodPut, fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/config", node, vmid), url.Values{
+	_, status, err := c.apiRequestRaw(ctx, http.MethodPut, fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/config", node, vmid), url.Values{
 		"env": []string{upsertRuntimeEnv(cfg.Env, token)},
-	}); err != nil {
+	})
+	if err != nil {
 		return errors.New("update container runtime env failed")
+	}
+	if status == http.StatusBadRequest {
+		return errors.New("update container runtime env failed: PVE rejected the env parameter (HTTP 400); the LXC runtime env option requires PVE 9.0+ (pve-container 6.0.15+)")
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("update container runtime env failed (HTTP %d)", status)
 	}
 	return nil
 }

--- a/packages/devsh/internal/pvelxc/client_test.go
+++ b/packages/devsh/internal/pvelxc/client_test.go
@@ -812,7 +812,7 @@ func TestExecdTokenFileInjectionFailureDeletesClone(t *testing.T) {
 
 // TestExecdTokenFileInjectionErrorSurfacesStatus pins the diagnostics of a
 // rejected runtime-env update: the error must carry the PVE HTTP status (a
-// 400 additionally names the PVE 9.0+ requirement for the LXC env option)
+// 400 additionally names the PVE 9.1+ requirement for the LXC env option)
 // without ever echoing the response body, which contains the submitted env
 // (and with it the token) in the test server's error payloads.
 func TestExecdTokenFileInjectionErrorSurfacesStatus(t *testing.T) {
@@ -828,7 +828,7 @@ func TestExecdTokenFileInjectionErrorSurfacesStatus(t *testing.T) {
 			wantSubstr: []string{
 				"update container runtime env failed",
 				"HTTP 400",
-				"PVE 9.0+",
+				"PVE 9.1+",
 			},
 		},
 		{
@@ -837,7 +837,7 @@ func TestExecdTokenFileInjectionErrorSurfacesStatus(t *testing.T) {
 			wantSubstr: []string{
 				"update container runtime env failed (HTTP 500)",
 			},
-			notSubstr: []string{"PVE 9.0+"},
+			notSubstr: []string{"PVE 9.1+"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/packages/devsh/internal/pvelxc/client_test.go
+++ b/packages/devsh/internal/pvelxc/client_test.go
@@ -810,6 +810,69 @@ func TestExecdTokenFileInjectionFailureDeletesClone(t *testing.T) {
 	}
 }
 
+// TestExecdTokenFileInjectionErrorSurfacesStatus pins the diagnostics of a
+// rejected runtime-env update: the error must carry the PVE HTTP status (a
+// 400 additionally names the PVE 9.0+ requirement for the LXC env option)
+// without ever echoing the response body, which contains the submitted env
+// (and with it the token) in the test server's error payloads.
+func TestExecdTokenFileInjectionErrorSurfacesStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		putStatus  int
+		wantSubstr []string
+		notSubstr  []string
+	}{
+		{
+			name:      "bad request names the PVE 9 requirement",
+			putStatus: http.StatusBadRequest,
+			wantSubstr: []string{
+				"update container runtime env failed",
+				"HTTP 400",
+				"PVE 9.0+",
+			},
+		},
+		{
+			name:      "server error carries only the status",
+			putStatus: http.StatusInternalServerError,
+			wantSubstr: []string{
+				"update container runtime env failed (HTTP 500)",
+			},
+			notSubstr: []string{"PVE 9.0+"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken))
+
+			srv, rec := newStartInstanceTestServer(t, "", tc.putStatus)
+			client := newStartTestClient(t, srv)
+
+			_, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID})
+			if err == nil {
+				t.Fatal("StartInstance() error = nil, want config injection error")
+			}
+			for _, want := range tc.wantSubstr {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("StartInstance() error = %q, want substring %q", err, want)
+				}
+			}
+			for _, unwanted := range tc.notSubstr {
+				if strings.Contains(err.Error(), unwanted) {
+					t.Errorf("StartInstance() error = %q, must not contain %q", err, unwanted)
+				}
+			}
+			if strings.Contains(err.Error(), testExecdToken) {
+				t.Errorf("StartInstance() error leaks the injected token: %v", err)
+			}
+			if idxDelete := rec.index("DELETE /api2/json/nodes/test-node/lxc/200"); idxDelete < 0 {
+				t.Fatalf("clone deletion not requested after injection failure; requests: %v", rec.reqs)
+			}
+			if idxStart := rec.index("POST /api2/json/nodes/test-node/lxc/200/status/start"); idxStart >= 0 {
+				t.Fatalf("start requested despite injection failure; requests: %v", rec.reqs)
+			}
+		})
+	}
+}
+
 // TestStartInstanceDeletesCloneWhenServiceURLUnbuildable exercises the
 // post-start cleanup gap: when no public domain, no DNS search suffix, and
 // no container IP are available, buildServiceURL cannot construct the

--- a/packages/devsh/internal/pvelxc/client_test.go
+++ b/packages/devsh/internal/pvelxc/client_test.go
@@ -791,28 +791,9 @@ func TestExecdTokenFileInvalidContentRejectedBeforeStart(t *testing.T) {
 	}
 }
 
-func TestExecdTokenFileInjectionFailureDeletesClone(t *testing.T) {
-	t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken))
-
-	srv, rec := newStartInstanceTestServer(t, "", http.StatusInternalServerError)
-	client := newStartTestClient(t, srv)
-
-	if _, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID}); err == nil {
-		t.Fatal("StartInstance() error = nil, want config injection error")
-	} else if strings.Contains(err.Error(), testExecdToken) {
-		t.Errorf("StartInstance() error leaks the injected token: %v", err)
-	}
-	if idxDelete := rec.index("DELETE /api2/json/nodes/test-node/lxc/200"); idxDelete < 0 {
-		t.Fatalf("clone deletion not requested after injection failure; requests: %v", rec.reqs)
-	}
-	if idxStart := rec.index("POST /api2/json/nodes/test-node/lxc/200/status/start"); idxStart >= 0 {
-		t.Fatalf("start requested despite injection failure; requests: %v", rec.reqs)
-	}
-}
-
 // TestExecdTokenFileInjectionErrorSurfacesStatus pins the diagnostics of a
 // rejected runtime-env update: the error must carry the PVE HTTP status (a
-// 400 additionally names the PVE 9.1+ requirement for the LXC env option)
+// 400 additionally includes a conditional PVE 9.1+ hint for unsupported env
 // without ever echoing the response body, which contains the submitted env
 // (and with it the token) in the test server's error payloads.
 func TestExecdTokenFileInjectionErrorSurfacesStatus(t *testing.T) {
@@ -823,11 +804,12 @@ func TestExecdTokenFileInjectionErrorSurfacesStatus(t *testing.T) {
 		notSubstr  []string
 	}{
 		{
-			name:      "bad request names the PVE 9 requirement",
+			name:      "bad request includes the PVE 9 hint",
 			putStatus: http.StatusBadRequest,
 			wantSubstr: []string{
 				"update container runtime env failed",
 				"HTTP 400",
+				"if env is unsupported",
 				"PVE 9.1+",
 			},
 		},


### PR DESCRIPTION
## Summary

Follow-up diagnostics for the failed weekly PVE run [31914417182](https://github.com/karlorz/cmux/actions/runs/31914417182). That run died at container creation with the sanitized message `update container runtime env failed`, which hid the cause.

Root cause (verified against Proxmox source): the host runs **PVE 8.4.16**, and the LXC `env` config option that #1316's token injection relies on only exists in **pve-container ≥ 6.0.15 (PVE 9)**. PVE 8.x rejects the config PUT with HTTP 400 (unknown parameter). This PR changes no behavior — it makes the failure self-diagnosing:

- `setContainerRuntimeEnv` now includes the HTTP status code in errors (response bodies stay excluded — they can echo the submitted env, and with it the token).
- On HTTP 400 the error names the requirement: `the LXC runtime env option requires PVE 9.0+ (pve-container 6.0.15+)`.

The weekly workflow stays red until the host is upgraded to PVE 9 or an SSH/console fallback is chosen — this PR only ensures the next failure explains itself in one log line.

## Test plan

- New `TestExecdTokenFileInjectionErrorSurfacesStatus` (subtests: 400 → status + PVE 9.0+ hint; 500 → bare status, no hint; both assert no token leak via the mock's env-echoing error bodies, and clone cleanup still runs).
- `go test ./...` in `packages/devsh` — all packages pass.
- `bun check` — lint + typecheck pass (also via pre-commit hook).