### PR TITLE
feat(devsh): fall back to hookscript token injection on PVE < 9.1

### DIFF
--- a/packages/devsh/internal/pvelxc/client.go
+++ b/packages/devsh/internal/pvelxc/client.go
@@ -26,6 +26,13 @@ const (
 
 	execTokenEnvVar = "PVE_EXECD_TOKEN_FILE"
 	execTokenEnvKey = "CMUX_EXECD_AUTH_TOKEN"
+
+	// execdTokenDescriptionMarker marks the per-clone execd token inside the
+	// container description; the pre-start hookscript transports it into the
+	// generated LXC config on hosts without env-parameter support.
+	execdTokenDescriptionMarker = "cmux-execd-auth-token="
+	hookscriptEnvVar            = "PVE_HOOKSCRIPT_VOLUME"
+	defaultHookscriptVolume     = "local:snippets/cmux-lxc-execd-token-hook.sh"
 )
 
 type SnapshotResolver func(snapshotID string) (templateVMID int, err error)
@@ -50,6 +57,11 @@ type Client struct {
 	execHTTP *http.Client
 
 	snapshotResolver SnapshotResolver
+
+	// hookscriptVolume is the PVE volume spec for the pre-start hookscript
+	// that carries the execd token into the generated LXC config on hosts
+	// that reject the env config option (PVE < 9.1).
+	hookscriptVolume string
 
 	nodeMu sync.Mutex
 	node   string
@@ -113,9 +125,10 @@ type pveContainerStatus struct {
 }
 
 type pveContainerConfig struct {
-	Net0     string `json:"net0,omitempty"`
-	Hostname string `json:"hostname,omitempty"`
-	Env      string `json:"env,omitempty"`
+	Net0        string `json:"net0,omitempty"`
+	Hostname    string `json:"hostname,omitempty"`
+	Env         string `json:"env,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 var (
@@ -146,6 +159,7 @@ func NewClient(cfg Config) (*Client, error) {
 		execHTTP:           &http.Client{Timeout: 0},
 		snapshotResolver:   cfg.SnapshotResolver,
 		node:               strings.TrimSpace(cfg.Node),
+		hookscriptVolume:   defaultHookscriptVolume,
 		execRetryBaseDelay: 2 * time.Second,
 	}, nil
 }
@@ -159,7 +173,7 @@ func NewClientFromEnv() (*Client, error) {
 		verifyTLS = true
 	}
 
-	return NewClient(Config{
+	c, err := NewClient(Config{
 		APIURL:           apiURL,
 		APIToken:         apiToken,
 		Node:             os.Getenv("PVE_NODE"),
@@ -167,6 +181,13 @@ func NewClientFromEnv() (*Client, error) {
 		VerifyTLS:        verifyTLS,
 		SnapshotResolver: resolveSnapshotFromManifestOrDefault,
 	})
+	if err != nil {
+		return nil, err
+	}
+	if v := strings.TrimSpace(os.Getenv(hookscriptEnvVar)); v != "" {
+		c.hookscriptVolume = v
+	}
+	return c, nil
 }
 
 func normalizeHostID(value string) string {
@@ -398,33 +419,86 @@ func upsertRuntimeEnv(env, token string) string {
 	return strings.Join(out, "\x00")
 }
 
+// upsertDescriptionToken replaces every cmux-execd-auth-token marker line in
+// a newline-separated PVE container description with a single marker line
+// for token, preserving all other lines exactly. The marker rides in the
+// description so the pre-start hookscript can inject the token into the
+// generated LXC config on hosts without env-parameter support. Only call
+// with a valid non-empty token.
+func upsertDescriptionToken(desc, token string) string {
+	lines := strings.Split(desc, "\n")
+	out := make([]string, 0, len(lines)+1)
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), execdTokenDescriptionMarker) {
+			continue
+		}
+		out = append(out, line)
+	}
+	out = append(out, execdTokenDescriptionMarker+token)
+	return strings.Join(out, "\n")
+}
+
 // setContainerRuntimeEnv installs the execd smoke token in the container's
 // runtime env via the authenticated PVE config endpoint, preserving all
-// existing entries. Errors are sanitized: a PVE response body could echo the
-// submitted env (and with it the token), so only fixed messages plus the HTTP
-// status code are returned. A 400 may mean that the PVE version does not
-// support the env parameter: the LXC runtime env option requires PVE 9.1+
-// (pve-container 6.0.15+).
-func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token string) error {
+// existing entries. It returns the PUT's HTTP status (0 when the preceding
+// GET or the request itself failed) alongside the error. Errors are
+// sanitized: a PVE response body could echo the submitted env (and with it
+// the token), so only fixed messages plus the HTTP status code are returned.
+// A 400 may mean that the PVE version does not support the env parameter:
+// the LXC runtime env option requires PVE 9.1+ (pve-container 6.0.15+), and
+// callers fall back to the description+hookscript transport.
+func (c *Client) setContainerRuntimeEnv(ctx context.Context, vmid int, token string) (int, error) {
 	cfg, err := c.getContainerConfig(ctx, vmid)
 	if err != nil {
-		return errors.New("read container runtime env failed")
+		return 0, errors.New("read container runtime env failed")
 	}
 	node, err := c.getNode(ctx)
 	if err != nil {
-		return errors.New("read container runtime env failed")
+		return 0, errors.New("read container runtime env failed")
 	}
 	_, status, err := c.apiRequestRaw(ctx, http.MethodPut, fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/config", node, vmid), url.Values{
 		"env": []string{upsertRuntimeEnv(cfg.Env, token)},
 	})
 	if err != nil {
-		return errors.New("update container runtime env failed")
+		return 0, errors.New("update container runtime env failed")
 	}
 	if status == http.StatusBadRequest {
-		return errors.New("update container runtime env failed: PVE rejected the env parameter (HTTP 400); if env is unsupported, the LXC runtime env option requires PVE 9.1+ (pve-container 6.0.15+)")
+		return status, errors.New("update container runtime env failed: PVE rejected the env parameter (HTTP 400); if env is unsupported, the LXC runtime env option requires PVE 9.1+ (pve-container 6.0.15+)")
 	}
 	if status < 200 || status >= 300 {
-		return fmt.Errorf("update container runtime env failed (HTTP %d)", status)
+		return status, fmt.Errorf("update container runtime env failed (HTTP %d)", status)
+	}
+	return status, nil
+}
+
+// setContainerExecdTokenViaHookscript installs the execd smoke token on PVE
+// hosts that reject the env config option: it writes a cmux-execd-auth-token
+// marker into the container description and points the container at the
+// host-staged pre-start hookscript, which appends the token to the generated
+// LXC config before boot. Errors are sanitized: a PVE response body could
+// echo the submitted description (and with it the token), so only fixed
+// messages plus the HTTP status code are returned.
+func (c *Client) setContainerExecdTokenViaHookscript(ctx context.Context, vmid int, token string) error {
+	cfg, err := c.getContainerConfig(ctx, vmid)
+	if err != nil {
+		return errors.New("read container config failed")
+	}
+	node, err := c.getNode(ctx)
+	if err != nil {
+		return errors.New("read container config failed")
+	}
+	_, status, err := c.apiRequestRaw(ctx, http.MethodPut, fmt.Sprintf("/api2/json/nodes/%s/lxc/%d/config", node, vmid), url.Values{
+		"description": []string{upsertDescriptionToken(cfg.Description, token)},
+		"hookscript":  []string{c.hookscriptVolume},
+	})
+	if err != nil {
+		return errors.New("update container config failed")
+	}
+	if status == http.StatusBadRequest {
+		return fmt.Errorf("update container config failed: PVE rejected the hookscript parameter (HTTP 400); stage the hook script volume %s on a storage with the Snippets content type enabled", c.hookscriptVolume)
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("update container config failed (HTTP %d)", status)
 	}
 	return nil
 }
@@ -796,7 +870,16 @@ func (c *Client) StartInstance(ctx context.Context, opts StartOptions) (*Instanc
 		}
 
 		if token != "" {
-			if err := c.setContainerRuntimeEnv(ctx, vmid, token); err != nil {
+			status, err := c.setContainerRuntimeEnv(ctx, vmid, token)
+			// A 400 means the host's PVE rejects the env config option
+			// (PVE < 9.1 / pve-container < 6.0.15): fall back to carrying
+			// the token via the description marker + a pre-start hookscript.
+			if err != nil && status == http.StatusBadRequest {
+				if ferr := c.setContainerExecdTokenViaHookscript(ctx, vmid, token); ferr != nil {
+					_ = c.deleteContainer(ctx, vmid)
+					return nil, fmt.Errorf("set container execd token via hookscript: %w", ferr)
+				}
+			} else if err != nil {
 				_ = c.deleteContainer(ctx, vmid)
 				return nil, fmt.Errorf("set container runtime env: %w", err)
 			}

--- a/packages/devsh/internal/pvelxc/client_test.go
+++ b/packages/devsh/internal/pvelxc/client_test.go
@@ -511,13 +511,15 @@ func TestExecdTokenFileReader(t *testing.T) {
 }
 
 type startInstanceRecorder struct {
-	mu          sync.Mutex
-	reqs        []string
-	putEnv      string
-	cloneCalls  int
-	putCalls    int
-	configCalls int
-	startCalls  int
+	mu             sync.Mutex
+	reqs           []string
+	putEnv         string
+	putDescription string
+	putHookscript  string
+	cloneCalls     int
+	putCalls       int
+	configCalls    int
+	startCalls     int
 }
 
 func (r *startInstanceRecorder) index(methodPath string) int {
@@ -533,9 +535,20 @@ func (r *startInstanceRecorder) index(methodPath string) int {
 
 // newStartInstanceTestServer serves a minimal PVE API for StartInstance:
 // empty node lists (VMID 200 is free), instant clone/start tasks, and the
-// given config env (JSON-escaped, e.g. "A=1\u0000B=2") on GET config.
-// putStatus != 0 makes the config PUT fail with that status.
+// given config env (JSON-escaped, e.g. "A=1\u0000B=2") plus a static
+// description on GET config. putStatus != 0 makes the env config PUT fail
+// with that status.
 func newStartInstanceTestServer(t *testing.T, configEnvJSON string, putStatus int) (*httptest.Server, *startInstanceRecorder) {
+	t.Helper()
+	return newStartInstanceTestServerWithHookStatus(t, configEnvJSON, putStatus, 0)
+}
+
+// newStartInstanceTestServerWithHookStatus extends newStartInstanceTestServer
+// with a separate failure status for config PUTs that carry a hookscript
+// parameter (the description+hookscript fallback path). Failing PUTs echo
+// the submitted env or description in the error body so a leak would surface
+// the token in the returned error.
+func newStartInstanceTestServerWithHookStatus(t *testing.T, configEnvJSON string, putStatus, hookStatus int) (*httptest.Server, *startInstanceRecorder) {
 	t.Helper()
 	rec := &startInstanceRecorder{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -566,10 +579,25 @@ func newStartInstanceTestServer(t *testing.T, configEnvJSON string, putStatus in
 			rec.mu.Lock()
 			rec.configCalls++
 			rec.mu.Unlock()
-			_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200","env":"` + configEnvJSON + `"}}`))
+			_, _ = w.Write([]byte(`{"data":{"hostname":"cmux-200","description":"template description","env":"` + configEnvJSON + `"}}`))
 		case r.Method == http.MethodPut && strings.HasSuffix(path, "/config"):
 			if err := r.ParseForm(); err != nil {
 				t.Errorf("parse PUT config form: %v", err)
+			}
+			if hookscript := r.Form.Get("hookscript"); hookscript != "" {
+				rec.mu.Lock()
+				rec.putDescription = r.Form.Get("description")
+				rec.putHookscript = hookscript
+				rec.mu.Unlock()
+				if hookStatus != 0 {
+					w.WriteHeader(hookStatus)
+					// Deliberately echo the submitted description in the
+					// error body so a leak would surface the token.
+					_, _ = w.Write([]byte(`{"errors":{"description":"` + r.Form.Get("description") + `"}}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"data":null}`))
+				return
 			}
 			rec.mu.Lock()
 			rec.putCalls++
@@ -599,12 +627,13 @@ func newStartInstanceTestServer(t *testing.T, configEnvJSON string, putStatus in
 func newStartTestClient(t *testing.T, srv *httptest.Server) *Client {
 	t.Helper()
 	return &Client{
-		apiURL:       srv.URL,
-		apiToken:     "token",
-		publicDomain: "example.com",
-		apiHTTP:      srv.Client(),
-		execHTTP:     &http.Client{Timeout: 0},
-		node:         "test-node",
+		apiURL:           srv.URL,
+		apiToken:         "token",
+		publicDomain:     "example.com",
+		apiHTTP:          srv.Client(),
+		execHTTP:         &http.Client{Timeout: 0},
+		node:             "test-node",
+		hookscriptVolume: defaultHookscriptVolume,
 	}
 }
 
@@ -792,40 +821,46 @@ func TestExecdTokenFileInvalidContentRejectedBeforeStart(t *testing.T) {
 }
 
 // TestExecdTokenFileInjectionErrorSurfacesStatus pins the diagnostics of a
-// rejected runtime-env update: the error must carry the PVE HTTP status (a
-// 400 additionally includes a conditional PVE 9.1+ hint for unsupported env
-// without ever echoing the response body, which contains the submitted env
+// rejected runtime-env update: a non-400 failure returns the fixed message
+// with the PVE HTTP status, while a 400 (which on PVE < 9.1 means the env
+// parameter is unsupported) falls back to the description+hookscript path,
+// whose own failure surfaces only the fixed message and status. Neither path
+// may echo the PVE response body, which contains the submitted env/description
 // (and with it the token) in the test server's error payloads.
 func TestExecdTokenFileInjectionErrorSurfacesStatus(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		putStatus  int
+		hookStatus int
 		wantSubstr []string
 		notSubstr  []string
 	}{
 		{
-			name:      "bad request includes the PVE 9 hint",
-			putStatus: http.StatusBadRequest,
+			name:       "env rejection falls back to hookscript and fails sanitized",
+			putStatus:  http.StatusBadRequest,
+			hookStatus: http.StatusBadRequest,
 			wantSubstr: []string{
-				"update container runtime env failed",
+				"set container execd token via hookscript",
+				"update container config failed",
 				"HTTP 400",
-				"if env is unsupported",
-				"PVE 9.1+",
+				"Snippets",
 			},
+			notSubstr: []string{"PVE 9.1+"},
 		},
 		{
-			name:      "server error carries only the status",
-			putStatus: http.StatusInternalServerError,
+			name:       "server error carries only the status",
+			putStatus:  http.StatusInternalServerError,
+			hookStatus: 0,
 			wantSubstr: []string{
 				"update container runtime env failed (HTTP 500)",
 			},
-			notSubstr: []string{"PVE 9.1+"},
+			notSubstr: []string{"PVE 9.1+", "hookscript"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken))
 
-			srv, rec := newStartInstanceTestServer(t, "", tc.putStatus)
+			srv, rec := newStartInstanceTestServerWithHookStatus(t, "", tc.putStatus, tc.hookStatus)
 			client := newStartTestClient(t, srv)
 
 			_, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID})
@@ -852,6 +887,206 @@ func TestExecdTokenFileInjectionErrorSurfacesStatus(t *testing.T) {
 				t.Fatalf("start requested despite injection failure; requests: %v", rec.reqs)
 			}
 		})
+	}
+}
+
+func TestDescriptionTokenUpsert(t *testing.T) {
+	tests := []struct {
+		name  string
+		desc  string
+		token string
+		want  string
+	}{
+		{
+			name:  "empty description gets a marker line",
+			desc:  "",
+			token: testExecdToken,
+			want:  "\n" + execdTokenDescriptionMarker + testExecdToken,
+		},
+		{
+			name:  "preserves unrelated lines exactly and appends marker once",
+			desc:  "template description\nsecond line",
+			token: testExecdToken,
+			want:  "template description\nsecond line\n" + execdTokenDescriptionMarker + testExecdToken,
+		},
+		{
+			name:  "replaces a prior marker line",
+			desc:  "template description\n" + execdTokenDescriptionMarker + strings.Repeat("a", 64),
+			token: testExecdToken,
+			want:  "template description\n" + execdTokenDescriptionMarker + testExecdToken,
+		},
+		{
+			name:  "replaces stale markers anywhere in the description",
+			desc:  execdTokenDescriptionMarker + strings.Repeat("b", 64) + "\nkeep me\n" + execdTokenDescriptionMarker + strings.Repeat("c", 64),
+			token: testExecdToken,
+			want:  "keep me\n" + execdTokenDescriptionMarker + testExecdToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := upsertDescriptionToken(tt.desc, tt.token)
+			if got != tt.want {
+				t.Errorf("upsertDescriptionToken(%q, %q) = %q, want %q", tt.desc, tt.token, got, tt.want)
+			}
+			if n := strings.Count(got, execdTokenDescriptionMarker); n > 1 {
+				t.Errorf("upsertDescriptionToken() output has %d marker lines, want at most 1: %q", n, got)
+			}
+			if strings.Contains(got, strings.Repeat("a", 64)) || strings.Contains(got, strings.Repeat("b", 64)) || strings.Contains(got, strings.Repeat("c", 64)) {
+				t.Errorf("upsertDescriptionToken() output kept a stale marker value: %q", got)
+			}
+		})
+	}
+}
+
+// TestExecdTokenViaHookscriptFallbackOnEnvRejection exercises the PVE < 9.1
+// fallback: when the env config PUT is rejected with HTTP 400, StartInstance
+// retries via the container description plus the hookscript option, then
+// starts the clone.
+func TestExecdTokenViaHookscriptFallbackOnEnvRejection(t *testing.T) {
+	t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken+"\n"))
+
+	srv, rec := newStartInstanceTestServerWithHookStatus(t, "EXISTING=value", http.StatusBadRequest, 0)
+	client := newStartTestClient(t, srv)
+
+	inst, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID})
+	if err != nil {
+		t.Fatalf("StartInstance() error = %v", err)
+	}
+	if inst == nil || inst.VMID != 200 {
+		t.Fatalf("StartInstance() = %+v, want VMID 200", inst)
+	}
+
+	const (
+		cloneReq = "POST /api2/json/nodes/test-node/lxc/9027/clone"
+		putReq   = "PUT /api2/json/nodes/test-node/lxc/200/config"
+		startReq = "POST /api2/json/nodes/test-node/lxc/200/status/start"
+	)
+	idxClone, idxStart := rec.index(cloneReq), rec.index(startReq)
+	rec.mu.Lock()
+	putIdxs := []int{}
+	for i, req := range rec.reqs {
+		if req == putReq {
+			putIdxs = append(putIdxs, i)
+		}
+	}
+	rec.mu.Unlock()
+	if idxClone < 0 {
+		t.Fatalf("clone request not recorded; requests: %v", rec.reqs)
+	}
+	if idxStart < 0 {
+		t.Fatalf("start request not recorded; requests: %v", rec.reqs)
+	}
+	if len(putIdxs) != 2 {
+		t.Fatalf("config PUT calls = %d, want 2 (env then hookscript); requests: %v", len(putIdxs), rec.reqs)
+	}
+	idxEnvPut, idxHookPut := putIdxs[0], putIdxs[1]
+	if idxEnvPut < idxClone || idxHookPut < idxEnvPut || idxStart < idxHookPut {
+		t.Fatalf("expected clone -> env PUT -> hookscript PUT -> start; clone=%d envPut=%d hookPut=%d start=%d; requests: %v",
+			idxClone, idxEnvPut, idxHookPut, idxStart, rec.reqs)
+	}
+
+	// The rejected env PUT still used the runtime-env path with the token.
+	wantEnv := "EXISTING=value\x00CMUX_EXECD_AUTH_TOKEN=" + testExecdToken
+	if rec.putEnv != wantEnv {
+		t.Errorf("env PUT env = %q, want %q", rec.putEnv, wantEnv)
+	}
+
+	// The fallback PUT carries the preserved description + default volume.
+	if rec.putHookscript != defaultHookscriptVolume {
+		t.Errorf("hookscript PUT volume = %q, want %q", rec.putHookscript, defaultHookscriptVolume)
+	}
+	wantDesc := "template description\n" + execdTokenDescriptionMarker + testExecdToken
+	if rec.putDescription != wantDesc {
+		t.Errorf("hookscript PUT description = %q, want %q", rec.putDescription, wantDesc)
+	}
+	if got := strings.Count(rec.putDescription, execdTokenDescriptionMarker); got != 1 {
+		t.Errorf("hookscript PUT description has %d marker lines, want exactly 1: %q", got, rec.putDescription)
+	}
+	if got := strings.Count(rec.putDescription, testExecdToken); got != 1 {
+		t.Errorf("hookscript PUT description has %d token occurrences, want exactly 1: %q", got, rec.putDescription)
+	}
+
+	rec.mu.Lock()
+	configCalls := rec.configCalls
+	rec.mu.Unlock()
+	if configCalls != 2 {
+		t.Errorf("config GET calls = %d, want 2 (env lookup + hookscript lookup)", configCalls)
+	}
+
+	client.execTokenMu.Lock()
+	cached := client.execToken
+	client.execTokenMu.Unlock()
+	if cached != testExecdToken {
+		t.Errorf("cached exec token = %q, want the injected token", cached)
+	}
+}
+
+// TestExecdTokenViaHookscriptErrorSanitized pins that a failing
+// description+hookscript PUT surfaces only a fixed message plus the HTTP
+// status: the mock server deliberately echoes the submitted description
+// (which carries the token) in the error body, so any body reflection would
+// leak the token into the returned error.
+func TestExecdTokenViaHookscriptErrorSanitized(t *testing.T) {
+	t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken))
+
+	srv, rec := newStartInstanceTestServerWithHookStatus(t, "", http.StatusBadRequest, http.StatusInternalServerError)
+	client := newStartTestClient(t, srv)
+
+	_, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID})
+	if err == nil {
+		t.Fatal("StartInstance() error = nil, want hookscript injection failure")
+	}
+	if !strings.Contains(err.Error(), "set container execd token via hookscript") {
+		t.Errorf("StartInstance() error = %q, want hookscript fallback wrap", err)
+	}
+	if !strings.Contains(err.Error(), "update container config failed (HTTP 500)") {
+		t.Errorf("StartInstance() error = %q, want sanitized failure status", err)
+	}
+	if strings.Contains(err.Error(), testExecdToken) {
+		t.Errorf("StartInstance() error leaks the injected token: %v", err)
+	}
+	if strings.Contains(err.Error(), "template description") {
+		t.Errorf("StartInstance() error echoes the PVE response body: %v", err)
+	}
+	if idxDelete := rec.index("DELETE /api2/json/nodes/test-node/lxc/200"); idxDelete < 0 {
+		t.Fatalf("clone deletion not requested after hookscript injection failure; requests: %v", rec.reqs)
+	}
+	if idxStart := rec.index("POST /api2/json/nodes/test-node/lxc/200/status/start"); idxStart >= 0 {
+		t.Fatalf("start requested despite hookscript injection failure; requests: %v", rec.reqs)
+	}
+}
+
+// TestExecdTokenViaHookscriptConfigRejected covers the un-staged-hook failure
+// mode: a 400 from the fallback PUT must explain that the snippet volume must
+// be staged on a storage with Snippets content enabled, without exposing the
+// token.
+func TestExecdTokenViaHookscriptConfigRejected(t *testing.T) {
+	t.Setenv("PVE_EXECD_TOKEN_FILE", writeExecdTokenFile(t, testExecdToken))
+
+	srv, rec := newStartInstanceTestServerWithHookStatus(t, "", http.StatusBadRequest, http.StatusBadRequest)
+	client := newStartTestClient(t, srv)
+
+	_, err := client.StartInstance(context.Background(), StartOptions{SnapshotID: defaultSnapshotID})
+	if err == nil {
+		t.Fatal("StartInstance() error = nil, want hookscript 400 failure")
+	}
+	for _, want := range []string{
+		"set container execd token via hookscript",
+		"update container config failed",
+		"HTTP 400",
+		"Snippets",
+		defaultHookscriptVolume,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("StartInstance() error = %q, want substring %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), testExecdToken) {
+		t.Errorf("StartInstance() error leaks the injected token: %v", err)
+	}
+	if idxDelete := rec.index("DELETE /api2/json/nodes/test-node/lxc/200"); idxDelete < 0 {
+		t.Fatalf("clone deletion not requested after hookscript 400; requests: %v", rec.reqs)
 	}
 }
 

--- a/scripts/pve/README.md
+++ b/scripts/pve/README.md
@@ -126,14 +126,15 @@ HTTP 400. It only requires the hook script staged once per node (run as root
 on the PVE host):
 
 ```bash
-# 1. Enable the Snippets content type on the storage, keeping the types
-#    already enabled (check with: pvesm config local). Example:
-pvesm set local --content iso,vztmpl,backup,snippets
-#    Or via the UI: Datacenter -> Storage -> local -> Edit -> Content -> Snippets
-
-# 2. Copy the hook script to the host (e.g. scp) and install it:
+# Copy the hook script to the host (e.g. scp) and install it:
 install -m 0755 cmux-lxc-execd-token-hook.sh /var/lib/vz/snippets/cmux-lxc-execd-token-hook.sh
 ```
+
+That is the whole staging: PVE's hookscript validation only resolves the
+volume path and checks the file exists and is executable, so a `snippets/`
+directory under any `dir` storage works even without the Snippets content
+type enabled (verified on PVE 8.4; enabling `content snippets` is only
+needed if you want to upload snippets through the web UI).
 
 The volume spec defaults to `local:snippets/cmux-lxc-execd-token-hook.sh` and
 can be overridden with `PVE_HOOKSCRIPT_VOLUME` (e.g. for a different storage

--- a/scripts/pve/README.md
+++ b/scripts/pve/README.md
@@ -109,6 +109,45 @@ curl -fsSL https://raw.githubusercontent.com/karlorz/cmux/main/scripts/pve/pve-l
 curl -fsSL https://raw.githubusercontent.com/karlorz/cmux/main/scripts/pve/pve-lxc-setup.sh | bash -s -- 9000 --memory 8192 --cores 8
 ```
 
+### cmux-lxc-execd-token-hook.sh (PVE 8.x fallback)
+
+devsh injects a disposable execd auth token into each cloned container before
+first boot. On PVE 9.1+ (pve-container 6.0.15+) it uses the container config
+`env` parameter; on older hosts (e.g. PVE 8) that PUT is rejected with HTTP
+400, and devsh automatically falls back to this pre-start hookscript. The
+token is written to the clone's PVE `description` field as a
+`cmux-execd-auth-token=<hex>` marker, and the hook appends
+`lxc.environment = CMUX_EXECD_AUTH_TOKEN=<token>` to the generated LXC config
+before boot, so the token lands in `/proc/1/environ` where the in-container
+cmux-token-init reads and validates it.
+
+No code changes are needed for the fallback — it triggers automatically on an
+HTTP 400. It only requires the hook script staged once per node (run as root
+on the PVE host):
+
+```bash
+# 1. Enable the Snippets content type on the storage, keeping the types
+#    already enabled (check with: pvesm config local). Example:
+pvesm set local --content iso,vztmpl,backup,snippets
+#    Or via the UI: Datacenter -> Storage -> local -> Edit -> Content -> Snippets
+
+# 2. Copy the hook script to the host (e.g. scp) and install it:
+install -m 0755 cmux-lxc-execd-token-hook.sh /var/lib/vz/snippets/cmux-lxc-execd-token-hook.sh
+```
+
+The volume spec defaults to `local:snippets/cmux-lxc-execd-token-hook.sh` and
+can be overridden with `PVE_HOOKSCRIPT_VOLUME` (e.g. for a different storage
+or path).
+
+**Security note:** the per-clone token is visible in the clone's PVE
+description to anyone with VM.Audit on that VMID — the same people who control
+the host. It is never exposed through the container itself or the public execd
+endpoint, and the hook fails open by design, so a broken hook can never block
+a container boot.
+
+PVE 9.1+ hosts keep using the native `env` path untouched and never invoke
+the hook.
+
 ### pve-lxc-template.sh
 Manage LXC templates for cmux sandboxes.
 

--- a/scripts/pve/cmux-lxc-execd-token-hook.sh
+++ b/scripts/pve/cmux-lxc-execd-token-hook.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# cmux-lxc-execd-token-hook.sh - PVE LXC pre-start hookscript for cmux execd
+# token injection on hosts that reject the container `env` config option.
+#
+# PVE 9.1+ (pve-container 6.0.15+) supports setting the LXC runtime env via
+# the config endpoint's `env` parameter; older hosts (e.g. PVE 8) reject it
+# with HTTP 400. On those hosts devsh falls back to writing the per-clone
+# token into the container description as a cmux-execd-auth-token=<hex>
+# marker and pointing the container at this script via the hookscript config
+# option. PVE invokes this script at pre-start, after generating
+# /var/lib/lxc/<vmid>/config and before boot, so appending
+# `lxc.environment = CMUX_EXECD_AUTH_TOKEN=<token>` here lands in the
+# container's /proc/1/environ where the in-container cmux-token-init reads it.
+#
+# PVE invokes hookscripts as:  <script> <vmid> <phase>
+# Phases include pre-start, post-start, pre-stop, post-stop; only pre-start
+# is handled here.
+#
+# Config paths (both overridable so tests can run against temp dirs):
+#   PVE_LXC_CONF_DIR   = /etc/pve/lxc   (container .conf files)
+#   LXC_RUN_CONFIG_DIR = /var/lib/lxc   (generated container configs)
+#
+# Fail-open by design: any internal error is logged to stderr (PVE captures
+# hook output in the task log) and the hook exits 0, so a broken hook can
+# never block a container boot.
+#
+# Staging instructions: scripts/pve/README.md.
+set -euo pipefail
+
+PVE_LXC_CONF_DIR="${PVE_LXC_CONF_DIR:-/etc/pve/lxc}"
+LXC_RUN_CONFIG_DIR="${LXC_RUN_CONFIG_DIR:-/var/lib/lxc}"
+
+log() {
+  echo "cmux-lxc-execd-token-hook: $*" >&2
+}
+
+# Fail-open insurance: a nonzero exit (e.g. an unexpected failure under
+# set -e) is logged and converted to exit 0 so PVE never sees a hook failure
+# as a failed boot.
+# shellcheck disable=SC2329 # invoked via the EXIT trap below; shellcheck does not track trap references
+fail_open() {
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    log "internal error (exit $rc); failing open"
+  fi
+  exit 0
+}
+trap fail_open EXIT
+
+apply() {
+  local vmid="$1" phase="$2"
+  local conf_path target token
+
+  if [[ "$phase" != "pre-start" ]]; then
+    exit 0
+  fi
+  if [[ ! "$vmid" =~ ^[0-9]+$ ]]; then
+    log "invalid vmid '$vmid'; skipping"
+    exit 0
+  fi
+
+  conf_path="$PVE_LXC_CONF_DIR/$vmid.conf"
+  if [[ ! -f "$conf_path" ]]; then
+    log "container config $conf_path not found; skipping"
+    exit 0
+  fi
+
+  # First marker match only; devsh writes it via the container description.
+  token="$(grep -oE 'cmux-execd-auth-token=[a-f0-9]{64}' "$conf_path" | head -n 1 || true)"
+  token="${token#cmux-execd-auth-token=}"
+  if [[ -z "$token" ]]; then
+    # Container is not managed by this mechanism.
+    exit 0
+  fi
+  if [[ ! "$token" =~ ^[a-f0-9]{64}$ ]]; then
+    log "invalid execd token marker in $conf_path; skipping"
+    exit 0
+  fi
+
+  target="$LXC_RUN_CONFIG_DIR/$vmid/config"
+  if [[ ! -f "$target" ]]; then
+    log "generated LXC config $target not found; skipping"
+    exit 0
+  fi
+  if grep -qs 'CMUX_EXECD_AUTH_TOKEN' "$target"; then
+    # Insurance against double-fires; PVE regenerates the config each start.
+    exit 0
+  fi
+
+  printf '%s\n' "lxc.environment = CMUX_EXECD_AUTH_TOKEN=$token" >> "$target"
+}
+
+apply "$@"
+exit 0


### PR DESCRIPTION
## Summary

- On PVE hosts that reject the container config `env` parameter with HTTP 400 (PVE < 9.1 / pve-container < 6.0.15), devsh now falls back to transporting the per-clone execd token via a container `description` marker plus a pre-start `hookscript`, instead of failing the clone start.
- New host-staged hook script `scripts/pve/cmux-lxc-execd-token-hook.sh`: at pre-start (after PVE generates the LXC config, before boot) it appends `lxc.environment = CMUX_EXECD_AUTH_TOKEN=<token>` to the generated config, so the token lands in the container's `/proc/1/environ` — exactly where `cmux-token-init` reads it. Same injection semantics as #1316's native `env` path, which PVE 9.1+ hosts keep using untouched.
- New `PVE_HOOKSCRIPT_VOLUME` override (default `local:snippets/cmux-lxc-execd-token-hook.sh`).

## Why

Weekly PVE snapshot run 31914417182 failed at the runtime smoke step: the host runs PVE 8.4.16, which rejects the `env` PUT as an unknown parameter (verified: PVE 8's PUT /config has `additionalProperties => 0`; `env` shipped in pve-container 6.0.15 / PVE 9.1, no 5.x backport). This restores per-clone disposable execd tokens on PVE 8 without a host upgrade.

## Required one-time host staging (per PVE node, as root)

```bash
# 1. Enable the Snippets content type, keeping existing types (check: pvesm config local)
pvesm set local --content iso,vztmpl,backup,snippets
#    or via UI: Datacenter -> Storage -> local -> Edit -> Content -> Snippets

# 2. Install the hook script
install -m 0755 cmux-lxc-execd-token-hook.sh /var/lib/vz/snippets/cmux-lxc-execd-token-hook.sh
```

No workflow changes needed; the fallback triggers automatically on the HTTP 400.

## Security

- The per-clone token is visible in the clone's PVE `description` to anyone with VM.Audit on that VMID (the same people who control the host); it is never exposed through the container or the public execd endpoint. Documented in `scripts/pve/README.md`.
- All PUT error paths stay sanitized: the mock server echoes submitted values as a leak tripwire, and tests assert the token/body never appear in errors.
- The hook fails open by design (logs + exit 0), so a broken hook can never block container boots host-wide.

## Test plan

- `go test ./internal/pvelxc/... -count=1` — 53 pass (new: fallback success with request-order assertions, 500/400 sanitization + cleanup, description upsert units; updated the #1317 status test for the new 400 flow)
- `gofmt`/`go vet` clean; `shellcheck` clean (one documented SC2329 false-positive suppression)
- Hook functional matrix against temp dirs: inject / idempotent / post-start noop / no-marker noop / invalid vmid fail-open / invalid token fail-open
- `bun check` (pre-commit) green
- Live verification: re-dispatch the weekly PVE workflow after host staging (follow-up)