### PR TITLE
fix(docker): install Claude Code via npm in the worker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -365,6 +365,7 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 COPY configs/ide-deps.json ./configs/ide-deps.json
 COPY scripts/bump-ide-deps.ts ./scripts/bump-ide-deps.ts
 COPY scripts/apply-ide-deps-package-overrides.ts ./scripts/apply-ide-deps-package-overrides.ts
+COPY scripts/print-ide-deps-package-installs.ts ./scripts/print-ide-deps-package-installs.ts
 COPY scripts/lib ./scripts/lib
 COPY scripts/snapshot.py ./scripts/snapshot.py
 COPY Dockerfile ./Dockerfile
@@ -377,6 +378,7 @@ RUN if [ -n "${IDE_DEPS_PACKAGE_OVERRIDES:-}" ]; then \
     else \
       echo "No IDE_DEPS_PACKAGE_OVERRIDES provided; skipping."; \
     fi
+RUN bun run ./scripts/print-ide-deps-package-installs.ts > /cmux/configs/ide-deps-installs.txt
 
 RUN mkdir -p /builtins && \
   echo '{"name":"builtins","type":"module","version":"1.0.0"}' > /builtins/package.json
@@ -880,38 +882,24 @@ RUN curl -fsSL https://bun.sh/install | bash && \
 ENV PATH="/usr/local/bin:$PATH"
 ENV BUN_INSTALL_CACHE_DIR=/cmux/node_modules/.bun
 
-# Global CLIs are sourced from configs/ide-deps.json.
+# Global CLIs are sourced from configs/ide-deps.json. The builder writes
+# installer|name|spec lines so Claude Code uses npm (bun fails extracting 2.1.89).
 COPY --from=builder /cmux/configs/ide-deps.json /tmp/ide-deps.json
+COPY --from=builder /cmux/configs/ide-deps-installs.txt /tmp/ide-deps-installs.txt
 RUN --mount=type=cache,target=/root/.bun/install/cache <<'EOF'
 set -eux
-packages="$(node - <<'NODE'
-const fs = require("node:fs");
-const deps = JSON.parse(fs.readFileSync("/tmp/ide-deps.json", "utf8"));
-const entries = Object.entries(deps.packages ?? {});
-for (const [name, value] of entries) {
-  if (typeof name !== "string" || typeof value !== "string" || value.trim().length === 0) {
-    throw new Error(`Invalid package entry ${name}: ${value}`);
-  }
-  const trimmedValue = value.trim();
-  const installMode = /^https?:\/\//.test(trimmedValue) ? "remote" : "version";
-  process.stdout.write(`${name}|${installMode}|${trimmedValue}\n`);
-}
-NODE
-)"
-if [ -z "${packages}" ]; then
-  echo "No packages found in /tmp/ide-deps.json" >&2
+if [ ! -s /tmp/ide-deps-installs.txt ]; then
+  echo "No packages found in /tmp/ide-deps-installs.txt" >&2
   exit 1
 fi
-while IFS='|' read -r package_name install_mode install_value; do
+while IFS='|' read -r installer package_name install_spec; do
   [ -z "${package_name}" ] && continue
-  if [ "${install_mode}" = "remote" ]; then
-    npm install -g "${install_value}"
+  if [ "${installer}" = "npm" ]; then
+    npm install -g "${install_spec}"
   else
-    bun add -g "${package_name}@${install_value}"
+    bun add -g "${install_spec}"
   fi
-done <<EOF_PACKAGES
-${packages}
-EOF_PACKAGES
+done < /tmp/ide-deps-installs.txt
 EOF
 
 # Install cursor cli

--- a/apps/server/src/runtime-dockerfile-ide-deps-installs.test.ts
+++ b/apps/server/src/runtime-dockerfile-ide-deps-installs.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const dockerfilePath = join(repoRoot, "Dockerfile");
+
+describe("worker image global CLI installer plan", () => {
+  const dockerfile = readFileSync(dockerfilePath, "utf8");
+
+  it("builds installer|name|spec lines after IDE dep bump/overrides", () => {
+    expect(dockerfile).toContain(
+      "COPY scripts/print-ide-deps-package-installs.ts ./scripts/print-ide-deps-package-installs.ts",
+    );
+    expect(dockerfile).toContain(
+      "RUN bun run ./scripts/print-ide-deps-package-installs.ts > /cmux/configs/ide-deps-installs.txt",
+    );
+    expect(dockerfile).toContain(
+      "COPY --from=builder /cmux/configs/ide-deps-installs.txt /tmp/ide-deps-installs.txt",
+    );
+  });
+
+  it("installs from the plan file instead of bun add -g for every versioned package", () => {
+    expect(dockerfile).toContain('if [ "${installer}" = "npm" ]; then');
+    expect(dockerfile).toContain('npm install -g "${install_spec}"');
+    expect(dockerfile).toContain('bun add -g "${install_spec}"');
+    expect(dockerfile).not.toContain(
+      'bun add -g "${package_name}@${install_value}"',
+    );
+  });
+});

--- a/scripts/lib/ideDeps.test.ts
+++ b/scripts/lib/ideDeps.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   applyPackageOverrides,
+  formatGlobalPackageInstallLines,
   formatPackageInstallSpec,
   isRemotePackageSource,
   parsePackageOverrides,
+  selectGlobalPackageInstaller,
   type IdeDeps,
 } from "./ideDeps";
 
@@ -54,5 +56,44 @@ describe("ideDeps package overrides", () => {
         "https://example.com/releases/download/pkg.tgz",
       ),
     ).toBe("https://example.com/releases/download/pkg.tgz");
+  });
+});
+
+describe("global package installer selection", () => {
+  it("uses npm for Claude Code versions because bun fails extracting the 2.1.89 tarball", () => {
+    expect(selectGlobalPackageInstaller("@anthropic-ai/claude-code", "2.1.89")).toBe(
+      "npm",
+    );
+  });
+
+  it("uses npm for remote tarball URLs and bun for other versioned packages", () => {
+    expect(
+      selectGlobalPackageInstaller(
+        "@openai/codex",
+        "https://example.com/releases/download/codex.tgz",
+      ),
+    ).toBe("npm");
+    expect(selectGlobalPackageInstaller("@openai/codex", "0.147.0")).toBe("bun");
+    expect(selectGlobalPackageInstaller("@sourcegraph/amp", "0.0.1")).toBe("bun");
+  });
+
+  it("formats installer|name|spec lines for the Docker/snapshot install loop", () => {
+    const deps: IdeDeps = {
+      extensions: [],
+      packages: {
+        "@openai/codex": "0.147.0",
+        "@anthropic-ai/claude-code": "2.1.89",
+        "@sourcegraph/amp": "https://example.com/amp.tgz",
+      },
+    };
+
+    expect(formatGlobalPackageInstallLines(deps)).toBe(
+      [
+        "bun|@openai/codex|@openai/codex@0.147.0",
+        "npm|@anthropic-ai/claude-code|@anthropic-ai/claude-code@2.1.89",
+        "npm|@sourcegraph/amp|https://example.com/amp.tgz",
+        "",
+      ].join("\n"),
+    );
   });
 });

--- a/scripts/lib/ideDeps.ts
+++ b/scripts/lib/ideDeps.ts
@@ -57,6 +57,34 @@ export function formatPackageInstallSpec(
   return isRemotePackageSource(value) ? value : `${packageName}@${value}`;
 }
 
+// bun add -g fails extracting @anthropic-ai/claude-code@2.1.89 on linux/amd64
+// ("Fail extracting tarball"). Keep this list in sync with
+// scripts/snapshot/helpers.py:NPM_GLOBAL_INSTALL_PACKAGES.
+export const NPM_GLOBAL_INSTALL_PACKAGES = new Set<string>([
+  "@anthropic-ai/claude-code",
+]);
+
+export function selectGlobalPackageInstaller(
+  packageName: string,
+  value: string,
+): "npm" | "bun" {
+  if (
+    isRemotePackageSource(value) ||
+    NPM_GLOBAL_INSTALL_PACKAGES.has(packageName)
+  ) {
+    return "npm";
+  }
+  return "bun";
+}
+
+export function formatGlobalPackageInstallLines(deps: IdeDeps): string {
+  const lines = Object.entries(deps.packages).map(([packageName, value]) => {
+    const installer = selectGlobalPackageInstaller(packageName, value);
+    return `${installer}|${packageName}|${formatPackageInstallSpec(packageName, value)}`;
+  });
+  return `${lines.join("\n")}\n`;
+}
+
 export function parsePackageOverrides(raw: string): IdePackageOverrides {
   const parsed = packageOverridesSchema.parse(JSON.parse(raw));
   const normalizedEntries = Object.entries(parsed).map(([packageName, value]) => {

--- a/scripts/print-ide-deps-package-installs.ts
+++ b/scripts/print-ide-deps-package-installs.ts
@@ -1,0 +1,4 @@
+import { formatGlobalPackageInstallLines, readIdeDeps } from "./lib/ideDeps";
+
+const deps = await readIdeDeps(process.cwd());
+process.stdout.write(formatGlobalPackageInstallLines(deps));

--- a/scripts/snapshot-pvelxc.py
+++ b/scripts/snapshot-pvelxc.py
@@ -73,6 +73,7 @@ from snapshot import (
     format_dependency_graph,
     is_remote_package_source,
     maybe_apply_ide_package_overrides,
+    select_global_package_installer,
 )
 
 # ---------------------------------------------------------------------------
@@ -3913,6 +3914,7 @@ async def task_install_global_cli(ctx: PveTaskContext) -> None:
 
     for index, (name, spec, install_spec) in enumerate(package_specs, 1):
         is_remote = is_remote_package_source(spec)
+        installer = select_global_package_installer(name, spec)
         install_label = spec if is_remote else install_spec
         ctx.console.info(
             f"Installing package {index}/{len(package_specs)}: {install_label}"
@@ -3925,7 +3927,7 @@ async def task_install_global_cli(ctx: PveTaskContext) -> None:
             try:
                 cmd = (
                     f"npm install -g {quoted_install_spec}"
-                    if is_remote
+                    if installer == "npm"
                     else f"bun add -g {quoted_install_spec}"
                 )
                 await ctx.run(f"install-pkg-{task_label}", cmd)

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -55,6 +55,7 @@ from snapshot import (
     HttpExecClient,
     run_task_graph,
     format_dependency_graph,
+    select_global_package_installer,
 )
 
 # ---------------------------------------------------------------------------
@@ -1680,11 +1681,12 @@ async def task_install_global_cli(ctx: TaskContext) -> None:
 
     for index, (name, spec, install_spec) in enumerate(package_specs, 1):
         is_remote = is_remote_package_source(spec)
+        installer = select_global_package_installer(name, spec)
         task_label = format_package_task_label(name)
         quoted_install_spec = shlex.quote(install_spec)
         install_cmd = (
             f"npm install -g {quoted_install_spec}"
-            if is_remote
+            if installer == "npm"
             else f"bun add -g {quoted_install_spec}"
         )
         install_label = spec if is_remote else install_spec

--- a/scripts/snapshot/__init__.py
+++ b/scripts/snapshot/__init__.py
@@ -30,6 +30,7 @@ from .helpers import (
     format_package_task_label,
     is_remote_package_source,
     maybe_apply_ide_package_overrides,
+    select_global_package_installer,
 )
 
 __all__ = [
@@ -54,4 +55,5 @@ __all__ = [
     "format_package_task_label",
     "is_remote_package_source",
     "maybe_apply_ide_package_overrides",
+    "select_global_package_installer",
 ]

--- a/scripts/snapshot/helpers.py
+++ b/scripts/snapshot/helpers.py
@@ -25,6 +25,17 @@ def is_remote_package_source(spec: str) -> bool:
     return parsed.scheme in ("http", "https") and bool(parsed.netloc)
 
 
+# bun add -g fails extracting @anthropic-ai/claude-code@2.1.89 on linux/amd64.
+# Keep this list in sync with scripts/lib/ideDeps.ts:NPM_GLOBAL_INSTALL_PACKAGES.
+NPM_GLOBAL_INSTALL_PACKAGES = frozenset({"@anthropic-ai/claude-code"})
+
+
+def select_global_package_installer(package_name: str, spec: str) -> str:
+    if is_remote_package_source(spec) or package_name in NPM_GLOBAL_INSTALL_PACKAGES:
+        return "npm"
+    return "bun"
+
+
 def maybe_apply_ide_package_overrides(repo_root: Path, console: Console) -> None:
     raw_overrides = os.environ.get("IDE_DEPS_PACKAGE_OVERRIDES", "").strip()
     if not raw_overrides:


### PR DESCRIPTION
## Summary

Docker (Worker Image) #634 (`0423b76b2`, merge of #1320) failed on `linux/amd64` while installing `@anthropic-ai/claude-code@2.1.89`:

```text
bun add -g @anthropic-ai/claude-code@2.1.89
error: Fail extracting tarball for "@anthropic-ai/claude-code"
```

`linux/arm64` succeeded. The weekly snapshot PR only changed `configs/ide-deps.json`, which invalidated the cached global-CLI layer. The repo still pins Claude Code to 2.1.89 (43 MB unpacked) via `IDE_DEPS_PACKAGE_OVERRIDES` after bumping to latest 2.1.233 (170 KB).

This change selects `npm install -g` for `@anthropic-ai/claude-code` (and existing remote tarball URLs) in a shared installer plan consumed by the worker Dockerfile and snapshot global-CLI steps.

## Test plan

- [x] `bunx vitest run scripts/lib/ideDeps.test.ts apps/server/src/runtime-dockerfile-ide-deps-installs.test.ts`
- [x] `bun run ./scripts/print-ide-deps-package-installs.ts` emits `npm|@anthropic-ai/claude-code|...`
- [x] `bun check`
- [ ] Docker (Worker Image) linux/amd64 + linux/arm64 green on this PR (no local Docker)