### PR TITLE
chore: run Weekly PVE LXC Snapshot on Sunday only

### DIFF
--- a/.github/workflows/pve-lxc-snapshot.yml
+++ b/.github/workflows/pve-lxc-snapshot.yml
@@ -2,7 +2,7 @@ name: Weekly PVE LXC Snapshot
 
 on:
   schedule:
-    - cron: "0 22 * * *" # Every day 6am HKT
+    - cron: "0 22 * * 6" # Every Sunday 06:00 HKT (Saturday 22:00 UTC)
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
The workflow is named **Weekly PVE LXC Snapshot** but its cron is `0 22 * * *` (every day at 22:00 UTC / 06:00 HKT). GitHub Actions has been firing it nightly and opening snapshot PRs almost every run.

This restores a real weekly cadence and keeps `workflow_dispatch` for on-demand rebuilds.

- Before: `0 22 * * *` — every day 06:00 HKT
- After: `0 22 * * 6` — **Sunday 06:00 HKT** (Saturday 22:00 UTC)

That is the same local clock as the current daily job, Sunday only. Daily Morph Snapshot still uses Sunday 22:00 UTC (`0 22 * * 0` = Monday 06:00 HKT); this PR keeps the PVE job on the HKT Sunday morning slot instead.

## Why
Nightly template rebuilds churn PVE disk (clone → convert → leftover templates) and produce overlapping snapshot PRs (`#1329`, `#1326` currently open). Weekly is what the workflow name already claimed.

## Test plan
- [x] Cron comment includes both HKT and UTC
- [ ] After merge, confirm the next scheduled run is Saturday 22:00 UTC (Actions → Weekly PVE LXC Snapshot)
- [ ] Manual `workflow_dispatch` still works if a rebuild is needed off-schedule
- [ ] Do not merge the existing nightly snapshot PRs as part of this change unless they are still wanted